### PR TITLE
Add interface_name_field support in sync process

### DIFF
--- a/netbox_librenms_plugin/__init__.py
+++ b/netbox_librenms_plugin/__init__.py
@@ -3,6 +3,7 @@ from netbox.plugins import PluginConfig
 __author__ = "Andy Norwood"
 __version__ = "0.2.9"
 
+
 class LibreNMSSyncConfig(PluginConfig):
     name = "netbox_librenms_plugin"
     verbose_name = "NetBox Librenms Plugin"
@@ -10,7 +11,7 @@ class LibreNMSSyncConfig(PluginConfig):
     author = __author__
     version = __version__
     base_url = "librenms_plugin"
-    min_version = '4.1.0'
+    min_version = "4.1.0"
     required_settings = ["librenms_url", "api_token"]
     default_settings = {
         "enable_caching": True,

--- a/netbox_librenms_plugin/static/netbox_librenms_plugin/js/librenms_sync.js
+++ b/netbox_librenms_plugin/static/netbox_librenms_plugin/js/librenms_sync.js
@@ -107,7 +107,8 @@ function initializeVCMemberSelect() {
                         },
                         body: JSON.stringify({
                             device_id: deviceId,
-                            interface_name: interfaceName
+                            interface_name: interfaceName,
+                            interface_name_field: document.querySelector('input[name="interface_name_field"]:checked').value
                         })
                     })
                         .then(response => {
@@ -115,7 +116,6 @@ function initializeVCMemberSelect() {
                         })
                         .then(data => {
                             const row = document.querySelector(`tr[data-interface="${rowId}"]`);
-
 
                             if (data.status === 'success' && row) {
                                 const formattedRow = data.formatted_row;
@@ -127,7 +127,7 @@ function initializeVCMemberSelect() {
                                 row.querySelector('td[data-col="enabled"]').innerHTML = formattedRow.enabled;
                                 row.querySelector('td[data-col="description"]').innerHTML = formattedRow.description;
 
-                                filterCableTable();
+                                initializeFilters();
                             }
                         });
                 });

--- a/netbox_librenms_plugin/tables.py
+++ b/netbox_librenms_plugin/tables.py
@@ -41,7 +41,6 @@ class LibreNMSInterfaceTable(tables.Table):
     def __init__(self, *args, device=None, interface_name_field=None, **kwargs):
         self.device = device
         self.interface_name_field = interface_name_field or get_interface_name_field()
-        print(f"TABLE: interface_name_field: {self.interface_name_field}")
 
         # Update column accessors after initialization
         for column in ["selection", "name"]:
@@ -241,7 +240,10 @@ class LibreNMSInterfaceTable(tables.Table):
         port_data["exists_in_netbox"] = bool(port_data["netbox_interface"])
 
         # Clear description if it matches interface name
