### PR TITLE
Add support for IPv6 handling in IP address synchronization

### DIFF
--- a/netbox_librenms_plugin/tables/ipaddresses.py
+++ b/netbox_librenms_plugin/tables/ipaddresses.py
@@ -28,25 +28,25 @@ class IPAddressTable(tables.Table):
             "id": "librenms-ipaddress-table",
         }
         row_attrs = {
-            "data-interface": lambda record: record["ipv4_address"],
-            "data-name": lambda record: record["ipv4_address"],
+            "data-interface": lambda record: record["ip_address"],
+            "data-name": lambda record: record["ip_address"],
         }
 
     selection = ToggleColumn(
         orderable=False,
         visible=True,
         attrs={"td": {"data-col": "selection"}, "input": {"name": "select"}},
-        accessor="ipv4_address",
+        accessor="ip_address",
     )
 
     address = tables.Column(
-        accessor="ipv4_address",
+        accessor="ip_address",
         verbose_name="IP Address",
         linkify=lambda record: record.get("ip_url"),
         attrs={"td": {"data-col": "address"}},
     )
     prefix_length = tables.Column(
-        accessor="ipv4_prefixlen",
+        accessor="prefix_length",
         verbose_name="Prefix Length",
         attrs={"td": {"data-col": "prefix"}},
     )
