### PR TITLE
Add slug check to Site and Location Sync

### DIFF
--- a/netbox_librenms_plugin/views/sync/locations_sync.py
+++ b/netbox_librenms_plugin/views/sync/locations_sync.py
@@ -81,7 +81,7 @@ class SyncSiteLocationView(LibreNMSAPIMixin, SingleTableView):
     def match_site_with_location(self, site, librenms_locations):
         """Match a NetBox site with a LibreNMS location."""
         for location in librenms_locations:
-            if location["location"].lower() == site.name.lower():
+            if location["location"].lower() == site.name.lower() or location["location"].lower() == site.slug.lower():
                 return location
         return None
 


### PR DESCRIPTION
Fixes #100

Update `match_site_with_location` to match slugs in addition to site names.

* Modify `match_site_with_location` in `netbox_librenms_plugin/views/sync/locations_sync.py` to also check if the slug exists in LibreNMS.
