### PR TITLE
Update LibreNMS plugin configuration to allow disabling of SSL verification

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -103,6 +103,7 @@ PLUGINS_CONFIG = {
         'librenms_url': 'https://your-librenms-instance.com',
         'api_token': 'your_librenms_api_token',
         'cache_timeout': 300,
+        'verify_ssl': True, # Change to False if needed.
     }
 }
 ```

--- a/netbox_librenms_plugin/__init__.py
+++ b/netbox_librenms_plugin/__init__.py
@@ -8,7 +8,10 @@ class LibreNMSSyncConfig(PluginConfig):
     version = "0.2.6"
     base_url = "librenms_plugin"
     required_settings = []
-    default_settings = {"enable_caching": True}
+    default_settings = {
+        "enable_caching": True,
+        "verify_ssl": True
+    }
 
 
 config = LibreNMSSyncConfig

--- a/netbox_librenms_plugin/librenms_api.py
+++ b/netbox_librenms_plugin/librenms_api.py
@@ -15,6 +15,7 @@ class LibreNMSAPI:
         self.cache_timeout = get_plugin_config(
             "netbox_librenms_plugin", "cache_timeout", 300
         )
+        self.verify_ssl = get_plugin_config("netbox_librenms_plugin", "verify_ssl")
 
         if not self.librenms_url or not self.api_token:
             raise ValueError("LibrenMS URL or API token is not configured.")
@@ -31,6 +32,7 @@ class LibreNMSAPI:
                 f"{self.librenms_url}/api/v0/devices/{device_ip}",
                 headers=self.headers,
                 timeout=10,
+                verify=self.verify_ssl,
             )
             if response.status_code == 200:
                 device_data = response.json()["devices"][0]
@@ -51,6 +53,7 @@ class LibreNMSAPI:
                     "columns": "port_id,ifName,ifType,ifSpeed,ifAdminStatus,ifDescr,ifAlias,ifPhysAddress,ifMtu"
                 },
                 timeout=10,
+                verify=self.verify_ssl,
             )
             response.raise_for_status()
             data = response.json()
@@ -87,6 +90,7 @@ class LibreNMSAPI:
                 headers=self.headers,
                 json=data,
                 timeout=10,
+                verify=self.verify_ssl,
             )
             response.raise_for_status()
 
@@ -122,6 +126,7 @@ class LibreNMSAPI:
                 headers=self.headers,
                 json=field_data,
                 timeout=10,
+                verify=self.verify_ssl,
             )
             response.raise_for_status()
 
@@ -147,6 +152,7 @@ class LibreNMSAPI:
                 f"{self.librenms_url}/api/v0/resources/locations/",
                 headers=self.headers,
                 timeout=10,
+                verify=self.verify_ssl,
             )
             response.raise_for_status()
             result = response.json()
@@ -179,6 +185,7 @@ class LibreNMSAPI:
                 headers=self.headers,
                 json=location_data,
                 timeout=10,
+                verify=self.verify_ssl,
             )
             response.raise_for_status()
 
@@ -216,6 +223,7 @@ class LibreNMSAPI:
                 headers=self.headers,
                 json=location_data,
                 timeout=10,
+                verify=self.verify_ssl,
             )
             response.raise_for_status()
             result = response.json()

--- a/netbox_librenms_plugin/views/base_views.py
+++ b/netbox_librenms_plugin/views/base_views.py
@@ -57,7 +57,6 @@ class CacheMixin:
         Get the cache key for the object.
         """
         model_name = obj._meta.model_name
-        print(f"cache key: {self.cache_prefix}_{model_name}_{obj.pk}")
         return f"{self.cache_prefix}_{model_name}_{obj.pk}"
 
     def get_last_fetched_key(self, obj):

--- a/netbox_librenms_plugin/views/sync_views.py
+++ b/netbox_librenms_plugin/views/sync_views.py
@@ -80,7 +80,6 @@ class SyncInterfacesView(CacheMixin, View):
         """
         cached_data = cache.get(self.get_cache_key(obj))
         if not cached_data:
-            print(f"No cached data found for device {obj}")
             messages.warning(
                 self.request,
                 "No cached data found. Please refresh the data before syncing.",
@@ -92,7 +91,6 @@ class SyncInterfacesView(CacheMixin, View):
         """
         Sync the selected interfaces.
         """
-        print(f"port data: {ports_data}")
         with transaction.atomic():
             for port in ports_data:
                 if port["ifName"] in selected_interfaces:


### PR DESCRIPTION
This pull request updates the LibreNMS plugin configuration to include a new setting called "verify_ssl". By default, the value of "verify_ssl" is set to True, but it can be changed to False if needed. This allows users to disable SSL verification when making requests to the LibreNMS API.