### PR TITLE
feat: add two-tier permission system with plugin and object-level access control

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -6,6 +6,7 @@
   * [Initial Setup](usage_tips/README.md)
   * [Custom Field Setup](usage_tips/custom_field.md)
   * [Multi-Server Setup](usage_tips/multi_server_configuration.md)
+  * [Permissions & Access](usage_tips/permissions.md)
   * [Suggested Workflow](usage_tips/suggested_workflow.md)
 * [Import Devices](librenms_import/overview.md)
   * [Overview](librenms_import/overview.md)

--- a/docs/usage_tips/permissions.md
+++ b/docs/usage_tips/permissions.md
@@ -1,0 +1,151 @@
+# Permissions & Access Control
+
+## Overview
+
+The plugin uses a two-tier permission system that works with NetBox's built-in permissions. Both tiers must be satisfied for users to perform actions:
+
+1. **Plugin permissions** control access to plugin pages and features
+2. **NetBox object permissions** control what objects users can create or modify
+
+This design ensures the plugin respects your existing NetBox permission structure. A user might have full plugin access but still be restricted to creating certain objects based on their NetBox permissions.
+
+
+> Superusers have full access to all plugin features and NetBox objects by default. So the following applies only to regular users who can be granted specific permissions as needed.
+
+
+## Two-Tier Permission Model
+
+### How the Tiers Work Together?
+
+A user needs both tiers of permissions to complete an action. For example, to view the Librenms Import page AND import a device:
+
+1. **Tier 1: Plugin permission**: User needs View AND Change permission on **LibreNMS Settings**
+
+    - View: allows access to the plugin pages and pulling data from LibreNMS.
+    - Change: allows performing actions that modify Netbox or Librenms data
+
+The Plugin also enforces Netbox object permissions so the following permission would also be required:
+
+2. **Tier 2: Object permission**: User needs `dcim.add_device` (to create the device in NetBox)
+
+If either permission is missing, the operation fails with an appropriate error message.
+
+## Creating Permissions
+
+All permissions are created using Netbox's standard Object permissions UI.
+
+For details on how NetBox permissions work, see the [NetBox Permissions documentation](https://netboxlabs.com/docs/netbox/administration/permissions/).
+
+### Plugin Permissions
+
+To grant a user or group access to the plugin:
+
+1. Go to **Admin → Permissions**
+2. Click **Add**
+3. For **Object types**, select "NetBox Librenms Plugin | LibreNMS Settings"
+4. Under **Actions**, check the permissions to grant:
+      - ☑ **Can view** — for read-only access
+      - ☑ **Can change** — for write access (requires View as well)
+5. Assign to specific **Users** or **Groups**
+6. Click **Save**
+
+### NetBox Object Permissions
+
+NetBox object permissions are created similarly but for different object types (DCIM, IPAM, VIRTUALIZATION, etc.).
+
+### Interface Type Mapping Permissions
+
+The Interface Type Mapping feature uses its own object permissions in addition to the plugin permissions. To manage interface mappings, users need:
+
+- **Plugin permission**: View permission on LibreNMS Settings (to access the page)
+- **Object permissions**: `netbox_librenms_plugin.add_interfacetypemapping`, `change_interfacetypemapping`, or `delete_interfacetypemapping` as needed
+
+These permissions are enforced automatically by NetBox's generic views.
+
+
+## Example Scenarios
+
+### Read-Only Access
+
+- **Plugin permissions**: Librenms Setting View only (Can view LibreNMS Plugin pages)
+- **NetBox permissions**: View permissions for devices, interfaces, etc.
+
+Users can access all plugin pages, refresh data from LibreNMS, and review comparison tables, but cannot import devices or sync data.
+
+### Full Plugin Access
+
+- **Plugin permissions**: View + Change (Can view LibreNMS Plugin Pages and Import and sync devices data)
+- **NetBox permissions**: Add/change permissions for devices, interfaces, cables, IP addresses
+
+Users have full access to all plugin features and can import devices, sync interfaces, and create cables.
+
+
+## Further Details
+### Tier 1: Plugin Permissions
+
+Plugins permissions use the **LibreNMS Settings** model permissions:
+
+| Permission | NetBox UI Selection | Grants |
+|------------|---------------------|--------|
+| `view_librenmssettings` | LibreNMS Settings → ☑ Can view | Access all plugin pages, view LibreNMS data |
+| `change_librenmssettings` | LibreNMS Settings → ☑ Can change | Import devices, sync data, save settings |
+
+Users without View permission won't see the LibreNMS menu or the LibreNMS Sync tab. Users with **View** but not **Change** can browse all plugin pages but cannot perform import or sync actions that modify Netbox data and Librenms data like Locatons and Adding devices.
+
+### Tier 2: NetBox Object Permissions
+
+When the plugin creates or modifies NetBox objects (devices, interfaces, cables, IP addresses), NetBox enforces its standard object permissions. The plugin checks these permissions and will block operations if the user lacks the required access.
+
+| Plugin Action | Required Object Permissions |
+|---------------|----------------------------|
+| Import device | `dcim.add_device`, `dcim.add_interface` |
+| Import device with VC | Above + `dcim.add_virtualchassis` |
+| Import VM | `virtualization.add_virtualmachine` |
+| Sync interfaces | `dcim.add_interface`, `dcim.change_interface` |
+| Delete interfaces | `dcim.delete_interface` |
+| Sync VM interfaces | `virtualization.add_vminterface`, `virtualization.change_vminterface` |
+| Delete VM interfaces | `virtualization.delete_vminterface` |
+| Sync cables | `dcim.add_cable`, `dcim.change_cable` |
+| Sync IP addresses | `ipam.add_ipaddress`, `ipam.change_ipaddress` |
+| Sync device fields | `dcim.change_device` |
+| Create platform | `dcim.add_platform` |
+
+
+### Why LibreNMS Settings Permissions?
+
+NetBox's permission system is object-based—permissions are tied to specific models like Device, Interface, or Cable. However, the plugin's Import and Sync pages are feature pages that don't have their own dedicated models. They work with LibreNMS data and create or modify existing NetBox objects.
+
+To control access to these pages, the plugin uses the **LibreNMS Settings** model permissions as a gate for all plugin features:
+
+- **No dedicated models for pages** — The Import and Sync pages aren't objects, so we need an existing model to attach permissions to
+- **No custom migrations required** — Uses Django's built-in model permissions that NetBox already understands
+- **Standard NetBox workflow** — Administrators assign permissions the same way they do for any other NetBox object
+- **Single permission per access level** — One "View" permission for read access, one "Change" permission for write access
+
+While using a settings model for access control may seem unconventional, it provides a simple and maintainable way to gate plugin access without introducing custom permission infrastructure.
+
+
+## Special note: Background Jobs and Superuser Access
+
+The device import page can use background jobs to help support large device sets, and virtual chassis detection. However, NetBox restricts access to background job status APIs to superusers. There is no permission in NetBox for this.  This is a core design decision, not a plugin limitation.
+
+| User Type | Background Jobs |
+|-----------|-----------------|
+| Superuser | Full access to background jobs with real-time status updates |
+| Non-superuser | Automatic fallback to synchronous processing |
+
+The plugin automatically detects whether the current user is a superuser and adjusts behavior accordingly. Non-superuser users don't need to change any settings—the plugin simply processes requests synchronously instead of as background jobs. All import and filter operations work correctly regardless of superuser status.
+
+## Troubleshooting
+
+**User can't see the LibreNMS menu**
+: The user doesn't have View permission for the plugin. Add an Object Permission for "LibreNMS Settings" with "Can view" checked.
+
+**User sees pages but can't import or sync**
+: The user has View permission but not Change permission. Edit their Object Permission to also include "Can change".
+
+**User gets "permission denied" when importing devices**
+: The user has plugin permissions but may be missing NetBox object permissions. Check that they have `dcim.add_device` and related permissions.
+
+**Background jobs show 403 errors in console**
+: This is expected for non-superuser users. The plugin automatically falls back to synchronous mode, so functionality is not affected. The console errors can be ignored.

--- a/docs/usage_tips/permissions.md
+++ b/docs/usage_tips/permissions.md
@@ -15,7 +15,7 @@ This design ensures the plugin respects your existing NetBox permission structur
 
 ## Two-Tier Permission Model
 
-### How the Tiers Work Together?
+### How Do the Tiers Work Together?
 
 A user needs both tiers of permissions to complete an action. For example, to view the Librenms Import page AND import a device:
 
@@ -90,7 +90,7 @@ Plugins permissions use the **LibreNMS Settings** model permissions:
 | `view_librenmssettings` | LibreNMS Settings → ☑ Can view | Access all plugin pages, view LibreNMS data |
 | `change_librenmssettings` | LibreNMS Settings → ☑ Can change | Import devices, sync data, save settings |
 
-Users without View permission won't see the LibreNMS menu or the LibreNMS Sync tab. Users with **View** but not **Change** can browse all plugin pages but cannot perform import or sync actions that modify Netbox data and Librenms data like Locatons and Adding devices.
+Users without View permission won't see the LibreNMS menu or the LibreNMS Sync tab. Users with **View** but not **Change** can browse all plugin pages but cannot perform import or sync actions that modify Netbox data and Librenms data like Locations and Adding devices.
 
 ### Tier 2: NetBox Object Permissions
 
@@ -148,4 +148,4 @@ The plugin automatically detects whether the current user is a superuser and adj
 : The user has plugin permissions but may be missing NetBox object permissions. Check that they have `dcim.add_device` and related permissions.
 
 **Background jobs show 403 errors in console**
-: This is expected for non-superuser users. The plugin automatically falls back to synchronous mode, so functionality is not affected. The console errors can be ignored.
+: In normal usage, the UI only enables background jobs for users allowed to use them and falls back to synchronous processing otherwise, so 403s from background job APIs should not appear. If you see these errors, it usually means a direct API call or custom integration is hitting background-task endpoints without superuser access; update that integration to use synchronous flows or run it with appropriate permissions.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -10,6 +10,7 @@ nav:
     - Initial Setup: usage_tips/README.md
     - Custom Field Setup: usage_tips/custom_field.md
     - Multi-Server Setup: usage_tips/multi_server_configuration.md
+    - Permissions & Access: usage_tips/permissions.md
     - Suggested Workflow: usage_tips/suggested_workflow.md
   - Import Devices:
     - Overview: librenms_import/overview.md

--- a/netbox_librenms_plugin/constants.py
+++ b/netbox_librenms_plugin/constants.py
@@ -1,0 +1,3 @@
+# Plugin permissions (from LibreNMSSettings model)
+PERM_VIEW_PLUGIN = "netbox_librenms_plugin.view_librenmssettings"
+PERM_CHANGE_PLUGIN = "netbox_librenms_plugin.change_librenmssettings"

--- a/netbox_librenms_plugin/import_utils.py
+++ b/netbox_librenms_plugin/import_utils.py
@@ -1280,7 +1280,11 @@ def bulk_import_devices_shared(
         user = getattr(job.job, "user", None)
 
     # Check permissions at start of bulk operation
-    required_perms = ["dcim.add_device", "dcim.add_interface"]
+    required_perms = [
+        "dcim.add_device",
+        "dcim.add_interface",
+        "dcim.add_virtualchassis",
+    ]
     require_permissions(user, required_perms, "import devices")
 
     total = len(device_ids)

--- a/netbox_librenms_plugin/jobs.py
+++ b/netbox_librenms_plugin/jobs.py
@@ -201,6 +201,7 @@ class ImportDevicesJob(JobRunner):
                 manual_mappings_per_device=manual_mappings_per_device,
                 libre_devices_cache=libre_devices_cache,
                 job=self,  # Pass job context for logging and cancellation
+                user=self.job.user,  # Pass user for permission checks
             )
 
         # Import VMs
@@ -209,7 +210,9 @@ class ImportDevicesJob(JobRunner):
             self.logger.info(f"Importing {len(vm_imports)} VMs...")
             from netbox_librenms_plugin.import_utils import bulk_import_vms
 
-            vm_result = bulk_import_vms(vm_imports, api, sync_options, libre_devices_cache, job=self)
+            vm_result = bulk_import_vms(
+                vm_imports, api, sync_options, libre_devices_cache, job=self, user=self.job.user
+            )
 
         # Combine results
         imported_device_pks = [item["device"].pk for item in device_result.get("success", []) if item.get("device")]

--- a/netbox_librenms_plugin/navigation.py
+++ b/netbox_librenms_plugin/navigation.py
@@ -1,7 +1,9 @@
 from netbox.plugins import PluginMenu, PluginMenuButton, PluginMenuItem
 
+from netbox_librenms_plugin.constants import PERM_VIEW_PLUGIN
+
 menu = PluginMenu(
-    label="LibreNMS Plugin",  # This will be your main menu heading
+    label="LibreNMS",
     icon_class="mdi mdi-network",
     groups=(
         (
@@ -10,12 +12,12 @@ menu = PluginMenu(
                 PluginMenuItem(
                     link="plugins:netbox_librenms_plugin:settings",
                     link_text="Plugin Settings",
-                    permissions=["netbox_librenms_plugin.view_librenmssettings"],
+                    permissions=[PERM_VIEW_PLUGIN],
                 ),
                 PluginMenuItem(
                     link="plugins:netbox_librenms_plugin:interfacetypemapping_list",
                     link_text="Interface Mappings",
-                    permissions=["netbox_librenms_plugin.view_interfacetypemapping"],
+                    permissions=[PERM_VIEW_PLUGIN],
                     buttons=(
                         PluginMenuButton(
                             link="plugins:netbox_librenms_plugin:interfacetypemapping_add",
@@ -37,7 +39,7 @@ menu = PluginMenu(
                 PluginMenuItem(
                     link="plugins:netbox_librenms_plugin:librenms_import",
                     link_text="LibreNMS Import",
-                    permissions=["dcim.view_device"],
+                    permissions=[PERM_VIEW_PLUGIN],
                 ),
             ),
         ),
@@ -47,17 +49,17 @@ menu = PluginMenu(
                 PluginMenuItem(
                     link="plugins:netbox_librenms_plugin:site_location_sync",
                     link_text="Site & Location Sync",
-                    permissions=["dcim.view_site"],
+                    permissions=[PERM_VIEW_PLUGIN],
                 ),
                 PluginMenuItem(
                     link="plugins:netbox_librenms_plugin:device_status_list",
                     link_text="Device Status",
-                    permissions=["dcim.view_device"],
+                    permissions=[PERM_VIEW_PLUGIN],
                 ),
                 PluginMenuItem(
                     link="plugins:netbox_librenms_plugin:vm_status_list",
                     link_text="VM Status",
-                    permissions=["virtualization.view_virtualmachine"],
+                    permissions=[PERM_VIEW_PLUGIN],
                 ),
             ),
         ),

--- a/netbox_librenms_plugin/static/netbox_librenms_plugin/js/librenms_import.js
+++ b/netbox_librenms_plugin/static/netbox_librenms_plugin/js/librenms_import.js
@@ -765,6 +765,10 @@
                 }
             })
                 .then(response => {
+                    // Check for HTTP errors first
+                    if (!response.ok) {
+                        throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+                    }
                     // Check if response is JSON (background job) or HTML (synchronous)
                     const contentType = response.headers.get('content-type');
                     if (contentType && contentType.includes('application/json')) {
@@ -789,15 +793,11 @@
                         } else {
                             // Unexpected JSON response
                             alert('Unexpected response from server. Please try again.');
-                            if (modalInstance) {
-                                modalInstance.hide();
-                            }
+                            filterModalManager.hide();
                         }
                     } else if (result.type === 'html') {
                         // Synchronous response - navigate to the URL to reload with results
-                        if (modalInstance) {
-                            modalInstance.hide();
-                        }
+                        filterModalManager.hide();
                         // Navigate to the results URL, allowing proper browser history
                         window.location.href = finalUrl;
                     }
@@ -813,7 +813,9 @@
                         // Request was cancelled by user - silent
                     } else {
                         console.error('Error fetching filtered results:', error);
-                        alert('Error loading filtered results. Please try again.');
+                        // Show more specific error if available
+                        const errorMsg = error.message || 'Error loading filtered results. Please try again.';
+                        alert(errorMsg);
                     }
 
                     // Hide modal on error

--- a/netbox_librenms_plugin/tables/device_status.py
+++ b/netbox_librenms_plugin/tables/device_status.py
@@ -90,6 +90,7 @@ class DeviceImportTable(tables.Table):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+
         # Cache querysets to avoid N queries per render
         from dcim.models import DeviceRole
         from virtualization.models import Cluster
@@ -425,6 +426,7 @@ class DeviceImportTable(tables.Table):
         """
         Render action buttons for import using HTMX.
         Shows Import button if can import, otherwise shows Preview/Configure.
+        Permission checks are handled by backend require_write_permission() which shows toast.
         """
         validation = record.get("_validation", {})
         device_id = record.get("device_id")

--- a/netbox_librenms_plugin/tables/interfaces.py
+++ b/netbox_librenms_plugin/tables/interfaces.py
@@ -49,9 +49,9 @@ class LibreNMSInterfaceTable(tables.Table):
         self._meta.row_attrs = {
             "data-interface": lambda record: record.get(self.interface_name_field),
             "data-name": lambda record: record.get(self.interface_name_field),
-            "data-enabled": lambda record: record.get("ifAdminStatus", "").lower()
-            if record.get("ifAdminStatus")
-            else "",
+            "data-enabled": lambda record: (
+                record.get("ifAdminStatus", "").lower() if record.get("ifAdminStatus") else ""
+            ),
         }
 
         super().__init__(*args, **kwargs)

--- a/netbox_librenms_plugin/tables/locations.py
+++ b/netbox_librenms_plugin/tables/locations.py
@@ -11,11 +11,11 @@ class SiteLocationSyncTable(tables.Table):
     """
 
     netbox_site = tables.Column(linkify=True)
-    latitude = tables.Column(accessor="netbox_site.latitude")
-    longitude = tables.Column(accessor="netbox_site.longitude")
-    librenms_location = tables.Column(accessor="librenms_location.location", verbose_name="LibreNMS Location")
-    librenms_latitude = tables.Column(accessor="librenms_location.lat", verbose_name="LibreNMS Latitude")
-    librenms_longitude = tables.Column(accessor="librenms_location.lng", verbose_name="LibreNMS Longitude")
+    latitude = tables.Column(accessor="netbox_site__latitude")
+    longitude = tables.Column(accessor="netbox_site__longitude")
+    librenms_location = tables.Column(accessor="librenms_location__location", verbose_name="LibreNMS Location")
+    librenms_latitude = tables.Column(accessor="librenms_location__lat", verbose_name="LibreNMS Latitude")
+    librenms_longitude = tables.Column(accessor="librenms_location__lng", verbose_name="LibreNMS Longitude")
     actions = tables.Column(empty_values=())
 
     def render_latitude(self, value, record):

--- a/netbox_librenms_plugin/templates/netbox_librenms_plugin/librenms_import.html
+++ b/netbox_librenms_plugin/templates/netbox_librenms_plugin/librenms_import.html
@@ -200,12 +200,22 @@
                 </div>
                 <div class="p-3 my-3 bg-primary-subtle border border-primary rounded-1">
                   <div class="form-check">
+                    {% if can_use_background_jobs %}
                     {{ filter_form.use_background_job }}
                     <label class="form-check-label" for="{{ filter_form.use_background_job.id_for_label }}">
                       {{ filter_form.use_background_job.label }}
                     </label>
                     {% if filter_form.use_background_job.help_text %}
                       <small class="form-text text-muted d-block">{{ filter_form.use_background_job.help_text }}</small>
+                    {% endif %}
+                    {% else %}
+                    <input type="checkbox" class="form-check-input" disabled title="Background jobs require superuser access">
+                    <label class="form-check-label text-muted">
+                      {{ filter_form.use_background_job.label }}
+                    </label>
+                    <small class="form-text text-muted d-block">
+                      <i class="mdi mdi-information-outline"></i> Background jobs require superuser access. Filters will process synchronously.
+                    </small>
                     {% endif %}
                   </div>
                 </div>
@@ -413,9 +423,11 @@
           <p class="text-info mb-3" id="filter-device-count" style="display: none;">
             <strong>LibreNMS Devices:</strong> <span id="filter-device-count-value">0</span>
           </p>
+          {% if can_use_background_jobs %}
           <button type="button" class="btn btn-secondary btn-sm" id="cancel-filter-btn">
             <i class="mdi mdi-close"></i> Cancel
           </button>
+          {% endif %}
         </div>
       </div>
     </div>

--- a/netbox_librenms_plugin/tests/test_permissions.py
+++ b/netbox_librenms_plugin/tests/test_permissions.py
@@ -1,0 +1,753 @@
+from unittest.mock import MagicMock, patch
+
+
+class TestLibreNMSPermissionMixin:
+    """Tests for permission mixin functionality."""
+
+    def test_has_write_permission_granted(self):
+        """User with change permission has write access."""
+        from netbox_librenms_plugin.views.mixins import LibreNMSPermissionMixin
+
+        mixin = LibreNMSPermissionMixin()
+        mixin.request = MagicMock()
+        mixin.request.user.has_perm.return_value = True
+
+        assert mixin.has_write_permission() is True
+
+    def test_has_write_permission_denied(self):
+        """User without change permission lacks write access."""
+        from netbox_librenms_plugin.views.mixins import LibreNMSPermissionMixin
+
+        mixin = LibreNMSPermissionMixin()
+        mixin.request = MagicMock()
+        mixin.request.user.has_perm.return_value = False
+
+        assert mixin.has_write_permission() is False
+
+    def test_require_write_permission_allowed(self):
+        """User with write permission gets None (allowed to proceed)."""
+        from netbox_librenms_plugin.views.mixins import LibreNMSPermissionMixin
+
+        mixin = LibreNMSPermissionMixin()
+        mixin.request = MagicMock()
+        mixin.request.user.has_perm.return_value = True
+
+        result = mixin.require_write_permission()
+        assert result is None
+
+    def test_require_write_permission_denied(self):
+        """User without write permission gets redirect response to referrer."""
+        from netbox_librenms_plugin.views.mixins import LibreNMSPermissionMixin
+
+        mixin = LibreNMSPermissionMixin()
+        mixin.request = MagicMock()
+        mixin.request.user.has_perm.return_value = False
+        mixin.request.path = "/some/path/"
+        mixin.request.META = {"HTTP_REFERER": "/original/page/"}
+        mixin.request.headers = {}  # Not an HTMX request
+
+        with patch("netbox_librenms_plugin.views.mixins.redirect") as mock_redirect:
+            with patch("netbox_librenms_plugin.views.mixins.messages"):
+                result = mixin.require_write_permission()
+
+        mock_redirect.assert_called_once_with("/original/page/")
+        assert result is not None
+
+    def test_require_write_permission_denied_htmx(self):
+        """HTMX request without write permission gets HX-Redirect response."""
+        from netbox_librenms_plugin.views.mixins import LibreNMSPermissionMixin
+
+        mixin = LibreNMSPermissionMixin()
+        mixin.request = MagicMock()
+        mixin.request.user.has_perm.return_value = False
+        mixin.request.path = "/some/path/"
+        mixin.request.META = {"HTTP_REFERER": "/original/page/"}
+        mixin.request.headers = {"HX-Request": "true"}
+
+        with patch("netbox_librenms_plugin.views.mixins.messages"):
+            result = mixin.require_write_permission()
+
+        # Should return HttpResponse with HX-Redirect header
+        assert result is not None
+        assert result["HX-Redirect"] == "/original/page/"
+
+    def test_require_write_permission_json_allowed(self):
+        """User with write permission gets None (allowed to proceed)."""
+        from netbox_librenms_plugin.views.mixins import LibreNMSPermissionMixin
+
+        mixin = LibreNMSPermissionMixin()
+        mixin.request = MagicMock()
+        mixin.request.user.has_perm.return_value = True
+
+        result = mixin.require_write_permission_json()
+        assert result is None
+
+    def test_require_write_permission_json_denied(self):
+        """User without write permission gets JsonResponse with 403."""
+        import json
+        from netbox_librenms_plugin.views.mixins import LibreNMSPermissionMixin
+
+        mixin = LibreNMSPermissionMixin()
+        mixin.request = MagicMock()
+        mixin.request.user.has_perm.return_value = False
+
+        result = mixin.require_write_permission_json()
+
+        assert result is not None
+        assert result.status_code == 403
+        content = json.loads(result.content)
+        assert content["error"] == "You do not have permission to perform this action."
+
+    def test_require_write_permission_json_custom_message(self):
+        """Custom error message is returned in JsonResponse."""
+        import json
+        from netbox_librenms_plugin.views.mixins import LibreNMSPermissionMixin
+
+        mixin = LibreNMSPermissionMixin()
+        mixin.request = MagicMock()
+        mixin.request.user.has_perm.return_value = False
+
+        result = mixin.require_write_permission_json(error_message="Custom denied message")
+
+        assert result is not None
+        assert result.status_code == 403
+        content = json.loads(result.content)
+        assert content["error"] == "Custom denied message"
+
+
+class TestAPIPermissions:
+    """Tests for API permission class."""
+
+    def test_get_requires_view_permission(self):
+        """GET requests require view permission."""
+        from netbox_librenms_plugin.api.views import LibreNMSPluginPermission
+        from netbox_librenms_plugin.constants import PERM_VIEW_PLUGIN
+
+        permission = LibreNMSPluginPermission()
+        request = MagicMock()
+        request.method = "GET"
+        request.user.has_perm.return_value = True
+
+        assert permission.has_permission(request, None) is True
+        request.user.has_perm.assert_called_with(PERM_VIEW_PLUGIN)
+
+    def test_post_requires_change_permission(self):
+        """POST requests require change permission."""
+        from netbox_librenms_plugin.api.views import LibreNMSPluginPermission
+        from netbox_librenms_plugin.constants import PERM_CHANGE_PLUGIN
+
+        permission = LibreNMSPluginPermission()
+        request = MagicMock()
+        request.method = "POST"
+        request.user.has_perm.return_value = True
+
+        assert permission.has_permission(request, None) is True
+        request.user.has_perm.assert_called_with(PERM_CHANGE_PLUGIN)
+
+    def test_put_requires_change_permission(self):
+        """PUT requests require change permission."""
+        from netbox_librenms_plugin.api.views import LibreNMSPluginPermission
+        from netbox_librenms_plugin.constants import PERM_CHANGE_PLUGIN
+
+        permission = LibreNMSPluginPermission()
+        request = MagicMock()
+        request.method = "PUT"
+        request.user.has_perm.return_value = True
+
+        assert permission.has_permission(request, None) is True
+        request.user.has_perm.assert_called_with(PERM_CHANGE_PLUGIN)
+
+    def test_delete_requires_change_permission(self):
+        """DELETE requests require change permission."""
+        from netbox_librenms_plugin.api.views import LibreNMSPluginPermission
+        from netbox_librenms_plugin.constants import PERM_CHANGE_PLUGIN
+
+        permission = LibreNMSPluginPermission()
+        request = MagicMock()
+        request.method = "DELETE"
+        request.user.has_perm.return_value = True
+
+        assert permission.has_permission(request, None) is True
+        request.user.has_perm.assert_called_with(PERM_CHANGE_PLUGIN)
+
+    def test_get_denied_without_view_permission(self):
+        """GET requests denied without view permission."""
+        from netbox_librenms_plugin.api.views import LibreNMSPluginPermission
+
+        permission = LibreNMSPluginPermission()
+        request = MagicMock()
+        request.method = "GET"
+        request.user.has_perm.return_value = False
+
+        assert permission.has_permission(request, None) is False
+
+    def test_post_denied_without_change_permission(self):
+        """POST requests denied without change permission."""
+        from netbox_librenms_plugin.api.views import LibreNMSPluginPermission
+
+        permission = LibreNMSPluginPermission()
+        request = MagicMock()
+        request.method = "POST"
+        request.user.has_perm.return_value = False
+
+        assert permission.has_permission(request, None) is False
+
+
+class TestPermissionConstants:
+    """Tests for permission constants."""
+
+    def test_view_permission_constant(self):
+        """View permission constant is correct."""
+        from netbox_librenms_plugin.constants import PERM_VIEW_PLUGIN
+
+        assert PERM_VIEW_PLUGIN == "netbox_librenms_plugin.view_librenmssettings"
+
+    def test_change_permission_constant(self):
+        """Change permission constant is correct."""
+        from netbox_librenms_plugin.constants import PERM_CHANGE_PLUGIN
+
+        assert PERM_CHANGE_PLUGIN == "netbox_librenms_plugin.change_librenmssettings"
+
+
+# =============================================================================
+# Phase 2: Object Permission Tests
+# =============================================================================
+
+
+class TestObjectPermissionHelpers:
+    """Tests for Phase 2 object permission helper functions."""
+
+    def test_check_user_permissions_all_granted(self):
+        """Returns True when user has all permissions."""
+        from netbox_librenms_plugin.import_utils import check_user_permissions
+
+        user = MagicMock()
+        user.has_perm.return_value = True
+
+        has_all, missing = check_user_permissions(user, ["dcim.add_device", "dcim.add_interface"])
+
+        assert has_all is True
+        assert missing == []
+        assert user.has_perm.call_count == 2
+
+    def test_check_user_permissions_some_missing(self):
+        """Returns False with list of missing permissions."""
+        from netbox_librenms_plugin.import_utils import check_user_permissions
+
+        user = MagicMock()
+        user.has_perm.side_effect = lambda p: p != "dcim.add_interface"
+
+        has_all, missing = check_user_permissions(user, ["dcim.add_device", "dcim.add_interface"])
+
+        assert has_all is False
+        assert missing == ["dcim.add_interface"]
+
+    def test_check_user_permissions_all_missing(self):
+        """Returns False with all permissions listed as missing."""
+        from netbox_librenms_plugin.import_utils import check_user_permissions
+
+        user = MagicMock()
+        user.has_perm.return_value = False
+
+        has_all, missing = check_user_permissions(user, ["dcim.add_device", "dcim.add_interface"])
+
+        assert has_all is False
+        assert "dcim.add_device" in missing
+        assert "dcim.add_interface" in missing
+
+    def test_check_user_permissions_no_user(self):
+        """Raises PermissionDenied when user is None."""
+        import pytest
+        from django.core.exceptions import PermissionDenied
+
+        from netbox_librenms_plugin.import_utils import check_user_permissions
+
+        with pytest.raises(PermissionDenied, match="No user context"):
+            check_user_permissions(None, ["dcim.add_device"])
+
+    def test_require_permissions_passes_when_granted(self):
+        """Does not raise when user has all permissions."""
+        from netbox_librenms_plugin.import_utils import require_permissions
+
+        user = MagicMock()
+        user.has_perm.return_value = True
+
+        # Should not raise
+        require_permissions(user, ["dcim.add_device", "dcim.add_interface"], "import devices")
+
+    def test_require_permissions_raises_on_missing(self):
+        """Raises PermissionDenied with descriptive message."""
+        import pytest
+        from django.core.exceptions import PermissionDenied
+
+        from netbox_librenms_plugin.import_utils import require_permissions
+
+        user = MagicMock()
+        user.has_perm.return_value = False
+
+        with pytest.raises(PermissionDenied) as exc_info:
+            require_permissions(user, ["dcim.add_device"], "import devices")
+
+        # Check error message contains action description and missing permission
+        assert "import devices" in str(exc_info.value)
+        assert "dcim.add_device" in str(exc_info.value)
+
+    def test_require_permissions_lists_multiple_missing(self):
+        """Error message includes all missing permissions."""
+        import pytest
+        from django.core.exceptions import PermissionDenied
+
+        from netbox_librenms_plugin.import_utils import require_permissions
+
+        user = MagicMock()
+        user.has_perm.return_value = False
+
+        with pytest.raises(PermissionDenied) as exc_info:
+            require_permissions(
+                user,
+                ["dcim.add_device", "dcim.add_interface"],
+                "import devices",
+            )
+
+        error_msg = str(exc_info.value)
+        assert "dcim.add_device" in error_msg
+        assert "dcim.add_interface" in error_msg
+
+
+class TestNetBoxObjectPermissionMixin:
+    """Tests for the NetBoxObjectPermissionMixin class."""
+
+    def test_check_object_permissions_all_granted(self):
+        """Returns True when user has all object permissions."""
+        from netbox_librenms_plugin.views.mixins import NetBoxObjectPermissionMixin
+
+        mixin = NetBoxObjectPermissionMixin()
+        mixin.request = MagicMock()
+        mixin.request.user.has_perm.return_value = True
+
+        mock_model = MagicMock()
+        mixin.required_object_permissions = {
+            "POST": [("add", mock_model), ("change", mock_model)],
+        }
+
+        with patch("netbox_librenms_plugin.views.mixins.get_permission_for_model") as mock_get:
+            mock_get.side_effect = ["dcim.add_interface", "dcim.change_interface"]
+            has_all, missing = mixin.check_object_permissions("POST")
+
+        assert has_all is True
+        assert missing == []
+
+    def test_check_object_permissions_some_missing(self):
+        """Returns False with missing permission strings."""
+        from netbox_librenms_plugin.views.mixins import NetBoxObjectPermissionMixin
+
+        mixin = NetBoxObjectPermissionMixin()
+        mixin.request = MagicMock()
+        mixin.request.user.has_perm.side_effect = lambda p: p != "dcim.add_interface"
+
+        mock_model = MagicMock()
+        mixin.required_object_permissions = {
+            "POST": [("add", mock_model)],
+        }
+
+        with patch("netbox_librenms_plugin.views.mixins.get_permission_for_model") as mock_get:
+            mock_get.return_value = "dcim.add_interface"
+            has_all, missing = mixin.check_object_permissions("POST")
+
+        assert has_all is False
+        assert "dcim.add_interface" in missing
+
+    def test_check_object_permissions_no_requirements(self):
+        """Returns True when no permissions required for method."""
+        from netbox_librenms_plugin.views.mixins import NetBoxObjectPermissionMixin
+
+        mixin = NetBoxObjectPermissionMixin()
+        mixin.request = MagicMock()
+        mixin.required_object_permissions = {}  # No requirements
+
+        has_all, missing = mixin.check_object_permissions("POST")
+
+        assert has_all is True
+        assert missing == []
+
+    def test_require_object_permissions_returns_none_when_granted(self):
+        """Returns None when all permissions are granted."""
+        from netbox_librenms_plugin.views.mixins import NetBoxObjectPermissionMixin
+
+        mixin = NetBoxObjectPermissionMixin()
+        mixin.request = MagicMock()
+        mixin.request.user.has_perm.return_value = True
+
+        mock_model = MagicMock()
+        mixin.required_object_permissions = {
+            "POST": [("add", mock_model)],
+        }
+
+        with patch("netbox_librenms_plugin.views.mixins.get_permission_for_model") as mock_get:
+            mock_get.return_value = "dcim.add_cable"
+            response = mixin.require_object_permissions("POST")
+
+        assert response is None
+
+    def test_require_object_permissions_returns_redirect_response(self):
+        """Returns redirect response with message when permissions missing."""
+        from netbox_librenms_plugin.views.mixins import NetBoxObjectPermissionMixin
+
+        mixin = NetBoxObjectPermissionMixin()
+        mixin.request = MagicMock()
+        mixin.request.user.has_perm.return_value = False
+        mixin.request.META = {"HTTP_REFERER": "/original/page/"}
+        mixin.request.headers = {}  # Not an HTMX request
+
+        mock_model = MagicMock()
+        mixin.required_object_permissions = {
+            "POST": [("add", mock_model)],
+        }
+
+        with patch("netbox_librenms_plugin.views.mixins.get_permission_for_model") as mock_get:
+            with patch("netbox_librenms_plugin.views.mixins.messages") as mock_messages:
+                with patch("netbox_librenms_plugin.views.mixins.redirect") as mock_redirect:
+                    mock_get.return_value = "dcim.add_cable"
+                    response = mixin.require_object_permissions("POST")
+
+        assert response is not None
+        # Verify error message was added
+        mock_messages.error.assert_called_once()
+        error_msg = mock_messages.error.call_args[0][1]
+        assert "dcim.add_cable" in error_msg
+        # Verify redirect was called
+        mock_redirect.assert_called_once_with("/original/page/")
+
+    def test_require_object_permissions_htmx_returns_hx_redirect(self):
+        """HTMX request returns HX-Redirect header when permissions missing."""
+        from netbox_librenms_plugin.views.mixins import NetBoxObjectPermissionMixin
+
+        mixin = NetBoxObjectPermissionMixin()
+        mixin.request = MagicMock()
+        mixin.request.user.has_perm.return_value = False
+        mixin.request.META = {"HTTP_REFERER": "/original/page/"}
+        mixin.request.headers = {"HX-Request": "true"}
+
+        mock_model = MagicMock()
+        mixin.required_object_permissions = {
+            "POST": [("add", mock_model)],
+        }
+
+        with patch("netbox_librenms_plugin.views.mixins.get_permission_for_model") as mock_get:
+            with patch("netbox_librenms_plugin.views.mixins.messages"):
+                mock_get.return_value = "dcim.add_cable"
+                response = mixin.require_object_permissions("POST")
+
+        assert response is not None
+        assert response["HX-Redirect"] == "/original/page/"
+
+    def test_require_object_permissions_json_allowed(self):
+        """Returns None when all object permissions are granted."""
+        from netbox_librenms_plugin.views.mixins import NetBoxObjectPermissionMixin
+
+        mixin = NetBoxObjectPermissionMixin()
+        mixin.request = MagicMock()
+        mixin.request.user.has_perm.return_value = True
+
+        mock_model = MagicMock()
+        mixin.required_object_permissions = {
+            "POST": [("delete", mock_model)],
+        }
+
+        with patch("netbox_librenms_plugin.views.mixins.get_permission_for_model") as mock_get:
+            mock_get.return_value = "dcim.delete_interface"
+            response = mixin.require_object_permissions_json("POST")
+
+        assert response is None
+
+    def test_require_object_permissions_json_denied(self):
+        """Returns JsonResponse with 403 when object permissions missing."""
+        import json
+
+        from netbox_librenms_plugin.views.mixins import NetBoxObjectPermissionMixin
+
+        mixin = NetBoxObjectPermissionMixin()
+        mixin.request = MagicMock()
+        mixin.request.user.has_perm.return_value = False
+
+        mock_model = MagicMock()
+        mixin.required_object_permissions = {
+            "POST": [("delete", mock_model)],
+        }
+
+        with patch("netbox_librenms_plugin.views.mixins.get_permission_for_model") as mock_get:
+            mock_get.return_value = "dcim.delete_interface"
+            response = mixin.require_object_permissions_json("POST")
+
+        assert response is not None
+        assert response.status_code == 403
+        content = json.loads(response.content)
+        assert "dcim.delete_interface" in content["error"]
+
+    def test_require_all_permissions_allowed(self):
+        """Returns None when both write and object permissions granted."""
+        from netbox_librenms_plugin.views.mixins import (
+            LibreNMSPermissionMixin,
+            NetBoxObjectPermissionMixin,
+        )
+
+        class TestView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixin):
+            pass
+
+        mixin = TestView()
+        mixin.request = MagicMock()
+        mixin.request.user.has_perm.return_value = True
+
+        mock_model = MagicMock()
+        mixin.required_object_permissions = {
+            "POST": [("change", mock_model)],
+        }
+
+        with patch("netbox_librenms_plugin.views.mixins.get_permission_for_model") as mock_get:
+            mock_get.return_value = "dcim.change_device"
+            response = mixin.require_all_permissions("POST")
+
+        assert response is None
+
+    def test_require_all_permissions_denied_write(self):
+        """Returns error when write permission denied (doesn't check object perms)."""
+        from netbox_librenms_plugin.views.mixins import (
+            LibreNMSPermissionMixin,
+            NetBoxObjectPermissionMixin,
+        )
+
+        class TestView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixin):
+            pass
+
+        mixin = TestView()
+        mixin.request = MagicMock()
+        mixin.request.user.has_perm.return_value = False
+        mixin.request.META = {"HTTP_REFERER": "/original/page/"}
+        mixin.request.headers = {}
+
+        mixin.required_object_permissions = {"POST": []}
+
+        with patch("netbox_librenms_plugin.views.mixins.redirect") as mock_redirect:
+            with patch("netbox_librenms_plugin.views.mixins.messages"):
+                response = mixin.require_all_permissions("POST")
+
+        assert response is not None
+        mock_redirect.assert_called_once_with("/original/page/")
+
+    def test_require_all_permissions_denied_object(self):
+        """Returns error when object permissions denied (write passes)."""
+        from netbox_librenms_plugin.views.mixins import (
+            LibreNMSPermissionMixin,
+            NetBoxObjectPermissionMixin,
+        )
+
+        class TestView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixin):
+            pass
+
+        mixin = TestView()
+        mixin.request = MagicMock()
+        # has_write_permission passes, but object perms fail
+        mixin.request.user.has_perm.side_effect = lambda p: p == "netbox_librenms_plugin.change_librenmssettings"
+        mixin.request.META = {"HTTP_REFERER": "/original/page/"}
+        mixin.request.headers = {}
+
+        mock_model = MagicMock()
+        mixin.required_object_permissions = {
+            "POST": [("add", mock_model)],
+        }
+
+        with patch("netbox_librenms_plugin.views.mixins.get_permission_for_model") as mock_get:
+            with patch("netbox_librenms_plugin.views.mixins.messages"):
+                with patch("netbox_librenms_plugin.views.mixins.redirect") as mock_redirect:
+                    mock_get.return_value = "dcim.add_device"
+                    response = mixin.require_all_permissions("POST")
+
+        assert response is not None
+        mock_redirect.assert_called_once()
+
+    def test_require_all_permissions_json_allowed(self):
+        """Returns None when both write and object permissions granted (JSON variant)."""
+        from netbox_librenms_plugin.views.mixins import (
+            LibreNMSPermissionMixin,
+            NetBoxObjectPermissionMixin,
+        )
+
+        class TestView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixin):
+            pass
+
+        mixin = TestView()
+        mixin.request = MagicMock()
+        mixin.request.user.has_perm.return_value = True
+
+        mock_model = MagicMock()
+        mixin.required_object_permissions = {
+            "POST": [("delete", mock_model)],
+        }
+
+        with patch("netbox_librenms_plugin.views.mixins.get_permission_for_model") as mock_get:
+            mock_get.return_value = "dcim.delete_interface"
+            response = mixin.require_all_permissions_json("POST")
+
+        assert response is None
+
+    def test_require_all_permissions_json_denied_write(self):
+        """Returns JSON 403 when write permission denied (JSON variant)."""
+        import json
+
+        from netbox_librenms_plugin.views.mixins import (
+            LibreNMSPermissionMixin,
+            NetBoxObjectPermissionMixin,
+        )
+
+        class TestView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixin):
+            pass
+
+        mixin = TestView()
+        mixin.request = MagicMock()
+        mixin.request.user.has_perm.return_value = False
+
+        response = mixin.require_all_permissions_json("POST")
+
+        assert response is not None
+        assert response.status_code == 403
+        content = json.loads(response.content)
+        assert "error" in content
+
+
+class TestBulkImportPermissions:
+    """Tests for permission checks in bulk import functions."""
+
+    @patch("netbox_librenms_plugin.import_utils.require_permissions")
+    @patch("netbox_librenms_plugin.import_utils.LibreNMSAPI")
+    def test_bulk_import_devices_checks_permissions(self, mock_api_class, mock_require):
+        """bulk_import_devices_shared calls require_permissions."""
+        from netbox_librenms_plugin.import_utils import bulk_import_devices_shared
+
+        user = MagicMock()
+        mock_api = MagicMock()
+        mock_api_class.return_value = mock_api
+
+        # Set up API to return empty device so loop completes quickly
+        mock_api.get_device_info.return_value = (False, None)
+
+        bulk_import_devices_shared(
+            device_ids=[1],
+            user=user,
+            server_key="default",
+        )
+
+        mock_require.assert_called_once()
+        call_args = mock_require.call_args
+        assert user == call_args[0][0]
+        assert "dcim.add_device" in call_args[0][1]
+        assert "dcim.add_interface" in call_args[0][1]
+
+    @patch("netbox_librenms_plugin.import_utils.require_permissions")
+    @patch("netbox_librenms_plugin.import_utils.LibreNMSAPI")
+    def test_bulk_import_devices_extracts_user_from_job(self, mock_api_class, mock_require):
+        """bulk_import_devices_shared extracts user from job if not provided."""
+        from netbox_librenms_plugin.import_utils import bulk_import_devices_shared
+
+        job_user = MagicMock()
+        job = MagicMock()
+        job.job.user = job_user
+
+        mock_api = MagicMock()
+        mock_api_class.return_value = mock_api
+        mock_api.get_device_info.return_value = (False, None)
+
+        bulk_import_devices_shared(
+            device_ids=[1],
+            job=job,
+            server_key="default",
+        )
+
+        mock_require.assert_called_once()
+        call_args = mock_require.call_args
+        assert job_user == call_args[0][0]
+
+    @patch("netbox_librenms_plugin.import_utils.require_permissions")
+    def test_bulk_import_vms_checks_permissions(self, mock_require):
+        """bulk_import_vms calls require_permissions."""
+        from netbox_librenms_plugin.import_utils import bulk_import_vms
+
+        user = MagicMock()
+        api = MagicMock()
+        api.server_key = "default"
+
+        # Empty vm_imports to complete quickly
+        bulk_import_vms(
+            vm_imports={},
+            api=api,
+            user=user,
+        )
+
+        mock_require.assert_called_once()
+        call_args = mock_require.call_args
+        assert user == call_args[0][0]
+        assert "virtualization.add_virtualmachine" in call_args[0][1]
+
+    @patch("netbox_librenms_plugin.import_utils.require_permissions")
+    def test_bulk_import_vms_extracts_user_from_job(self, mock_require):
+        """bulk_import_vms extracts user from job if not provided."""
+        from netbox_librenms_plugin.import_utils import bulk_import_vms
+
+        job_user = MagicMock()
+        job = MagicMock()
+        job.job.user = job_user
+
+        api = MagicMock()
+        api.server_key = "default"
+
+        bulk_import_vms(
+            vm_imports={},
+            api=api,
+            job=job,
+        )
+
+        mock_require.assert_called_once()
+        call_args = mock_require.call_args
+        assert job_user == call_args[0][0]
+
+
+class TestBulkImportPermissionDenied:
+    """Tests for permission denied behavior in bulk import."""
+
+    @patch("netbox_librenms_plugin.import_utils.check_user_permissions")
+    def test_bulk_import_devices_raises_on_missing_permissions(self, mock_check):
+        """bulk_import_devices_shared raises PermissionDenied when permissions missing."""
+        import pytest
+        from django.core.exceptions import PermissionDenied
+
+        from netbox_librenms_plugin.import_utils import bulk_import_devices_shared
+
+        mock_check.return_value = (False, ["dcim.add_device"])
+
+        user = MagicMock()
+
+        with pytest.raises(PermissionDenied):
+            bulk_import_devices_shared(
+                device_ids=[1],
+                user=user,
+                server_key="default",
+            )
+
+    @patch("netbox_librenms_plugin.import_utils.check_user_permissions")
+    def test_bulk_import_vms_raises_on_missing_permissions(self, mock_check):
+        """bulk_import_vms raises PermissionDenied when permissions missing."""
+        import pytest
+        from django.core.exceptions import PermissionDenied
+
+        from netbox_librenms_plugin.import_utils import bulk_import_vms
+
+        mock_check.return_value = (False, ["virtualization.add_virtualmachine"])
+
+        user = MagicMock()
+        api = MagicMock()
+
+        with pytest.raises(PermissionDenied):
+            bulk_import_vms(
+                vm_imports={1: {"cluster_id": 1}},
+                api=api,
+                user=user,
+            )

