### PR TITLE
Increase API request timeout to 20 seconds

### DIFF
--- a/netbox_librenms_plugin/librenms_api.py
+++ b/netbox_librenms_plugin/librenms_api.py
@@ -208,7 +208,7 @@ class LibreNMSAPI:
                 f"{self.librenms_url}/api/v0/devices",
                 headers=self.headers,
                 json=payload,
-                timeout=10,
+                timeout=20,
                 verify=self.verify_ssl,
             )
             response.raise_for_status()


### PR DESCRIPTION
Adjust the API request timeout from 10 seconds to 20 seconds to allow for longer processing times.