### PR TITLE
Fix JavaScript initialization and HTMX event listener issues

### DIFF
--- a/netbox_librenms_plugin/static/netbox_librenms_plugin/js/librenms_import.js
+++ b/netbox_librenms_plugin/static/netbox_librenms_plugin/js/librenms_import.js
@@ -1031,15 +1031,6 @@ function initializeImportPage() {
     initializeFilterForm();
     initializeBulkImport();
     initializeHTMXHandlers();
-    
-    // Ensure HTMX processes the table element (for deviceImported trigger)
-    // This is especially important after page reloads from background jobs
-    const objectList = document.getElementById('object_list');
-    if (objectList && typeof htmx !== 'undefined') {
-        console.log('LibreNMS Import: Processing HTMX attributes on table');
-        htmx.process(objectList);
-    }
-    
     console.log('LibreNMS Import: Initialization complete');
 }
 

--- a/netbox_librenms_plugin/templates/netbox_librenms_plugin/librenms_import.html
+++ b/netbox_librenms_plugin/templates/netbox_librenms_plugin/librenms_import.html
@@ -269,11 +269,7 @@
 
     {# Objects table #}
     <div class="card">
-      <div class="htmx-container" id="object_list"
-           hx-trigger="deviceImported from:body"
-           hx-get="{{ request.path }}?{{ request.GET.urlencode }}"
-           hx-select="#object_list"
-           hx-swap="outerHTML">
+      <div class="htmx-container" id="object_list">
         {% include 'inc/paginator.html' with htmx=True table=table paginator=table.paginator page=table.page %}
         <div class="table-responsive">
           {% include 'inc/table.html' %}


### PR DESCRIPTION
## Fixes JavaScript initialization and device import row updates

### Issues Fixed
1. **Non-responsive buttons/checkboxes** after filter execution (small datasets)
   - Caused by JavaScript const redeclaration during HTMX content swaps
   - Fixed with IIFE wrapper and initialization guard

2. **Table rows not updating** after device import from background job results
   - Caused by full table refresh loading stale cached data
   - Replaced with targeted HTMX out-of-band row swaps

### Implementation
- Backend: Re-validates imported devices and returns updated row HTML (consistent with role/rack dropdown pattern)
- Frontend: Removed table refresh mechanism and workarounds
- More efficient: only affected rows update, not entire table
- Works for both synchronous and background job filter results