### PR TITLE
Fix: Add permissions to Interface Mappings menu item

### DIFF
--- a/netbox_librenms_plugin/navigation.py
+++ b/netbox_librenms_plugin/navigation.py
@@ -15,6 +15,7 @@ menu = PluginMenu(
                 PluginMenuItem(
                     link="plugins:netbox_librenms_plugin:interfacetypemapping_list",
                     link_text="Interface Mappings",
+                    permissions=["netbox_librenms_plugin.view_interfacetypemapping"],
                     buttons=(
                         PluginMenuButton(
                             link="plugins:netbox_librenms_plugin:interfacetypemapping_add",


### PR DESCRIPTION
- Added missing view_interfacetypemapping permission to Interface Mappings menu item
- Prevents menu from being visible to unauthenticated users
