### PR TITLE
feat: Implement functionality for managing NetBox-only interfaces

### DIFF
--- a/netbox_librenms_plugin/templates/netbox_librenms_plugin/_interface_sync_content.html
+++ b/netbox_librenms_plugin/templates/netbox_librenms_plugin/_interface_sync_content.html
@@ -6,7 +6,7 @@
 
 {% with model_name=interface_sync.object|meta:"model_name" %}
 <form method="post"
-action="{% url 'plugins:netbox_librenms_plugin:sync_selected_interfaces' object_type=model_name object_id=interface_sync.object.pk %}?interface_name_field={{ interface_name_field }}">
+    action="{% url 'plugins:netbox_librenms_plugin:sync_selected_interfaces' object_type=model_name object_id=interface_sync.object.pk %}?interface_name_field={{ interface_name_field }}">
     {% endwith %}
     {% csrf_token %}
     {% block table_actions %}
@@ -25,27 +25,33 @@ action="{% url 'plugins:netbox_librenms_plugin:sync_selected_interfaces' object_
                 <h6 class="mb-0">Exclude from Sync:</h6>
                 <div class="d-flex align-items-center m-0">
                     <span class="small me-1">Type</span>
-                    <input class="form-check-input form-check-input-sm" type="checkbox" name="exclude_columns" value="type" id="excludeType">
+                    <input class="form-check-input form-check-input-sm" type="checkbox" name="exclude_columns"
+                        value="type" id="excludeType">
                 </div>
                 <div class="d-flex align-items-center m-1">
                     <span class="small me-1">Speed</span>
-                    <input class="form-check-input form-check-input-sm" type="checkbox" name="exclude_columns" value="speed" id="excludeSpeed">
+                    <input class="form-check-input form-check-input-sm" type="checkbox" name="exclude_columns"
+                        value="speed" id="excludeSpeed">
                 </div>
                 <div class="d-flex align-items-center m-1">
                     <span class="small me-1">MAC</span>
-                    <input class="form-check-input form-check-input-sm" type="checkbox" name="exclude_columns" value="mac_address" id="excludeMACAddress">
+                    <input class="form-check-input form-check-input-sm" type="checkbox" name="exclude_columns"
+                        value="mac_address" id="excludeMACAddress">
                 </div>
                 <div class="d-flex align-items-center m-1">
                     <span class="small me-1">MTU</span>
-                    <input class="form-check-input form-check-input-sm" type="checkbox" name="exclude_columns" value="mtu" id="excludeMTU">
+                    <input class="form-check-input form-check-input-sm" type="checkbox" name="exclude_columns"
+                        value="mtu" id="excludeMTU">
                 </div>
                 <div class="d-flex align-items-center m-1">
                     <span class="small me-1">Enabled</span>
-                    <input class="form-check-input form-check-input-sm" type="checkbox" name="exclude_columns" value="enabled" id="excludeEnabled">
+                    <input class="form-check-input form-check-input-sm" type="checkbox" name="exclude_columns"
+                        value="enabled" id="excludeEnabled">
                 </div>
                 <div class="d-flex align-items-center m-1">
                     <span class="small me-1">Description</span>
-                    <input class="form-check-input form-check-input-sm" type="checkbox" name="exclude_columns" value="description" id="excludeDescription">
+                    <input class="form-check-input form-check-input-sm" type="checkbox" name="exclude_columns"
+                        value="description" id="excludeDescription">
                 </div>
             </div>
         </div>
@@ -58,9 +64,18 @@ action="{% url 'plugins:netbox_librenms_plugin:sync_selected_interfaces' object_
             <div class="d-flex justify-content-between align-items-center mb-3">
                 <div>
                     {% if interface_sync.object.virtual_chassis %}
-                        <button type="button" class="btn btn-secondary" id="bulk-vc-member-button" data-bs-toggle="modal" data-bs-target="#bulkVCMemberModal" disabled>
-                            Bulk Edit VC Member
-                        </button>
+                    <button type="button" class="btn btn-secondary" id="bulk-vc-member-button" data-bs-toggle="modal"
+                        data-bs-target="#bulkVCMemberModal" disabled>
+                        Bulk Edit VC Member
+                    </button>
+                    {% endif %}
+                    {% if interface_sync.netbox_only_interfaces %}
+                    <a href="#" class="ms-2 text-warning text-decoration-none netbox-only-link" data-bs-toggle="modal"
+                        data-bs-target="#netboxOnlyInterfacesModal"
+                        title="Click to view and delete NetBox-only interfaces">
+                        <i class="mdi mdi-alert-circle-outline me-1"></i>
+                        {{interface_sync.netbox_only_interfaces|length}} NetBox only interfaces
+                    </a>
                     {% endif %}
                 </div>
                 <div class="ms-auto d-flex align-items-center">