@@ -62,7 +62,7 @@ class IPAddressTable(tables.Table):
     )
     vrf = tables.TemplateColumn(
         template_code="""
-        <select id="vrf_select_{{ record.ipv4_address|slugify }}" class="form-select vrf-select" data-ip="{{ record.ipv4_address }}" data-prefix="{{ record.ipv4_prefixlen }}" data-row-id="{{ record.ipv4_address }}" name="vrf_{{ record.ipv4_address }}">
+        <select id="vrf_select_{{ record.ip_address|slugify }}" class="form-select vrf-select" data-ip="{{ record.ip_address }}" data-prefix="{{ record.prefix_length }}" data-row-id="{{ record.ip_address }}" name="vrf_{{ record.ip_address }}">
             <option value="">Global</option>
             {% for vrf in record.vrfs %}
                 <option value="{{ vrf.pk }}" {% if record.vrf_id == vrf.pk %}selected{% endif %}>
@@ -85,7 +85,7 @@ class IPAddressTable(tables.Table):
             return format_html(
                 '<button type="submit" class="btn btn-sm btn-warning" onclick="document.getElementById(\'selected_ip\').value=\'{}\'">'
                 '<i class="mdi mdi-pencil" aria-hidden="true"></i> Update</button>',
-                record["ipv4_address"],
+                record["ip_address"],
             )
         elif value == "matched":
             return format_html(
@@ -95,7 +95,7 @@ class IPAddressTable(tables.Table):
             return format_html(
                 '<button type="submit" class="btn btn-sm btn-primary" onclick="document.getElementById(\'selected_ip\').value=\'{}\'">'
                 '<i class="mdi mdi-plus-thick" aria-hidden="true"></i> Create</button>',
-                record["ipv4_address"],
+                record["ip_address"],
             )
         return format_html('<span class="text-muted">Missing NetBox Object</span>')
 

--- a/netbox_librenms_plugin/views/base/ip_addresses_view.py
+++ b/netbox_librenms_plugin/views/base/ip_addresses_view.py
@@ -1,7 +1,6 @@
 import json
 
 from dcim.models import Device
-from virtualization.models import VirtualMachine
 from django.contrib import messages
 from django.core.cache import cache
 from django.http import Http404, JsonResponse
@@ -9,6 +8,7 @@ from django.shortcuts import get_object_or_404, render
 from django.utils import timezone
 from django.views import View
 from ipam.models import VRF, IPAddress
+from virtualization.models import VirtualMachine
 
 from netbox_librenms_plugin.tables.ipaddresses import IPAddressTable
 from netbox_librenms_plugin.utils import get_interface_name_field
@@ -34,7 +34,7 @@ class BaseIPAddressTableView(LibreNMSAPIMixin, CacheMixin, View):
     def enrich_ip_data(self, ip_data, obj, interface_name_field):
         """
         Enrich IP data with NetBox information in a more efficient manner.
-        
+
         This optimized implementation:
         1. Caches port data to reduce API calls
         2. Pre-loads all relevant device data
@@ -43,86 +43,87 @@ class BaseIPAddressTableView(LibreNMSAPIMixin, CacheMixin, View):
         # Prefetch all necessary data
         prefetched_data = self._prefetch_netbox_data(obj)
         port_data_cache = {}  # Cache for LibreNMS port data to minimize API calls
-        
+
         enriched_data = []
-        
+
         # Process each IP address from LibreNMS
         for ip_entry in ip_data:
             # Get or fetch port data (with caching)
-            port_info = self._get_port_info(ip_entry["port_id"], port_data_cache, interface_name_field)
-            
+            port_info = self._get_port_info(
+                ip_entry["port_id"], port_data_cache, interface_name_field
+            )
+
             # Create enriched IP structure with base data
-            enriched_ip = self._create_base_ip_entry(ip_entry, obj, prefetched_data["vrfs"])
-            
+            enriched_ip = self._create_base_ip_entry(
+                ip_entry, obj, prefetched_data["vrfs"]
+            )
+
             # Get LibreNMS interface name if available
             librenms_interface_name = None
             if port_info:
                 librenms_interface_name = port_info.get(interface_name_field)
                 enriched_ip["interface_name"] = librenms_interface_name
-            
-            # Check if IP exists in NetBox
-            ip_with_mask = f"{ip_entry['ipv4_address']}/{ip_entry['ipv4_prefixlen']}"
+
+            # IP with mask is already calculated in _create_base_ip_entry
+            ip_with_mask = enriched_ip["ip_with_mask"]
             ip_address = prefetched_data["ip_addresses_map"].get(ip_with_mask)
-            
+
             if ip_address:
                 # Process existing IP
                 self._enrich_existing_ip(
-                    enriched_ip, 
-                    ip_address, 
+                    enriched_ip,
+                    ip_address,
                     ip_entry["port_id"],
                     librenms_interface_name,
-                    prefetched_data
+                    prefetched_data,
                 )
             else:
                 # New IP that doesn't exist in NetBox
                 enriched_ip["exists"] = False
                 enriched_ip["status"] = "sync"
-                
+
             # Add interface information (regardless of IP status)
             self._add_interface_info_to_ip(
                 enriched_ip,
                 ip_entry["port_id"],
                 librenms_interface_name,
-                prefetched_data
+                prefetched_data,
             )
-                
+
             enriched_data.append(enriched_ip)
-            
+
         return enriched_data
 
     def _prefetch_netbox_data(self, obj):
         """Prefetch all necessary NetBox data to minimize database queries"""
         # Get all interfaces for the device
         all_interfaces = list(obj.interfaces.all())
-        
+
         # Create maps for efficient lookups
         interfaces_by_librenms_id = {
             interface.custom_field_data.get("librenms_id"): interface
             for interface in all_interfaces
             if interface.custom_field_data.get("librenms_id")
         }
-        
-        interfaces_by_name = {
-            interface.name: interface
-            for interface in all_interfaces
-        }
-        
+
+        interfaces_by_name = {interface.name: interface for interface in all_interfaces}
+
         # Get all IP addresses
         ip_addresses_map = {
             str(ip.address): ip
             for ip in IPAddress.objects.select_related("assigned_object_type", "vrf")
         }
-        
+
         # Get all VRFs
         vrfs = list(VRF.objects.all())
-        
+
         return {
             "interfaces_by_librenms_id": interfaces_by_librenms_id,
             "interfaces_by_name": interfaces_by_name,
             "all_interfaces": all_interfaces,
             "device": obj,
             "ip_addresses_map": ip_addresses_map,
-            "vrfs": vrfs
+            "vrfs": vrfs,
         }
 
     def _get_port_info(self, port_id, port_data_cache, interface_name_field):
@@ -133,14 +134,33 @@ class BaseIPAddressTableView(LibreNMSAPIMixin, CacheMixin, View):
                 port_data_cache[port_id] = port_data["port"][0]
             else:
                 port_data_cache[port_id] = None
-        
+
         return port_data_cache[port_id]
 
     def _create_base_ip_entry(self, ip_entry, obj, vrfs):
         """Create the base data structure for an IP entry"""
+        # Determine if this is an IPv4 or IPv6 address and create unified fields
+        if "ip_address" in ip_entry and "prefix_length" in ip_entry:
+            # Use unified format directly if available
+            ip_address = ip_entry["ip_address"]
+            prefix_length = ip_entry["prefix_length"]
+        else:
+            # Legacy format handling
+            if "ipv6_compressed" in ip_entry:
+                ip_address = ip_entry["ipv6_compressed"]
+                prefix_length = ip_entry["ipv6_prefixlen"]
+            elif "ipv4_address" in ip_entry:
+                ip_address = ip_entry["ipv4_address"]
+                prefix_length = ip_entry["ipv4_prefixlen"]
+            else:
+                raise KeyError("No valid IP address format found in LibreNMS data")
+
+        ip_with_mask = f"{ip_address}/{prefix_length}"
+
         return {
-            "ipv4_address": ip_entry["ipv4_address"],
-            "ipv4_prefixlen": ip_entry["ipv4_prefixlen"],
+            "ip_address": ip_address,
+            "prefix_length": prefix_length,
+            "ip_with_mask": ip_with_mask,
             "port_id": ip_entry["port_id"],
             "device": obj.name,
             "device_url": obj.get_absolute_url(),
@@ -148,41 +168,47 @@ class BaseIPAddressTableView(LibreNMSAPIMixin, CacheMixin, View):
             "vrfs": vrfs,
         }
 
-    def _enrich_existing_ip(self, enriched_ip, ip_address, port_id, librenms_interface_name, prefetched_data):
+    def _enrich_existing_ip(
+        self, enriched_ip, ip_address, port_id, librenms_interface_name, prefetched_data
+    ):
         """Add information for IP addresses that exist in NetBox"""
         enriched_ip["ip_url"] = ip_address.get_absolute_url()
         enriched_ip["exists"] = True
-        
+
         # Add VRF info if available
         if ip_address.vrf:
             enriched_ip["vrf_id"] = ip_address.vrf.pk
             enriched_ip["vrf"] = ip_address.vrf.name
-        
+
         # Set initial status to update (will change to matched if criteria met)
         enriched_ip["status"] = "update"
-        
+
         # Only proceed if IP is assigned to an object
         if not ip_address.assigned_object:
             return
-        
+
         assigned_interface = ip_address.assigned_object
-        
+
         # Check if interface matches by LibreNMS ID
         if port_id in prefetched_data["interfaces_by_librenms_id"]:
             interface = prefetched_data["interfaces_by_librenms_id"][port_id]
             if assigned_interface == interface:
                 enriched_ip["status"] = "matched"
                 return
-                
+
         # Check if interface matches by name
-        if (librenms_interface_name and 
-                assigned_interface.name == librenms_interface_name):
+        if (
+            librenms_interface_name
+            and assigned_interface.name == librenms_interface_name
+        ):
             enriched_ip["status"] = "matched"
             # Add interface information
             enriched_ip["interface_name"] = assigned_interface.name
             enriched_ip["interface_url"] = assigned_interface.get_absolute_url()
 
-    def _add_interface_info_to_ip(self, enriched_ip, port_id, librenms_interface_name, prefetched_data):
+    def _add_interface_info_to_ip(
+        self, enriched_ip, port_id, librenms_interface_name, prefetched_data
+    ):
         """Add interface information to the IP entry regardless of IP status"""
         # First try to match by LibreNMS ID (highest priority)
         if port_id in prefetched_data["interfaces_by_librenms_id"]:
@@ -190,9 +216,12 @@ class BaseIPAddressTableView(LibreNMSAPIMixin, CacheMixin, View):
             enriched_ip["interface_name"] = interface.name
             enriched_ip["interface_url"] = interface.get_absolute_url()
             return
-            
+
         # Then try to match by interface name
-        if librenms_interface_name and librenms_interface_name in prefetched_data["interfaces_by_name"]:
+        if (
+            librenms_interface_name
+            and librenms_interface_name in prefetched_data["interfaces_by_name"]
+        ):
             interface = prefetched_data["interfaces_by_name"][librenms_interface_name]
             # Don't overwrite the interface name from LibreNMS but do add the URL
             enriched_ip["interface_url"] = interface.get_absolute_url()
@@ -212,12 +241,8 @@ class BaseIPAddressTableView(LibreNMSAPIMixin, CacheMixin, View):
             interface_name_field = get_interface_name_field(request)
 
         if fetch_fresh:
-            # Always fetch new data when requested
             success, ip_data = self.get_ip_addresses(obj)
-            if not success:
-                return None
         else:
-            # Try to use cached data
             cached_ip_data = cache.get(self.get_cache_key(obj, "ip_addresses"))
             if cached_ip_data:
                 ip_data = cached_ip_data.get("ip_addresses", [])
@@ -306,16 +331,19 @@ class SingleIPAddressVerifyView(CacheMixin, View):
             obj = Device.objects.filter(pk=object_id).first()
             if obj:
                 return obj
-            
+
             obj = VirtualMachine.objects.filter(pk=object_id).first()
             if obj:
                 return obj
-            
-            raise Http404(f"Object with ID {object_id} not found in Device or VirtualMachine models")
-        
+
+            raise Http404(
+                f"Object with ID {object_id} not found in Device or VirtualMachine models"
+            )
+
     def _parse_ip_address(self, ip_address):
         """
         Parse IP address string into address and prefix length.
+        Works with both IPv4 and IPv6 addresses.
         """
         ip_address_parts = ip_address.split("/")
         address_no_mask = ip_address_parts[0].strip()
@@ -330,20 +358,15 @@ class SingleIPAddressVerifyView(CacheMixin, View):
             raise ValueError("Prefix length is missing from the IP address")
 
     def _find_in_cache(self, cached_data, address, prefix_len):
-        """
-        Find IP address in cache data.
-        """
+        """Find IP address in cache data using unified fields only."""
         if not cached_data:
             return None, None, None
 
         for ip_entry in cached_data.get("ip_addresses", []):
-            cache_address = ip_entry.get("ipv4_address")
-            cache_prefix = ip_entry.get("ipv4_prefixlen")
-
-            if cache_address == address and str(cache_prefix) == str(prefix_len):
-                original_vrf_id = ip_entry.get("vrf_id")
-                original_port_id = ip_entry.get("port_id")
-                return ip_entry, original_vrf_id, original_port_id
+            if ip_entry["ip_address"] == address and str(
+                ip_entry["prefix_length"]
+            ) == str(prefix_len):
+                return (ip_entry, ip_entry.get("vrf_id"), ip_entry.get("port_id"))
 
         return None, None, None
 
@@ -434,8 +457,9 @@ class SingleIPAddressVerifyView(CacheMixin, View):
 
             # Basic record with default values
             updated_record = {
-                "ipv4_address": address_no_mask,
-                "ipv4_prefixlen": prefix_len,
+                "ip_address": address_no_mask,
+                "prefix_length": prefix_len,
+                "ip_with_mask": f"{address_no_mask}/{prefix_len}",
                 "device": obj.name,
                 "device_url": obj.get_absolute_url(),
                 "vrf_id": vrf_id,

--- a/netbox_librenms_plugin/views/sync/ipaddresses_sync.py
+++ b/netbox_librenms_plugin/views/sync/ipaddresses_sync.py
@@ -58,7 +58,6 @@ class SyncIPAddressesView(CacheMixin, View):
             url_name = "plugins:netbox_librenms_plugin:vm_librenms_sync"
         return f"{reverse(url_name, args=[obj.pk])}?tab=ipaddresses"
 
-
     def post(self, request, object_type, pk):
         """Handle POST request for IP address synchronization"""
         obj = self.get_object(object_type, pk)
@@ -74,7 +73,9 @@ class SyncIPAddressesView(CacheMixin, View):
             messages.error(request, "No IP addresses selected for synchronization.")
             return redirect(self.get_ip_tab_url(obj))
 
-        results = self.process_ip_sync(request, selected_ips, cached_ips, obj, object_type)
+        results = self.process_ip_sync(
+            request, selected_ips, cached_ips, obj, object_type
+        )
         self.display_sync_results(request, results)
 
         return redirect(self.get_ip_tab_url(obj))
@@ -87,7 +88,7 @@ class SyncIPAddressesView(CacheMixin, View):
             for ip_address in selected_ips:
                 try:
                     ip_data = next(
-                        ip for ip in cached_ips if ip["ipv4_address"] == ip_address
+                        ip for ip in cached_ips if ip["ip_address"] == ip_address
                     )
 
                     vrf = self.get_vrf_selection(request, ip_address)
@@ -101,8 +102,8 @@ class SyncIPAddressesView(CacheMixin, View):
                         else:
                             interface = VMInterface.objects.get(id=interface_id)
 
-                    # Construct CIDR notation using prefix from data
-                    ip_with_mask = f"{ip_data['ipv4_address']}/{ip_data['ipv4_prefixlen']}"
+                    # Use the unified IP address with mask
+                    ip_with_mask = ip_data["ip_with_mask"]
 
                     # Check if IP exists in any VRF
                     existing_ip = IPAddress.objects.filter(address=ip_with_mask).first()


### PR DESCRIPTION
This PR add support for IPv6 in IP address table and synchronization.

Key changes include:

- **Unified IP Address Fields:** Standardized the use of `ip_address` and `prefix_length` fields to represent both IPv4 and IPv6 addresses, replacing the separate `ipv4_address`, `ipv6_compressed`, `ipv4_prefixlen`, and `ipv6_prefixlen` fields.
- **Generalised Parsing:** Updated the IP address parsing logic to correctly handle both IPv4 and IPv6 formats.
- **Table Updates:** Modified the IPAddressTable to use the new unified fields for displaying IP addresses and prefix lengths.
- **Cache Handling:** Adjusted the cache lookup and data retrieval mechanisms to work with the unified IP address fields.