### PR TITLE
Fix URL error when no interfaces are selected during sync

### DIFF
--- a/netbox_librenms_plugin/views/sync/cables_sync.py
+++ b/netbox_librenms_plugin/views/sync/cables_sync.py
@@ -127,7 +127,9 @@ class SyncCablesView(CacheMixin, View):
         if not self.validate_prerequisites(
             cached_links, selected_interfaces, initial_device
         ):
-            return redirect(self.get_cables_tab_url(initial_device))
+            return redirect(
+            f"{reverse('plugins:netbox_librenms_plugin:device_librenms_sync', args=[initial_device.pk])}?tab=cables"
+        )
 
         results = {"valid": [], "invalid": [], "duplicate": [], "missing_remote": []}
 

--- a/netbox_librenms_plugin/views/sync/interfaces_sync.py
+++ b/netbox_librenms_plugin/views/sync/interfaces_sync.py
@@ -40,11 +40,17 @@ class SyncInterfacesView(CacheMixin, View):
         exclude_columns = request.POST.getlist("exclude_columns")
 
         if selected_interfaces is None:
-            return redirect(f"plugins:netbox_librenms_plugin:{url_name}", pk=object_id)
+            return redirect(
+                reverse(url_name, kwargs={"pk": object_id})
+                + f"?tab=interfaces&interface_name_field={interface_name_field}"
+            )
 
         ports_data = self.get_cached_ports_data(request, obj)
         if ports_data is None:
-            return redirect(f"plugins:netbox_librenms_plugin:{url_name}", pk=object_id)
+            return redirect(
+                reverse(url_name, kwargs={"pk": object_id})
+                + f"?tab=interfaces&interface_name_field={interface_name_field}"
+            )
 
         self.sync_selected_interfaces(
             obj, selected_interfaces, ports_data, exclude_columns, interface_name_field


### PR DESCRIPTION
Correct the redirect URLs to ensure proper navigation when no interfaces are selected.