### PR TITLE
Update documentation and README for latest release and custom field usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 # NetBox LibreNMS Plugin
 
-This plugin provides the ability to sync selected data between Netbox and LibreNMS.
-
-The plugin allows Netbox to remain the source of truth by allowing intentional syncing of data between NetBox and LibreNMS. The intention is to make it easier to maintain accurate data between the two systems.
+The NetBox LibreNMS Plugin enables integration between NetBox and LibreNMS, allowing you to leverage data from both systems. NetBox remains the Source of Truth (SoT) for you network, but 
+this plugin allows you to easily onboard device objects from existing data in LibreNMS. The plugin does not automatically create objects in NetBox to ensure only verified data is used to populate NetBox. 
 
 This is in early development.
 
@@ -10,8 +9,9 @@ This is in early development.
 
 The plugin offers the following key features:
 
-### Interface Synchronization
+### Interface Sync
 Pull interface data from Devices and Virtual Machines from LibreNMS into NetBox. The following interface attributes are synchronized:
+
 - Name
 - Description
 - Status (Enabled/Disabled)
@@ -21,7 +21,9 @@ Pull interface data from Devices and Virtual Machines from LibreNMS into NetBox.
 - MAC Address
 
 > Set custom mappings for interface types to ensure that the correct interface type is used when syncing from LibreNMS to NetBox.
-> Speed and Type are Device only
+
+### Cable Sync
+Create cable connection in NetBox from LibreNMS links data.
 
 ### Add device to LibreNMS from Netbox
 
@@ -122,6 +124,14 @@ Apply database migrations with Netbox `manage.py`:
 
 ```
 (venv) $ python manage.py migrate
+```
+
+### Collect Static Files
+
+The plugin includes static files that need to be collected by NetBox. Run the following command to collect static files:
+
+```
+(venv) $ python manage.py collectstatic --no-input
 ```
 
 ### Restart Netbox

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,83 @@
 # Changelog
 
+## 0.2.8 (2024-11-29)
+### Use of Custom Field
+This release introduces the option of using a custom field `librenms_id` (integer) to device and virtual machine objects in NetBox. The plugin will work without it but it is recommended for LibreNMS API lookups especially if no primary IP or FQDN available. 
+
+**Note: New static javascript file requires running collectstatic after update**
+
+```
+(venv) $ python manage.py collectstatic --no-input
+```
+
+
+### New Features
+* Add device to LibreNMS using SNMPv3
+* Create cable connection from LIbreNMS links data31
+* Plugin can now use primary IP, hostname or Primary IP DNS Name to identify device in LibreNMS 
+* Exclude specific columns when syncing data 
+* Filter interface and cable tables 
+* Bulk edit Virtual Chassis members
+
+
+
+### Improvements
+* Add pagination to SiteLocationSyncTable
+* Add site location filtering functionality and update template for search 
+* Refactor LibreNMSAPI to enhance device ID retrieval logic and include DNS name handling 
+* Enhance cable sync with device ID handling and user guidance modal
+* Add device mismatch check and user feedback 
+* Add check for empty MAC address in format_mac_address function
+* Increase API request timeout to 20 seconds 
+* Fix dropdown menu size issue on click 
+
+
+### Under the hood
+
+* Refactor interface enabled status logic 
+* Fix handling of data-enabled attribute in interface table
+* Improve interface mapping logic for speed matchingpull/24
+* Refactor cable context handling and improve data rendering in cable tables
+* Refactor Javascript into single file. Add cable sync filters and countdown timer 
+* Refactor device addition and enhance SNMP v3 support
+
+
+## 0.2.7 (2024-11-11)
+### What's Changed
+* Add new interface table logic to handle virtual chassis member selection 
+* Update LibreNMS plugin configuration to allow disabling of SSL verification
+
+### Interface name change
+*The LibreNMS Sync interface names now use the ifDescr from Librenms. This displays the full interface name to better align with the device type library convention. e.g GigabitEthernet1/0/1 instead of Gig1/0/1.*
+
+## 0.2.6 (2024-10-25)
+### New Feature
+
+* Sync Virtual Machine interfaces
+
+### Bug fix
+* Pagination bug where page contents would duplicate now fixed.
+
+### Under the hood
+* Refactoring of views into separate files for better maintainability.
+* Code formatting improvements
+* Remove unused elements
+
+##  0.2.5 (2024-10-21)
+Bug fix release:
+* Missing commas in LibreNMS api module
+
+## 0.2.4 (2024-10-21)
+### Enhancements
+
+* Add mac_address, MTU to interface sync
+* Enable select all and shift click on interface sync page rows, and other improvements
+* Interface mapping now accounts for speed of interface
+    > Update to Interface mapping modal may require recreation of existing mapping. 
+* Updated LibreNMS Sync page layout to prepare for new features
+### Under the hood
+* Refactor all views to be class-based
+* Big refactor of device LibreNMS sync views to make way for new features
 ## 0.2.3 (2024-09-30)
 
 * Fix bug where wrong template is used when editing interface mappings

