### PR TITLE
Fix missing add_device_modal.html template and form handling

### DIFF
--- a/netbox_librenms_plugin/forms.py
+++ b/netbox_librenms_plugin/forms.py
@@ -42,9 +42,6 @@ class AddToLIbreSNMPV2(forms.Form):
         required=True,
         widget=forms.TextInput(attrs={"id": "id_hostname_v2"}),
     )
-    snmp_version = forms.CharField(
-        widget=forms.HiddenInput(attrs={"id": "id_snmp_version_v2"})
-    )
     community = forms.CharField(label="SNMP Community", max_length=255, required=True)
 
 
@@ -59,9 +56,6 @@ class AddToLIbreSNMPV3(forms.Form):
         max_length=255,
         required=True,
         widget=forms.TextInput(attrs={"id": "id_hostname_v3"}),
-    )
-    snmp_version = forms.CharField(
-        widget=forms.HiddenInput(attrs={"id": "id_snmp_version_v3"}), initial="v3"
     )
     authlevel = forms.ChoiceField(
         label="Auth Level",

--- a/netbox_librenms_plugin/static/netbox_librenms_plugin/js/librenms_sync.js
+++ b/netbox_librenms_plugin/static/netbox_librenms_plugin/js/librenms_sync.js
@@ -396,7 +396,7 @@ function toggleSNMPForms() {
 
     const v2Form = document.getElementById('snmpv2-form');
     const v3Form = document.getElementById('snmpv3-form');
-
+    
     if (version === 'v2c') {
         v2Form.style.display = 'block';
         v3Form.style.display = 'none';

--- a/netbox_librenms_plugin/templates/netbox_librenms_plugin/librenms_sync_base.html
+++ b/netbox_librenms_plugin/templates/netbox_librenms_plugin/librenms_sync_base.html
@@ -286,11 +286,11 @@
                 <form method="post" action="{% url 'plugins:netbox_librenms_plugin:add_device_to_librenms' object.id %}"
                     id="snmpv2-form">
                     {% csrf_token %}
+                    <input type="hidden" name="snmp_version" value="v2c">
                     <div class="mb-3">
                         {{ v2form.hostname.label_tag }}
                         {{ v2form.hostname }}
                     </div>
-                    {{ v2form.snmp_version }}
                     <div class="mb-3">
                         {{ v2form.community.label_tag }}
                         {{ v2form.community }}
@@ -302,13 +302,13 @@
                 <form method="post" action="{% url 'plugins:netbox_librenms_plugin:add_device_to_librenms' object.id %}"
                     id="snmpv3-form" style="display: none;">
                     {% csrf_token %}
+                    <input type="hidden" name="snmp_version" value="v3">
                     <div class="mb-3">
                         {{ v3form.hostname.label_tag }}
                         {{ v3form.hostname }}
                     </div>
-                    {{ v3form.snmp_version }}
                     {% for field in v3form %}
-                    {% if field.name != 'hostname' and field.name != 'snmp_version' %}
+                    {% if field.name != 'hostname' %}
                     <div class="mb-3">
                         {{ field.label_tag }}
                         {{ field }}

--- a/netbox_librenms_plugin/views/sync/devices_sync.py
+++ b/netbox_librenms_plugin/views/sync/devices_sync.py
@@ -10,13 +10,10 @@ from netbox_librenms_plugin.forms import AddToLIbreSNMPV2, AddToLIbreSNMPV3
 from netbox_librenms_plugin.views.mixins import LibreNMSAPIMixin
 
 
-class AddDeviceToLibreNMSView(LibreNMSAPIMixin, FormView):
+class AddDeviceToLibreNMSView(LibreNMSAPIMixin, View):
     """
     Add a device to LibreNMS using the API.
     """
-
-    template_name = "add_device_modal.html"
-    success_url = reverse_lazy("device_list")
 
     def get_form_class(self):
         """Return the correct form class based on the SNMP version."""
@@ -38,7 +35,12 @@ class AddDeviceToLibreNMSView(LibreNMSAPIMixin, FormView):
         form = form_class(request.POST)
         if form.is_valid():
             return self.form_valid(form)
-        return self.form_invalid(form)
+        else:
+            # Handle form validation errors
+            for field, errors in form.errors.items():
+                for error in errors:
+                    messages.error(request, f"{field}: {error}")
+            return redirect(self.object.get_absolute_url())
 
     def form_valid(self, form):
         """Handle the form submission"""


### PR DESCRIPTION
Address the missing `add_device_modal.html` template error and rework the form handling for adding devices to LibreNMS. 