### PR TITLE
Add hardware filter to LibreNMS device import

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -12,7 +12,7 @@ The plugin offers the following key features:
 
 Search and import devices from LibreNMS into NetBox with comprehensive validation and control:
 
-* Filter devices by location, type, OS, hostname, or system name
+* Filter devices by location, type, OS, hostname, system name, or hardware model
 * Validate import prerequisites (Site, Device Type, Device Role)
 * Smart matching for Sites, Device Types, and Platforms
 * Import as physical Devices or Virtual Machines

--- a/docs/librenms_import/overview.md
+++ b/docs/librenms_import/overview.md
@@ -18,7 +18,7 @@ The plugin validates all required NetBox objects (Site, Device Type, Device Role
 ## Key Features
 
 **Flexible Filtering**
-: Search by location, type, operating system, hostname, or system name. Combine filters for precise device selection.
+: Search by location, type, operating system, hostname, system name, or hardware model. Combine filters for precise device selection.
 
 **Smart Validation**
 : Automatic matching for Sites, Device Types, and Platforms based on LibreNMS data. Clear indicators for what's missing.

--- a/docs/librenms_import/search.md
+++ b/docs/librenms_import/search.md
@@ -17,6 +17,9 @@ LibreNMS Hostname
 LibreNMS System Name
 : When used alone, performs an exact match on the SNMP sysName. When combined with other filters, performs a partial match.
 
+Hardware
+: Partial match by LibreNMS hardware model. For example, "C9300" matches devices with hardware like "Cisco C9300-48P".
+
 ## Additional Search Options
 
 Include Disabled Devices
@@ -56,6 +59,12 @@ Type: network
 ```
 Type: network
 OS: ios
+```
+
+**Find specific hardware model**
+```
+Hardware: C9300
+Type: network
 ```
 
 **Find a specific device by name**

--- a/netbox_librenms_plugin/forms.py
+++ b/netbox_librenms_plugin/forms.py
@@ -442,6 +442,12 @@ class LibreNMSImportFilterForm(forms.Form):
         widget=forms.TextInput(attrs={"placeholder": "Exact or partial sysName match"}),
         help_text="SNMP sysName. (exact match only; combine with another filter for partial matching)",
     )
+    librenms_hardware = forms.CharField(
+        required=False,
+        label="Hardware",
+        widget=forms.TextInput(attrs={"placeholder": "e.g., C9300-48P, ASR-920"}),
+        help_text="LibreNMS hardware model (partial match)",
+    )
     show_disabled = forms.BooleanField(
         required=False,
         initial=False,
@@ -494,6 +500,7 @@ class LibreNMSImportFilterForm(forms.Form):
                 "librenms_os",
                 "librenms_hostname",
                 "librenms_sysname",
+                "librenms_hardware",
             ]
             has_filters = any(data.get(field) for field in filter_fields)
 
@@ -521,6 +528,7 @@ class LibreNMSImportFilterForm(forms.Form):
                 "librenms_os",
                 "librenms_hostname",
                 "librenms_sysname",
+                "librenms_hardware",
             )
 
             if not any(cleaned_data.get(field) for field in filter_fields):

--- a/netbox_librenms_plugin/templates/netbox_librenms_plugin/librenms_import.html
+++ b/netbox_librenms_plugin/templates/netbox_librenms_plugin/librenms_import.html
@@ -142,6 +142,13 @@
                       <small class="form-text text-muted">{{ filter_form.librenms_sysname.help_text }}</small>
                     {% endif %}
                   </div>
+                  <div class="col-md-6">
+                    <label for="{{ filter_form.librenms_hardware.id_for_label }}" class="form-label">{{ filter_form.librenms_hardware.label }}</label>
+                    {{ filter_form.librenms_hardware }}
+                    {% if filter_form.librenms_hardware.help_text %}
+                      <small class="form-text text-muted">{{ filter_form.librenms_hardware.help_text }}</small>
+                    {% endif %}
+                  </div>
                 </div>
                 <div class="row mb-3">
                   <div class="col-md-6">

--- a/netbox_librenms_plugin/views/imports/list.py
+++ b/netbox_librenms_plugin/views/imports/list.py
@@ -136,6 +136,7 @@ class LibreNMSImportView(LibreNMSAPIMixin, generic.ObjectListView):
             "librenms_os",
             "librenms_hostname",
             "librenms_sysname",
+            "librenms_hardware",
         )
         filters_present = any(request.GET.get(field) for field in libre_filter_fields)
         filters_submitted = request.GET.get("apply_filters") or filters_present
@@ -215,6 +216,8 @@ class LibreNMSImportView(LibreNMSAPIMixin, generic.ObjectListView):
                 libre_filters["hostname"] = hostname
             if sysname := request.GET.get("librenms_sysname"):
                 libre_filters["sysname"] = sysname
+            if hardware := request.GET.get("librenms_hardware"):
+                libre_filters["hardware"] = hardware
 
             # Check if data is already cached before deciding on background job
             # This prevents creating a job when cached results are available
@@ -388,6 +391,8 @@ class LibreNMSImportView(LibreNMSAPIMixin, generic.ObjectListView):
             libre_filters["hostname"] = hostname
         if sysname := data_source.get("librenms_sysname"):
             libre_filters["sysname"] = sysname
+        if hardware := data_source.get("librenms_hardware"):
+            libre_filters["hardware"] = hardware
 
         self._libre_filters = libre_filters
 


### PR DESCRIPTION
- Added librenms_hardware form field to import filter form
- Integrated hardware filtering across forms, views, and import utils
- Updated template to display hardware field next to sysname field
- Added client-side filtering for partial hardware model matching
- Updated documentation to include hardware filter in all references