### PR TITLE
Allow primary ip or device names. LibreNMS API calls now use device ID and store it.

### DIFF
--- a/netbox_librenms_plugin/templates/netbox_librenms_plugin/_interface_sync.html
+++ b/netbox_librenms_plugin/templates/netbox_librenms_plugin/_interface_sync.html
@@ -7,24 +7,22 @@
     <div class="btn-list">
         <form method="post">
             {% csrf_token %}
-            {% if has_primary_ip %}
-                {% if object_in_librenms %}
-                    {% with model_name=object|meta:"model_name" %}
-                        {% if model_name == "device" %}
-                            <button hx-post="{% url 'plugins:netbox_librenms_plugin:device_interface_sync' pk=object.pk %}"
-                                    hx-target="#interface-sync-content"
-                                    class="btn btn-outline-primary">
-                                Refresh Interfaces
-                            </button>
-                        {% elif model_name == "virtualmachine" %}
-                            <button hx-post="{% url 'plugins:netbox_librenms_plugin:vm_interface_sync' pk=object.pk %}"
-                                    hx-target="#interface-sync-content"
-                                    class="btn btn-outline-primary">
-                                Refresh Interfaces
-                            </button>
-                        {% endif %}
-                    {% endwith %}
-                {% endif %}
+            {% if has_librenms_id %}
+                {% with model_name=object|meta:"model_name" %}
+                    {% if model_name == "device" %}
+                        <button hx-post="{% url 'plugins:netbox_librenms_plugin:device_interface_sync' pk=object.pk %}"
+                                hx-target="#interface-sync-content"
+                                class="btn btn-outline-primary">
+                            Refresh Interfaces
+                        </button>
+                    {% elif model_name == "virtualmachine" %}
+                        <button hx-post="{% url 'plugins:netbox_librenms_plugin:vm_interface_sync' pk=object.pk %}"
+                                hx-target="#interface-sync-content"
+                                class="btn btn-outline-primary">
+                            Refresh Interfaces
+                        </button>
+                    {% endif %}
+                {% endwith %}
             {% endif %}
         </form>
     </div>

--- a/netbox_librenms_plugin/templates/netbox_librenms_plugin/librenms_sync_base.html
+++ b/netbox_librenms_plugin/templates/netbox_librenms_plugin/librenms_sync_base.html
@@ -33,8 +33,8 @@
                     <tr>
                         <th scope="row">Status</th>
                         <td>
-                            <span class="{% if object_in_librenms %}text-success{% else %}text-danger{% endif %}">
-                                {% if object_in_librenms %}
+                            <span class="{% if has_librenms_id %}text-success{% else %}text-danger{% endif %}">
+                                {% if has_librenms_id %}
                                     <a href="{{ librenms_device_url }}" target="_blank">Found in LibreNMS</a>
                                 {% else %}
                                     Not found in LibreNMS
@@ -42,7 +42,7 @@
                             </span>
                         </td>
                     </tr>
-                    {% if object_in_librenms %}
+                    {% if has_librenms_id %}
                         <tr>
                             <th scope="row">LibreNMS ID</th>
                             <td>{{ librenms_device_id }}</td>
@@ -88,8 +88,8 @@
     <span class="fs-5 mt-2 text-muted">Last data updated: {{ last_fetched|date:"Y-m-d  H:i" }}</span>
 {% endif %}
 
-{% if object.primary_ip %}
-    {% if object_in_librenms %}
+{% if librenms_device_id %}
+    {% if has_librenms_id %}
         <!-- Tab Navigation -->
         <ul class="nav nav-tabs mt-3" id="librenmsSync" role="tablist">
             <li class="nav-item" role="presentation">
@@ -140,9 +140,9 @@
         <div class="alert alert-info">
             LibreNMS sync is managed by virtual chassis member <a href="{{ vc_primary_device.get_absolute_url }}">{{ vc_primary_device }}</a>
         </div>
-    {% elif not has_primary_ip %}
+    {% elif not has_librenms_id %}
         <div class="alert alert-warning">
-            A primary IP is required for LibreNMS sync
+            A primary IP or device name is required for LibreNMS sync
         </div>
     {% endif %}
 {% endif %}

