### PR TITLE
Add librenms_id field to Interface Table and sync logic

### DIFF
--- a/netbox_librenms_plugin/views/sync/interfaces_sync.py
+++ b/netbox_librenms_plugin/views/sync/interfaces_sync.py
@@ -227,3 +227,12 @@ class SyncInterfacesView(CacheMixin, View):
                     setattr(interface, netbox_key, librenms_interface.get(librenms_key))
             else:
                 setattr(interface, netbox_key, librenms_interface.get(librenms_key))
+
+        # Initialize the librenms_id key if it doesn't exist
+        if "librenms_id" not in interface.custom_field_data:
+            interface.custom_field_data["librenms_id"] = None
+
+        # Now update the value
+        interface.custom_field_data["librenms_id"] = librenms_interface.get("port_id")
+
+        interface.save()


### PR DESCRIPTION
Introduce the `librenms_id` field in the LibreNMS Interface Table and implement synchronization logic to ensure it reflects the corresponding value from NetBox. 