### PR TITLE
Fix/api-endpoints-correction

### DIFF
--- a/netbox_librenms_plugin/librenms_api.py
+++ b/netbox_librenms_plugin/librenms_api.py
@@ -288,7 +288,7 @@ class LibreNMSAPI:
         """
         try:
             response = requests.get(
-                f"{self.librenms_url}/api/v0/devices/{hostname}/oxidized",
+                f"{self.librenms_url}/api/v0/devices/{hostname}",
                 headers=self.headers,
                 timeout=DEFAULT_API_TIMEOUT,
                 verify=self.verify_ssl,
@@ -621,9 +621,9 @@ class LibreNMSAPI:
         """
         try:
             response = requests.get(
-                f"{self.librenms_url}/api/v0/resources/locations",
+                f"{self.librenms_url}/api/v0/ports/{port_id}",
                 headers=self.headers,
-                timeout=EXTENDED_API_TIMEOUT,
+                timeout=DEFAULT_API_TIMEOUT,
                 verify=self.verify_ssl,
             )
             response.raise_for_status()


### PR DESCRIPTION
- Restore get_device_id_by_hostname to use /api/v0/devices/{hostname}
- Restore get_port_by_id to use /api/v0/ports/{port_id}
- Fixes endpoints that were incorrectly changed in commit 7c29c04