@@ -69,7 +84,7 @@ action="{% url 'plugins:netbox_librenms_plugin:sync_selected_interfaces' object_
                         Cache expires in: <span id="countdown-timer"
                             data-expiry="{{ interface_sync.cache_expiry|date:'c' }}"></span>
                     </div>
-        
+
                     {% endif %}
                     <div class="color-key me-3">
                         <span class="badge text-success text-white">Matching values</span>
@@ -77,21 +92,24 @@ action="{% url 'plugins:netbox_librenms_plugin:sync_selected_interfaces' object_
                         <span class="badge text-danger text-white">Not present in NetBox</span>
                     </div>
                 </div>
-                <button class="btn btn-sm btn-secondary" type="button" data-bs-toggle="collapse" data-bs-target="#interfaceFilterSection" aria-expanded="false" aria-controls="interfaceFilterSection">
+                <button class="btn btn-sm btn-secondary" type="button" data-bs-toggle="collapse"
+                    data-bs-target="#interfaceFilterSection" aria-expanded="false"
+                    aria-controls="interfaceFilterSection">
                     <i class="mdi mdi-filter"></i> Toggle Filters
                 </button>
             </div>
             <div class="collapse mb-3" id="interfaceFilterSection">
                 <div class="mb-2">
                     <small class="text-muted">
-                        <i class="mdi mdi-information"></i> Filters apply to currently displayed interfaces. Adjust the "per page" setting to apply the filters to more interfaces.
+                        <i class="mdi mdi-information"></i> Filters apply to currently displayed interfaces. Adjust the
+                        "per page" setting to apply the filters to more interfaces.
                     </small>
                 </div>
                 <div class="filter-container d-flex gap-2">
                     <input type="text" id="filter-name" placeholder="Filter by Name" class="form-control">
                     {% if interface_sync.table.attrs.id == 'librenms-interface-table' %}
-                        <input type="text" id="filter-type" placeholder="Filter by Type" class="form-control">
-                        <input type="text" id="filter-speed" placeholder="Filter by Speed" class="form-control">
+                    <input type="text" id="filter-type" placeholder="Filter by Type" class="form-control">
+                    <input type="text" id="filter-speed" placeholder="Filter by Speed" class="form-control">
                     {% endif %}
                     <input type="text" id="filter-mac" placeholder="Filter by MAC" class="form-control">
                     <input type="text" id="filter-mtu" placeholder="Filter by MTU" class="form-control">
@@ -106,14 +124,27 @@ action="{% url 'plugins:netbox_librenms_plugin:sync_selected_interfaces' object_
                     flex-wrap: wrap;
                     align-items: center;
                 }
+
                 /* Updated rules using min-width */
                 td[data-col="device_selection"] {
                     width: 300px;
                     min-width: 200px;
                 }
+
                 td[data-col="device_selection"] .ts-wrapper {
                     width: 100%;
                     max-width: 100%;
+                }
+
+                /* NetBox-only interfaces link styling */
+                .netbox-only-link {
+                    cursor: pointer;
+                    transition: opacity 0.2s ease;
+                }
+
+                .netbox-only-link:hover {
+                    opacity: 0.8;
+                    text-decoration: underline !important;
                 }
             </style>
 
@@ -161,7 +192,8 @@ action="{% url 'plugins:netbox_librenms_plugin:sync_selected_interfaces' object_
 </div>
 
 <!-- Bulk VC Member Selection Modal -->
-<div class="modal fade" id="bulkVCMemberModal" tabindex="-1" aria-labelledby="bulkVCMemberModalLabel" aria-hidden="true">
+<div class="modal fade" id="bulkVCMemberModal" tabindex="-1" aria-labelledby="bulkVCMemberModalLabel"
+    aria-hidden="true">
     <div class="modal-dialog">
         <div class="modal-content">
             <div class="modal-header">
@@ -173,13 +205,92 @@ action="{% url 'plugins:netbox_librenms_plugin:sync_selected_interfaces' object_
                 <select id="bulk-vc-member-select" class="form-select">
                     {% for member in interface_sync.virtual_chassis_members %}
                     {{ member.name }}
