### PR TITLE
Add background job support for device imports

### DIFF
--- a/netbox_librenms_plugin/forms.py
+++ b/netbox_librenms_plugin/forms.py
@@ -70,6 +70,25 @@ class LibreNMSSettingsForm(NetBoxModelForm):
         help_text="Number of devices that triggers background job processing (applies when mode is 'threshold')",
     )
 
+    import_job_mode = forms.ChoiceField(
+        label="Import Job Mode",
+        choices=[
+            ("always", "Always use background jobs"),
+            ("never", "Never use background jobs"),
+            ("threshold", "Use threshold-based decision"),
+        ],
+        widget=forms.Select(attrs={"class": "form-select"}),
+        help_text="Control when to use background jobs for device imports",
+    )
+
+    import_job_threshold = forms.IntegerField(
+        label="Import Count Threshold",
+        min_value=1,
+        max_value=500,
+        widget=forms.NumberInput(attrs={"class": "form-control"}),
+        help_text="Number of devices that triggers background job for imports (applies when mode is 'threshold')",
+    )
+
     class Meta:
         model = LibreNMSSettings
         fields = [
@@ -79,6 +98,8 @@ class LibreNMSSettingsForm(NetBoxModelForm):
             "strip_domain_default",
             "background_job_mode",
             "background_job_threshold",
+            "import_job_mode",
+            "import_job_threshold",
         ]
 
     def __init__(self, *args, **kwargs):

--- a/netbox_librenms_plugin/jobs.py
+++ b/netbox_librenms_plugin/jobs.py
@@ -114,3 +114,241 @@ class FilterDevicesJob(JobRunner):
             f"Job completed successfully. Processed {len(validated_devices)} devices. "
             f"Results available via shared cache for {api.cache_timeout} seconds."
         )
