### PR TITLE
Fix NameError in get_device_id_by_ip method

### DIFF
--- a/netbox_librenms_plugin/librenms_api.py
+++ b/netbox_librenms_plugin/librenms_api.py
@@ -265,7 +265,7 @@ class LibreNMSAPI:
         """
         try:
             response = requests.get(
-                f"{self.librenms_url}/api/v0/resources/fdb/{mac_address}",
+                f"{self.librenms_url}/api/v0/devices/{ip_address}",
                 headers=self.headers,
                 timeout=DEFAULT_API_TIMEOUT,
                 verify=self.verify_ssl,


### PR DESCRIPTION
Fixes #197 - Corrects undefined 'mac_address' variable error

The get_device_id_by_ip() method was incorrectly using 'mac_address' variable in the API URL instead of the 'ip_address' parameter that was passed to the function.