--- a/netbox_librenms_plugin/views/base/cables_view.py
+++ b/netbox_librenms_plugin/views/base/cables_view.py
@@ -14,10 +14,10 @@ from netbox_librenms_plugin.utils import (
     get_interface_name_field,
     get_virtual_chassis_member,
 )
-from netbox_librenms_plugin.views.mixins import CacheMixin, LibreNMSAPIMixin
+from netbox_librenms_plugin.views.mixins import CacheMixin, LibreNMSAPIMixin, LibreNMSPermissionMixin
 
 
-class BaseCableTableView(LibreNMSAPIMixin, CacheMixin, View):
+class BaseCableTableView(LibreNMSPermissionMixin, LibreNMSAPIMixin, CacheMixin, View):
     """
     Base view for synchronizing cable information from LibreNMS.
     """

--- a/netbox_librenms_plugin/views/base/interfaces_view.py
+++ b/netbox_librenms_plugin/views/base/interfaces_view.py
@@ -8,10 +8,10 @@ from netbox_librenms_plugin.utils import (
     get_interface_name_field,
     get_virtual_chassis_member,
 )
-from netbox_librenms_plugin.views.mixins import CacheMixin, LibreNMSAPIMixin
+from netbox_librenms_plugin.views.mixins import CacheMixin, LibreNMSAPIMixin, LibreNMSPermissionMixin
 
 
-class BaseInterfaceTableView(LibreNMSAPIMixin, CacheMixin, View):
+class BaseInterfaceTableView(LibreNMSPermissionMixin, LibreNMSAPIMixin, CacheMixin, View):
     """
     Base view for fetching interface data from LibreNMS and generating table data.
     """