--- a/docs/custom_field.md
+++ b/docs/custom_field.md
@@ -1,0 +1,73 @@
+# Using the `librenms_id` Custom Field
+
+## Overview
+
+To enhance device identification and synchronization between NetBox and LibreNMS, this plugin supports using a custom field `librenms_id` on Device and Virtual Machine objects. While the plugin works without it, using this custom field is recommended for LibreNMS API lookups, and to assist with matching the remote device and remote interface for cable creation in Netbox. It can also be entered manually if no primary IP or FQDN is available.
+
+The plugin will automatically populate this field with the LibreNMS ID when opening the LibreNMS Sync page if the device has been found in LibreNMS.
+
+## Benefits of Using `librenms_id`
+
+- **Improved Device Matching:** Ensures accurate matching between NetBox and LibreNMS devices.
+- **Fallback Identification:** Useful when devices lack a primary IP or FQDN.
+- **Efficient Synchronization:** Enhances the reliability of API lookups.
+- **Cable creation:** Allows better device identification for the creation of cables between NetBox devices.
+
+## Suggested Custom Field Setup
+
+Follow these steps to create the `librenms_id` custom field in NetBox:
+
+1. **Navigate to Custom Fields:**
+
+    - Go to **Customization** in the NetBox sidebar.
+    - Click on **Custom Fields**.
+
+2. **Add a New Custom Field:**
+
+    - Click the **Add a custom field** button.
+
+3. **Configure the Custom Field:**
+
+    - **Object Types:** 
+        - Check **dcim > device**
+        - Check **virtualization > virtual machine**
+    - **Name:** `librenms_id`
+    - **Label:** `LibreNMS ID`
+    - **Description:** (Optional) Add a description like "LibreNMS Device ID for synchronization".
+    - **Type:** Integer
+    - **Required:** Leave unchecked (optional).
+    - **Default Value:** Leave blank.
+
+
+4. **Save the Custom Field:**
+
+    - Click **Create** to save the custom field.
+
+
+
+### Manually assign a value to `librenms_id`
+
+You can manually assign a value to the `librenms_id` custom field for a device using the following steps:
+
+1. **Edit the Device:**
+
+    - Navigate to the device in NetBox.
+    - Click the **Edit** button.
+
+2. **Set the LibreNMS ID:**
+
+    - Scroll to the **Custom Fields** section.
+    - Enter the LibreNMS device ID in the `librenms_id` field.
+
+3. **Save Changes:**
+
+    - Click **Update** to save the device.
+
+
+
+
+## Notes
+
+- If `librenms_id` is set, the plugin will prioritize it over other identification methods.
+- Ensure the `librenms_id` corresponds to the correct device ID in LibreNMS to prevent mismatches.
+- The custom field is optional but recommended for optimal plugin performance.

--- a/docs/feature_list.md
+++ b/docs/feature_list.md
@@ -1,0 +1,39 @@
+# Features List
+
+### Device 
+
+- LibreNMS device identification via:
+    - [Custom field `librenms_id`](custom_field.md) *(recommended)*
+    - Primary IP address
+    - Primary IP DNS name
+    - Hostname
+- Add device to LibreNMS from netbox via SNMP v2c or v3
+
+### [Virtual Chassis Support](virtual_chassis.md)
+- Automatic VC member selection for each interface
+- Member-specific interface synchronization
+- Bulk member editing capabilities
+
+### Interface 
+- Create or Update interface in NetBox from LibreNMS interface data
+    - Name
+    - Description
+    - Status (Enabled/Disabled)
+    - Type (with custom mapping support)
+    - Speed
+    - MAC Address
+    - MTU
+- Sync all or specific fields
+
+### Cable 
+- Create Cable connection in NetBox from LibreNMS links data
+
+### Location 
+- NetBox Site to LibreNMS location synchronization
+- Sync location latitude and longitude values from NetBoxx to LibreNMS
+
+### [Interface Mapping](interface_mappings.md) 
+- Customizable LibreNMS to NetBox interface type mappings
+- Interface Speed-based mapping rules
+
+

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,8 @@
 # NetBox LibreNMS Plugin
 
-This plugin provides the ability to sync data between Netbox and LibreNMS.
+### Intro
+The NetBox LibreNMS Plugin enables integration between NetBox and LibreNMS, allowing you to leverage data from both systems. NetBox remains the Source of Truth (SoT) for you network, but 
+this plugin allows you to easily onboard device objects from existing data in LibreNMS. The plugin does not automatically create objects in NetBox to ensure only verified data is used to populate NetBox. 
 
 This is in early development.
 
@@ -8,8 +10,9 @@ This is in early development.
 
 The plugin offers the following key features:
 
-### Interface Synchronization
+### Interface Sync
 Pull interface data from Devices and Virtual Machines from LibreNMS into NetBox. The following interface attributes are synchronized:
+
 - Name
 - Description
 - Status (Enabled/Disabled)
