### PR TITLE
Add all LibreNMS SNMP fields to add device form

### DIFF
--- a/netbox_librenms_plugin/forms.py
+++ b/netbox_librenms_plugin/forms.py
@@ -128,6 +128,80 @@ class AddToLIbreSNMPV2(forms.Form):
         widget=forms.HiddenInput(attrs={"id": "id_snmp_version_v2"})
     )
     community = forms.CharField(label="SNMP Community", max_length=255, required=True)
+    port = forms.IntegerField(
+        label="SNMP Port",
+        required=False,
+        help_text="Leave blank to use default SNMP port (161)",
+        widget=forms.NumberInput(attrs={"placeholder": "161"}),
+    )
+    transport = forms.ChoiceField(
+        label="Transport",
+        choices=[
+            ("udp", "UDP"),
+            ("tcp", "TCP"),
+            ("udp6", "UDP6"),
+            ("tcp6", "TCP6"),
+        ],
+        required=False,
+        initial="udp",
+    )
+    port_association_mode = forms.ChoiceField(
+        label="Port Association Mode",
+        choices=[
+            ("ifIndex", "ifIndex"),
+            ("ifName", "ifName"),
+            ("ifDescr", "ifDescr"),
+            ("ifAlias", "ifAlias"),
+        ],
+        required=False,
+        initial="ifIndex",
+        help_text="Method to identify ports",
+    )
+    poller_group = forms.ChoiceField(
+        label="Poller Group",
+        required=False,
+        help_text="Poller group for distributed poller setup",
+    )
+    force_add = forms.BooleanField(
+        label="Force Add",
+        required=False,
+        initial=False,
+        help_text="Skip duplicate device and SNMP reachability checks (hostname must still be unique)",
+    )
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # Populate poller groups from LibreNMS API
+        self.fields["poller_group"].choices = self._get_poller_group_choices()
+
+    def _get_poller_group_choices(self):
+        """Get poller group choices from LibreNMS API."""
+        from .librenms_api import LibreNMSAPI
+
+        choices = [("0", "Default (0)")]
+
+        try:
+            api = LibreNMSAPI()
+            success, poller_groups = api.get_poller_groups()
+
+            if success and poller_groups:
+                for group in poller_groups:
+                    group_id = str(group.get("id", ""))
+                    group_name = group.get("group_name", "")
+                    group_descr = group.get("descr", "")
+
+                    if group_id:
+                        # Format: "Group Name (ID)" or "Group Name - Description (ID)"
+                        if group_descr and group_descr != group_name:
+                            label = f"{group_name} - {group_descr} ({group_id})"
+                        else:
+                            label = f"{group_name} ({group_id})"
+                        choices.append((group_id, label))
+        except Exception:
+            # If API call fails, just use default option
+            pass
+
+        return choices
 
 
 class AddToLIbreSNMPV3(forms.Form):
@@ -184,6 +258,80 @@ class AddToLIbreSNMPV3(forms.Form):
         choices=[("AES", "AES"), ("DES", "DES")],
         required=True,
     )