--- a/netbox_librenms_plugin/views/base/ip_addresses_view.py
+++ b/netbox_librenms_plugin/views/base/ip_addresses_view.py
@@ -12,10 +12,10 @@ from virtualization.models import VirtualMachine
 
 from netbox_librenms_plugin.tables.ipaddresses import IPAddressTable
 from netbox_librenms_plugin.utils import get_interface_name_field
-from netbox_librenms_plugin.views.mixins import CacheMixin, LibreNMSAPIMixin
+from netbox_librenms_plugin.views.mixins import CacheMixin, LibreNMSAPIMixin, LibreNMSPermissionMixin
 
 
-class BaseIPAddressTableView(LibreNMSAPIMixin, CacheMixin, View):
+class BaseIPAddressTableView(LibreNMSPermissionMixin, LibreNMSAPIMixin, CacheMixin, View):
     """
     Base view for synchronizing IP address information from LibreNMS.
     """
@@ -301,7 +301,7 @@ class BaseIPAddressTableView(LibreNMSAPIMixin, CacheMixin, View):
         )
 
 
-class SingleIPAddressVerifyView(CacheMixin, View):
+class SingleIPAddressVerifyView(LibreNMSPermissionMixin, CacheMixin, View):
     """
     View for verifying single IP address data with different VRF.
     """

