### PR TITLE
Refactor settings page: replace fetch with HTMX and simplify JavaScript

### DIFF
--- a/netbox_librenms_plugin/models.py
+++ b/netbox_librenms_plugin/models.py
@@ -20,7 +20,7 @@ class LibreNMSSettings(models.Model):
         max_length=100,
         default="-M{position}",
         help_text="Pattern for naming virtual chassis member devices. "
-        "Available placeholders: {master_name}, {position}, {serial}. "
+        "Available placeholders: {position}, {serial}. "
         "Example: '-M{position}' results in 'switch01-M2'",
     )
 

--- a/netbox_librenms_plugin/templates/netbox_librenms_plugin/settings.html
+++ b/netbox_librenms_plugin/templates/netbox_librenms_plugin/settings.html
@@ -18,7 +18,7 @@
 {% endblock tabs %}
 
 {% block content %}
-    <div class="tab-content">
+    <div class="tab-content" data-active-tab="{{ active_tab|default:'' }}">
         <!-- Server Config Tab -->
         <div class="tab-pane fade show active" id="config" role="tabpanel" aria-labelledby="config-tab">
             <form action="" method="post" class="form" enctype="multipart/form-data">
@@ -40,7 +40,7 @@
                                         Configure which LibreNMS server to use for synchronization operations.
                                         Multiple servers can be configured in the NetBox configuration file.
                                     </p>
-                                    {% render_field form.selected_server %}
+                                    {% render_field server_form.selected_server %}
                                 </div>
                                 <div class="text-end mt-auto">
                                     <button type="submit" id="save-server-btn" class="btn btn-primary" disabled>
@@ -64,11 +64,16 @@
                                 <p class="text-muted mb-3">Test the connection to the selected LibreNMS server to verify configuration.</p>
                                 <button type="button"
                                         id="test-connection-btn"
-                                        class="btn btn-outline-info w-100">
+                                        class="btn btn-outline-info w-100"
+                                        hx-post="{% url 'plugins:netbox_librenms_plugin:test_connection' %}"
+                                        hx-target="#test-result"
+                                        hx-swap="innerHTML"
+                                        hx-include="[name='selected_server']">
                                     <i class="ti ti-network me-1"></i> Test Connection
+                                    <span class="spinner-border spinner-border-sm ms-1 htmx-indicator" role="status" style="display: none;"></span>
                                 </button>
                                 <!-- Test result area -->
-                                <div id="test-result" class="mt-3 d-none"></div>
+                                <div id="test-result" class="mt-3"></div>
                             </div>
                         </div>
                     </div>
@@ -134,7 +139,6 @@
             <form action="" method="post" class="form" enctype="multipart/form-data">
                 {% csrf_token %}
                 <input type="hidden" name="form_type" value="import_settings">
-                <input type="hidden" name="selected_server" value="{{ form.selected_server.value }}">
 
                 <div class="row justify-content-start">
                     <!-- Left Column: Device Naming and Virtual Chassis -->
@@ -156,24 +160,24 @@
                                     <div class="col-12">
                                         <div class="form-group mb-3">
                                             <div class="form-check form-switch">
-                                                {{ form.use_sysname_default }}
-                                                <label class="form-check-label" for="{{ form.use_sysname_default.id_for_label }}">
-                                                    {{ form.use_sysname_default.label }}
+                                                {{ import_form.use_sysname_default }}
+                                                <label class="form-check-label" for="{{ import_form.use_sysname_default.id_for_label }}">
+                                                    {{ import_form.use_sysname_default.label }}
                                                 </label>
-                                                {% if form.use_sysname_default.help_text %}
-                                                    <small class="form-text text-muted d-block">{{ form.use_sysname_default.help_text }}</small>
+                                                {% if import_form.use_sysname_default.help_text %}
+                                                    <small class="form-text text-muted d-block">{{ import_form.use_sysname_default.help_text }}</small>
                                                 {% endif %}
                                             </div>
                                         </div>
 
                                         <div class="form-group mb-3">
                                             <div class="form-check form-switch">
-                                                {{ form.strip_domain_default }}
-                                                <label class="form-check-label" for="{{ form.strip_domain_default.id_for_label }}">
-                                                    {{ form.strip_domain_default.label }}
+                                                {{ import_form.strip_domain_default }}
+                                                <label class="form-check-label" for="{{ import_form.strip_domain_default.id_for_label }}">
+                                                    {{ import_form.strip_domain_default.label }}
                                                 </label>
