### PR TITLE
feat: add empty state cards for sync tabs

### DIFF
--- a/netbox_librenms_plugin/templates/netbox_librenms_plugin/_cable_sync_content.html
+++ b/netbox_librenms_plugin/templates/netbox_librenms_plugin/_cable_sync_content.html
@@ -70,6 +70,13 @@
         </div>
     </div>
 </form>
+{% else %}
+<div class="card">
+    <div class="card-body text-center text-muted py-4">
+        <i class="mdi mdi-sync-off mdi-48px"></i>
+        <p class="mt-2 mb-0">No cable data loaded. Click <strong>Refresh Cables</strong> to fetch data from LibreNMS.</p>
+    </div>
+</div>
 {% endif %}
 <!-- Interface Type Help Modal -->
 <div class="modal fade" id="cableSyncHelpModal" tabindex="-1" aria-labelledby="cableSyncHelpModalLabel"

--- a/netbox_librenms_plugin/templates/netbox_librenms_plugin/_interface_sync_content.html
+++ b/netbox_librenms_plugin/templates/netbox_librenms_plugin/_interface_sync_content.html
@@ -156,6 +156,13 @@
         </div>
     </div>
 </form>
+{% else %}
+<div class="card">
+    <div class="card-body text-center text-muted py-4">
+        <i class="mdi mdi-sync-off mdi-48px"></i>
+        <p class="mt-2 mb-0">No interface data loaded. Click <strong>Refresh Interfaces</strong> to fetch data from LibreNMS.</p>
+    </div>
+</div>
 {% endif %} <!-- End if interface_sync.table -->
 
 <!-- Interface Type Help Modal -->

--- a/netbox_librenms_plugin/templates/netbox_librenms_plugin/_ipaddress_sync_content.html
+++ b/netbox_librenms_plugin/templates/netbox_librenms_plugin/_ipaddress_sync_content.html
@@ -73,4 +73,11 @@
         </div>
     </div>
 </form>
+{% else %}
+<div class="card">
+    <div class="card-body text-center text-muted py-4">
+        <i class="mdi mdi-sync-off mdi-48px"></i>
+        <p class="mt-2 mb-0">No IP address data loaded. Click <strong>Refresh IP Addresses</strong> to fetch data from LibreNMS.</p>
+    </div>
+</div>
 {% endif %}


### PR DESCRIPTION
Show informative empty state cards when no data is loaded for cable, interface, and IP address sync tabs. Cards display a sync-off icon and prompt users to click the refresh button.