--- a/netbox_librenms_plugin/views/base/librenms_sync_view.py
+++ b/netbox_librenms_plugin/views/base/librenms_sync_view.py
@@ -9,10 +9,10 @@ from netbox_librenms_plugin.utils import (
     get_librenms_sync_device,
     match_librenms_hardware_to_device_type,
 )
-from netbox_librenms_plugin.views.mixins import LibreNMSAPIMixin
+from netbox_librenms_plugin.views.mixins import LibreNMSAPIMixin, LibreNMSPermissionMixin
 
 
-class BaseLibreNMSSyncView(LibreNMSAPIMixin, generic.ObjectListView):
+class BaseLibreNMSSyncView(LibreNMSPermissionMixin, LibreNMSAPIMixin, generic.ObjectListView):
     """
     Base view for LibreNMS sync information.
     """

--- a/netbox_librenms_plugin/views/imports/actions.py
+++ b/netbox_librenms_plugin/views/imports/actions.py
@@ -560,12 +560,12 @@ class BulkImportDevicesView(LibreNMSPermissionMixin, LibreNMSAPIMixin, View):
         except PermissionDenied as exc:
             # Handle permission errors with a user-friendly message
             logger.warning(f"Permission denied during import: {exc}")
+            messages.error(request, str(exc))
             if request.headers.get("HX-Request"):
                 return HttpResponse(
-                    f'<div class="alert alert-danger"><i class="mdi mdi-alert-circle"></i> {exc}</div>',
-                    status=403,
+                    "",
+                    headers={"HX-Redirect": "/plugins/librenms_plugin/librenms-import/"},
                 )
