### PR TITLE
docs: update README with device field sync details

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,13 @@ this plugin allows you to easily onboard device objects from existing data in Li
 
 The plugin offers the following key features:
 
+### Device Field Sync
+Synchronize device information from LibreNMS to NetBox. The following device fields can be synchronized:
+
+- Serial Number (including virtual chassis members)
+- Device Type
+- Platform
+
 ### Interface Sync
 Pull interface data from Devices and Virtual Machines from LibreNMS into NetBox. The following interface attributes are synchronized:
 
@@ -35,7 +42,7 @@ Create IP address in NetBox from LibreNMS device IP data.
 The plugin also supports synchronizing NetBox Sites with LibreNMS locations:
 - Compare NetBox sites to LibreNMS location data
 - Create LibreNMS locations to match NetBox sites
-- Update existing LibreNMS locations langitude and longitude values based on NetBox data
+- Update existing LibreNMS locations latitude and longitude values based on NetBox data ⚠️ *(currently not working due to LibreNMS API issue)*
 - Sync device site to LibreNMS location
 
 ### Multi LibreNMS Server Configuration

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,6 +8,14 @@ The NetBox LibreNMS Plugin enables integration between NetBox and LibreNMS, allo
 
 The plugin offers the following key features:
 
+### Device Field Sync
+
+Synchronize device information from LibreNMS to NetBox. The following device fields can be synchronized:
+
+* Serial Number (including virtual chassis members)
+* Device Type
+* Platform
+
 ### Interface Sync
 
 Pull interface data from Devices and Virtual Machines from LibreNMS into NetBox. The following interface attributes are synchronized:
@@ -40,7 +48,7 @@ The plugin also supports synchronizing NetBox Sites with LibreNMS locations:
 
 * Compare NetBox sites to LibreNMS location data
 * Create LibreNMS locations to match NetBox sites
-* Update existing LibreNMS locations langitude and longitude values based on NetBox data
+* Update existing LibreNMS locations latitude and longitude values based on NetBox data ⚠️ *(currently not working due to LibreNMS API issue)*
 * Sync device site to LibreNMS location
 
 ### Screnshots/GIFs


### PR DESCRIPTION

* Added a new "Device Field Sync" section to both `README.md` and `docs/README.md`, detailing which device fields (Serial Number, Device Type, Platform) can be synchronized from LibreNMS to NetBox. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R11-R17) [[2]](diffhunk://#diff-0b5ca119d2be595aa307d34512d9679e49186307ef94201e4b3dfa079aa89938R11-R18)
* Added a warning that updating LibreNMS locations' latitude and longitude from NetBox is currently not working due to a LibreNMS API issue, in both `README.md` and `docs/README.md`. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L38-R45) [[2]](diffhunk://#diff-0b5ca119d2be595aa307d34512d9679e49186307ef94201e4b3dfa079aa89938L43-R51)