+
+
+class ImportDevicesJob(JobRunner):
+    """
+    Background job for importing LibreNMS devices to NetBox.
+
+    Handles bulk device/VM imports in the background to keep browser responsive.
+    Benefits:
+    - Active cancellation via NetBox Jobs interface
+    - Browser remains responsive during large imports
+    - Job progress tracked with device count logging
+    - Errors collected per device without stopping entire import
+
+    Jobs are triggered based on user-configured import threshold settings:
+    - 'always': All import operations run as background jobs
+    - 'never': All operations run synchronously (no cancellation, browser may hang)
+    - 'threshold': Jobs run when device count exceeds configured threshold (default: 10)
+
+    Results stored in job.data with structure:
+    {
+        "imported_device_pks": [1, 2, 3],  # NetBox Device PKs
+        "imported_vm_pks": [10, 11],       # NetBox VirtualMachine PKs
+        "total": 5,
+        "success_count": 4,
+        "failed_count": 1,
+        "skipped_count": 0,
+        "errors": [{"device_id": 123, "error": "..."}]
+    }
+    """
+
+    class Meta:
+        name = "LibreNMS Device Import"
+
+    def run(
+        self,
+        device_ids,
+        vm_imports,
+        server_key=None,
+        sync_options=None,
+        manual_mappings_per_device=None,
+        libre_devices_cache=None,
+        **kwargs,
+    ):
+        """
+        Execute device/VM imports in background.
+
+        Args:
+            device_ids: List of LibreNMS device IDs to import as Devices
+            vm_imports: Dict mapping device_id to cluster/role info for VM imports
+            server_key: Optional LibreNMS server key for multi-server setups
+            sync_options: Dict with sync_interfaces, sync_cables, sync_ips, use_sysname, strip_domain
+            manual_mappings_per_device: Dict mapping device_id to manual_mappings dict
+            libre_devices_cache: Optional dict mapping device_id to pre-fetched device data
+            **kwargs: Additional job parameters
+        """
+        # Debug: Log import attempt
+        import sys
+        self.logger.warning(f"Python executable: {sys.executable}")
+        self.logger.warning(f"Python path: {sys.path[:3]}...")  # First 3 entries
+        
+        try:
+            import netbox_librenms_plugin.import_utils as import_utils_module
+            self.logger.warning(f"import_utils module loaded from: {import_utils_module.__file__}")
+            self.logger.warning(f"Available functions: {[x for x in dir(import_utils_module) if not x.startswith('_')][:10]}...")
+            self.logger.warning(f"bulk_import_devices_shared exists: {'bulk_import_devices_shared' in dir(import_utils_module)}")
+        except Exception as debug_err:
+            self.logger.warning(f"Debug import failed: {debug_err}")
+
+        from netbox_librenms_plugin.import_utils import (
+            bulk_import_devices_shared,
+            create_vm_from_librenms,
+            get_librenms_device_by_id,
+            validate_device_for_import,
+            _determine_device_name,
+        )
+        from netbox_librenms_plugin.import_validation_helpers import (
+            apply_cluster_to_validation,
+            apply_role_to_validation,
+        )
+        from netbox_librenms_plugin.librenms_api import LibreNMSAPI
+        from dcim.models import DeviceRole
+        from virtualization.models import Cluster
+        from django.core.cache import cache
+
+        total_count = len(device_ids) + len(vm_imports)
+        self.logger.info(f"Starting LibreNMS import job for {total_count} devices/VMs")
+        self.logger.info(f"Device imports: {len(device_ids)}, VM imports: {len(vm_imports)}")
+        if server_key:
+            self.logger.info(f"Using LibreNMS server: {server_key}")
+
+        # Initialize API client
+        api = LibreNMSAPI(server_key=server_key)
+
+        # Import devices using shared function with job context
+        device_result = {"success": [], "failed": [], "skipped": [], "virtual_chassis_created": 0}
+        if device_ids:
+            self.logger.info(f"Importing {len(device_ids)} devices...")
+            device_result = bulk_import_devices_shared(
+                device_ids=device_ids,
+                server_key=server_key,
+                sync_options=sync_options,
+                manual_mappings_per_device=manual_mappings_per_device,
+                libre_devices_cache=libre_devices_cache,
+                job=self,  # Pass job context for logging and cancellation
+            )
+
+        # Import VMs
+        vm_result = {"success": [], "failed": [], "skipped": []}
+        if vm_imports:
+            self.logger.info(f"Importing {len(vm_imports)} VMs...")
+            vm_ids_to_import = list(vm_imports.keys())
+            
+            for idx, vm_id in enumerate(vm_ids_to_import, start=1):
+                # Check for job cancellation every 5 VMs
+                if idx % 5 == 0:
+                    # Refresh job from DB to get current status
+                    self.job.refresh_from_db()
+                    job_status = self.job.status
+                    status_value = job_status.value if hasattr(job_status, 'value') else job_status
+                    if status_value in ('failed', 'errored'):
+                        self.logger.warning(f"Import job cancelled at VM {idx} of {len(vm_ids_to_import)}")
+                        break
+                    self.logger.info(f"Imported VM {idx} of {len(vm_ids_to_import)}")
+
+                try:
+                    # Try to use cached device data first
+                    libre_device = None
+                    if libre_devices_cache and vm_id in libre_devices_cache:
+                        libre_device = libre_devices_cache[vm_id]
+                    else:
+                        cache_key = f"import_device_data_{vm_id}"
+                        libre_device = cache.get(cache_key)
+
+                    if not libre_device:
+                        libre_device = get_librenms_device_by_id(api, vm_id)
+
+                    if not libre_device:
+                        vm_result["failed"].append({
+                            "device_id": vm_id,
+                            "error": f"Device {vm_id} not found in LibreNMS",
+                        })
+                        self.logger.error(f"Device {vm_id} not found in LibreNMS")
+                        continue
+
+                    # Validate as VM
+                    validation = validate_device_for_import(
+                        libre_device, import_as_vm=True, api=api
+                    )
+
+                    # Check if VM already exists
+                    if validation.get("existing_device"):
+                        vm_result["skipped"].append({
+                            "device_id": vm_id,
+                            "reason": f"VM already exists: {validation['existing_device'].name}",
+                        })
+                        self.logger.info(f"VM already exists: {validation['existing_device'].name}")
+                        continue
+
+                    # Apply manual cluster and role selections
+                    vm_mappings = vm_imports[vm_id]
+                    cluster_id = vm_mappings.get("cluster_id")
+                    role_id = vm_mappings.get("device_role_id")
+
+                    if cluster_id:
+                        cluster = Cluster.objects.filter(id=cluster_id).first()
+                        if cluster:
+                            apply_cluster_to_validation(validation, cluster)
+
+                    role = None
+                    if role_id:
+                        role = DeviceRole.objects.filter(id=role_id).first()
+                        if role:
+                            apply_role_to_validation(validation, role, is_vm=True)
+
+                    # Create the VM
+                    use_sysname = sync_options.get("use_sysname", True) if sync_options else True
+                    strip_domain = sync_options.get("strip_domain", False) if sync_options else False
+
+                    vm_name = _determine_device_name(
+                        libre_device,
+                        use_sysname=use_sysname,
+                        strip_domain=strip_domain,
+                        device_id=vm_id,
+                    )
+
+                    # Update validation with the final name
+                    libre_device["_computed_name"] = vm_name
+
+                    vm = create_vm_from_librenms(
+                        libre_device, validation, use_sysname=use_sysname, role=role
+                    )
+
+                    vm_result["success"].append({
+                        "device_id": vm_id,
+                        "device": vm,
+                        "message": f"VM {vm.name} created successfully",
+                    })
+                    self.logger.info(f"Successfully imported VM {vm.name} (ID: {vm_id})")
+
+                except Exception as vm_error:
+                    # Log error but continue with other VMs
+                    self.logger.error(f"Failed to import VM {vm_id}: {vm_error}", exc_info=True)
+                    vm_result["failed"].append({"device_id": vm_id, "error": str(vm_error)})
+
+        # Combine results
+        imported_device_pks = [item["device"].pk for item in device_result.get("success", []) if item.get("device")]
+        imported_vm_pks = [item["device"].pk for item in vm_result.get("success", []) if item.get("device")]
+        
+        # Also store LibreNMS device IDs for re-rendering table rows
+        imported_libre_device_ids = [item["device_id"] for item in device_result.get("success", [])]
+        imported_libre_vm_ids = [item["device_id"] for item in vm_result.get("success", [])]
+        
+        success_count = len(device_result.get("success", [])) + len(vm_result.get("success", []))
+        failed_count = len(device_result.get("failed", [])) + len(vm_result.get("failed", []))
+        skipped_count = len(device_result.get("skipped", [])) + len(vm_result.get("skipped", []))
+        
+        all_errors = device_result.get("failed", []) + vm_result.get("failed", [])
+
+        # Store results in job.data
+        self.job.data = {
+            "imported_device_pks": imported_device_pks,
+            "imported_vm_pks": imported_vm_pks,
+            "imported_libre_device_ids": imported_libre_device_ids,
+            "imported_libre_vm_ids": imported_libre_vm_ids,
+            "server_key": server_key,
+            "total": total_count,
+            "success_count": success_count,
+            "failed_count": failed_count,
+            "skipped_count": skipped_count,
+            "virtual_chassis_created": device_result.get("virtual_chassis_created", 0),
+            "errors": all_errors,
+            "completed": True,
+        }
+        self.job.save(update_fields=["data"])
+
+        self.logger.info(
+            f"Import job completed. Success: {success_count}, Failed: {failed_count}, Skipped: {skipped_count}"
+        )