-            messages.error(request, str(exc))
             return redirect("plugins:netbox_librenms_plugin:librenms_import")
 
         except Exception as exc:  # pragma: no cover - defensive guard

--- a/netbox_librenms_plugin/views/mapping_views.py
+++ b/netbox_librenms_plugin/views/mapping_views.py
@@ -9,9 +9,10 @@ from netbox_librenms_plugin.forms import (
 )
 from netbox_librenms_plugin.models import InterfaceTypeMapping
 from netbox_librenms_plugin.tables.mappings import InterfaceTypeMappingTable
+from netbox_librenms_plugin.views.mixins import LibreNMSPermissionMixin
 
 
-class InterfaceTypeMappingListView(generic.ObjectListView):
+class InterfaceTypeMappingListView(LibreNMSPermissionMixin, generic.ObjectListView):
     """
     Provides a view for listing all `InterfaceTypeMapping` objects.
     """
@@ -23,7 +24,7 @@ class InterfaceTypeMappingListView(generic.ObjectListView):
     template_name = "netbox_librenms_plugin/interfacetypemapping_list.html"
 
 
-class InterfaceTypeMappingCreateView(generic.ObjectEditView):
+class InterfaceTypeMappingCreateView(LibreNMSPermissionMixin, generic.ObjectEditView):
     """
     Provides a view for creating a new `InterfaceTypeMapping` object.
     """
