### PR TITLE
Fix/ci workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/lint-format.yaml
+++ b/.github/workflows/lint-format.yaml
@@ -15,10 +15,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.9'
           cache: 'pip'

--- a/.github/workflows/mkdocs.yaml
+++ b/.github/workflows/mkdocs.yaml
@@ -10,8 +10,8 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+      - uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4
         with:
           python-version: 3.x
       - run: pip install mkdocs-material mkdocs-autorefs mkdocs-material-extensions mkdocstrings mkdocstrings-python-legacy mkdocs-include-markdown-plugin

--- a/.github/workflows/publish-pypi.yaml
+++ b/.github/workflows/publish-pypi.yaml
@@ -16,9 +16,9 @@ jobs:
     steps:
     - name: Clean previous builds
       run: rm -rf dist/
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
     - name: Set up Python
-      uses: actions/setup-python@v5.1.0
+      uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5.1.0
       with:
         python-version: "3.x"
     - name: Install pypa/build
@@ -30,7 +30,7 @@ jobs:
     - name: Build a binary wheel and a source tarball
       run: python3 -m build
     - name: Store the distribution packages
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: python-package-distributions
         path: dist/
@@ -50,9 +50,9 @@ jobs:
 
     steps:
     - name: Download all the dists
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
       with:
         name: python-package-distributions
         path: dist/
     - name: Publish distribution 📦 to PyPI
-      uses: pypa/gh-action-pypi-publish@release/v1
+      uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # release/v1

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -39,17 +39,17 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@main
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           path: netbox-librenms-plugin
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@main
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: ${{ matrix.python-version }}
 
       - name: Checkout NetBox
-        uses: actions/checkout@main
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: "netbox-community/netbox"
           path: netbox
@@ -64,7 +64,7 @@ jobs:
       - name: Set up configuration
         working-directory: netbox
         run: |
-          ln -s $(pwd)/../netbox-librenms-plugin/media/configuration.testing.py netbox/netbox/configuration.py
+          ln -s "$(pwd)/../netbox-librenms-plugin/media/configuration.testing.py" netbox/netbox/configuration.py
 
           python -m pip install --upgrade pip
           python -m pip install tblib

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ repos:
     rev: v0.14.13  # Use the latest version from https://github.com/astral-sh/ruff-pre-commit/releases
     hooks:
       # Run the linter
-      - id: ruff
+      - id: ruff-check
         args: [--fix]
       # Run the formatter
       - id: ruff-format


### PR DESCRIPTION
## Summary
pin GitHub Actions to commit SHAs and add Dependabot
in March 2025 popular tj-actions/changed-files action was compromised — more than 350 Git tags were updated to a commit that attempted to dump the runner's secrets, affecting more than 23,000 repositories.
Dependabot works with SHA and versions in comments - that's a proposal.
Ruff changed hook name as well, ruff still works for now, but it's marked as deprecated.

## Motivation / Problem
What issue does this solve?
- Maintenance / cleanup

Link any related issues if applicable.

## Scope of Change
Tick all that apply:

- [ ] Sync/Import logic
- [ ] NetBox models / ORM
- [ ] LibreNMS API interaction
- [x] Config / settings
- [ ] Web UI / templates
- [ ] Database migrations
- [ ] Tests
- [ ] Docs only
- Other (please descibe)?

## How Was This Tested?
Tick all that apply and describe briefly.

- [ ] Unit tests
- [ ] Manual testing
- [x] Not tested (explain why)
works for me on other repos - but can't easily test actions

### Manual Test Steps (if applicable)
1.
2.
3.

## Risk Assessment
- Does this change affect existing users?  
- Could this cause unintended imports / updates?

Shouldn't change anything - pinned SHA are to the same versions as they were - didn't update to newer.

## Backwards Compatibility
- [x] No breaking changes
- [ ] Breaking change (explain and document)

## Other Notes
Anything the maintainer(s) should pay particular attention to?