--- a/netbox_librenms_plugin/migrations/0010_librenmssettings_import_job_settings.py
+++ b/netbox_librenms_plugin/migrations/0010_librenmssettings_import_job_settings.py
@@ -1,0 +1,34 @@
+# Generated manually for netbox_librenms_plugin
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("netbox_librenms_plugin", "0009_librenmssettings_background_job_settings"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="librenmssettings",
+            name="import_job_mode",
+            field=models.CharField(
+                choices=[
+                    ("always", "Always use background jobs"),
+                    ("never", "Never use background jobs"),
+                    ("threshold", "Use threshold-based decision"),
+                ],
+                default="threshold",
+                help_text="Control when to use background jobs for device imports",
+                max_length=20,
+            ),
+        ),
+        migrations.AddField(
+            model_name="librenmssettings",
+            name="import_job_threshold",
+            field=models.IntegerField(
+                default=5,
+                help_text="Number of devices that triggers background job for imports (applies when mode is 'threshold')",
+            ),
+        ),
+    ]

--- a/netbox_librenms_plugin/models.py
+++ b/netbox_librenms_plugin/models.py
@@ -50,6 +50,22 @@ class LibreNMSSettings(models.Model):
         help_text="Number of devices that triggers background job processing (applies when mode is 'threshold')",
     )
 
+    import_job_mode = models.CharField(
+        max_length=20,
+        choices=[
+            ("always", "Always use background jobs"),
+            ("never", "Never use background jobs"),
+            ("threshold", "Use threshold-based decision"),
+        ],
+        default="threshold",
+        help_text="Control when to use background jobs for device imports",
+    )
+
+    import_job_threshold = models.IntegerField(
+        default=5,
+        help_text="Number of devices that triggers background job for imports (applies when mode is 'threshold')",
+    )
+
     class Meta:
         verbose_name = "LibreNMS Settings"
         verbose_name_plural = "LibreNMS Settings"

--- a/netbox_librenms_plugin/static/netbox_librenms_plugin/js/librenms_import.js
+++ b/netbox_librenms_plugin/static/netbox_librenms_plugin/js/librenms_import.js
@@ -525,6 +525,381 @@ function pollJobStatus(jobId, jobPk, pollUrl, baseUrl, originalFilters, deviceCo
     poll();
 }
 
