### PR TITLE
Add interface type mapping template back

### DIFF
--- a/netbox_librenms_plugin/templates/netbox_librenms_plugin/interfacetypemapping.html
+++ b/netbox_librenms_plugin/templates/netbox_librenms_plugin/interfacetypemapping.html
@@ -1,0 +1,28 @@
+{% extends 'generic/object.html' %}
+{% load helpers %}
+{% load plugins %}
+
+{% block content %}
+<div class="row mb-3">
+  <div class="col col-md-12">
+    <div class="card">
+      <table class="table table-hover attr-table">
+        <thead>
+          <tr>
+            <th>LibreNMS Type</th>
+            <th>LibreNMS Speed (Kbps)</th>
+            <th>NetBox Type</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>{{ object.librenms_type }}</td>
+            <td>{{ object.librenms_speed }}</td>
+            <td>{{ object.get_netbox_type_display }}</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</div> 
+{% endblock %}


### PR DESCRIPTION
Restore the interface type mapping template to fix missing template errors