+    port = forms.IntegerField(
+        label="SNMP Port",
+        required=False,
+        help_text="Leave blank to use default SNMP port (161)",
+        widget=forms.NumberInput(attrs={"placeholder": "161"}),
+    )
+    transport = forms.ChoiceField(
+        label="Transport",
+        choices=[
+            ("udp", "UDP"),
+            ("tcp", "TCP"),
+            ("udp6", "UDP6"),
+            ("tcp6", "TCP6"),
+        ],
+        required=False,
+        initial="udp",
+    )
+    port_association_mode = forms.ChoiceField(
+        label="Port Association Mode",
+        choices=[
+            ("ifIndex", "ifIndex"),
+            ("ifName", "ifName"),
+            ("ifDescr", "ifDescr"),
+            ("ifAlias", "ifAlias"),
+        ],
+        required=False,
+        initial="ifIndex",
+        help_text="Method to identify ports",
+    )
+    poller_group = forms.ChoiceField(
+        label="Poller Group",
+        required=False,
+        help_text="Poller group for distributed poller setup",
+    )
+    force_add = forms.BooleanField(
+        label="Force Add",
+        required=False,
+        initial=False,
+        help_text="Skip duplicate device and SNMP reachability checks (hostname must still be unique)",
+    )
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # Populate poller groups from LibreNMS API
+        self.fields["poller_group"].choices = self._get_poller_group_choices()
+
+    def _get_poller_group_choices(self):
+        """Get poller group choices from LibreNMS API."""
+        from .librenms_api import LibreNMSAPI
+
+        choices = [("0", "Default (0)")]
+
+        try:
+            api = LibreNMSAPI()
+            success, poller_groups = api.get_poller_groups()
+
+            if success and poller_groups:
+                for group in poller_groups:
+                    group_id = str(group.get("id", ""))
+                    group_name = group.get("group_name", "")
+                    group_descr = group.get("descr", "")
+
+                    if group_id:
+                        # Format: "Group Name (ID)" or "Group Name - Description (ID)"
+                        if group_descr and group_descr != group_name:
+                            label = f"{group_name} - {group_descr} ({group_id})"
+                        else:
+                            label = f"{group_name} ({group_id})"
+                        choices.append((group_id, label))
+        except Exception:
+            # If API call fails, just use default option
+            pass
+
+        return choices
 
 
 class DeviceStatusFilterForm(NetBoxModelFilterSetForm):

--- a/netbox_librenms_plugin/templates/netbox_librenms_plugin/librenms_sync_base.html
+++ b/netbox_librenms_plugin/templates/netbox_librenms_plugin/librenms_sync_base.html
@@ -555,7 +555,7 @@
 
 <!-- Add to LibreNMS Modal -->
 <div class="modal fade" id="add-device-modal" tabindex="-1" aria-labelledby="addDeviceModalLabel" aria-hidden="true">
-    <div class="modal-dialog">
+    <div class="modal-dialog modal-lg">
         <div class="modal-content">
             <div class="modal-header">
                 <h5 class="modal-title" id="addDeviceModalLabel">Add Device to LibreNMS</h5>
@@ -584,6 +584,30 @@
                         {{ v2form.community.label_tag }}
                         {{ v2form.community }}
                     </div>
+                    <div class="mb-3">
+                        {{ v2form.port.label_tag }}
+                        {{ v2form.port }}
+                        <div class="form-text">{{ v2form.port.help_text }}</div>
+                    </div>
+                    <div class="mb-3">
+                        {{ v2form.transport.label_tag }}
+                        {{ v2form.transport }}
+                    </div>
+                    <div class="mb-3">
+                        {{ v2form.port_association_mode.label_tag }}
+                        {{ v2form.port_association_mode }}
+                        <div class="form-text">{{ v2form.port_association_mode.help_text }}</div>
+                    </div>
+                    <div class="mb-3">
+                        {{ v2form.poller_group.label_tag }}
+                        {{ v2form.poller_group }}
+                        <div class="form-text">{{ v2form.poller_group.help_text }}</div>
+                    </div>
+                    <div class="mb-3 form-check">
+                        {{ v2form.force_add }}
+                        {{ v2form.force_add.label_tag }}
+                        <div class="form-text">{{ v2form.force_add.help_text }}</div>
+                    </div>
                     <button type="submit" class="btn btn-primary">Add Device</button>
                 </form>
 
@@ -592,18 +616,53 @@
                     id="snmpv3-form" style="display: none;">
                     {% csrf_token %}
                     <input type="hidden" name="snmp_version" value="v3">
