### PR TITLE
Refactor/remove-dead-import-result-view

### DIFF
--- a/netbox_librenms_plugin/import_utils.py
+++ b/netbox_librenms_plugin/import_utils.py
@@ -1716,7 +1716,10 @@ def bulk_import_vms(
 
             if not libre_device:
                 result["failed"].append(
-                    {"device_id": vm_id, "error": f"Device {vm_id} not found in LibreNMS"}
+                    {
+                        "device_id": vm_id,
+                        "error": f"Device {vm_id} not found in LibreNMS",
+                    }
                 )
                 log.error(f"Device {vm_id} not found in LibreNMS")
                 continue

--- a/netbox_librenms_plugin/jobs.py
+++ b/netbox_librenms_plugin/jobs.py
@@ -172,18 +172,9 @@ class ImportDevicesJob(JobRunner):
             libre_devices_cache: Optional dict mapping device_id to pre-fetched device data
             **kwargs: Additional job parameters
         """
-        from dcim.models import DeviceRole
-        from virtualization.models import Cluster
 
         from netbox_librenms_plugin.import_utils import (
-            _determine_device_name,
             bulk_import_devices_shared,
-            create_vm_from_librenms,
-            validate_device_for_import,
-        )
-        from netbox_librenms_plugin.import_validation_helpers import (
-            apply_cluster_to_validation,
-            apply_role_to_validation,
         )
         from netbox_librenms_plugin.librenms_api import LibreNMSAPI
 

--- a/netbox_librenms_plugin/urls.py
+++ b/netbox_librenms_plugin/urls.py
@@ -28,7 +28,6 @@ from .views import (
     InterfaceTypeMappingView,
     LibreNMSImportView,
     LibreNMSSettingsView,
-    LoadImportJobResultsView,
     SingleCableVerifyView,
     SingleInterfaceVerifyView,
     SingleIPAddressVerifyView,
@@ -201,11 +200,7 @@ urlpatterns = [
         name="bulk_import_confirm",
     ),
     path(
-        "device-import/job/<int:job_id>/results/",
-        LoadImportJobResultsView.as_view(),
-        name="load_import_job_results",
-    ),
-    path(
+
         "device-import/validation/<str:device_id>/",
         DeviceValidationDetailsView.as_view(),
         name="device_validation_details",

--- a/netbox_librenms_plugin/views/__init__.py
+++ b/netbox_librenms_plugin/views/__init__.py
@@ -15,7 +15,6 @@ from .imports import (
     DeviceValidationDetailsView,
     DeviceVCDetailsView,
     LibreNMSImportView,
-    LoadImportJobResultsView,
 )
 from .mapping_views import (
     InterfaceTypeMappingBulkDeleteView,

--- a/netbox_librenms_plugin/views/imports/__init__.py
+++ b/netbox_librenms_plugin/views/imports/__init__.py
@@ -8,7 +8,6 @@ from .actions import (  # noqa: F401
     DeviceRoleUpdateView,
     DeviceValidationDetailsView,
     DeviceVCDetailsView,
-    LoadImportJobResultsView,
 )
 from .list import LibreNMSImportView  # noqa: F401
 
@@ -21,5 +20,4 @@ __all__ = [
     "DeviceValidationDetailsView",
     "DeviceVCDetailsView",
     "LibreNMSImportView",
-    "LoadImportJobResultsView",
 ]


### PR DESCRIPTION
Remove LoadImportJobResultsView class and URL mapping as it was never called
in practice. Background job imports redirect to base import page following
standard NetBox pattern rather than using HTMX to update table rows. Clean up unused import from job module