@@ -33,7 +34,7 @@ class InterfaceTypeMappingCreateView(generic.ObjectEditView):
 
 
 @register_model_view(InterfaceTypeMapping, "bulk_import", path="import", detail=False)
-class InterfaceTypeMappingBulkImportView(generic.BulkImportView):
+class InterfaceTypeMappingBulkImportView(LibreNMSPermissionMixin, generic.BulkImportView):
     """
     Provides a view for bulk importing `InterfaceTypeMapping` objects from CSV, JSON, or YAML.
     Supports three import methods: direct import, file upload, and data file.
@@ -43,7 +44,7 @@ class InterfaceTypeMappingBulkImportView(generic.BulkImportView):
     model_form = InterfaceTypeMappingImportForm
 
 
-class InterfaceTypeMappingView(generic.ObjectView):
+class InterfaceTypeMappingView(LibreNMSPermissionMixin, generic.ObjectView):
     """
     Provides a view for displaying details of a specific `InterfaceTypeMapping` object.
     """
@@ -51,7 +52,7 @@ class InterfaceTypeMappingView(generic.ObjectView):
     queryset = InterfaceTypeMapping.objects.all()
 
 
-class InterfaceTypeMappingEditView(generic.ObjectEditView):
+class InterfaceTypeMappingEditView(LibreNMSPermissionMixin, generic.ObjectEditView):
     """
     Provides a view for editing a specific `InterfaceTypeMapping` object.
     """
@@ -60,7 +61,7 @@ class InterfaceTypeMappingEditView(generic.ObjectEditView):
     form = InterfaceTypeMappingForm
 
 
-class InterfaceTypeMappingDeleteView(generic.ObjectDeleteView):
+class InterfaceTypeMappingDeleteView(LibreNMSPermissionMixin, generic.ObjectDeleteView):
     """
     Provides a view for deleting a specific `InterfaceTypeMapping` object.
     """
@@ -68,7 +69,7 @@ class InterfaceTypeMappingDeleteView(generic.ObjectDeleteView):
     queryset = InterfaceTypeMapping.objects.all()
 
 
-class InterfaceTypeMappingBulkDeleteView(generic.BulkDeleteView):
+class InterfaceTypeMappingBulkDeleteView(LibreNMSPermissionMixin, generic.BulkDeleteView):
     """
     Provides a view for deleting multiple `InterfaceTypeMapping` objects.
     """
@@ -77,7 +78,7 @@ class InterfaceTypeMappingBulkDeleteView(generic.BulkDeleteView):
     table = InterfaceTypeMappingTable
 
 
-class InterfaceTypeMappingChangeLogView(generic.ObjectChangeLogView):
+class InterfaceTypeMappingChangeLogView(LibreNMSPermissionMixin, generic.ObjectChangeLogView):
     """
     Provides a view for displaying the change log of a specific `InterfaceTypeMapping` object.
     """

--- a/netbox_librenms_plugin/views/object_sync/devices.py
+++ b/netbox_librenms_plugin/views/object_sync/devices.py
@@ -8,6 +8,7 @@ from django.urls import reverse
 from django.views import View
 from utilities.views import ViewTab, register_model_view
 
+from netbox_librenms_plugin.constants import PERM_VIEW_PLUGIN
 from netbox_librenms_plugin.tables.cables import (
     LibreNMSCableTable,
     VCCableTable,
@@ -22,7 +23,7 @@ from ..base.cables_view import BaseCableTableView
 from ..base.interfaces_view import BaseInterfaceTableView
 from ..base.ip_addresses_view import BaseIPAddressTableView
 from ..base.librenms_sync_view import BaseLibreNMSSyncView
-from ..mixins import CacheMixin
+from ..mixins import CacheMixin, LibreNMSPermissionMixin
 
 
 @register_model_view(Device, name="librenms_sync", path="librenms-sync")
@@ -31,7 +32,7 @@ class DeviceLibreNMSSyncView(BaseLibreNMSSyncView):
 
     queryset = Device.objects.all()
     model = Device
-    tab = ViewTab(label="LibreNMS Sync", permission="dcim.view_device")
+    tab = ViewTab(label="LibreNMS Sync", permission=PERM_VIEW_PLUGIN)
 
     def get_interface_context(self, request, obj):
         interface_name_field = get_interface_name_field(request)
@@ -68,7 +69,7 @@ class DeviceInterfaceTableView(BaseInterfaceTableView):
         return table
 
 
-class SingleInterfaceVerifyView(CacheMixin, View):
+class SingleInterfaceVerifyView(LibreNMSPermissionMixin, CacheMixin, View):
     """Verify single interface data for a device via cached LibreNMS payload."""
 
     def post(self, request):

--- a/netbox_librenms_plugin/views/object_sync/vms.py
+++ b/netbox_librenms_plugin/views/object_sync/vms.py
@@ -2,6 +2,7 @@ from django.urls import reverse
 from utilities.views import ViewTab, register_model_view
 from virtualization.models import VirtualMachine
 
+from netbox_librenms_plugin.constants import PERM_VIEW_PLUGIN
 from netbox_librenms_plugin.tables.interfaces import LibreNMSVMInterfaceTable
 from netbox_librenms_plugin.utils import get_interface_name_field
 
@@ -18,7 +19,7 @@ class VMLibreNMSSyncView(BaseLibreNMSSyncView):
     model = VirtualMachine
     tab = ViewTab(
         label="LibreNMS Sync",
-        permission="virtualization.view_virtualmachine",
+        permission=PERM_VIEW_PLUGIN,
     )
 
     def get_interface_context(self, request, obj):

--- a/netbox_librenms_plugin/views/status_check.py
+++ b/netbox_librenms_plugin/views/status_check.py
@@ -12,12 +12,12 @@ from netbox_librenms_plugin.forms import (
 )
 from netbox_librenms_plugin.tables.device_status import DeviceStatusTable
 from netbox_librenms_plugin.tables.VM_status import VMStatusTable
-from netbox_librenms_plugin.views.mixins import LibreNMSAPIMixin
+from netbox_librenms_plugin.views.mixins import LibreNMSAPIMixin, LibreNMSPermissionMixin
 
 logger = logging.getLogger(__name__)
 
 
-class DeviceStatusListView(LibreNMSAPIMixin, generic.ObjectListView):
+class DeviceStatusListView(LibreNMSPermissionMixin, LibreNMSAPIMixin, generic.ObjectListView):
     """
     Check the status of NetBox devices in LibreNMS.
     Shows NetBox devices with their LibreNMS status.