+/**
+ * Poll import job status and redirect when complete.
+ * Similar to filter polling but for device import jobs.
+ *
+ * @param {string} jobId - Job UUID for API polling
+ * @param {number} jobPk - Job PK for result loading
+ * @param {string} pollUrl - API endpoint to poll
+ * @param {number} deviceCount - Number of devices being imported
+ */
+function pollImportJobStatus(jobId, jobPk, pollUrl, deviceCount) {
+    const messageEl = document.getElementById('import-progress-message');
+    const cancelBtn = document.getElementById('cancel-import-btn');
+
+    // Get CSRF token
+    let csrfToken = getCookie('csrftoken');
+    if (!csrfToken) {
+        const csrfInput = document.querySelector('[name=csrfmiddlewaretoken]');
+        if (csrfInput) {
+            csrfToken = csrfInput.value;
+        }
+    }
+
+    // Update modal message with device count
+    if (messageEl) {
+        if (deviceCount !== undefined && deviceCount !== null) {
+            messageEl.textContent = `Importing ${deviceCount} device${deviceCount !== 1 ? 's' : ''}...`;
+        } else {
+            messageEl.textContent = 'Importing devices...';
+        }
+    }
+
+    // Track cancel state
+    let cancelInProgress = false;
+
+    // Wire cancel button to stop the job
+    if (cancelBtn) {
+        cancelBtn.onclick = function () {
+            cancelInProgress = true;
+            cancelBtn.disabled = true;
+            const originalText = cancelBtn.textContent;
+
+            if (messageEl) {
+                messageEl.textContent = 'Cancelling import...';
+            }
+            cancelBtn.textContent = 'Cancelling...';
+
+            const stopUrl = `/api/core/background-tasks/${jobId}/stop/`;
+
+            fetch(stopUrl, {
+                method: 'POST',
+                headers: {
+                    'X-CSRFToken': csrfToken,
+                    'Content-Type': 'application/json',
+                    'Accept': 'application/json'
+                }
+            })
+                .then(res => {
+                    if (res.status === 404 || res.status === 410) {
+                        if (messageEl) {
+                            messageEl.textContent = 'Import already completed, loading results...';
+                        }
+                        cancelBtn.textContent = 'Completed';
+
+                        const modal = document.getElementById('import-processing-modal');
+                        if (modal && modal._bsModal) {
+                            modal._bsModal.hide();
+                            delete modal._bsModal;
+                        }
+
+                        // Redirect to results page
+                        const baseUrl = '/plugins/librenms_plugin/device-import/job/' + jobPk + '/results/';
+                        setTimeout(() => {
+                            window.location.href = baseUrl;
+                        }, 100);
+                        return Promise.resolve();
+                    }
+
+                    if (res.ok) {
+                        if (messageEl) {
+                            messageEl.textContent = 'Verifying import stopped...';
+                        }
+                        cancelBtn.textContent = 'Verifying...';
+
+                        return new Promise(resolve => setTimeout(resolve, JOB_CANCEL_WAIT_MS))
+                            .then(() => {
+                                if (messageEl) {
+                                    messageEl.textContent = 'Updating job status...';
+                                }
+                                cancelBtn.textContent = 'Updating...';
+
+                                const syncUrl = `/api/plugins/librenms_plugin/jobs/${jobPk}/sync-status/`;
+
+                                return fetch(syncUrl, {
+                                    method: 'POST',
+                                    headers: {
+                                        'X-CSRFToken': csrfToken,
+                                        'Accept': 'application/json'
+                                    }
+                                });
+                            })
+                            .then(syncRes => {
+                                return syncRes.json().then(data => {
+                                    if (syncRes.ok) {
+                                        if (messageEl) {
+                                            messageEl.textContent = 'Import cancelled successfully.';
+                                        }
+                                        cancelBtn.textContent = 'Cancelled';
+
+                                        const modal = document.getElementById('import-processing-modal');
+                                        if (modal && modal._bsModal) {
+                                            modal._bsModal.hide();
+                                            delete modal._bsModal;
+                                        }
+
+                                        setTimeout(() => {
+                                            window.location.href = '/plugins/librenms_plugin/librenms-import/';
+                                        }, JOB_CANCEL_REDIRECT_MS);
+                                    } else {
+                                        throw new Error(`Sync failed: ${syncRes.status}`);
+                                    }
+                                });
+                            })
+                            .catch(syncErr => {
+                                if (messageEl) {
+                                    messageEl.textContent = 'Import stopped (status sync failed).';
+                                }
+                                cancelBtn.textContent = 'Stopped';
+
+                                const modal = document.getElementById('import-processing-modal');
+                                if (modal && modal._bsModal) {
+                                    modal._bsModal.hide();
+                                    delete modal._bsModal;
+                                }
+
+                                setTimeout(() => {
+                                    window.location.href = '/plugins/librenms_plugin/librenms-import/';
+                                }, JOB_CANCEL_ERROR_REDIRECT_MS);
+                            });
+                    } else {
+                        if (res.status === 404 || res.status === 410 || res.status === 400) {
+                            if (messageEl) {
+                                messageEl.textContent = 'Import completed, loading results...';
+                            }
+                            cancelBtn.textContent = 'Completed';
+
+                            const modal = document.getElementById('import-processing-modal');
+                            if (modal && modal._bsModal) {
+                                modal._bsModal.hide();
+                                delete modal._bsModal;
+                            }
+
+                            setTimeout(() => {
+                                window.location.href = '/plugins/librenms_plugin/device-import/job/' + jobPk + '/results/';
+                            }, 100);
+                            return;
+                        }
+
+                        if (messageEl) {
+                            messageEl.textContent = 'Failed to cancel import. Closing...';
+                        }
+                        cancelBtn.textContent = 'Close';
+                        cancelBtn.disabled = false;
+
+                        const modal = document.getElementById('import-processing-modal');
+                        if (modal && modal._bsModal) {
+                            modal._bsModal.hide();
+                            delete modal._bsModal;
+                        }
+
+                        setTimeout(() => window.location.href = '/plugins/librenms_plugin/librenms-import/', 1000);
+                    }
+                })
+                .catch(err => {
+                    if (messageEl) {
+                        messageEl.textContent = 'Error cancelling import.';
+                    }
+                    cancelBtn.textContent = originalText;
+                    cancelBtn.disabled = false;
+                    alert('Error stopping import job. Please try again.');
+                });
+        };
+    }
+
+    // Poll function
+    let pollingStopped = false;
+    const poll = () => {
+        if (cancelInProgress) {
+            console.log('[Import Job Polling] Skipping poll - cancel in progress');
+            return;
+        }
+
+        if (pollingStopped) {
+            console.log('[Import Job Polling] Polling stopped, not continuing');
+            return;
+        }
+
+        console.log('[Import Job Polling] Fetching job status from:', pollUrl);
+        fetch(pollUrl, {
+            headers: {
+                'Accept': 'application/json'
+            }
+        })
+            .then(res => {
+                if (!res.ok) {
+                    if (res.status === 404) {
+                        // Job no longer in Redis queue, fall back to database endpoint
+                        if (cancelBtn) {
+                            cancelBtn.disabled = true;
+                            cancelBtn.textContent = 'Import Finalizing...';
+                        }
+                        return fetch(`/api/core/jobs/${jobId}/`, {
+                            headers: {
+                                'Accept': 'application/json'
+                            }
+                        }).then(dbRes => {
+                            if (!dbRes.ok) {
+                                throw new Error(`Database job not found: ${dbRes.status}`);
+                            }
+                            return dbRes.json();
+                        });
+                    }
+                    throw new Error(`HTTP ${res.status}`);
+                }
+                return res.json();
+            })
+            .then(data => {
+                const statusValue = data.status?.value || data.status;
+
+                // Update modal message based on status
+                if (messageEl) {
+                    const statusMessages = {
+                        'queued': 'Import job queued, waiting to start...',
+                        'scheduled': 'Import job scheduled...',
+                        'started': 'Importing devices...',
+                        'deferred': 'Import job deferred...',
+                        'finished': 'Import completed!',
+                        'completed': 'Import completed!',
+                        'failed': 'Import job failed.',
+                        'stopped': 'Import job stopped.',
+                        'errored': 'Import job encountered an error.'
+                    };
+                    messageEl.textContent = statusMessages[statusValue] || `Import status: ${statusValue}`;
+                }
+
+                if (statusValue === 'completed' || statusValue === 'finished') {
+                    console.log('[Import Job Polling] Import completed, fetching updated rows via HTMX...');
+                    pollingStopped = true;
+
+                    const modal = document.getElementById('import-processing-modal');
+                    if (modal && modal._bsModal) {
+                        modal._bsModal.hide();
+                        delete modal._bsModal;
+                    }
+
+                    // Fetch updated rows via HTMX to update the table in place
+                    const resultsUrl = '/plugins/librenms_plugin/device-import/job/' + jobPk + '/results/';
+                    
+                    // Get CSRF token
+                    let csrfToken = getCookie('csrftoken');
+                    if (!csrfToken) {
+                        const csrfInput = document.querySelector('[name=csrfmiddlewaretoken]');
+                        if (csrfInput) {
+                            csrfToken = csrfInput.value;
+                        }
+                    }
+
+                    fetch(resultsUrl, {
+                        method: 'GET',
+                        headers: {
+                            'HX-Request': 'true',
+                            'X-CSRFToken': csrfToken
+                        }
+                    })
+                        .then(response => {
+                            if (!response.ok) {
+                                throw new Error(`HTTP ${response.status}`);
+                            }
+                            return response.text();
+                        })
+                        .then(html => {
+                            if (html.trim()) {
+                                // Parse the HTML and insert/update rows
+                                const parser = new DOMParser();
+                                const doc = parser.parseFromString(html, 'text/html');
+                                const newRows = doc.querySelectorAll('tr[hx-swap-oob="true"]');
+                                
+                                if (newRows.length > 0) {
+                                    console.log(`[Import Job] Updating ${newRows.length} table rows`);
+                                    newRows.forEach(newRow => {
+                                        const rowId = newRow.id;
+                                        if (rowId) {
+                                            const existingRow = document.getElementById(rowId);
+                                            if (existingRow) {
+                                                existingRow.outerHTML = newRow.outerHTML;
+                                            } else {
+                                                // Row not found, might need to append
+                                                const tableBody = document.querySelector('#device-import-table tbody');
+                                                if (tableBody) {
+                                                    tableBody.insertAdjacentHTML('beforeend', newRow.outerHTML);
+                                                }
+                                            }
+                                        }
+                                    });
+                                } else {
+                                    // No OOB rows, check for plain rows
+                                    const plainRows = doc.querySelectorAll('tr[id^="device-row-"]');
+                                    if (plainRows.length > 0) {
+                                        console.log(`[Import Job] Updating ${plainRows.length} plain table rows`);
+                                        plainRows.forEach(newRow => {
+                                            const rowId = newRow.id;
+                                            const existingRow = document.getElementById(rowId);
+                                            if (existingRow) {
+                                                existingRow.outerHTML = newRow.outerHTML;
+                                            }
+                                        });
+                                    } else {
+                                        // No rows found, reload page
+                                        console.log('[Import Job] No updated rows received, reloading page');
+                                        window.location.reload();
+                                    }
+                                }
+                            } else {
+                                // Empty response with HX-Refresh header means reload
+                                console.log('[Import Job] Empty response, reloading page');
+                                window.location.reload();
+                            }
+                        })
+                        .catch(err => {
+                            console.error('[Import Job] Error fetching results:', err);
+                            // Fallback to page reload
+                            window.location.href = '/plugins/librenms_plugin/librenms-import/';
+                        });
+                    return;
+                } else if (statusValue === 'stopped') {
+                    console.log('[Import Job Polling] Import stopped by user');
+                    pollingStopped = true;
+
+                    const modal = document.getElementById('import-processing-modal');
+                    if (modal && modal._bsModal) {
+                        modal._bsModal.hide();
+                        delete modal._bsModal;
+                    }
+
+                    setTimeout(() => window.location.href = '/plugins/librenms_plugin/librenms-import/', 100);
+                } else if (statusValue === 'failed' || statusValue === 'errored') {
+                    console.log('[Import Job Polling] Import failed or errored');
+                    pollingStopped = true;
+
+                    const modal = document.getElementById('import-processing-modal');
+                    if (modal && modal._bsModal) {
+                        modal._bsModal.hide();
+                        delete modal._bsModal;
+                    }
+
+                    const errorMsg = data.data?.error || 'Import job encountered an error.';
+                    alert('Error: ' + errorMsg);
+                    setTimeout(() => window.location.href = '/plugins/librenms_plugin/librenms-import/', 100);
+                } else if (statusValue === 'queued' || statusValue === 'started' || statusValue === 'deferred' || statusValue === 'scheduled') {
+                    // Continue polling
+                    setTimeout(poll, POLL_INTERVAL_MS);
+                } else {
+                    // Unknown status - continue polling
+                    setTimeout(poll, POLL_INTERVAL_MS);
+                }
+            })
+            .catch(err => {
+                // Retry polling on network errors
+                setTimeout(poll, POLL_INTERVAL_MS);
+            });
+    };
+
+    // Start polling
+    poll();
+}
+
 // ============================================
 // FILTER FORM INITIALIZATION
 // ============================================