@@ -19,13 +22,15 @@ Pull interface data from Devices and Virtual Machines from LibreNMS into NetBox.
 - MAC Address
 
 > Set custom mappings for interface types to ensure that the correct interface type is used when syncing from LibreNMS to NetBox.
-> Speed and Type are Device only
+
+### Cable Sync
+Create cable connection in NetBox from LibreNMS links data.
 
 ### Add device to LibreNMS from Netbox
 
-- Add device to LibreNMS from Netbox device page. Only SNMP v2c available.
+- Add device to LibreNMS from Netbox device page. SNMP v2c and v3 are supported.
 
-### Site & Location Synchronization
+### Site & Location Sync
 The plugin also supports synchronizing NetBox Sites with LibreNMS locations:
 
 - Compare NetBox sites to LibreNMS location data
@@ -58,11 +63,11 @@ Or just share your ideas for the plugin over in [discussions](https://github.com
 
 | NetBox Version | Plugin Version |
 |----------------|----------------|
-|     4.0        |      0.2.x     |
+|     4.1        |      0.2.x     |
 
 ## Installing
 
-Netbox 4.0+ is required.
+Netbox 4.1+ is required.
 
 ### Standard Installation
 
@@ -121,6 +126,14 @@ Apply database migrations with Netbox `manage.py`:
 
 ```
 (venv) $ python manage.py migrate
+```
+
+### Collect Static Files
+
+The plugin includes static files that need to be collected by NetBox. Run the following command to collect static files:
+
+```
+(venv) $ python manage.py collectstatic --no-input
 ```
 
 ### Restart Netbox

--- a/docs/interface_mappings.md
+++ b/docs/interface_mappings.md
@@ -10,9 +10,10 @@ A mapping of LibreNMS Type an LibreNMS Speed combine to make a unique group that
 > Note: The LibreNMS Speed is entered as Kbps
 
 Example:
-* ethernetCsmacd + 10000000 = 10GBASE-T (10GE)
-* ethernetCsmacd + 1000000 = 1000BASE-T (1GE)
-* ethernetCsmacd + 100000 = 100BASE-TX (10/100ME)
+
+    * ethernetCsmacd + 10000000 = 10GBASE-T (10GE)
+    * ethernetCsmacd + 1000000 = 1000BASE-T (1GE)
+    * ethernetCsmacd + 100000 = 100BASE-TX (10/100ME)
 
 
 ## How to Use Interface Mappings

--- a/docs/usage_tips.md
+++ b/docs/usage_tips.md
@@ -1,0 +1,56 @@
+# Usage Tips
+
+## Initial Setup
+
+1. [Configure Custom Field](custom_field.md)
+    - Set up the `librenms_id` custom field for optimal device matching
+    - This ensures reliable device identification between NetBox and LibreNMS
+
+2. [Configure Interface Mappings](interface_mappings.md)
+    - Review and set up interface type mappings before synchronization
+    - Create specific mappings for your network equipment types
+    - Pay attention to speed-based mappings for accurate interface types
+
+## Device Synchronization
+
+### Devices
+1. Ensure devices have either:
+    - Primary IP configured
+    - Valid DNS name (set on the Primary IP)
+    - hostname (that matches LibreNMS hostname)
+2. The plugin will populate the `librenms_id` custom field if the device is found in LibreNMS
+
+### Virtual Chassis
+1. Master or first member with primary IP is used for LibreNMS Sync
+2. When possible chassis member position should match interface names 
+    
+    *e.g. swtich 1 = eth1/0/1, switch 2 = eth2/0/1*
+
+3. Verify member selection before bulk synchronization
+
+## Interface Management
+
+1.  Verify Before Sync
+    - Review interface mappings indicated by the link icons
+    - Check speed and type matches
+    - Confirm member assignments for virtual chassis
+2. Exlude columns to exclude from interface sync
+    - Sync only the values you want to sync
+
+## Cable Management
+
+1. Preparation
+    - Ensure devices are properly identified in both systems
+    - Open LibreNMS Sync on all devices to populate librenms_id custom field
+    - Remote Device and Remote interface need to be found in NetBox for cable creation to work
+    - Check Device and Interface naming
+
+## Best Practices
+
+1. Regular Maintenance
+    - Periodically review and update interface mappings
+    - Keep custom fields current
+
+
+## Optimization
+    - DNS lookup time can slow response of the API call to LibreNMS

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -5,9 +5,12 @@ repo_name: /netbox-librenms-plugin
 #strict: true
 nav:
   - Home: index.md
-  - Usage: 
+  - Feature List:  feature_list.md
+  - Feature Guide: 
     - Interface Mappings: interface_mappings.md
     - Virtual Chassis: virtual_chassis.md
+    - Custom Field: custom_field.md
+  - Usage Tips: usage_tips.md
   - Contributing: contributing.md
   - Changelog: changelog.md
 


### PR DESCRIPTION
Revise the documentation to include new features, usage tips, and the importance of the `librenms_id` custom field for device synchronization between NetBox and LibreNMS.