### PR TITLE
chore: update pre-commit hooks, ruff config, and add uv dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,7 @@ updates:
       github-actions:
         patterns:
           - "*"
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -59,7 +59,7 @@ jobs:
         working-directory: netbox-librenms-plugin
         run: |
           pip install -e .
-          pip install pytest pytest-django
+          pip install pytest pytest-django pytest-cov
 
       - name: Set up configuration
         working-directory: netbox
@@ -75,4 +75,14 @@ jobs:
         env:
           NETBOX_CONFIGURATION: netbox.configuration
         run: |
-          python -m pytest ../../netbox-librenms-plugin/netbox_librenms_plugin/tests/ -v
+          python -m pytest ../../netbox-librenms-plugin/netbox_librenms_plugin/tests/ -v \
+            --cov=netbox_librenms_plugin \
+            --cov-report=html:../../netbox-librenms-plugin/coverage_html \
+            --cov-report=term-missing
+
+      - name: Upload coverage report
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        if: matrix.python-version == '3.12'
+        with:
+          name: coverage-report
+          path: netbox-librenms-plugin/coverage_html/

--- a/.gitignore
+++ b/.gitignore
@@ -164,6 +164,7 @@ pip-delete-this-directory.txt
 
 # Unit test / coverage reports
 htmlcov/
+coverage_html/
 .tox/
 .nox/
 .coverage

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.14.13  # Use the latest version from https://github.com/astral-sh/ruff-pre-commit/releases
+    rev: v0.15.4  # Use the latest version from https://github.com/astral-sh/ruff-pre-commit/releases
     hooks:
       # Run the linter
       - id: ruff-check
@@ -14,5 +14,6 @@ repos:
       - id: trailing-whitespace
       - id: end-of-file-fixer
       - id: check-yaml
+        exclude: ^mkdocs\.yml$
       - id: check-added-large-files
       - id: check-merge-conflict

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,11 +49,6 @@ addopts = "-v --tb=short"
 [tool.ruff]
 line-length = 120
 
-[tool.ruff.lint.mccabe]
-#Flag errors (`C901`) whenever the complexity level exceeds 15.
-#Rule not enforced - only to bump default 10 to 15 to allow for manual check
-max-complexity = 15
-
 [tool.ruff.lint]
 # Follow NetBox conventions - ignore certain rules
 ignore = [
@@ -61,6 +56,11 @@ ignore = [
     "F403",  # Undefined local with import star
     "F405",  # Undefined local with import star usage
 ]
+
+[tool.ruff.lint.mccabe]
+# Flag errors (`C901`) whenever the complexity level exceeds 15.
+# Rule not enforced - only to bump default 10 to 15 to allow for manual check
+max-complexity = 15
 
 [tool.ruff.lint.per-file-ignores]
 # Allow re-exports in __init__.py files

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,11 @@ addopts = "-v --tb=short"
 [tool.ruff]
 line-length = 120
 
+[tool.ruff.lint.mccabe]
+#Flag errors (`C901`) whenever the complexity level exceeds 15.
+#Rule not enforced - only to bump default 10 to 15 to allow for manual check
+max-complexity = 15
+
 [tool.ruff.lint]
 # Follow NetBox conventions - ignore certain rules
 ignore = [


### PR DESCRIPTION
## Summary
Tooling-only changes — no production logic modified.
Added test coverage report to CI (no gating, for information only)

## Motivation / Problem
- Maintenance / cleanup

## Scope of Change
- Other: tooling

## How Was This Tested?
- Manual testing: yes, tested in fork

### Manual Test Steps (if applicable)
ruff check --select C901  - now works with complexity 15 (up from default 10) - allows to have a look which functions may be too complex - and 15 is reasonable compromise in my opinion, 10 is a bit low.
This is not enforced.

## Risk Assessment
- Does this change affect existing users?  
No 
- Could this cause unintended imports / updates?
No, pulls up ruff version to be the same as used in CI atm.

## Backwards Compatibility
- No breaking changes

## Other Notes
- Exclude mkdocs.yml from the check-yaml hook. MkDocs uses custom YAML tags (!ENV, etc.) that the generic validator rejects; this exclusion prevents false-positive CI failures on docs changes.
- Add uv package-ecosystem entry on a weekly schedule so the uv.lock lock file is kept current automatically, mirroring the existing GitHub Actions update configuration.