-                                                {% if form.strip_domain_default.help_text %}
-                                                    <small class="form-text text-muted d-block">{{ form.strip_domain_default.help_text }}</small>
+                                                {% if import_form.strip_domain_default.help_text %}
+                                                    <small class="form-text text-muted d-block">{{ import_form.strip_domain_default.help_text }}</small>
                                                 {% endif %}
                                             </div>
                                         </div>
@@ -199,10 +203,15 @@
                                 <div class="row">
                                     <div class="col-12">
                                         <div class="form-group mb-3">
-                                            <label for="{{ form.vc_member_name_pattern.id_for_label }}" class="form-label">
-                                                {{ form.vc_member_name_pattern.label }}
+                                            <label for="{{ import_form.vc_member_name_pattern.id_for_label }}" class="form-label">
+                                                {{ import_form.vc_member_name_pattern.label }}
                                             </label>
-                                            {{ form.vc_member_name_pattern }}
+                                            {{ import_form.vc_member_name_pattern }}
+                                            {% if import_form.vc_member_name_pattern.errors %}
+                                                <div class="invalid-feedback d-block">
+                                                    {{ import_form.vc_member_name_pattern.errors }}
+                                                </div>
+                                            {% endif %}
                                         </div>
                                     </div>
                                 </div>
@@ -210,11 +219,12 @@
                                 <div class="row">
                                     <div class="col-12">
                                         <div class="alert alert-info mb-0">
-                                            <p class="small mb-2">Available placeholders (at least one required):</p>
+                                            <p class="small mb-2"><strong>Available placeholders:</strong></p>
                                             <ul class="mb-3 small" style="padding-left: 1.2rem;">
                                                 <li><code>{position}</code> - VC position number</li>
                                                 <li><code>{serial}</code> - Member serial number</li>
                                             </ul>
+                                            <p class="small mb-0"><strong>Note:</strong> The pattern is appended to the master device name. At least one placeholder is required to ensure each member gets a unique name.</p>
                                         </div>
                                     </div>
                                 </div>