@@ -1028,6 +1403,75 @@ function initializeHTMXHandlers() {
         const csrfToken = document.querySelector('[name=csrfmiddlewaretoken]');
         if (csrfToken) {
             event.detail.headers['X-CSRFToken'] = csrfToken.value;
+        }
+    });
+
+    // Intercept bulk import responses to handle JSON (background job) vs HTML (synchronous)
+    document.body.addEventListener('htmx:beforeSwap', function (event) {
+        // Only handle bulk import responses
+        if (!event.detail.requestConfig || 
+            !event.detail.requestConfig.path.includes('/device-import/bulk/')) {
+            return;
+        }
+
+        // Check if response is JSON
+        const xhr = event.detail.xhr;
+        const contentType = xhr.getResponseHeader('content-type');
+        
+        if (contentType && contentType.includes('application/json')) {
+            // Prevent default HTMX swap for JSON responses
+            event.detail.shouldSwap = false;
+            
+            try {
+                const data = JSON.parse(xhr.responseText);
+                
+                if (data.job_id && data.job_pk && data.device_count !== undefined) {
+                    // Background job response - start polling
+                    console.log('[Import] Background job enqueued:', data);
+                    
+                    // Show import processing modal
+                    const importModal = document.getElementById('import-processing-modal');
+                    if (!importModal) {
+                        // Create modal dynamically if it doesn't exist
+                        const modalHTML = `
+                            <div class="modal fade" id="import-processing-modal" tabindex="-1" data-bs-backdrop="static" data-bs-keyboard="false">
+                                <div class="modal-dialog modal-dialog-centered">
+                                    <div class="modal-content">
+                                        <div class="modal-header">
+                                            <h5 class="modal-title">Importing Devices</h5>
+                                        </div>
+                                        <div class="modal-body text-center">
+                                            <div class="spinner-border text-primary mb-3" role="status">
+                                                <span class="visually-hidden">Importing...</span>
+                                            </div>
+                                            <p id="import-progress-message">Importing devices...</p>
+                                        </div>
+                                        <div class="modal-footer">
+                                            <button type="button" class="btn btn-warning" id="cancel-import-btn">Cancel Import</button>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        `;
+                        document.body.insertAdjacentHTML('beforeend', modalHTML);
+                    }
+                    
+                    const modal = document.getElementById('import-processing-modal');
+                    const fallbackBackdrop = { element: null };
+                    showModal(modal, fallbackBackdrop);
+                    
+                    // Store reference for cancel button
+                    modal._bsModal = { hide: () => hideModal(modal, fallbackBackdrop) };
+                    
+                    // Start polling
+                    const pollUrl = `/api/core/background-tasks/${data.job_id}/`;
+                    pollImportJobStatus(data.job_id, data.job_pk, pollUrl, data.device_count);
+                } else {
+                    console.warn('[Import] Unexpected JSON response:', data);
+                }
+            } catch (e) {
+                console.error('[Import] Failed to parse JSON response:', e);
+            }
         }
     });
 

