### PR TITLE
Feature/snmpv1-support

### DIFF
--- a/netbox_librenms_plugin/forms.py
+++ b/netbox_librenms_plugin/forms.py
@@ -230,10 +230,11 @@ class InterfaceTypeMappingFilterForm(NetBoxModelFilterSetForm):
     model = InterfaceTypeMapping
 
 
-class AddToLIbreSNMPV2(forms.Form):
+class AddToLIbreSNMPV1V2(forms.Form):
     """
-    Form for adding devices to LibreNMS using SNMPv2 authentication.
+    Form for adding devices to LibreNMS using SNMPv1 or SNMPv2c authentication.
     Collects hostname/IP and SNMP community string information.
+    The SNMP version (v1 or v2c) is selected via a toggle button in the template.
     """
 
     hostname = forms.CharField(
@@ -241,7 +242,6 @@ class AddToLIbreSNMPV2(forms.Form):
         max_length=255,
         required=True,
     )
-    snmp_version = forms.CharField(widget=forms.HiddenInput(), initial="v2c")
     community = forms.CharField(label="SNMP Community", max_length=255, required=True)
     port = forms.IntegerField(
         label="SNMP Port",

--- a/netbox_librenms_plugin/librenms_api.py
+++ b/netbox_librenms_plugin/librenms_api.py
@@ -347,13 +347,13 @@ class LibreNMSAPI:
         Args:
             Dictionary containing device data including:
                 - hostname: Device hostname or IP
-                - snmp_version: SNMP version (v2c or v3)
+                - snmp_version: SNMP version (v1, v2c, or v3)
                 - force_add: Skip checks for duplicate device and SNMP reachability (optional, default False)
                 - port: SNMP port (optional, defaults to config value)
                 - transport: SNMP transport protocol (optional: udp, tcp, udp6, tcp6)
                 - port_association_mode: Port identification method (optional: ifIndex, ifName, ifDescr, ifAlias)
                 - poller_group: Poller group ID (optional, defaults to 0)
-                - community: SNMP community string (for v2c)
+                - community: SNMP community string (for v1 or v2c)
                 - authlevel, authname, authpass, authalgo, cryptopass, cryptoalgo: SNMP v3 parameters
 
         Returns:
@@ -375,7 +375,7 @@ class LibreNMSAPI:
         if data.get("poller_group") is not None:
             payload["poller_group"] = data["poller_group"]
 
-        if data["snmp_version"] == "v2c":
+        if data["snmp_version"] in ("v1", "v2c"):
             payload["community"] = data["community"]
         elif data["snmp_version"] == "v3":
             payload.update(

--- a/netbox_librenms_plugin/static/netbox_librenms_plugin/js/librenms_sync.js
+++ b/netbox_librenms_plugin/static/netbox_librenms_plugin/js/librenms_sync.js
@@ -640,21 +640,23 @@ function initializeTabs() {
 
 /**
  * Toggle SNMP form visibility based on selected version.
- * Shows either SNMPv2c or SNMPv3 configuration form.
+ * Shows either SNMPv1/v2c or SNMPv3 configuration form.
  */
 function toggleSNMPForms() {
-    const snmpSelect = document.querySelector('#add-device-modal select.form-select');
+    const snmpSelect = document.getElementById('snmp-version-select');
     if (!snmpSelect) return;
     const version = snmpSelect.value;
 
-    const v2Form = document.getElementById('snmpv2-form');
+    const v1v2Form = document.getElementById('snmpv1v2-form');
     const v3Form = document.getElementById('snmpv3-form');
 
-    if (version === 'v2c') {
-        v2Form.style.display = 'block';
+    if (!v1v2Form || !v3Form) return;
+
+    if (version === 'v1v2c') {
+        v1v2Form.style.display = 'block';
         v3Form.style.display = 'none';
-    } else {
-        v2Form.style.display = 'none';
+    } else if (version === 'v3') {
+        v1v2Form.style.display = 'none';
         v3Form.style.display = 'block';
     }
 }
@@ -664,7 +666,7 @@ function toggleSNMPForms() {
  * Sets up version toggle and displays correct form.
  */
 function initializeSNMPModalScripts() {
-    const snmpSelect = document.querySelector('#add-device-modal select.form-select');
+    const snmpSelect = document.getElementById('snmp-version-select');
     if (snmpSelect) {
         snmpSelect.addEventListener('change', toggleSNMPForms);
         // Initial call to set the correct form visibility

--- a/netbox_librenms_plugin/templates/netbox_librenms_plugin/librenms_sync_base.html
+++ b/netbox_librenms_plugin/templates/netbox_librenms_plugin/librenms_sync_base.html
@@ -565,48 +565,57 @@
                 <!-- SNMP Version Selector -->
                 <div class="mb-3">
                     <label class="form-label">SNMP Version</label>
-                    <select class="form-select" onchange="toggleSNMPForms(this.value)">
-                        <option value="v2c">SNMPv2c</option>
+                    <select class="form-select" id="snmp-version-select" onchange="toggleSNMPForms()">
+                        <option value="v1v2c" selected>SNMPv1/v2c</option>
                         <option value="v3">SNMPv3</option>
                     </select>
                 </div>
 
-                <!-- SNMPv2c form -->
+                <!-- SNMPv1/v2c form -->
                 <form method="post" action="{% url 'plugins:netbox_librenms_plugin:add_device_to_librenms' object.id %}"
-                    id="snmpv2-form" name="snmpv2-form">
+                    id="snmpv1v2-form" name="snmpv1v2-form" style="display: block;">
                     {% csrf_token %}
-                    {{ v2form.snmp_version }}
+                    <!-- v1/v2c Toggle Button -->
                     <div class="mb-3">
-                        {{ v2form.hostname.label_tag }}
-                        {{ v2form.hostname }}
+                        <label class="form-label">Protocol Version</label>
+                        <div class="btn-group" role="group" aria-label="SNMP v1/v2c toggle">
+                            <input type="radio" class="btn-check" name="v1v2-snmp_version" id="snmp-v1-toggle" value="v1" autocomplete="off">
+                            <label class="btn btn-outline-primary" for="snmp-v1-toggle">v1</label>
+                            <input type="radio" class="btn-check" name="v1v2-snmp_version" id="snmp-v2c-toggle" value="v2c" autocomplete="off" checked>
+                            <label class="btn btn-outline-primary" for="snmp-v2c-toggle">v2c</label>
+                        </div>
                     </div>
                     <div class="mb-3">
-                        {{ v2form.community.label_tag }}
-                        {{ v2form.community }}
+                        {{ v1v2form.hostname.label_tag }}
+                        {{ v1v2form.hostname }}
                     </div>
                     <div class="mb-3">
-                        {{ v2form.port.label_tag }}
-                        {{ v2form.port }}
-                        <div class="form-text">{{ v2form.port.help_text }}</div>
+                        {{ v1v2form.community.label_tag }}
+                        {{ v1v2form.community }}
                     </div>
                     <div class="mb-3">
-                        {{ v2form.transport.label_tag }}
-                        {{ v2form.transport }}
+                        {{ v1v2form.port.label_tag }}
+                        {{ v1v2form.port }}
+                        <div class="form-text">{{ v1v2form.port.help_text }}</div>
                     </div>
                     <div class="mb-3">
-                        {{ v2form.port_association_mode.label_tag }}
-                        {{ v2form.port_association_mode }}
-                        <div class="form-text">{{ v2form.port_association_mode.help_text }}</div>
+                        {{ v1v2form.transport.label_tag }}
+                        {{ v1v2form.transport }}
                     </div>
                     <div class="mb-3">
-                        {{ v2form.poller_group.label_tag }}
-                        {{ v2form.poller_group }}
-                        <div class="form-text">{{ v2form.poller_group.help_text }}</div>
+                        {{ v1v2form.port_association_mode.label_tag }}
+                        {{ v1v2form.port_association_mode }}
+                        <div class="form-text">{{ v1v2form.port_association_mode.help_text }}</div>
+                    </div>
+                    <div class="mb-3">
+                        {{ v1v2form.poller_group.label_tag }}
+                        {{ v1v2form.poller_group }}
+                        <div class="form-text">{{ v1v2form.poller_group.help_text }}</div>
                     </div>
                     <div class="mb-3 form-check">
-                        {{ v2form.force_add }}
-                        {{ v2form.force_add.label_tag }}
-                        <div class="form-text">{{ v2form.force_add.help_text }}</div>
+                        {{ v1v2form.force_add }}
+                        {{ v1v2form.force_add.label_tag }}
+                        <div class="form-text">{{ v1v2form.force_add.help_text }}</div>
                     </div>
                     <button type="submit" class="btn btn-primary">Add Device</button>
                 </form>

--- a/netbox_librenms_plugin/views/base/librenms_sync_view.py
+++ b/netbox_librenms_plugin/views/base/librenms_sync_view.py
@@ -3,7 +3,7 @@ import re
 from django.shortcuts import get_object_or_404, render
 from netbox.views import generic
 
-from netbox_librenms_plugin.forms import AddToLIbreSNMPV2, AddToLIbreSNMPV3
+from netbox_librenms_plugin.forms import AddToLIbreSNMPV1V2, AddToLIbreSNMPV3
 from netbox_librenms_plugin.utils import (
     get_interface_name_field,
     get_librenms_sync_device,
@@ -101,7 +101,7 @@ class BaseLibreNMSSyncView(LibreNMSAPIMixin, generic.ObjectListView):
                 "interface_sync": interface_context,
                 "cable_sync": cable_context,
                 "ip_sync": ip_context,
-                "v2form": AddToLIbreSNMPV2(prefix="v2"),
+                "v1v2form": AddToLIbreSNMPV1V2(prefix="v1v2"),
                 "v3form": AddToLIbreSNMPV3(prefix="v3"),
                 "librenms_device_id": self.librenms_id,
                 "found_in_librenms": librenms_info.get("found_in_librenms"),

--- a/netbox_librenms_plugin/views/sync/devices.py
+++ b/netbox_librenms_plugin/views/sync/devices.py
@@ -14,10 +14,7 @@ class AddDeviceToLibreNMSView(LibreNMSAPIMixin, View):
     def get_form_class(self):
         snmp_version = self.request.POST.get("snmp_version")
         if not snmp_version:
-            snmp_version = (
-                self.request.POST.get("v1v2-snmp_version")
-                or self.request.POST.get("v3-snmp_version")
-            )
+            snmp_version = self.request.POST.get("v1v2-snmp_version") or self.request.POST.get("v3-snmp_version")
 
         if snmp_version in ("v1", "v2c"):
             return AddToLIbreSNMPV1V2
@@ -33,10 +30,7 @@ class AddDeviceToLibreNMSView(LibreNMSAPIMixin, View):
         self.object = self.get_object(object_id)
         form_class = self.get_form_class()
 
-        snmp_version = (
-            request.POST.get("v1v2-snmp_version")
-            or request.POST.get("v3-snmp_version")
-        )
+        snmp_version = request.POST.get("v1v2-snmp_version") or request.POST.get("v3-snmp_version")
         prefix = "v1v2" if snmp_version in ("v1", "v2c") else "v3"
 
         form = form_class(request.POST, prefix=prefix)

--- a/netbox_librenms_plugin/views/sync/devices.py
+++ b/netbox_librenms_plugin/views/sync/devices.py
@@ -4,7 +4,7 @@ from django.shortcuts import get_object_or_404, redirect
 from django.views import View
 from virtualization.models import VirtualMachine
 
-from netbox_librenms_plugin.forms import AddToLIbreSNMPV2, AddToLIbreSNMPV3
+from netbox_librenms_plugin.forms import AddToLIbreSNMPV1V2, AddToLIbreSNMPV3
 from netbox_librenms_plugin.views.mixins import LibreNMSAPIMixin
 
 
@@ -14,10 +14,13 @@ class AddDeviceToLibreNMSView(LibreNMSAPIMixin, View):
     def get_form_class(self):
         snmp_version = self.request.POST.get("snmp_version")
         if not snmp_version:
-            snmp_version = self.request.POST.get("v2-snmp_version") or self.request.POST.get("v3-snmp_version")
+            snmp_version = (
+                self.request.POST.get("v1v2-snmp_version")
+                or self.request.POST.get("v3-snmp_version")
+            )
 
-        if snmp_version == "v2c":
-            return AddToLIbreSNMPV2
+        if snmp_version in ("v1", "v2c"):
+            return AddToLIbreSNMPV1V2
         return AddToLIbreSNMPV3
 
     def get_object(self, object_id):
@@ -31,26 +34,30 @@ class AddDeviceToLibreNMSView(LibreNMSAPIMixin, View):
         form_class = self.get_form_class()
 
         snmp_version = (
-            request.POST.get("snmp_version")
-            or request.POST.get("v2-snmp_version")
+            request.POST.get("v1v2-snmp_version")
             or request.POST.get("v3-snmp_version")
         )
-        prefix = "v2" if snmp_version == "v2c" else "v3"
+        prefix = "v1v2" if snmp_version in ("v1", "v2c") else "v3"
 
         form = form_class(request.POST, prefix=prefix)
         if form.is_valid():
-            return self.form_valid(form)
+            # Inject snmp_version from toggle into cleaned_data for v1/v2c forms
+            if snmp_version in ("v1", "v2c"):
+                form.cleaned_data["snmp_version"] = snmp_version
+            return self.form_valid(form, snmp_version=snmp_version)
 
         for field, errors in form.errors.items():
             for error in errors:
                 messages.error(request, f"{field}: {error}")
         return redirect(self.object.get_absolute_url())
 
-    def form_valid(self, form):
+    def form_valid(self, form, snmp_version=None):
         data = form.cleaned_data
+        # Use the snmp_version from toggle/form for v1/v2c, or from form data for v3
+        version = snmp_version or data.get("snmp_version")
         device_data = {
             "hostname": data.get("hostname"),
-            "snmp_version": data.get("snmp_version"),
+            "snmp_version": version,
             "force_add": data.get("force_add", False),
         }
 
@@ -66,7 +73,7 @@ class AddDeviceToLibreNMSView(LibreNMSAPIMixin, View):
             except (ValueError, TypeError):
                 pass
 
-        if device_data["snmp_version"] == "v2c":
+        if device_data["snmp_version"] in ("v1", "v2c"):
             device_data["community"] = data.get("community")
         elif device_data["snmp_version"] == "v3":
             device_data.update(


### PR DESCRIPTION
* Renamed AddToLIbreSNMPV2 → AddToLIbreSNMPV1V2 form class
* Added v1/v2c toggle button in the SNMP form
* Updated dropdown to show "SNMPv1/v2c" combined option
* Updated API and views to handle v1 alongside v2c
*Added unit tests for SNMPv1 and SNMPv3