@@ -254,18 +264,40 @@
 
 <script>
 document.addEventListener('DOMContentLoaded', function() {
-    const testBtn = document.getElementById('test-connection-btn');
-    const testResult = document.getElementById('test-result');
+    // Auto-select the correct tab if there was a validation error
+    // Uses the same pattern as librenms_sync.js for consistency
+    const tabContent = document.querySelector('.tab-content');
+    const activeTab = tabContent ? tabContent.dataset.activeTab : '';
+
+    if (activeTab === 'import_settings') {
+        const importTab = document.getElementById('import-settings-tab');
+        const importPane = document.getElementById('import-settings');
+        const configTab = document.getElementById('config-tab');
+        const configPane = document.getElementById('config');
+
+        if (importTab && importPane && configTab && configPane) {
+            // Deactivate config tab
+            configTab.classList.remove('active');
+            configTab.setAttribute('aria-selected', 'false');
+            configPane.classList.remove('show', 'active');
+
+            // Activate import settings tab
+            importTab.classList.add('active');
+            importTab.setAttribute('aria-selected', 'true');
+            importPane.classList.add('show', 'active');
+        }
+    }
+
     const serverSelect = document.getElementById('id_selected_server');
     const vcPatternInput = document.getElementById('id_vc_member_name_pattern');
     const saveServerBtn = document.getElementById('save-server-btn');
     const saveImportBtn = document.getElementById('save-import-btn');
+    const useSysnameCheckbox = document.getElementById('id_use_sysname_default');
+    const stripDomainCheckbox = document.getElementById('id_strip_domain_default');
 
     // Store the initial values to detect changes
     const initialServerValue = serverSelect.value;
     const initialVcPatternValue = vcPatternInput.value;
-    const useSysnameCheckbox = document.getElementById('id_use_sysname_default');
-    const stripDomainCheckbox = document.getElementById('id_strip_domain_default');
     const initialUseSysnameValue = useSysnameCheckbox ? useSysnameCheckbox.checked : true;
     const initialStripDomainValue = stripDomainCheckbox ? stripDomainCheckbox.checked : false;
 
@@ -273,14 +305,8 @@ document.addEventListener('DOMContentLoaded', function() {
     function updateServerSaveButton() {
         const hasChanges = serverSelect.value !== initialServerValue;
         saveServerBtn.disabled = !hasChanges;
-
-        if (hasChanges) {
-            saveServerBtn.classList.remove('btn-secondary');
-            saveServerBtn.classList.add('btn-primary');
-        } else {
-            saveServerBtn.classList.remove('btn-primary');
-            saveServerBtn.classList.add('btn-secondary');
-        }
+        saveServerBtn.classList.toggle('btn-primary', hasChanges);
+        saveServerBtn.classList.toggle('btn-secondary', !hasChanges);
     }
 
     // Enable/disable import save button based on changes
@@ -290,14 +316,8 @@ document.addEventListener('DOMContentLoaded', function() {
         const stripDomainChanged = stripDomainCheckbox ? (stripDomainCheckbox.checked !== initialStripDomainValue) : false;
         const hasChanges = vcPatternChanged || useSysnameChanged || stripDomainChanged;
         saveImportBtn.disabled = !hasChanges;
-
-        if (hasChanges) {
-            saveImportBtn.classList.remove('btn-secondary');
-            saveImportBtn.classList.add('btn-primary');
-        } else {
-            saveImportBtn.classList.remove('btn-primary');
-            saveImportBtn.classList.add('btn-secondary');
-        }
+        saveImportBtn.classList.toggle('btn-primary', hasChanges);
+        saveImportBtn.classList.toggle('btn-secondary', !hasChanges);
     }
 
     // Listen for changes on respective form fields
@@ -309,62 +329,6 @@ document.addEventListener('DOMContentLoaded', function() {
     // Initialize button states
     updateServerSaveButton();
     updateImportSaveButton();
-
-    testBtn.addEventListener('click', function() {
-        const selectedServer = serverSelect.value;
-
-        if (!selectedServer) {
-            showTestResult('error', 'Please select a server first.');
-            return;
-        }
-
-        // Disable button and show loading state
-        testBtn.disabled = true;
-        testBtn.innerHTML = '<span class="spinner-border spinner-border-sm me-1" role="status"></span> Testing...';
-
-        // Clear previous results
-        testResult.classList.add('d-none');
-
-        // Make AJAX request
-        fetch('{% url "plugins:netbox_librenms_plugin:test_connection" %}', {
-            method: 'POST',
-            headers: {
-                'Content-Type': 'application/json',
-                'X-CSRFToken': '{{ csrf_token }}'
-            },
-            body: JSON.stringify({
-                'server_key': selectedServer
-            })
-        })
-        .then(response => response.json())
-        .then(data => {
-            if (data.success) {
-                let message = `<strong>Connection successful!</strong><br>`;
-                if (data.system_info) {
-                    message += `LibreNMS Version: ${data.system_info.version}<br>`;
-                    message += `Database: ${data.system_info.database}<br>`;
-                    message += `PHP Version: ${data.system_info.php_version}`;
-                }
-                showTestResult('success', message);
-            } else {
-                showTestResult('error', `<strong>Connection failed:</strong><br>${data.error || 'Unknown error'}`);
-            }
-        })
-        .catch(error => {
-            showTestResult('error', `<strong>Network error:</strong><br>${error.message}`);
-        })
-        .finally(() => {
-            // Re-enable button
-            testBtn.disabled = false;
-            testBtn.innerHTML = '<i class="ti ti-network me-1"></i> Test Connection';
-        });
-    });
-
-    function showTestResult(type, message) {
-        testResult.className = `mt-2 alert alert-${type === 'success' ? 'success' : 'danger'}`;
-        testResult.innerHTML = message;
-        testResult.classList.remove('d-none');
-    }
 });
-    </script>
+</script>
 {% endblock %}

--- a/netbox_librenms_plugin/views/imports/list.py
+++ b/netbox_librenms_plugin/views/imports/list.py
@@ -312,13 +312,7 @@ class LibreNMSImportView(LibreNMSAPIMixin, generic.ObjectListView):
 
         # Load settings for import defaults
         try:
-            settings, _ = LibreNMSSettings.objects.get_or_create(
-                defaults={
-                    "selected_server": "default",
-                    "use_sysname_default": True,
-                    "strip_domain_default": False,
-                }
-            )
+            settings, _ = LibreNMSSettings.objects.get_or_create()
         except Exception:
             settings = None
 

--- a/netbox_librenms_plugin/views/settings_views.py
+++ b/netbox_librenms_plugin/views/settings_views.py
@@ -1,123 +1,117 @@
-import json
-
 from django.contrib import messages
-from django.http import JsonResponse
+from django.contrib.auth.mixins import PermissionRequiredMixin
+from django.http import HttpResponse
 from django.shortcuts import redirect, render
 from django.views import View
 
-from netbox_librenms_plugin.forms import LibreNMSSettingsForm
+from netbox_librenms_plugin.forms import ImportSettingsForm, ServerConfigForm
 from netbox_librenms_plugin.librenms_api import LibreNMSAPI
 from netbox_librenms_plugin.models import LibreNMSSettings
 
 
-class LibreNMSSettingsView(View):
+class LibreNMSSettingsView(PermissionRequiredMixin, View):
     """
     View for managing plugin settings including server selection and import options.
+    Uses two separate forms for cleaner validation and separation of concerns.
     """
 
+    permission_required = "netbox_librenms_plugin.change_librenmssettings"
     template_name = "netbox_librenms_plugin/settings.html"
 
     def get(self, request):
-        """Display the settings form."""
+        """Display both settings forms."""
         # Get or create the settings object
-        settings, created = LibreNMSSettings.objects.get_or_create(
-            defaults={"selected_server": "default"}
-        )
+        settings, created = LibreNMSSettings.objects.get_or_create()
 
-        form = LibreNMSSettingsForm(instance=settings)
+        # Instantiate both forms
+        server_form = ServerConfigForm(instance=settings)
+        import_form = ImportSettingsForm(instance=settings)
 
         return render(
             request,
             self.template_name,
             {
-                "form": form,
+                "server_form": server_form,
+                "import_form": import_form,
                 "object": settings,
             },
         )
 
     def post(self, request):
-        """Handle form submission."""
+        """Handle form submission - process the appropriate form based on form_type."""
         # Get or create the settings object
-        settings, created = LibreNMSSettings.objects.get_or_create(
-            defaults={"selected_server": "default"}
-        )
+        settings, created = LibreNMSSettings.objects.get_or_create()
 
         # Determine which form was submitted
         form_type = request.POST.get("form_type")
 
-        # Create a mutable copy of POST data to handle partial form submissions
-        post_data = request.POST.copy()
+        if form_type == "server_config":
+            # Process server configuration form
+            server_form = ServerConfigForm(request.POST, instance=settings)
+            import_form = ImportSettingsForm(
+                instance=settings
+            )  # Unbound form for display
 
-        form = LibreNMSSettingsForm(post_data, instance=settings)
-
-        # Run validation first
-        form.is_valid()
-
-        # For import_settings form, we don't need to validate selected_server
-        # as it's not being changed. Clear any validation errors for that field.
-        if form_type == "import_settings":
-            # Clear selected_server errors since we're not updating it
-            if "selected_server" in form.errors:
-                del form.errors["selected_server"]
-
-        # Check if form is valid (after potentially clearing selected_server errors)
-        has_errors = bool(form.errors)
-
-        if not has_errors:
-            # Only update the relevant field based on form_type
-            if form_type == "server_config":
-                settings.selected_server = form.cleaned_data["selected_server"]
-                settings.save()
+            if server_form.is_valid():
+                server_form.save()
                 messages.success(
                     request,
-                    f"LibreNMS server settings updated successfully. Active server: {form.cleaned_data['selected_server']}",
+                    f"LibreNMS server settings updated successfully. Active server: {server_form.cleaned_data['selected_server']}",
                 )
-            elif form_type == "import_settings":
-                settings.vc_member_name_pattern = form.cleaned_data[
-                    "vc_member_name_pattern"
-                ]
-                settings.use_sysname_default = form.cleaned_data["use_sysname_default"]
-                settings.strip_domain_default = form.cleaned_data[
-                    "strip_domain_default"
-                ]
-                settings.save()
+                return redirect("plugins:netbox_librenms_plugin:settings")
+
+        elif form_type == "import_settings":
+            # Process import settings form
+            server_form = ServerConfigForm(
+                instance=settings
+            )  # Unbound form for display
+            import_form = ImportSettingsForm(request.POST, instance=settings)
+
+            if import_form.is_valid():
+                import_form.save()
                 messages.success(
                     request,
                     "Import settings updated successfully.",
                 )
-            else:
-                # Fallback: save all fields if form_type not specified
-                form.save()
-                messages.success(request, "Settings updated successfully.")
+                return redirect("plugins:netbox_librenms_plugin:settings")
 
+        else:
+            # Unknown form_type - shouldn't happen, but handle gracefully
+            messages.error(request, "Invalid form submission.")
             return redirect("plugins:netbox_librenms_plugin:settings")
 
+        # If we get here, validation failed - render both forms
         return render(
             request,
             self.template_name,
             {
-                "form": form,
+                "server_form": server_form,
+                "import_form": import_form,
                 "object": settings,
+                "active_tab": form_type,  # Pass which tab should be active
             },
         )
 
 
 class TestLibreNMSConnectionView(View):
     """
-    AJAX view to test LibreNMS server connection.
+    HTMX view to test LibreNMS server connection.
+    Returns HTML fragment instead of JSON for HTMX compatibility.
     """
 
     def post(self, request):
         """Test connection to selected LibreNMS server."""
+        server_key = request.POST.get("selected_server")
+
+        if not server_key:
+            return HttpResponse(
+                '<div class="alert alert-warning">'
+                '<i class="ti ti-alert-circle me-2"></i>'
+                "<strong>No server selected.</strong> Please select a server first."
+                "</div>"
+            )
+
         try:
-            data = json.loads(request.body)
-            server_key = data.get("server_key")
-
-            if not server_key:
-                return JsonResponse(
-                    {"success": False, "error": "No server key provided"}, status=400
-                )
-
             # Initialize LibreNMS API client
             api_client = LibreNMSAPI(server_key=server_key)
 
@@ -125,34 +119,47 @@ class TestLibreNMSConnectionView(View):
             system_info = api_client.test_connection()
 
             if system_info and not system_info.get("error"):
-                return JsonResponse(
-                    {
-                        "success": True,
-                        "message": "Connection successful!",
-                        "system_info": {
-                            "version": system_info.get("local_ver", "Unknown"),
-                            "database": system_info.get("database_ver", "Unknown"),
-                            "php_version": system_info.get("php_ver", "Unknown"),
-                        },
-                    }
+                version = system_info.get("local_ver", "Unknown")
+                database = system_info.get("database_ver", "Unknown")
+                php_version = system_info.get("php_ver", "Unknown")
+
+                return HttpResponse(
+                    f'<div class="alert alert-success">'
+                    f'<i class="ti ti-check me-2"></i>'
+                    f"<strong>Connection successful!</strong><br>"
+                    f"LibreNMS Version: {version}<br>"
+                    f"Database: {database}<br>"
+                    f"PHP Version: {php_version}"
+                    f"</div>"
                 )
             elif system_info and system_info.get("error"):
-                return JsonResponse(
-                    {
-                        "success": False,
-                        "error": system_info.get("message", "Unknown error occurred"),
-                    }
+                error_msg = system_info.get("message", "Unknown error occurred")
+                return HttpResponse(
+                    f'<div class="alert alert-danger">'
+                    f'<i class="ti ti-alert-circle me-2"></i>'
+                    f"<strong>Connection failed:</strong><br>{error_msg}"
+                    f"</div>"
                 )
             else:
-                return JsonResponse(
-                    {"success": False, "error": "Failed to retrieve system information"}
+                return HttpResponse(
+                    '<div class="alert alert-danger">'
+                    '<i class="ti ti-alert-circle me-2"></i>'
+                    "<strong>Connection failed:</strong><br>"
+                    "Failed to retrieve system information"
+                    "</div>"
                 )
 
         except ValueError as e:
-            return JsonResponse(
-                {"success": False, "error": f"Configuration error: {str(e)}"}
+            return HttpResponse(
+                f'<div class="alert alert-danger">'
+                f'<i class="ti ti-alert-circle me-2"></i>'
+                f"<strong>Configuration error:</strong><br>{str(e)}"
+                f"</div>"
             )
         except Exception as e:
-            return JsonResponse(
-                {"success": False, "error": f"Connection failed: {str(e)}"}
+            return HttpResponse(
+                f'<div class="alert alert-danger">'
+                f'<i class="ti ti-alert-circle me-2"></i>'
+                f"<strong>Connection failed:</strong><br>{str(e)}"
+                f"</div>"
             )


### PR DESCRIPTION
- Replace vanilla fetch() with HTMX for connection test (consistent with plugin patterns)
- Convert TestConnectionView from JSON to HTML fragments for HTMX compatibility
- Move Django template variables to data attributes to eliminate VS Code warnings
- Simplify button state management with classList.toggle()
- Use manual tab activation matching librenms_sync.js pattern (avoid Bootstrap API)
- Split LibreNMSSettingsForm into ServerConfigForm and ImportSettingsForm
- Add comprehensive VC pattern validation with placeholder checking
- Reduce JavaScript by ~80 lines while improving maintainability