### PR TITLE
Fix FieldError for librenms_status on device/VM status pages 

### DIFF
--- a/netbox_librenms_plugin/tables/VM_status.py
+++ b/netbox_librenms_plugin/tables/VM_status.py
@@ -14,7 +14,7 @@ class VMStatusTable(VirtualMachineTable):
         verbose_name="LibreNMS Status",
         empty_values=(),
         accessor="librenms_status",
-        orderable=True,
+        orderable=False,
     )
 
     def render_librenms_status(self, value, record):

--- a/netbox_librenms_plugin/tables/device_status.py
+++ b/netbox_librenms_plugin/tables/device_status.py
@@ -9,11 +9,12 @@ class DeviceStatusTable(DeviceTable):
     """
     Table for displaying device LibreNMS status.
     """
+
     librenms_status = Column(
         verbose_name="LibreNMS Status",
         empty_values=(),
         accessor="librenms_status",
-        orderable=True,
+        orderable=False,
     )
 
     def render_librenms_status(self, value, record):
@@ -36,7 +37,7 @@ class DeviceStatusTable(DeviceTable):
                 )
             if vc_master and record.pk != vc_master.pk:
                 master_url = reverse(
-                    f"plugins:netbox_librenms_plugin:device_librenms_sync",
+                    "plugins:netbox_librenms_plugin:device_librenms_sync",
                     kwargs={"pk": vc_master.pk},
                 )
                 return mark_safe(

--- a/netbox_librenms_plugin/views/status_check.py
+++ b/netbox_librenms_plugin/views/status_check.py
@@ -69,7 +69,9 @@ class DeviceStatusListView(LibreNMSAPIMixin, generic.ObjectListView):
 
             return queryset
 
-        return Device.objects.none()
+        return Device.objects.none().annotate(
+            librenms_status=Value(None, output_field=BooleanField())
+        )
 
 
 class VMStatusListView(LibreNMSAPIMixin, generic.ObjectListView):
@@ -116,4 +118,6 @@ class VMStatusListView(LibreNMSAPIMixin, generic.ObjectListView):
 
             return queryset
 
-        return VirtualMachine.objects.none()
+        return VirtualMachine.objects.none().annotate(
+            librenms_status=Value(None, output_field=BooleanField())
+        )


### PR DESCRIPTION
This PR resolves a FieldError that occurred when accessing or sorting by the librenms_status column on the device and VM status pages.

Key changes:
- The queryset in status views now always annotates librenms_status, ensuring the field is available regardless of filters or ordering.
- The librenms_status column in device and VM status tables is set to orderable=False to prevent sorting-related errors.
- Documentation updated to explain the issue, the fix, and the NetBox version dependency.
