### PR TITLE
Add countdown interval variable to initializeCountdown function

### DIFF
--- a/netbox_librenms_plugin/static/netbox_librenms_plugin/js/librenms_sync.js
+++ b/netbox_librenms_plugin/static/netbox_librenms_plugin/js/librenms_sync.js
@@ -3,6 +3,8 @@ function initializeCountdown(elementId) {
     const countdownElement = document.getElementById(elementId);
     if (!countdownElement) return;
 
+    let countdownInterval;
+
     function updateCountdown() {
         const expiry = new Date(countdownElement.dataset.expiry).getTime();
         const now = new Date().getTime();
@@ -20,7 +22,8 @@ function initializeCountdown(elementId) {
     }
 
     updateCountdown();
-    return setInterval(updateCountdown, 1000);
+    countdownInterval = setInterval(updateCountdown, 1000);
+    return countdownInterval;
 }
 
 function initializeCountdowns() {


### PR DESCRIPTION
Introduce a variable to store the countdown interval in the `initializeCountdown` function to prevent errors in cosole after timeer runs out