--- a/netbox_librenms_plugin/templates/netbox_librenms_plugin/settings.html
+++ b/netbox_librenms_plugin/templates/netbox_librenms_plugin/settings.html
@@ -301,6 +301,72 @@
                                 </div>
                             </div>
                         </div>
+
+                        <!-- Import Job Processing Card -->
+                        <div class="card mb-3">
+                            <div class="card-header">
+                                <h3 class="card-title">
+                                    <i class="ti ti-download me-2"></i>
+                                    Import Job Processing
+                                </h3>
+                            </div>
+                            <div class="card-body">
+                                <p class="text-muted mb-3">
+                                    Configure when device import operations run as background jobs.
+                                </p>
+
+                                <div class="alert alert-info mb-3">
+                                    <p class="small mb-2"><strong>Background job benefits for imports:</strong></p>
+                                    <ul class="mb-0 small" style="padding-left: 1.2rem;">
+                                        <li>Browser remains responsive during large imports</li>
+                                        <li>Job progress tracked in NetBox Jobs table</li>
+                                        <li>Active cancellation of long-running imports</li>
+                                        <li>Error collection without stopping entire import</li>
+                                    </ul>
+                                </div>
+
+                                <div class="row">
+                                    <div class="col-md-6">
+                                        <div class="form-group mb-3">
+                                            <label for="{{ form.import_job_mode.id_for_label }}" class="form-label">
+                                                {{ form.import_job_mode.label }}
+                                            </label>
+                                            {{ form.import_job_mode }}
+                                        </div>
+                                    </div>
+
+                                    <div class="col-md-6">
+                                        <div class="form-group mb-3">
+                                            <label for="{{ form.import_job_threshold.id_for_label }}" class="form-label">
+                                                {{ form.import_job_threshold.label }}
+                                            </label>
+                                            {{ form.import_job_threshold }}
+                                            {% if form.import_job_threshold.help_text %}
+                                                <small class="form-text text-muted d-block">{{ form.import_job_threshold.help_text }}</small>
+                                            {% endif %}
+                                        </div>
+                                    </div>
+
+                                    <div class="col-12">
+                                        <div class="alert alert-warning mb-0">
+                                            <div class="d-flex">
+                                                <div>
+                                                    <i class="ti ti-alert-triangle me-2"></i>
+                                                </div>
+                                                <div>
+                                                    <strong>Note:</strong> Setting mode to "Never" will cause browser blocking during large imports.
+                                                    <ul class="mb-0 mt-2">
+                                                        <li>Import operations run even when you browse away from the page</li>
+                                                        <li>Large imports cannot be cancelled once started</li>
+                                                        <li>Recommended to use "Threshold" mode for flexibility</li>
+                                                    </ul>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
                     </div>
                 </div>
 