-        if port_data["ifAlias"] == interface_name:
+        if (
+            port_data["ifAlias"] == port_data["ifName"]
+            or port_data["ifAlias"] == port_data["ifDescr"]
+        ):
             port_data["ifAlias"] = ""
 
         formatted_data = {
@@ -477,7 +479,9 @@ class LibreNMSCableTable(tables.Table):
         verbose_name="Local Port", attrs={"td": {"data-col": "local_port"}}
     )
     remote_port = tables.Column(
-        verbose_name="Remote Port", attrs={"td": {"data-col": "remote_port"}}
+        accessor="remote_port_name",
+        verbose_name="Remote Port",
+        attrs={"td": {"data-col": "remote_port"}},
     )
     remote_device = tables.Column(
         verbose_name="Remote Device", attrs={"td": {"data-col": "remote_device"}}

--- a/netbox_librenms_plugin/templates/netbox_librenms_plugin/_interface_sync.html
+++ b/netbox_librenms_plugin/templates/netbox_librenms_plugin/_interface_sync.html
@@ -11,17 +11,11 @@
             <div class="btn-group btn-group-sm me-2" role="group" data-bs-toggle="tooltip" data-bs-placement="top" 
             title="Select interface name field: Select the field to use as the interface name.">
                 <input type="radio" class="btn-check" name="interface_name_field" value="ifDescr" id="ifDescr" 
-                    {% if interface_name_field == 'ifDescr' %}checked{% endif %}
-                    hx-post="{{ request.path }}"
-                    hx-target="#interface-sync"
-                    hx-include="[name='interface_name_field']">
+                    {% if interface_name_field == 'ifDescr' %}checked{% endif %}>
                 <label class="btn btn-outline-primary" for="ifDescr">ifDescr</label>
                 
                 <input type="radio" class="btn-check" name="interface_name_field" value="ifName" id="ifName" 
-                    {% if interface_name_field == 'ifName' %}checked{% endif %}
-                    hx-post="{{ request.path }}"
-                    hx-target="#interface-sync"
-                    hx-include="[name='interface_name_field']">
+                    {% if interface_name_field == 'ifName' %}checked{% endif %}>
                 <label class="btn btn-outline-primary" for="ifName">ifName</label>
             </div>
             {% if has_librenms_id %}

--- a/netbox_librenms_plugin/views/base/interfaces_view.py
+++ b/netbox_librenms_plugin/views/base/interfaces_view.py
@@ -4,9 +4,12 @@ from django.shortcuts import get_object_or_404, redirect, render
 from django.utils import timezone
 from django.views import View
 
-
-from netbox_librenms_plugin.utils import get_virtual_chassis_member, get_interface_name_field
+from netbox_librenms_plugin.utils import (
+    get_interface_name_field,
+    get_virtual_chassis_member,
+)
 from netbox_librenms_plugin.views.mixins import CacheMixin, LibreNMSAPIMixin
+
 
 class BaseInterfaceTableView(LibreNMSAPIMixin, CacheMixin, View):
     """
@@ -97,7 +100,6 @@ class BaseInterfaceTableView(LibreNMSAPIMixin, CacheMixin, View):
         table = None
 
         self.interface_name_field = get_interface_name_field(request)
-        print(f"get_context_data interface_name_field: {self.interface_name_field}")
 
         cached_data = cache.get(self.get_cache_key(obj, "ports"))
 
@@ -120,7 +122,9 @@ class BaseInterfaceTableView(LibreNMSAPIMixin, CacheMixin, View):
 
                 # Determine the correct chassis member based on the port description
                 if hasattr(obj, "virtual_chassis") and obj.virtual_chassis:
-                    chassis_member = get_virtual_chassis_member(obj, port[self.interface_name_field])
+                    chassis_member = get_virtual_chassis_member(
+                        obj, port[self.interface_name_field]
+                    )
                     netbox_interfaces = self.get_interfaces(chassis_member)
 
                 else:
@@ -133,7 +137,10 @@ class BaseInterfaceTableView(LibreNMSAPIMixin, CacheMixin, View):
                 port["netbox_interface"] = netbox_interface
 
                 # Ignore when description is the same as interface name
-                if port["ifAlias"] == port["ifDescr"] or port["ifAlias"] == port["ifName"]:
+                if (
+                    port["ifAlias"] == port["ifDescr"]
+                    or port["ifAlias"] == port["ifName"]
+                ):
                     port["ifAlias"] = ""
 
             table = self.get_table(ports_data, obj, self.interface_name_field)
@@ -157,5 +164,5 @@ class BaseInterfaceTableView(LibreNMSAPIMixin, CacheMixin, View):
             "last_fetched": last_fetched,
             "cache_expiry": cache_expiry,
             "virtual_chassis_members": virtual_chassis_members,
-            "interface_name_field": self.interface_name_field
+            "interface_name_field": self.interface_name_field,
         }

--- a/netbox_librenms_plugin/views/base/librenms_sync_view.py
+++ b/netbox_librenms_plugin/views/base/librenms_sync_view.py
@@ -2,8 +2,8 @@ from django.shortcuts import get_object_or_404, render
 from netbox.views import generic
 
 from netbox_librenms_plugin.forms import AddToLIbreSNMPV2, AddToLIbreSNMPV3
-from netbox_librenms_plugin.views.mixins import LibreNMSAPIMixin
 from netbox_librenms_plugin.utils import get_interface_name_field
+from netbox_librenms_plugin.views.mixins import LibreNMSAPIMixin
 
 
 class BaseLibreNMSSyncView(LibreNMSAPIMixin, generic.ObjectListView):

--- a/netbox_librenms_plugin/views/device_views.py
+++ b/netbox_librenms_plugin/views/device_views.py
@@ -23,8 +23,6 @@ from .base.librenms_sync_view import BaseLibreNMSSyncView
 from .mixins import CacheMixin
 
 
-
-
 @register_model_view(Device, name="librenms_sync", path="librenms-sync")
 class DeviceLibreNMSSyncView(BaseLibreNMSSyncView):
     """
@@ -78,12 +76,15 @@ class DeviceInterfaceTableView(BaseInterfaceTableView):
         """
         Returns the appropriate table instance for rendering interface data.
         """
-        print(f"GET_TABLE: interface_name_field: {interface_name_field}")
 
         if hasattr(obj, "virtual_chassis") and obj.virtual_chassis:
-            table = VCInterfaceTable(data, device=obj, interface_name_field=interface_name_field)
+            table = VCInterfaceTable(
+                data, device=obj, interface_name_field=interface_name_field
+            )
         else:
-            table = LibreNMSInterfaceTable(data, device=obj, interface_name_field=interface_name_field)
+            table = LibreNMSInterfaceTable(
+                data, device=obj, interface_name_field=interface_name_field
+            )
 
         table.htmx_url = f"{self.request.path}?tab={self.tab}"
         return table
@@ -101,8 +102,9 @@ class SingleInterfaceVerifyView(CacheMixin, View):
         data = json.loads(request.body)
         selected_device_id = data.get("device_id")
         interface_name = data.get("interface_name")
-
-        interface_name_field = get_interface_name_field()
+        interface_name_field = (
+            data.get("interface_name_field") or get_interface_name_field()
+        )
 
         if not selected_device_id:
             return JsonResponse(

--- a/netbox_librenms_plugin/views/vm_views.py
+++ b/netbox_librenms_plugin/views/vm_views.py
@@ -4,10 +4,11 @@ from utilities.views import ViewTab, register_model_view
 from virtualization.models import VirtualMachine
 
 from netbox_librenms_plugin.tables import LibreNMSVMInterfaceTable
+from netbox_librenms_plugin.utils import get_interface_name_field
 
 from .base.interfaces_view import BaseInterfaceTableView
-from .base.librenms_sync_view import BaseLibreNMSSyncView
 from .base.ip_addresses_view import BaseIPAddressTableView
+from .base.librenms_sync_view import BaseLibreNMSSyncView
 
 
 @register_model_view(VirtualMachine, name="librenms_sync", path="librenms-sync")
@@ -27,8 +28,9 @@ class VMLibreNMSSyncView(BaseLibreNMSSyncView):
         """
         Get the context data for interface sync for virtual machines.
         """
+        interface_name_field = get_interface_name_field(request)
         interface_sync_view = VMInterfaceTableView()
-        return interface_sync_view.get_context_data(request, obj)
+        return interface_sync_view.get_context_data(request, obj, interface_name_field)
 
     def get_cable_context(self, request, obj):
         """
@@ -51,8 +53,8 @@ class VMInterfaceTableView(BaseInterfaceTableView):
 
     model = VirtualMachine
 
-    def get_table(self, data, obj):
-        return LibreNMSVMInterfaceTable(data)   
+    def get_table(self, data, obj, interface_name_field):
+        return LibreNMSVMInterfaceTable(data)
 
     def get_interfaces(self, obj):
         return obj.interfaces.all()


### PR DESCRIPTION
Enhance the synchronization process by integrating the `interface_name_field` into the request payload and improving the logic for interface matching. Minor formatting adjustments included.