### PR TITLE
Add cached search management and code cleanup

### DIFF
--- a/netbox_librenms_plugin/forms.py
+++ b/netbox_librenms_plugin/forms.py
@@ -562,12 +562,12 @@ class LibreNMSImportFilterForm(forms.Form):
             success, locations = api.get_locations()
 
             if success and locations:
-                # Build choices list: (id, "name (id)")
+                # Build choices list: (id, name)
                 choices = [("", "All Locations")]
                 for loc in locations:
                     loc_id = str(loc.get("id", ""))
                     loc_name = loc.get("location", f"Location {loc_id}")
-                    choices.append((loc_id, f"{loc_name} (ID: {loc_id})"))
+                    choices.append((loc_id, loc_name))
 
                 # Sort by name
                 choices[1:] = sorted(choices[1:], key=lambda x: x[1])

--- a/netbox_librenms_plugin/tables/device_status.py
+++ b/netbox_librenms_plugin/tables/device_status.py
@@ -108,7 +108,11 @@ class DeviceImportTable(tables.Table):
             return
 
         # Get the ordering field and direction
-        order_by = self.order_by[0] if isinstance(self.order_by, (list, tuple)) else self.order_by
+        order_by = (
+            self.order_by[0]
+            if isinstance(self.order_by, (list, tuple))
+            else self.order_by
+        )
         reverse = order_by.startswith("-")
         field = order_by.lstrip("-")
 
@@ -266,7 +270,7 @@ class DeviceImportTable(tables.Table):
             "plugins:netbox_librenms_plugin:device_cluster_update",
             kwargs={"device_id": device_id},
         )
-        
+
         # Include VC detection flag in URL if present in validation (from initial load)
         vc_detection_flag = ""
         if validation.get("_vc_detection_enabled"):
@@ -336,7 +340,7 @@ class DeviceImportTable(tables.Table):
             "plugins:netbox_librenms_plugin:device_role_update",
             kwargs={"device_id": device_id},
         )
-        
+
         # Include VC detection flag in URL if present in validation (from initial load)
         vc_detection_flag = ""
         if validation.get("_vc_detection_enabled"):
@@ -414,7 +418,7 @@ class DeviceImportTable(tables.Table):
             "plugins:netbox_librenms_plugin:device_rack_update",
             kwargs={"device_id": device_id},
         )
-        
+
         # Include VC detection flag in URL if present in validation (from initial load)
         vc_detection_flag = ""
         if validation.get("_vc_detection_enabled"):
@@ -530,8 +534,6 @@ class DeviceImportTable(tables.Table):
     def render_virtual_chassis(self, value, record):
         """Render Virtual Chassis status and details button."""
         validation = record.get("_validation", {})
-        if validation.get("_vc_detection_skipped"):
-            return mark_safe('<span class="text-muted">Not requested</span>')
         vc_data = validation.get("virtual_chassis", {})
         device_id = record.get("device_id")
 
@@ -603,7 +605,7 @@ class DeviceImportTable(tables.Table):
         ).get("role"):
             role_id = validation["device_role"]["role"].id
             params.append(f"role_id={role_id}")
-        
+
         # Add VC detection flag if it was enabled during initial load
         if validation.get("_vc_detection_enabled"):
             params.append("enable_vc_detection=true")

--- a/netbox_librenms_plugin/templates/netbox_librenms_plugin/librenms_import.html
+++ b/netbox_librenms_plugin/templates/netbox_librenms_plugin/librenms_import.html
@@ -225,6 +225,48 @@
     </div>
   {% endif %}
 
+  {# Cached Searches Section #}
+  {% if cached_searches %}
+  <div class="card mb-3">
+    <div class="card-header d-flex justify-content-between align-items-center">
+      <h6 class="card-title mb-0">
+        Active Cached Searches
+        <span id="cached-searches-badge">{% badge cached_searches|length bg_color="primary" %}</span>
+      </h6>
+      <button class="btn btn-sm btn-outline-secondary" type="button" data-bs-toggle="collapse" data-bs-target="#cached-searches-collapse" aria-expanded="true" aria-controls="cached-searches-collapse">
+        <i class="mdi mdi-clock-fast"></i> Toggle Cached Searches
+      </button>
+    </div>
+    <div class="collapse show" id="cached-searches-collapse">
+      <div class="card-body p-2">
+        <div class="d-flex flex-wrap gap-2">
+          {% for search in cached_searches %}
+            <a href="?apply_filters=1{% for key, value in search.filters.items %}&librenms_{{ key }}={{ value|urlencode }}{% endfor %}{% if search.vc_enabled %}&enable_vc_detection=1{% endif %}"
+               class="btn btn-sm btn-outline-secondary"
+               style="text-decoration: none;"
+               title="Click to load this cached search">
+              <i class="mdi mdi-filter-outline"></i>
+              {% with display_data=search.display_filters|default:search.filters %}
+                {% for key, value in display_data.items %}
+                  {% if not forloop.first %} <span class="text-muted">|</span> {% endif %}
+                  {{ value }}
+                {% endfor %}
+              {% endwith %}
+              {% if search.vc_enabled %}
+                <span class="text-muted">| VC</span>
+              {% endif %}
+              <span class="text-muted ms-2">({{ search.device_count }} devices, <span class="cached-search-countdown" data-cache-timestamp="{{ search.cached_at }}" data-cache-timeout="{{ search.cache_timeout }}">{{ search.remaining_seconds }}s</span> left)</span>
+            </a>
+          {% endfor %}
+        </div>
+        <small class="text-muted d-block mt-2">
+          <i class="mdi mdi-information-outline"></i> Click any cached search to load those results again.
+        </small>
+      </div>
+    </div>
+  </div>
+  {% endif %}
+
   {# Applied filters #}
   {% if filter_form %}
     {% applied_filters model filter_form request.GET %}
@@ -259,14 +301,6 @@
         </p>
     </div>
   {% else %}
-    {% if vc_detection_skipped and filters_submitted %}
-      <div class="alert alert-info alert-dismissible fade show mb-3" role="alert">
-        <i class="mdi mdi-progress-clock"></i>
-        Virtual chassis detection is disabled for this search (default). Selecting a role from the drop down will trigger a virtual chassis check for that device.
-        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
-      </div>
-    {% endif %}
-
     {# Bulk import toolbar #}
     <div class="d-flex justify-content-between align-items-center flex-wrap gap-2 mb-3">
       <div class="d-flex align-items-center gap-2 flex-wrap">


### PR DESCRIPTION
- Add get_active_cached_searches() to list and manage cached filter results
- Display active cached searches in UI with countdown timers and quick reload
- Track cache metadata including filters, device count, and expiration time
- Simplify location choices display (remove redundant ID suffix)
- Remove debug console.log statements from JavaScript
- Clean up VC detection UI (remove redundant 'skipped' messaging)
- Improve code formatting and organization across multiple files