-                        <option value="{{ member.id }}">{{ member.name }}</option>
+                    <option value="{{ member.id }}">{{ member.name }}</option>
                     {% endfor %}
                 </select>
             </div>
             <div class="modal-footer">
                 <button class="btn btn-primary" id="apply-bulk-vc-member" data-bs-dismiss="modal">Apply</button>
                 <button class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+            </div>
+        </div>
+    </div>
+</div>
+
+<!-- NetBox-only Interfaces Modal -->
+<div class="modal fade" id="netboxOnlyInterfacesModal" tabindex="-1" aria-labelledby="netboxOnlyInterfacesModalLabel"
+    aria-hidden="true">
+    <div class="modal-dialog modal-lg">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="netboxOnlyInterfacesModalLabel">
+                    NetBox-only Interfaces - {{ interface_sync.object.name }}</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body">
+                <div class="alert alert-warning">
+                    <i class="mdi mdi-alert me-2"></i>
+                    <strong>Warning:</strong> The following interfaces exist in NetBox but are not found in the LibreNMS
+                    data.
+                    Deleting these interfaces will permanently remove them from NetBox. This action cannot be undone.
+                </div>
+
+                {% if interface_sync.netbox_only_interfaces %}
+                <form id="delete-netbox-interfaces-form">
+                    {% csrf_token %}
+                    <div class="table-responsive">
+                        <table class="table table-hover">
+                            <thead>
+                                <tr>
+                                    <th>
+                                        <input type="checkbox" id="select-all-netbox-interfaces"
+                                            class="form-check-input">
+                                    </th>
+                                    <th>Interface Name</th>
+                                    <th>Type</th>
+                                    <th>Status</th>
+                                    <th>Description</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {% for interface in interface_sync.netbox_only_interfaces %}
+                                <tr>
+                                    <td>
+                                        <input type="checkbox" name="interface_ids" value="{{ interface.id }}"
+                                            class="form-check-input netbox-interface-checkbox">
+                                    </td>
+                                    <td>
+                                        <a href="{{ interface.url }}" target="_blank">{{ interface.name }}</a>
+                                    </td>
+                                    <td>{{ interface.type }}</td>
+                                    <td>
+                                        {% if interface.enabled %}
+                                        <span class="text-success">Enabled</span>
+                                        {% else %}
+                                        <span class="text-danger">Disabled</span>
+                                        {% endif %}
+                                    </td>
+                                    <td>{{ interface.description|default:"-" }}</td>
+                                </tr>
+                                {% endfor %}
+                            </tbody>
+                        </table>
+                    </div>
+                </form>
+                {% else %}
+                <div class="alert alert-info">
+                    <i class="mdi mdi-information me-2"></i>
+                    No interfaces found that exist only in NetBox.
+                </div>
+                {% endif %}
+            </div>
+            <div class="modal-footer">
+                {% if interface_sync.netbox_only_interfaces %}
+                <button type="button" class="btn btn-danger" id="confirm-delete-interfaces">
+                    <i class="mdi mdi-delete"></i> Delete Selected Interfaces
+                </button>
+                {% endif %}
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
             </div>
         </div>
     </div>