-                    <div class="mb-3">
-                        {{ v3form.hostname.label_tag }}
-                        {{ v3form.hostname }}
+
+                    <div class="row">
+                        <!-- Left Column: Common fields (same as SNMPv2c) -->
+                        <div class="col-md-6">
+                            <div class="mb-3">
+                                {{ v3form.hostname.label_tag }}
+                                {{ v3form.hostname }}
+                            </div>
+                            <div class="mb-3">
+                                {{ v3form.port.label_tag }}
+                                {{ v3form.port }}
+                                <div class="form-text">{{ v3form.port.help_text }}</div>
+                            </div>
+                            <div class="mb-3">
+                                {{ v3form.transport.label_tag }}
+                                {{ v3form.transport }}
+                            </div>
+                            <div class="mb-3">
+                                {{ v3form.port_association_mode.label_tag }}
+                                {{ v3form.port_association_mode }}
+                                <div class="form-text">{{ v3form.port_association_mode.help_text }}</div>
+                            </div>
+                            <div class="mb-3">
+                                {{ v3form.poller_group.label_tag }}
+                                {{ v3form.poller_group }}
+                                <div class="form-text">{{ v3form.poller_group.help_text }}</div>
+                            </div>
+                            <div class="mb-3 form-check">
+                                {{ v3form.force_add }}
+                                {{ v3form.force_add.label_tag }}
+                                <div class="form-text">{{ v3form.force_add.help_text }}</div>
+                            </div>
+                        </div>
+
+                        <!-- Right Column: SNMPv3-specific fields -->
+                        <div class="col-md-6">
+                            {% for field in v3form %}
+                            {% if field.name not in 'hostname,snmp_version,port,transport,port_association_mode,poller_group,force_add' %}
+                            <div class="mb-3">
+                                {{ field.label_tag }}
+                                {{ field }}
+                            </div>
+                            {% endif %}
+                            {% endfor %}
+                        </div>
                     </div>
-                    {% for field in v3form %}
-                    {% if field.name != 'hostname' %}
-                    <div class="mb-3">
-                        {{ field.label_tag }}
-                        {{ field }}
-                    </div>
-                    {% endif %}
-                    {% endfor %}
+
                     <button type="submit" class="btn btn-primary">Add Device</button>
                 </form>
             </div>

--- a/netbox_librenms_plugin/views/sync/devices_sync.py
+++ b/netbox_librenms_plugin/views/sync/devices_sync.py
@@ -1,9 +1,7 @@
 from dcim.models import Device
 from django.contrib import messages
 from django.shortcuts import get_object_or_404, redirect
-from django.urls import reverse_lazy
 from django.views import View
-from django.views.generic import FormView
 from virtualization.models import VirtualMachine
 
 from netbox_librenms_plugin.forms import AddToLIbreSNMPV2, AddToLIbreSNMPV3
@@ -48,7 +46,23 @@ class AddDeviceToLibreNMSView(LibreNMSAPIMixin, View):
         device_data = {
             "hostname": data.get("hostname"),
             "snmp_version": data.get("snmp_version"),
+            "force_add": data.get("force_add", False),
         }
+
+        # Add optional common fields if provided
+        if data.get("port"):
+            device_data["port"] = data.get("port")
+        if data.get("transport"):
+            device_data["transport"] = data.get("transport")
+        if data.get("port_association_mode"):
+            device_data["port_association_mode"] = data.get("port_association_mode")
+        if data.get("poller_group"):
+            # Convert poller_group string to integer for LibreNMS API
+            try:
+                device_data["poller_group"] = int(data.get("poller_group"))
+            except (ValueError, TypeError):
+                pass  # Skip if conversion fails
+
         if device_data["snmp_version"] == "v2c":
             device_data["community"] = data.get("community")
         elif device_data["snmp_version"] == "v3":


### PR DESCRIPTION
- Add port, transport, port_association_mode, poller_group fields to both SNMPv2c and SNMPv3 forms
- Implement get_poller_groups() API method to fetch poller groups from LibreNMS
- Populate poller_group dropdown dynamically from LibreNMS API data
- Add force_add parameter to skip duplicate/SNMP checks
- Update modal to use two-column layout for SNMPv3 form (common fields left, auth fields right)
- Increase modal width to modal-lg for better layout