### PR TITLE
Add mac_address, MTU to table

### DIFF
--- a/netbox_librenms_plugin/librenms_api.py
+++ b/netbox_librenms_plugin/librenms_api.py
@@ -50,7 +50,7 @@ class LibreNMSAPI:
             response = requests.get(
                 f"{self.librenms_url}/api/v0/devices/{device_ip}/ports",
                 headers=self.headers,
-                params={'columns': 'port_id,ifName,ifType,ifSpeed,ifAdminStatus,ifDescr,ifAlias'}
+                params={'columns': 'port_id,ifName,ifType,ifSpeed,ifAdminStatus,ifDescr,ifAlias,ifPhysAddress,ifMtu'}
             )
             response.raise_for_status()
             data = response.json()

--- a/netbox_librenms_plugin/tables.py
+++ b/netbox_librenms_plugin/tables.py
@@ -9,6 +9,7 @@ from django.utils.html import format_html
 from .models import InterfaceTypeMapping
 from django_tables2 import CheckBoxColumn
 from django.middleware.csrf import get_token
+from .utils import format_mac_address
 
 
 class LibreNMSInterfaceTable(tables.Table):
@@ -19,6 +20,8 @@ class LibreNMSInterfaceTable(tables.Table):
     ifName = tables.Column(verbose_name="Interface Name")
     ifType = tables.Column(verbose_name="Interface Type")
     ifSpeed = tables.Column(verbose_name="Speed")
+    ifPhysAddress = tables.Column(verbose_name="MAC Address")
+    ifMtu = tables.Column(verbose_name="MTU")
     enabled = BooleanColumn(verbose_name="Enabled")
     ifDescr = tables.Column(accessor="ifAlias", verbose_name="Description")
 
@@ -75,6 +78,13 @@ class LibreNMSInterfaceTable(tables.Table):
 
     def render_ifDescr(self, value, record):
         return self._render_field(value, record, 'ifAlias', 'description')
+
+    def render_ifPhysAddress(self, value, record):
+        formatted_mac = format_mac_address(value)
+        return self._render_field(formatted_mac, record, 'ifPhysAddress', 'mac_address')
+    
+    def render_ifMtu(self, value, record):
+        return self._render_field(value, record, 'ifMtu', 'mtu')
 
     def _render_field(self, value, record, librenms_key, netbox_key):
         if not record.get('exists_in_netbox'):

--- a/netbox_librenms_plugin/utils.py
+++ b/netbox_librenms_plugin/utils.py
@@ -9,4 +9,25 @@ LIBRENMS_TO_NETBOX_MAPPING = {
     'ifType': 'type',
     'ifSpeed': 'speed',
     'ifAlias': 'description',
+    'ifPhysAddress': 'mac_address',
+    'ifMtu': 'mtu',
 }
+
+def format_mac_address(mac_address):
+    """
+    Validate and format MAC address string for table display.
+
+    Args:
+        mac_address (str): The MAC address string to format.
+
+    Returns:
+        str: The MAC address formatted as XX:XX:XX:XX:XX:XX. 
+    """
+    mac_address = mac_address.strip().replace(':', '').replace('-', '')
+
+    if len(mac_address) != 12:
+        return "Invalid MAC Address"  # Return a message if the address is not valid
+    
+    formatted_mac = ':'.join(mac_address[i:i+2] for i in range(0, len(mac_address), 2))
+    return formatted_mac.upper()
+


### PR DESCRIPTION
This PR will add MAC address and MTU data to the interface sync table.
Also no longer uses the ifAlias value from LibreNMS if the same as interface name