--- a/netbox_librenms_plugin/urls.py
+++ b/netbox_librenms_plugin/urls.py
@@ -3,6 +3,7 @@ from django.urls import include, path
 from .models import InterfaceTypeMapping
 from .views import (
     AddDeviceToLibreNMSView,
+    DeleteNetBoxInterfacesView,
     DeviceCableTableView,
     DeviceInterfaceTableView,
     DeviceIPAddressTableView,
@@ -89,6 +90,12 @@ urlpatterns = [
         "<str:object_type>/<int:object_id>/sync-interfaces/",
         SyncInterfacesView.as_view(),
         name="sync_selected_interfaces",
+    ),
+    # Delete NetBox-only interfaces URL
+    path(
+        "<str:object_type>/<int:object_id>/delete-netbox-interfaces/",
+        DeleteNetBoxInterfacesView.as_view(),
+        name="delete_netbox_interfaces",
     ),
     # Sync cables URL
     path(

--- a/netbox_librenms_plugin/views/__init__.py
+++ b/netbox_librenms_plugin/views/__init__.py
@@ -22,6 +22,7 @@ from .status_check import (
     VMStatusListView,
 )
 from .sync.cables_sync import SyncCablesView
+from .sync.cleanup_interfaces import DeleteNetBoxInterfacesView
 from .sync.devices_sync import AddDeviceToLibreNMSView, UpdateDeviceLocationView
 from .sync.interfaces_sync import SyncInterfacesView
 from .sync.locations_sync import SyncSiteLocationView

--- a/netbox_librenms_plugin/views/sync/cleanup_interfaces.py
+++ b/netbox_librenms_plugin/views/sync/cleanup_interfaces.py
@@ -1,0 +1,93 @@
+from dcim.models import Device, Interface
+from django.db import transaction
+from django.http import JsonResponse
+from django.shortcuts import get_object_or_404
+from django.views import View
+from virtualization.models import VirtualMachine, VMInterface
+
+from netbox_librenms_plugin.views.mixins import CacheMixin
+
+
+class DeleteNetBoxInterfacesView(CacheMixin, View):
+    """
+    View for deleting interfaces that exist in NetBox but not in LibreNMS.
+    """
+
+    def post(self, request, object_type, object_id):
+        """Delete selected NetBox-only interfaces."""
+
+        # Get the object
+        if object_type == "device":
+            obj = get_object_or_404(Device, pk=object_id)
+        elif object_type == "virtualmachine":
+            obj = get_object_or_404(VirtualMachine, pk=object_id)
+        else:
+            return JsonResponse({"error": "Invalid object type"}, status=400)
+
+        interface_ids = request.POST.getlist("interface_ids")
+
+        if not interface_ids:
+            return JsonResponse(
+                {"error": "No interfaces selected for deletion"}, status=400
+            )
+
+        deleted_count = 0
+        errors = []
+
+        try:
+            with transaction.atomic():
+                for interface_id in interface_ids:
+                    try:
+                        if object_type == "device":
+                            interface = Interface.objects.get(id=interface_id)
+                            # Verify the interface belongs to the device or its virtual chassis
+                            if hasattr(obj, "virtual_chassis") and obj.virtual_chassis:
+                                valid_device_ids = [
+                                    member.id
+                                    for member in obj.virtual_chassis.members.all()
+                                ]
+                                if interface.device_id not in valid_device_ids:
+                                    errors.append(
+                                        f"Interface {interface.name} does not belong to this device or its virtual chassis"
+                                    )
+                                    continue
+                            elif interface.device_id != obj.id:
+                                errors.append(
+                                    f"Interface {interface.name} does not belong to this device"
+                                )
+                                continue
+                        else:  # virtualmachine
+                            interface = VMInterface.objects.get(id=interface_id)
+                            if interface.virtual_machine_id != obj.id:
+                                errors.append(
+                                    f"Interface {interface.name} does not belong to this virtual machine"
+                                )
+                                continue
+
+                        interface_name = interface.name
+                        interface.delete()
+                        deleted_count += 1
+
+                    except (Interface.DoesNotExist, VMInterface.DoesNotExist):
+                        errors.append(f"Interface with ID {interface_id} not found")
+                        continue
+                    except Exception as e:
+                        errors.append(
+                            f"Error deleting interface {interface_name}: {str(e)}"
+                        )
+                        continue
+
+        except Exception as e:
+            return JsonResponse({"error": f"Transaction failed: {str(e)}"}, status=500)
+
+        response_data = {
+            "status": "success",
+            "deleted_count": deleted_count,
+            "message": f"Successfully deleted {deleted_count} interface(s)",
+        }
+
+        if errors:
+            response_data["errors"] = errors
+            response_data["message"] += f" with {len(errors)} error(s)"
+
+        return JsonResponse(response_data)

--- a/netbox_librenms_plugin/views/sync/netbox_only_interfaces.py
+++ b/netbox_librenms_plugin/views/sync/netbox_only_interfaces.py
@@ -1,0 +1,125 @@
+"""
+View for handling paginated NetBox-only interfaces in modal.
+"""
+from django.core.paginator import Paginator
+from django.http import JsonResponse
+from django.shortcuts import get_object_or_404
+from django.template.loader import render_to_string
+
+from dcim.models import Device
+from virtualization.models import VirtualMachine
+from netbox_librenms_plugin.views.base.interfaces_view import BaseInterfaceTableView
+
+
+class NetBoxOnlyInterfacesView(BaseInterfaceTableView):
+    """
+    View to return paginated NetBox-only interfaces for modal display.
+    """
+
+    def get_interfaces(self, obj):
+        """Get interfaces related to the object."""
+        return obj.interfaces.all()
+
+    def get_redirect_url(self, obj):
+        """Get the redirect URL for the object - not used in this view."""
+        return ""
+
+    def get_table(self, data, obj, interface_name_field):
+        """Get table instance - not used in this view since we return JSON."""
+        return None
+
+    def get(self, request, model_type, pk):
+        """
+        Return paginated NetBox-only interfaces as JSON for AJAX requests.
+        """
+        # Set the request attribute for the view
+        self.request = request
+        
+        # Determine the model based on model_type
+        if model_type == 'device':
+            self.model = Device
+        elif model_type == 'vm':
+            self.model = VirtualMachine
+        else:
+            return JsonResponse({'error': 'Invalid model type'}, status=400)
+
+        try:
+            obj = get_object_or_404(self.model, pk=pk)
+        except Exception as e:
+            return JsonResponse({'error': f'Object not found: {str(e)}'}, status=404)
+        
+        # Get interface name field
+        interface_name_field = request.GET.get('interface_name_field', 'ifName')
+        
+        try:
+            # Get context data (reuse existing logic)
+            context_data = self.get_context_data(request, obj, interface_name_field)
+            netbox_only_interfaces = context_data.get('netbox_only_interfaces', [])
+        except Exception as e:
+            import traceback
+            return JsonResponse({
+                'error': f'Error fetching interfaces: {str(e)}',
+                'traceback': traceback.format_exc()
+            }, status=500)
+        
+        # Pagination parameters
+        page_number = request.GET.get('page', 1)
+        per_page = int(request.GET.get('per_page', 25))  # NetBox default
+        
+        # Create paginator
+        paginator = Paginator(netbox_only_interfaces, per_page)
+        page_obj = paginator.get_page(page_number)
+        
+        # Generate smart page range (similar to NetBox's pagination)
+        page_range = []
+        if paginator.num_pages <= 10:
+            # Show all pages if 10 or fewer
+            page_range = list(range(1, paginator.num_pages + 1))
+        else:
+            # Smart pagination - show pages around current page
+            if page_obj.number <= 5:
+                page_range = list(range(1, 8)) + ['...', paginator.num_pages]
+            elif page_obj.number > paginator.num_pages - 5:
+                page_range = [1, '...'] + list(range(paginator.num_pages - 6, paginator.num_pages + 1))
+            else:
+                page_range = [1, '...'] + list(range(page_obj.number - 2, page_obj.number + 3)) + ['...', paginator.num_pages]
+        
+        # Prepare pagination info
+        pagination_info = {
+            'current_page': page_obj.number,
+            'total_pages': paginator.num_pages,
+            'total_count': paginator.count,
+            'has_previous': page_obj.has_previous(),
+            'has_next': page_obj.has_next(),
+            'previous_page_number': page_obj.previous_page_number() if page_obj.has_previous() else None,
+            'next_page_number': page_obj.next_page_number() if page_obj.has_next() else None,
+            'start_index': page_obj.start_index(),
+            'end_index': page_obj.end_index(),
+            'per_page': per_page,
+            'page_range': page_range,
+        }
+        
+        try:
+            # Render the table content
+            table_html = render_to_string(
+                'netbox_librenms_plugin/modals/_netbox_only_interfaces_table.html',
+                {
+                    'interfaces': page_obj.object_list,
+                    'pagination': pagination_info,
+                    'model_type': model_type,
+                    'object_pk': pk,
+                    'interface_name_field': interface_name_field,
+                },
+                request=request
+            )
+        except Exception as e:
+            import traceback
+            return JsonResponse({
+                'error': f'Error rendering template: {str(e)}',
+                'traceback': traceback.format_exc()
+            }, status=500)
+        
+        return JsonResponse({
+            'table_html': table_html,
+            'pagination': pagination_info,
+        })


### PR DESCRIPTION
This pull request introduces a new feature allowing users to view and delete "NetBox-only" interfaces—interfaces that exist in NetBox but are not present in LibreNMS—directly from the UI.

<img width="247" height="113" alt="{AC3F48E2-B9E2-47DD-9247-4C29E88E77CD}" src="https://github.com/user-attachments/assets/1ea90aae-dd6e-44a3-92bf-310e3140e021" />
