### PR TITLE
Refactor librenms_id handling in SyncInterfacesView

### DIFF
--- a/netbox_librenms_plugin/views/sync/interfaces_sync.py
+++ b/netbox_librenms_plugin/views/sync/interfaces_sync.py
@@ -232,11 +232,10 @@ class SyncInterfacesView(CacheMixin, View):
             else:
                 setattr(interface, netbox_key, librenms_interface.get(librenms_key))
 
-        # Initialize the librenms_id key if it doesn't exist
-        if "librenms_id" not in interface.custom_field_data:
-            interface.custom_field_data["librenms_id"] = None
-
-        # Now update the value
-        interface.custom_field_data["librenms_id"] = librenms_interface.get("port_id")
+        # Check if librenms_id custom field exists
+        if "librenms_id" in interface.cf:
+            interface.custom_field_data["librenms_id"] = librenms_interface.get(
+                "port_id"
+            )
 
         interface.save()


### PR DESCRIPTION
Improve the check for the existence of the librenms_id custom field before updating its value.