### PR TITLE
Add SNMP v3 support to 'Add to LibreNMS' option

### DIFF
--- a/netbox_librenms_plugin/forms.py
+++ b/netbox_librenms_plugin/forms.py
@@ -1,5 +1,6 @@
 # forms.py
 from netbox.forms import NetBoxModelForm
+from django import forms
 
 from .models import InterfaceTypeMapping
 
@@ -14,3 +15,53 @@ class InterfaceTypeMappingFilterForm(NetBoxModelForm):
     class Meta:
         model = InterfaceTypeMapping
         fields = ["librenms_type", "librenms_speed", "netbox_type"]
+
+
+class AddToLIbreSNMPV2(forms.Form):
+    hostname = forms.CharField(label="Hostname/IP", max_length=255, required=True)
+    snmp_version = forms.CharField(widget=forms.HiddenInput(), initial="v2c")
+    community = forms.CharField(label="SNMP Community", max_length=255, required=True)
+
+
+class AddToLIbreSNMPV3(forms.Form):
+    hostname = forms.CharField(label="Hostname/IP", max_length=255, required=True)
+    snmp_version = forms.CharField(widget=forms.HiddenInput(), initial="v3")
+    authlevel = forms.ChoiceField(
+        label="Auth Level",
+        choices=[
+            ("noAuthNoPriv", "noAuthNoPriv"),
+            ("authNoPriv", "authNoPriv"),
+            ("authPriv", "authPriv"),
+        ],
+        required=True,
+    )
+    authname = forms.CharField(label="Auth Username", max_length=255, required=True)
+    authpass = forms.CharField(
+        label="Auth Password",
+        max_length=255,
+        required=True,
+        widget=forms.PasswordInput(render_value=True),
+    )
+    authalgo = forms.ChoiceField(
+        label="Auth Algorithm",
+        choices=[
+            ("SHA", "SHA"),
+            ("MD5", "MD5"),
+            ("SHA-224", "SHA-224"),
+            ("SHA-256", "SHA-256"),
+            ("SHA-384", "SHA-384"),
+            ("SHA-512", "SHA-512"),
+        ],
+        required=True,
+    )
+    cryptopass = forms.CharField(
+        label="Crypto Password",
+        max_length=255,
+        required=True,
+        widget=forms.PasswordInput(render_value=True),
+    )
+    cryptoalgo = forms.ChoiceField(
+        label="Crypto Algorithm",
+        choices=[("AES", "AES"), ("DES", "DES")],
+        required=True,
+    )

--- a/netbox_librenms_plugin/static/netbox_librenms_plugin/js/librenms_sync.js
+++ b/netbox_librenms_plugin/static/netbox_librenms_plugin/js/librenms_sync.js
@@ -30,7 +30,7 @@ function initializeCountdowns() {
     if (window.cableCountdownInterval) {
         clearInterval(window.cableCountdownInterval);
     }
-    
+
     window.interfaceCountdownInterval = initializeCountdown("countdown-timer");
     window.cableCountdownInterval = initializeCountdown("cable-countdown-timer");
 }