--- a/netbox_librenms_plugin/views/base_views.py
+++ b/netbox_librenms_plugin/views/base_views.py
@@ -83,6 +83,11 @@ class BaseLibreNMSSyncView(LibreNMSAPIMixin, generic.ObjectListView):
         Handle GET request for the LibreNMS sync view.
         """
         obj = get_object_or_404(self.model, pk=pk)
+
+        # Get librenms_id once at the start
+        self.librenms_id = self.librenms_api.get_librenms_id(obj)
+        print(f"librenms_id: {self.librenms_id}")
+
         context = self.get_context_data(request, obj)
         return render(request, self.template_name, context)
 
@@ -90,7 +95,7 @@ class BaseLibreNMSSyncView(LibreNMSAPIMixin, generic.ObjectListView):
         context = {
             "object": obj,
             "tab": self.tab,
-            "has_primary_ip": bool(obj.primary_ip),
+            "has_librenms_id": bool(self.librenms_id),
         }
 
         if hasattr(obj, "virtual_chassis") and obj.virtual_chassis:
@@ -123,7 +128,6 @@ class BaseLibreNMSSyncView(LibreNMSAPIMixin, generic.ObjectListView):
 
         context.update(
             {
-                "object_in_librenms": librenms_info["obj_exists"],
                 "interface_sync": interface_context,
                 "cable_sync": cable_context,
                 "ip_sync": ip_context,
@@ -142,9 +146,9 @@ class BaseLibreNMSSyncView(LibreNMSAPIMixin, generic.ObjectListView):
             "librenms_device_location": "-",
         }
 
-        if obj.primary_ip:
+        if self.librenms_id:
             obj_exists, librenms_obj_data = self.librenms_api.get_device_info(
-                str(obj.primary_ip.address.ip)
+                self.librenms_id
             )
             if obj_exists and librenms_obj_data:
                 details.update(
@@ -156,7 +160,7 @@ class BaseLibreNMSSyncView(LibreNMSAPIMixin, generic.ObjectListView):
                 )
                 details["librenms_device_url"] = (
                     f"{self.librenms_api.librenms_url}/device/device="
-                    f"{details['librenms_device_id']}/"
+                    f"{self.librenms_id}/"
                 )
         return {"obj_exists": obj_exists, "details": details}
 
@@ -225,15 +229,14 @@ class BaseInterfaceTableView(LibreNMSAPIMixin, CacheMixin, View):
         """
         obj = self.get_object(pk)
 
-        ip_address = self.get_ip_address(obj)
-        if not ip_address:
-            messages.error(
-                request,
-                "This object has no primary IP set. Unable to fetch data from LibreNMS.",
-            )
+        # Get librenms_id at the start
+        self.librenms_id = self.librenms_api.get_librenms_id(obj)
+
+        if not self.librenms_id:
+            messages.error(request, "Device not found in LibreNMS.")
             return redirect(self.get_redirect_url(obj))
 
-        librenms_data = self.librenms_api.get_ports(ip_address)
+        librenms_data = self.librenms_api.get_ports(self.librenms_id)
 
         if "error" in librenms_data:
             messages.error(request, librenms_data["error"])
@@ -275,10 +278,14 @@ class BaseInterfaceTableView(LibreNMSAPIMixin, CacheMixin, View):
             netbox_interfaces = self.get_interfaces(obj)
 
             for port in ports_data:
-                port["enabled"] = True if port["ifAdminStatus"] is None else (
-                    port["ifAdminStatus"].lower() == "up"
-                    if isinstance(port["ifAdminStatus"], str)
-                    else bool(port["ifAdminStatus"])
+                port["enabled"] = (
+                    True
+                    if port["ifAdminStatus"] is None
+                    else (
+                        port["ifAdminStatus"].lower() == "up"
+                        if isinstance(port["ifAdminStatus"], str)
+                        else bool(port["ifAdminStatus"])
+                    )
                 )
 
                 # Determine the correct chassis member based on the port description

--- a/netbox_librenms_plugin/views/device_views.py
+++ b/netbox_librenms_plugin/views/device_views.py
@@ -8,12 +8,15 @@ from django.urls import reverse
 from django.views import View
 from utilities.views import ViewTab, register_model_view
 
-from netbox_librenms_plugin.tables import (LibreNMSInterfaceTable,
-                                           VCInterfaceTable)
+from netbox_librenms_plugin.tables import LibreNMSInterfaceTable, VCInterfaceTable
 
-from .base_views import (BaseCableTableView, BaseInterfaceTableView,
-                         BaseIPAddressTableView, BaseLibreNMSSyncView,
-                         CacheMixin)
+from .base_views import (
+    BaseCableTableView,
+    BaseInterfaceTableView,
+    BaseIPAddressTableView,
+    BaseLibreNMSSyncView,
+    CacheMixin,
+)
 
 
 @register_model_view(Device, name="librenms_sync", path="librenms-sync")


### PR DESCRIPTION
Introduce fetching device ID from librenms from either primary IP or device name. Store id in custom field 'librenms_id' or cache if unavailable. the librenms_id is used for all api calls to device endpoint. 
Update interface sync templates and views to utilize the LibreNMS ID for improved status checks and error handling.
Refactor code for better readability and maintainability.