### PR TITLE
Add check for empty MAC address in format_mac_address function

### DIFF
--- a/netbox_librenms_plugin/utils.py
+++ b/netbox_librenms_plugin/utils.py
@@ -33,6 +33,9 @@ def format_mac_address(mac_address: str) -> str:
     Returns:
         str: The MAC address formatted as XX:XX:XX:XX:XX:XX.
     """
+    if not mac_address:
+        return ""
+
     mac_address = mac_address.strip().replace(":", "").replace("-", "")
 
     if len(mac_address) != 12:


### PR DESCRIPTION
Implement a check to return an empty string if the MAC address input is empty.