@@ -71,7 +71,7 @@ class DeviceStatusListView(LibreNMSAPIMixin, generic.ObjectListView):
         return Device.objects.none()
 
 
-class VMStatusListView(LibreNMSAPIMixin, generic.ObjectListView):
+class VMStatusListView(LibreNMSPermissionMixin, LibreNMSAPIMixin, generic.ObjectListView):
     """
     Check the status of virtual machines in NetBox against LibreNMS
     """

--- a/netbox_librenms_plugin/views/sync/device_fields.py
+++ b/netbox_librenms_plugin/views/sync/device_fields.py
@@ -4,13 +4,21 @@ from django.shortcuts import get_object_or_404, redirect
 from django.views import View
 
 from netbox_librenms_plugin.utils import match_librenms_hardware_to_device_type
-from netbox_librenms_plugin.views.mixins import LibreNMSAPIMixin
+from netbox_librenms_plugin.views.mixins import LibreNMSAPIMixin, LibreNMSPermissionMixin, NetBoxObjectPermissionMixin
 
 
-class UpdateDeviceSerialView(LibreNMSAPIMixin, View):
+class UpdateDeviceSerialView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixin, LibreNMSAPIMixin, View):
     """Update NetBox device serial number from LibreNMS."""
 
+    required_object_permissions = {
+        "POST": [("change", Device)],
+    }
+
     def post(self, request, pk):
