### PR TITLE
Fix VM interface table error with dynamic select_related handling

### DIFF
--- a/netbox_librenms_plugin/views/base/interfaces_view.py
+++ b/netbox_librenms_plugin/views/base/interfaces_view.py
@@ -42,6 +42,14 @@ class BaseInterfaceTableView(LibreNMSAPIMixin, CacheMixin, View):
         """
         raise NotImplementedError
 
+    def get_select_related_field(self, obj):
+        """
+        Determine the appropriate select_related field based on object type
+        """
+        if self.model.__name__.lower() == 'virtualmachine':
+            return 'virtual_machine'
+        return 'device'
+
     def get_table(self, data, obj, interface_name_field):
         """
         Returns the table class to use for rendering interface data.
@@ -114,13 +122,15 @@ class BaseInterfaceTableView(LibreNMSAPIMixin, CacheMixin, View):
                     interfaces_by_device[member.id] = {
                         interface.name: interface
                         for interface in self.get_interfaces(member).select_related(
-                            "device"
+                            self.get_select_related_field(obj)
                         )
                     }
             else:
                 interfaces_by_device[obj.id] = {
                     interface.name: interface
-                    for interface in self.get_interfaces(obj).select_related("device")
+                    for interface in self.get_interfaces(obj).select_related(
+                        self.get_select_related_field(obj)
+                    )
                 }
 
             for port in ports_data:

--- a/netbox_librenms_plugin/views/sync/interfaces_sync.py
+++ b/netbox_librenms_plugin/views/sync/interfaces_sync.py
@@ -28,7 +28,9 @@ class SyncInterfacesView(CacheMixin, View):
         """
         # Use the correct URL name based on object type
         url_name = (
-            "device_librenms_sync" if object_type == "device" else "vm_librenms_sync"
+            "dcim:device_librenms_sync"
+            if object_type == "device"
+            else "plugins:netbox_librenms_plugin:vm_librenms_sync"
         )
         obj = self.get_object(object_type, object_id)
 
@@ -52,7 +54,7 @@ class SyncInterfacesView(CacheMixin, View):
 
         messages.success(request, "Selected interfaces synced successfully.")
         return redirect(
-            reverse("dcim:device_librenms_sync", kwargs={"pk": object_id})
+            reverse(url_name, kwargs={"pk": object_id})
             + f"?tab=interfaces&interface_name_field={interface_name_field}"
         )
 


### PR DESCRIPTION
Dynamic handling of the `select_related` field addresses the error in the VM interface table. 
Additionally, the URL naming for redirect after sync operations has been updated.