### PR TITLE
Refactor interface enabled status logic

### DIFF
--- a/netbox_librenms_plugin/views/base_views.py
+++ b/netbox_librenms_plugin/views/base_views.py
@@ -275,7 +275,7 @@ class BaseInterfaceTableView(LibreNMSAPIMixin, CacheMixin, View):
             netbox_interfaces = self.get_interfaces(obj)
 
             for port in ports_data:
-                port["enabled"] = (
+                port["enabled"] = True if port["ifAdminStatus"] is None else (
                     port["ifAdminStatus"].lower() == "up"
                     if isinstance(port["ifAdminStatus"], str)
                     else bool(port["ifAdminStatus"])

--- a/netbox_librenms_plugin/views/sync_views.py
+++ b/netbox_librenms_plugin/views/sync_views.py
@@ -124,7 +124,11 @@ class SyncInterfacesView(CacheMixin, View):
         # Update interface attributes
         self.update_interface_attributes(interface, librenms_interface, netbox_type)
 
-        interface.enabled = librenms_interface["ifAdminStatus"].lower() == "up"
+        interface.enabled = True if librenms_interface["ifAdminStatus"] is None else (
+            librenms_interface["ifAdminStatus"].lower() == "up"
+            if isinstance(librenms_interface["ifAdminStatus"], str)
+            else bool(librenms_interface["ifAdminStatus"])
+        )
         interface.save()
 
     def get_netbox_interface_type(self, librenms_interface):


### PR DESCRIPTION
Improve the logic for determining the enabled status of interfaces by handling cases where the `ifAdminStatus` is `None` or 'Null'. This change enhances clarity and consistency in the code.