@@ -90,10 +90,10 @@ function initializeVCMemberSelect() {
         const selects = interfaceTable.querySelectorAll('.form-select.tomselected');
 
         selects.forEach(select => {
-            
+
             if (select.tomselect && !select.dataset.interfaceSelectInitialized) {
                 select.dataset.interfaceSelectInitialized = 'true';
-                select.tomselect.on('change', function(value) {
+                select.tomselect.on('change', function (value) {
                     const deviceId = value;
                     const interfaceName = select.dataset.interface;
                     const rowId = select.dataset.rowId;
@@ -223,11 +223,48 @@ const urlParams = new URLSearchParams(window.location.search);
 const tab = urlParams.get('tab');
 if (tab === 'cables') {
     // Trigger click on cables tab
-    document.addEventListener('DOMContentLoaded', function() {
+    document.addEventListener('DOMContentLoaded', function () {
         document.getElementById('cables-tab').click();
     });
 }
 
+// Function to toggle SNMP forms based on version
+function toggleSNMPForms() {
+    const snmpSelect = document.querySelector('#add-device-modal select.form-select');
+    if (!snmpSelect) return;
+    const version = snmpSelect.value;
+
+    const v2Form = document.getElementById('snmpv2-form');
+    const v3Form = document.getElementById('snmpv3-form');
+
+    if (version === 'v2c') {
+        v2Form.style.display = 'block';
+        v3Form.style.display = 'none';
+    } else {
+        v2Form.style.display = 'none';
+        v3Form.style.display = 'block';
+    }
+}
+
+// Function to initialize modal-specific scripts
+function initializeModalScripts() {
+    const snmpSelect = document.querySelector('#add-device-modal select.form-select');
+    if (snmpSelect) {
+        snmpSelect.addEventListener('change', toggleSNMPForms);
+        // Initial call to set the correct form visibility
+        toggleSNMPForms();
+    }
+}
+
+// Listen for the modal 'shown.bs.modal' event to initialize scripts
+document.addEventListener('DOMContentLoaded', function () {
+    const addDeviceModal = document.getElementById('add-device-modal');
+    if (addDeviceModal) {
+        addDeviceModal.addEventListener('shown.bs.modal', function () {
+            initializeModalScripts();
+        });
+    }
+});
 
 // Function to initialize all necessary scripts
 function initializeScripts() {
@@ -236,6 +273,7 @@ function initializeScripts() {
     initializeInterfaceFilters();
     initializeCableFilters();
     initializeCountdowns();
+
 }
 
 

--- a/netbox_librenms_plugin/templates/netbox_librenms_plugin/librenms_sync_base.html
+++ b/netbox_librenms_plugin/templates/netbox_librenms_plugin/librenms_sync_base.html
@@ -12,18 +12,18 @@
 {% endblock %}
 
 {% block breadcrumbs %}
-  {{ block.super }}
-    {% with model_name=object|meta:"model_name" %}
-        {% if model_name == "device" %}
-            <li class="breadcrumb-item">
-                <a href="{% url 'dcim:site' pk=object.site.pk %}">{{ object.site }}</a>
-            </li>
-        {% elif model_name == "virtualmachine" %}
-            <li class="breadcrumb-item">
-                <a href="{% url 'virtualization:virtualmachine_list' %}?cluster_id={{ object.cluster.pk }}">{{ object.cluster }}</a>
-            </li>
-        {% endif %}
-    {% endwith %}
+{{ block.super }}
+{% with model_name=object|meta:"model_name" %}
+{% if model_name == "device" %}
+<li class="breadcrumb-item">
+    <a href="{% url 'dcim:site' pk=object.site.pk %}">{{ object.site }}</a>
+</li>
+{% elif model_name == "virtualmachine" %}
+<li class="breadcrumb-item">
+    <a href="{% url 'virtualization:virtualmachine_list' %}?cluster_id={{ object.cluster.pk }}">{{ object.cluster }}</a>
+</li>
+{% endif %}
+{% endwith %}
 {% endblock %}
 
 {% block content %}
@@ -39,47 +39,54 @@
                         <th scope="row">Status</th>
                         <td>
                             <span class="{% if has_librenms_id %}text-success{% else %}text-danger{% endif %}">
-                                {% if has_librenms_id %}
-                                    <a href="{{ librenms_device_url }}" target="_blank">Found in LibreNMS</a>
+                                {% if found_in_librenms %}
+                                <a href="{{ librenms_device_url }}" target="_blank">Found in LibreNMS</a>
                                 {% else %}
-                                    Not found in LibreNMS
+                                Not found in LibreNMS
+                                <div class="m-2"><button type="button" class="btn btn-primary" data-bs-toggle="modal"
+                                        data-bs-target="#add-device-modal">
+                                        Add to LibreNMS
+                                    </button>
+                                </div>
                                 {% endif %}
                             </span>
                         </td>
                     </tr>
-                    {% if has_librenms_id %}
-                        <tr>
-                            <th scope="row">LibreNMS ID</th>
-                            <td>{{ librenms_device_id }}</td>
-                        </tr>
-                        {% with model_name=object|meta:"model_name" %}
-                            {% if model_name == "device" %}
-                                <tr>
-                                    <th scope="row">Device Type</th>
-                                    <td>{{ librenms_device_hardware }}</td>
-                                </tr>
-                                <tr>
-                                    <th scope="row">LibreNMS Location</th>
-                                    <td>
-                                        <div class="d-flex justify-content-between align-items-center">
-                                            <span>{{ librenms_device_location }}</span>
-                                            <form method="post" action="{% url 'plugins:netbox_librenms_plugin:update_device_location' pk=object.pk %}">
-                                                {% csrf_token %}
-                                                {% if librenms_device_location != object.site.name %}
-                                                    <button type="submit" class="btn btn-primary" title="Sync LibreNMS location with NetBox Site: {{ object.site.name }}">
-                                                        <i class="mdi mdi-sync"></i>
-                                                    </button>
-                                                {% else %}
-                                                    <span class="text-success" title="LibreNMS location matches NetBox site">
-                                                        <i class="ms-1 mdi mdi-check-circle"></i>
-                                                    </span>
-                                                {% endif %}
-                                            </form>
-                                        </div>
-                                    </td>
-                                </tr>
-                            {% endif %}
-                        {% endwith %}
+                    {% if found_in_librenms %}
+                    <tr>
+                        <th scope="row">LibreNMS ID</th>
+                        <td>{{ librenms_device_id }}</td>
+                    </tr>
+                    {% with model_name=object|meta:"model_name" %}
+                    {% if model_name == "device" %}
+                    <tr>
+                        <th scope="row">Device Type</th>
+                        <td>{{ librenms_device_hardware }}</td>
+                    </tr>
+                    <tr>
+                        <th scope="row">LibreNMS Location</th>
+                        <td>
+                            <div class="d-flex justify-content-between align-items-center">
+                                <span>{{ librenms_device_location }}</span>
+                                <form method="post"
+                                    action="{% url 'plugins:netbox_librenms_plugin:update_device_location' pk=object.pk %}">
+                                    {% csrf_token %}
+                                    {% if librenms_device_location != object.site.name %}
+                                    <button type="submit" class="btn btn-primary"
+                                        title="Sync LibreNMS location with NetBox Site: {{ object.site.name }}">
+                                        <i class="mdi mdi-sync"></i>
+                                    </button>
+                                    {% else %}
+                                    <span class="text-success" title="LibreNMS location matches NetBox site">
+                                        <i class="ms-1 mdi mdi-check-circle"></i>
+                                    </span>
+                                    {% endif %}
+                                </form>
+                            </div>
+                        </td>
+                    </tr>
+                    {% endif %}
+                    {% endwith %}
                     {% endif %}
                 </tbody>
             </table>
@@ -90,66 +97,90 @@
 
 <!-- Last Updated Information and Cache Countdown -->
 {% if last_fetched %}
-    <span class="fs-5 mt-2 text-muted">Last data updated: {{ last_fetched|date:"Y-m-d  H:i" }}</span>
+<span class="fs-5 mt-2 text-muted">Last data updated: {{ last_fetched|date:"Y-m-d H:i" }}</span>
 {% endif %}
 
 {% if librenms_device_id %}
-    {% if has_librenms_id %}
-        <!-- Tab Navigation -->
-        <ul class="nav nav-tabs mt-3" id="librenmsSync" role="tablist">
-            <li class="nav-item" role="presentation">
-                <button class="nav-link active" id="interfaces-tab" data-bs-toggle="tab" data-bs-target="#interfaces" type="button" role="tab" aria-controls="interfaces" aria-selected="true">
-                    Interfaces
-                </button>
-            </li>
-            {% if cable_sync %}
-            <li class="nav-item" role="presentation">
-                <button class="nav-link" id="cables-tab" data-bs-toggle="tab" data-bs-target="#cables" type="button" role="tab" aria-controls="cables" aria-selected="false">
-                    Cables
-                </button>
-            </li>
-            {% endif %}
-            <li class="nav-item" role="presentation">
-                <button class="nav-link" id="ipaddresses-tab" data-bs-toggle="tab" data-bs-target="#ipaddresses" type="button" role="tab" aria-controls="ipaddresses" aria-selected="false">
-                    IP Addresses
-                </button>
-            </li>
-        </ul>
-
-        <!-- Tab Content -->
-        <div class="tab-content mt-3" id="librenmsTabContent">
-            <div class="tab-pane fade show active" id="interfaces" role="tabpanel" aria-labelledby="interfaces-tab">
-                {% include 'netbox_librenms_plugin/_interface_sync.html' %}
-            </div>
-            <div class="tab-pane fade" id="cables" role="tabpanel" aria-labelledby="cables-tab">
-                {% include 'netbox_librenms_plugin/_cable_sync.html' %}
-            </div>
-            <div class="tab-pane fade" id="ipaddresses" role="tabpanel" aria-labelledby="ipaddresses-tab">
-                {% include 'netbox_librenms_plugin/_ipaddress_sync.html' %}
-            </div>
-        </div>
-    {% else %}
-        <button type="button" 
-            class="btn btn-primary" 
-            data-bs-toggle="modal" 
-            data-bs-target="#add-device-modal">
-        Add to LibreNMS
+{% if found_in_librenms %}
+<!-- Tab Navigation -->
+<ul class="nav nav-tabs mt-3" id="librenmsSync" role="tablist">
+    <li class="nav-item" role="presentation">
+        <button class="nav-link active" id="interfaces-tab" data-bs-toggle="tab" data-bs-target="#interfaces"
+            type="button" role="tab" aria-controls="interfaces" aria-selected="true">
+            Interfaces
         </button>
+    </li>
+    {% if cable_sync %}
+    <li class="nav-item" role="presentation">
+        <button class="nav-link" id="cables-tab" data-bs-toggle="tab" data-bs-target="#cables" type="button" role="tab"
+            aria-controls="cables" aria-selected="false">
+            Cables
+        </button>
+    </li>
     {% endif %}
+    <li class="nav-item" role="presentation">
+        <button class="nav-link" id="ipaddresses-tab" data-bs-toggle="tab" data-bs-target="#ipaddresses" type="button"
+            role="tab" aria-controls="ipaddresses" aria-selected="false">
+            IP Addresses
+        </button>
+    </li>
+</ul>
+
+<!-- Tab Content -->
+<div class="tab-content mt-3" id="librenmsTabContent">
+    <div class="tab-pane fade show active" id="interfaces" role="tabpanel" aria-labelledby="interfaces-tab">
+        {% include 'netbox_librenms_plugin/_interface_sync.html' %}
+    </div>
+    <div class="tab-pane fade" id="cables" role="tabpanel" aria-labelledby="cables-tab">
+        {% include 'netbox_librenms_plugin/_cable_sync.html' %}
+    </div>
+    <div class="tab-pane fade" id="ipaddresses" role="tabpanel" aria-labelledby="ipaddresses-tab">
+        {% include 'netbox_librenms_plugin/_ipaddress_sync.html' %}
+    </div>
+</div>
 {% else %}
-    {% if is_vc_member and not has_vc_primary_ip %}
-        <div class="alert alert-warning">
-            Virtual chassis primary device <a href="{{ vc_primary_device.get_absolute_url }}">{{ vc_primary_device }}</a> requires a primary IP for LibreNMS sync
+<div>
+    <div class="alert alert-warning d-flex align-items-center">
+        <i class="mdi mdi-alert me-2"></i>
+        <div>
+            <strong>Device not found:</strong>
+            Device has custom field 'librenms_id' set to <code>{{ librenms_device_id }}</code> but was not found in
+            LibreNMS.
+            <hr class="my-2">
+            <span class="text-muted">
+                Options:
+                <ul class="mb-0">
+                    <li>Remove custom field value and let LibreNMS plugin try to find it</li>
+                    <li>Manually enter the correct LibreNMS device ID</li>
+                </ul>
+            </span>
         </div>
-    {% elif is_vc_member and has_vc_primary_ip %}
-        <div class="alert alert-info">
-            LibreNMS sync is managed by virtual chassis member <a href="{{ vc_primary_device.get_absolute_url }}">{{ vc_primary_device }}</a>
-        </div>
-    {% elif not has_librenms_id %}
-        <div class="alert alert-warning">
-            A primary IP or device name is required for LibreNMS sync
-        </div>
-    {% endif %}
+    </div>
+
+</div>
+{% endif %}
+{% else %}
+{% if is_vc_member and not has_vc_primary_ip %}
+<div class="alert alert-warning">
+    Virtual chassis primary device <a href="{{ vc_primary_device.get_absolute_url }}">{{ vc_primary_device }}</a>
+    requires a primary IP for LibreNMS sync
+</div>
+{% elif is_vc_member and has_vc_primary_ip %}
+<div class="alert alert-info">
+    LibreNMS sync is managed by virtual chassis member <a href="{{ vc_primary_device.get_absolute_url }}">{{
+        vc_primary_device }}</a>
+</div>
+{% elif not found_in_librenms %}
+<div class="alert alert-warning">
+    Device requires one of the following to help identify the device in LibreNMS:
+    <ul>
+        <li>Device name (FQDN)</li>
+        <li>Primary IP DNS name (FQDN)</li>
+        <li>Primary IP address</li>
+    </ul>
+</div>
+
+{% endif %}
 {% endif %}
 <!-- End Tab Content -->
 
@@ -157,56 +188,63 @@
 <!-- Add to LibreNMS Modal Placeholder-->
 <div id="modal-div"></div>
 
-<div class="modal fade" id="add-device-modal" tabindex="-1" role="dialog">
-    <div class="modal-dialog" role="document">
+
+<!-- Add to LibreNMS Modal -->
+<div class="modal fade" id="add-device-modal" tabindex="-1" aria-labelledby="addDeviceModalLabel" aria-hidden="true">
+    <div class="modal-dialog">
         <div class="modal-content">
             <div class="modal-header">
-                {% with model_name=object|meta:"model_name" %}
-                <form method="post" action="{% url 'plugins:netbox_librenms_plugin:add_device_to_librenms' object_type=model_name object_id=object.pk %}">
-                {% endwith %}
-                {% csrf_token %}
-                <input type="hidden" name="device_id" value="{{ device.pk }}">
-                <div class="modal-header">
-                    <h5 class="modal-title">Add Device to LibreNMS</h5>
-                </div>
-                <div class="modal-body">
-                    <div class="alert alert-info" role="alert">
-                    <p>Note: Only SNMP v2c is supported at this time.</p>
-                    <p>If required, add device using LibreNMS then return this sync page.</p>
-                    </div>
-                    <div class="form-group">
-                    <label for="hostname">Hostname/IP</label>
-                    <input type="text" class="form-control" id="hostname" name="hostname" value="{{ object.primary_ip.address.ip }}" required>
-                    </div>
-                    
-                    {% with model_name=object|meta:"model_name" %}
-                        {% if model_name == "device" %}
-                            <div class="form-group">
-                                <label for="site">Site</label>
-                                <input type="text" class="form-control" id="site" name="site" value="{{ object.site.name }}" required>
-                            </div>
-                        {% endif %}
-                    {% endwith %}
-                    <div class="form-group">
-                    <label for="snmpCommunity">SNMP Community</label>
-                    <input type="password" class="form-control" id="snmpCommunity" name="community" autocomplete="off" required>
-                    </div>
-                    <div class="form-group">
-                    <label for="snmpVersion">SNMP Version</label>
-                    <select class="form-control" id="snmpVersion" name="version">
-                        <option value="v2c">v2c</option>
+                <h5 class="modal-title" id="addDeviceModalLabel">Add Device to LibreNMS</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body">
+                <!-- SNMP Version Selector -->
+                <div class="mb-3">
+                    <label class="form-label">SNMP Version</label>
+                    <select class="form-select" onchange="toggleSNMPForms(this.value)">
+                        <option value="v2c">SNMPv2c</option>
+                        <option value="v3">SNMPv3</option>
                     </select>
+                </div>
+
+                <!-- SNMPv2c form -->
+                <form method="post" action="{% url 'plugins:netbox_librenms_plugin:add_device_to_librenms' object.id %}"
+                    id="snmpv2-form">
+                    {% csrf_token %}
+                    <div class="mb-3">
+                        {{ v2form.hostname.label_tag }}
+                        {{ v2form.hostname }}
                     </div>
-                </div>
-                <div class="modal-footer">
-                    <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">Cancel</button>
+                    {{ v2form.snmp_version }}
+                    <div class="mb-3">
+                        {{ v2form.community.label_tag }}
+                        {{ v2form.community }}
+                    </div>
                     <button type="submit" class="btn btn-primary">Add Device</button>
-                </div>
+                </form>
+
+                <!-- SNMPv3 form -->
+                <form method="post" action="{% url 'plugins:netbox_librenms_plugin:add_device_to_librenms' object.id %}"
+                    id="snmpv3-form" style="display: none;">
+                    {% csrf_token %}
+                    <div class="mb-3">
+                        {{ v3form.hostname.label_tag }}
+                        {{ v3form.hostname }}
+                    </div>
+                    {{ v3form.snmp_version }}
+                    {% for field in v3form %}
+                    {% if field.name != 'hostname' and field.name != 'snmp_version' %}
+                    <div class="mb-3">
+                        {{ field.label_tag }}
+                        {{ field }}
+                    </div>
+                    {% endif %}
+                    {% endfor %}
+                    <button type="submit" class="btn btn-primary">Add Device</button>
                 </form>
             </div>
         </div>
     </div>
 </div>
-
 
 {% endblock %} <!-- End content -->

--- a/netbox_librenms_plugin/templates/netbox_librenms_plugin/librenms_sync_base.html
+++ b/netbox_librenms_plugin/templates/netbox_librenms_plugin/librenms_sync_base.html
@@ -172,7 +172,7 @@
 </div>
 {% elif not found_in_librenms %}
 <div class="alert alert-warning">
-    Device requires one of the following to help identify the device in LibreNMS:
+    To match a device with LibreNMS, one of these identifiers must match:
     <ul>
         <li>Device name (FQDN)</li>
         <li>Primary IP DNS name (FQDN)</li>

--- a/netbox_librenms_plugin/urls.py
+++ b/netbox_librenms_plugin/urls.py
@@ -88,7 +88,7 @@ urlpatterns = [
     ),
     # Add Device to LibreNMS URLs
     path(
-        "<str:object_type>/<int:object_id>/add-device-to-librenms/",
+        "add-device/<int:object_id>/",
         AddDeviceToLibreNMSView.as_view(),
         name="add_device_to_librenms",
     ),

--- a/netbox_librenms_plugin/views/base_views.py
+++ b/netbox_librenms_plugin/views/base_views.py
@@ -138,8 +138,8 @@ class BaseLibreNMSSyncView(LibreNMSAPIMixin, generic.ObjectListView):
             {
                 "interface_sync": interface_context,
                 "cable_sync": cable_context,
-                'v2form': AddToLIbreSNMPV2(),
-                'v3form': AddToLIbreSNMPV3(),
+                "v2form": AddToLIbreSNMPV2(),
+                "v3form": AddToLIbreSNMPV3(),
                 "ip_sync": ip_context,
                 "found_in_librenms": librenms_info["found_in_librenms"],
                 "librenms_device_id": self.librenms_id,
@@ -265,7 +265,7 @@ class BaseInterfaceTableView(LibreNMSAPIMixin, CacheMixin, View):
             timeout=self.librenms_api.cache_timeout,
         )
 
-        messages.success(request, "Interface Data refreshed successfully.")
+        messages.success(request, "Interface data refreshed successfully.")
 
         context = self.get_context_data(request, obj)
         context = {"interface_sync": context}
@@ -532,7 +532,7 @@ class BaseCableTableView(LibreNMSAPIMixin, CacheMixin, View):
                 {"cable_sync": {"object": obj, "table": None, "cache_expiry": None}},
             )
 
-        messages.success(request, "Cable Data refreshed successfully.")
+        messages.success(request, "Cable data refreshed successfully.")
         return render(
             request,
             self.partial_template_name,


### PR DESCRIPTION
Introduce a new form for SNMP v3 alongside the existing SNMP v2 form when adding devices to LibreNMS.  Minor updates to the user interface and code structure enhance overall usability.