+        # Check both plugin write and NetBox object permissions
+        if error := self.require_all_permissions("POST"):
+            return error
+
         device = get_object_or_404(Device, pk=pk)
         self.librenms_id = self.librenms_api.get_librenms_id(device)
 
@@ -45,10 +53,18 @@ class UpdateDeviceSerialView(LibreNMSAPIMixin, View):
         return redirect("plugins:netbox_librenms_plugin:device_librenms_sync", pk=pk)
 
 
-class UpdateDeviceTypeView(LibreNMSAPIMixin, View):
+class UpdateDeviceTypeView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixin, LibreNMSAPIMixin, View):
     """Update NetBox DeviceType using LibreNMS hardware metadata."""
 
+    required_object_permissions = {
+        "POST": [("change", Device)],
+    }
+
     def post(self, request, pk):
+        # Check both plugin write and NetBox object permissions
+        if error := self.require_all_permissions("POST"):
+            return error
+
         device = get_object_or_404(Device, pk=pk)
         self.librenms_id = self.librenms_api.get_librenms_id(device)
 
@@ -90,10 +106,18 @@ class UpdateDeviceTypeView(LibreNMSAPIMixin, View):
         return redirect("plugins:netbox_librenms_plugin:device_librenms_sync", pk=pk)
 
 
-class UpdateDevicePlatformView(LibreNMSAPIMixin, View):
+class UpdateDevicePlatformView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixin, LibreNMSAPIMixin, View):
     """Update NetBox Platform based on LibreNMS OS info."""
 
+    required_object_permissions = {
+        "POST": [("change", Device)],
+    }
+
     def post(self, request, pk):
+        # Check both plugin write and NetBox object permissions
+        if error := self.require_all_permissions("POST"):
+            return error
+
         device = get_object_or_404(Device, pk=pk)
         self.librenms_id = self.librenms_api.get_librenms_id(device)
 
@@ -141,10 +165,21 @@ class UpdateDevicePlatformView(LibreNMSAPIMixin, View):
         return redirect("plugins:netbox_librenms_plugin:device_librenms_sync", pk=pk)
 
 
-class CreateAndAssignPlatformView(LibreNMSAPIMixin, View):
+class CreateAndAssignPlatformView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixin, LibreNMSAPIMixin, View):
     """Create a new Platform and assign it to the device."""
 
+    required_object_permissions = {
+        "POST": [
+            ("change", Device),
+            ("add", Platform),
+        ],
+    }
+
     def post(self, request, pk):
+        # Check both plugin write and NetBox object permissions
+        if error := self.require_all_permissions("POST"):
+            return error
+
         device = get_object_or_404(Device, pk=pk)
 
         platform_name = request.POST.get("platform_name")
@@ -184,10 +219,18 @@ class CreateAndAssignPlatformView(LibreNMSAPIMixin, View):
         return redirect("plugins:netbox_librenms_plugin:device_librenms_sync", pk=pk)
 
 
-class AssignVCSerialView(LibreNMSAPIMixin, View):
+class AssignVCSerialView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixin, LibreNMSAPIMixin, View):
     """Assign serial numbers to each virtual chassis member."""
 
+    required_object_permissions = {
+        "POST": [("change", Device)],
+    }
+
     def post(self, request, pk):
+        # Check both plugin write and NetBox object permissions
+        if error := self.require_all_permissions("POST"):
+            return error
+
         device = get_object_or_404(Device, pk=pk)
 
         if not device.virtual_chassis:

--- a/netbox_librenms_plugin/views/sync/interfaces.py
+++ b/netbox_librenms_plugin/views/sync/interfaces.py
@@ -20,8 +20,10 @@ class SyncInterfacesView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixin, C
         """Return the required permissions based on object type."""
         if object_type == "device":
             return [("add", Interface), ("change", Interface)]
-        else:
+        elif object_type == "virtualmachine":
             return [("add", VMInterface), ("change", VMInterface)]
+        else:
+            raise Http404(f"Invalid object type: {object_type}")
 
     def post(self, request, object_type, object_id):
         # Set permissions dynamically based on object type
@@ -219,8 +221,10 @@ class DeleteNetBoxInterfacesView(LibreNMSPermissionMixin, NetBoxObjectPermission
         """Return the required permissions based on object type."""
         if object_type == "device":
             return [("delete", Interface)]
-        else:
+        elif object_type == "virtualmachine":
             return [("delete", VMInterface)]
+        else:
+            raise Http404(f"Invalid object type: {object_type}")
 
     def post(self, request, object_type, object_id):
         # Check plugin write permission first

--- a/netbox_librenms_plugin/views/sync/locations.py
+++ b/netbox_librenms_plugin/views/sync/locations.py
@@ -8,10 +8,10 @@ from django_tables2 import SingleTableView
 
 from netbox_librenms_plugin.filtersets import SiteLocationFilterSet
 from netbox_librenms_plugin.tables.locations import SiteLocationSyncTable
-from netbox_librenms_plugin.views.mixins import LibreNMSAPIMixin
+from netbox_librenms_plugin.views.mixins import LibreNMSAPIMixin, LibreNMSPermissionMixin
 
 
-class SyncSiteLocationView(LibreNMSAPIMixin, SingleTableView):
+class SyncSiteLocationView(LibreNMSPermissionMixin, LibreNMSAPIMixin, SingleTableView):
     """Synchronize NetBox Sites with LibreNMS locations."""
 
     table_class = SiteLocationSyncTable
@@ -78,6 +78,10 @@ class SyncSiteLocationView(LibreNMSAPIMixin, SingleTableView):
         return lat_match and lng_match
 
     def post(self, request):
+        # Check write permission before modifying LibreNMS locations
+        if error := self.require_write_permission():
+            return error
+
         action = request.POST.get("action")
         pk = request.POST.get("pk")
         if not pk:


### PR DESCRIPTION
## Summary

Adds a two-tier permission system to all plugin views:

1. **Plugin-level access** — `view_librenmssettings` gates page access; `change_librenmssettings` gates write actions
2. **NetBox object permissions** — Sync/import POST handlers check model-specific permissions (e.g., `dcim.add_cable`, `dcim.change_device`)

## Changes

### Core
- New `LibreNMSPermissionMixin` and `NetBoxObjectPermissionMixin` in `views/mixins.py`
- Permission constants in `constants.py`
- `LibreNMSPluginPermission` class for API endpoints

### Views
- All views now inherit `LibreNMSPermissionMixin`
- All sync POST handlers call `require_write_permission()` / `require_all_permissions()`
- Import views check write permissions before confirm/import operations

### Background Jobs
- Non-superusers automatically fall back to synchronous mode (NetBox core restricts `/api/core/background-tasks/` to superusers)
- Import template conditionally shows background job UI

### Navigation
- All menu items require `view_librenmssettings` — unauthorized users don't see the menu

### Documentation
- User-facing permissions guide at `docs/usage_tips/permissions.md`
- Added to mkdocs.yml nav

### Tests
- New `test_permissions.py` (780+ lines) covering mixins, API permissions, object permission helpers
- Updated `test_background_jobs.py` for superuser fallback logic