@@ -337,10 +403,14 @@ document.addEventListener('DOMContentLoaded', function() {
     const stripDomainCheckbox = document.getElementById('id_strip_domain_default');
     const backgroundJobModeSelect = document.getElementById('id_background_job_mode');
     const backgroundJobThresholdInput = document.getElementById('id_background_job_threshold');
+    const importJobModeSelect = document.getElementById('id_import_job_mode');
+    const importJobThresholdInput = document.getElementById('id_import_job_threshold');
     const initialUseSysnameValue = useSysnameCheckbox ? useSysnameCheckbox.checked : true;
     const initialStripDomainValue = stripDomainCheckbox ? stripDomainCheckbox.checked : false;
     const initialBackgroundJobModeValue = backgroundJobModeSelect ? backgroundJobModeSelect.value : '';
     const initialBackgroundJobThresholdValue = backgroundJobThresholdInput ? backgroundJobThresholdInput.value : '';
+    const initialImportJobModeValue = importJobModeSelect ? importJobModeSelect.value : '';
+    const initialImportJobThresholdValue = importJobThresholdInput ? importJobThresholdInput.value : '';
 
     // Enable/disable server save button based on changes
     function updateServerSaveButton() {
@@ -363,7 +433,9 @@ document.addEventListener('DOMContentLoaded', function() {
         const stripDomainChanged = stripDomainCheckbox ? (stripDomainCheckbox.checked !== initialStripDomainValue) : false;
         const backgroundJobModeChanged = backgroundJobModeSelect ? (backgroundJobModeSelect.value !== initialBackgroundJobModeValue) : false;
         const backgroundJobThresholdChanged = backgroundJobThresholdInput ? (backgroundJobThresholdInput.value !== initialBackgroundJobThresholdValue) : false;
-        const hasChanges = vcPatternChanged || useSysnameChanged || stripDomainChanged || backgroundJobModeChanged || backgroundJobThresholdChanged;
+        const importJobModeChanged = importJobModeSelect ? (importJobModeSelect.value !== initialImportJobModeValue) : false;
+        const importJobThresholdChanged = importJobThresholdInput ? (importJobThresholdInput.value !== initialImportJobThresholdValue) : false;
+        const hasChanges = vcPatternChanged || useSysnameChanged || stripDomainChanged || backgroundJobModeChanged || backgroundJobThresholdChanged || importJobModeChanged || importJobThresholdChanged;
         saveImportBtn.disabled = !hasChanges;
 
         if (hasChanges) {
@@ -382,6 +454,8 @@ document.addEventListener('DOMContentLoaded', function() {
     if (stripDomainCheckbox) stripDomainCheckbox.addEventListener('change', updateImportSaveButton);
     if (backgroundJobModeSelect) backgroundJobModeSelect.addEventListener('change', updateImportSaveButton);
     if (backgroundJobThresholdInput) backgroundJobThresholdInput.addEventListener('input', updateImportSaveButton);
+    if (importJobModeSelect) importJobModeSelect.addEventListener('change', updateImportSaveButton);
+    if (importJobThresholdInput) importJobThresholdInput.addEventListener('input', updateImportSaveButton);
 
     // Initialize button states
     updateServerSaveButton();

--- a/netbox_librenms_plugin/urls.py
+++ b/netbox_librenms_plugin/urls.py
@@ -28,6 +28,7 @@ from .views import (
     InterfaceTypeMappingView,
     LibreNMSImportView,
     LibreNMSSettingsView,
+    LoadImportJobResultsView,
     SingleCableVerifyView,
     SingleInterfaceVerifyView,
     SingleIPAddressVerifyView,
@@ -198,6 +199,11 @@ urlpatterns = [
         "device-import/bulk/confirm/",
         BulkImportConfirmView.as_view(),
         name="bulk_import_confirm",
+    ),
+    path(
+        "device-import/job/<int:job_id>/results/",
+        LoadImportJobResultsView.as_view(),
+        name="load_import_job_results",
     ),
     path(
         "device-import/validation/<str:device_id>/",

--- a/netbox_librenms_plugin/views/__init__.py
+++ b/netbox_librenms_plugin/views/__init__.py
@@ -15,6 +15,7 @@ from .imports import (
     DeviceValidationDetailsView,
     DeviceVCDetailsView,
     LibreNMSImportView,
+    LoadImportJobResultsView,
 )
 from .mapping_views import (
     InterfaceTypeMappingBulkDeleteView,

--- a/netbox_librenms_plugin/views/imports/__init__.py
+++ b/netbox_librenms_plugin/views/imports/__init__.py
@@ -8,6 +8,7 @@ from .actions import (  # noqa: F401
     DeviceRoleUpdateView,
     DeviceValidationDetailsView,
     DeviceVCDetailsView,
+    LoadImportJobResultsView,
 )
 from .list import LibreNMSImportView  # noqa: F401
 
@@ -20,4 +21,5 @@ __all__ = [
     "DeviceValidationDetailsView",
     "DeviceVCDetailsView",
     "LibreNMSImportView",
+    "LoadImportJobResultsView",
 ]


### PR DESCRIPTION
Features:

- New ImportDevicesJob for bulk import operations
- Configurable import job mode (always/never/threshold)
- Default threshold of 5 devices for background processing
- Job polling with cancellation support in frontend
- Per-device error collection without stopping import
- Progress logging during background execution

Implementation:

- Split bulk_import_devices into shared/public variants
- Added import_job_mode and import_job_threshold to LibreNMSSettings
- Enhanced JavaScript polling for import job status
- Added LoadImportJobResultsView for result display
- Updated settings UI with import job configuration
- Job stores imported device/VM PKs and LibreNMS IDs for re-rendering