### PR TITLE
fix: vc verify views crash when no member has primary_ip

### DIFF
--- a/netbox_librenms_plugin/tests/test_verify_views.py
+++ b/netbox_librenms_plugin/tests/test_verify_views.py
@@ -1,0 +1,204 @@
+"""Tests for SingleCableVerifyView and SingleInterfaceVerifyView VC resolution.
+
+Covers the fix for the NoneType crash when a VC device has no primary_ip
+on any member — both views must use get_librenms_sync_device() and guard
+against None.
+"""
+
+import json
+from unittest.mock import MagicMock, patch
+
+
+def _make_request(body: dict) -> MagicMock:
+    """Create a mock POST request with JSON body."""
+    request = MagicMock()
+    request.body = json.dumps(body).encode()
+    request.user.has_perm.return_value = True
+    return request
+
+
+def _make_device(pk=1, has_vc=False, name="test-device"):
+    """Create a mock Device with optional virtual_chassis."""
+    device = MagicMock()
+    device.pk = pk
+    device.id = pk
+    device.name = name
+    device._meta.model_name = "device"
+    device.virtual_chassis = MagicMock() if has_vc else None
+    device.interfaces.filter.return_value.first.return_value = None
+    return device
+
+
+# ---------------------------------------------------------------------------
+# SingleCableVerifyView
+# ---------------------------------------------------------------------------
+class TestSingleCableVerifyView:
+    """SingleCableVerifyView.post() VC resolution and None guard."""
+
+    def _make_view(self):
+        from netbox_librenms_plugin.views.base.cables_view import SingleCableVerifyView
+
+        view = object.__new__(SingleCableVerifyView)
+        view._librenms_api = MagicMock()
+        return view
+
+    @patch("netbox_librenms_plugin.views.base.cables_view.get_object_or_404")
+    @patch("netbox_librenms_plugin.views.base.cables_view.get_librenms_sync_device")
+    @patch("netbox_librenms_plugin.views.base.cables_view.cache")
+    def test_vc_device_no_primary_ip_returns_empty_row(self, mock_cache, mock_sync, mock_get_obj):
+        """VC with no primary_ip: get_librenms_sync_device returns None → empty row, no crash."""
+        device = _make_device(pk=1, has_vc=True)
+        mock_get_obj.return_value = device
+        mock_sync.return_value = None
+
+        view = self._make_view()
+        request = _make_request({"device_id": 1, "local_port_id": "42"})
+        response = view.post(request)
+
+        data = json.loads(response.content)
+        assert data["status"] == "success"
+        assert data["formatted_row"]["cable_status"] == "Missing Ports"
+        mock_cache.get.assert_not_called()
+
+    @patch("netbox_librenms_plugin.views.base.cables_view.get_object_or_404")
+    @patch("netbox_librenms_plugin.views.base.cables_view.get_librenms_sync_device")
+    @patch("netbox_librenms_plugin.views.base.cables_view.cache")
+    def test_vc_device_with_sync_device_uses_cache(self, mock_cache, mock_sync, mock_get_obj):
+        """VC with valid sync device: cache is queried with the sync device's key."""
+        device = _make_device(pk=1, has_vc=True)
+        sync_device = _make_device(pk=2, name="sync-device")
+        mock_get_obj.return_value = device
+        mock_sync.return_value = sync_device
+        mock_cache.get.return_value = None  # No cached data
+
+        view = self._make_view()
+        request = _make_request({"device_id": 1, "local_port_id": "42"})
+        view.post(request)
+
+        mock_sync.assert_called_once_with(device)
+        mock_cache.get.assert_called_once()
+        cache_key = mock_cache.get.call_args[0][0]
+        assert "device" in cache_key
+        assert "2" in cache_key
+
+    @patch("netbox_librenms_plugin.views.base.cables_view.get_object_or_404")
+    @patch("netbox_librenms_plugin.views.base.cables_view.get_librenms_sync_device")
+    @patch("netbox_librenms_plugin.views.base.cables_view.cache")
+    def test_non_vc_device_skips_sync_device_lookup(self, mock_cache, mock_sync, mock_get_obj):
+        """Non-VC device: get_librenms_sync_device is NOT called."""
+        device = _make_device(pk=5, has_vc=False)
+        mock_get_obj.return_value = device
+        mock_cache.get.return_value = None
+
+        view = self._make_view()
+        request = _make_request({"device_id": 5, "local_port_id": "10"})
+        view.post(request)
+
+        mock_sync.assert_not_called()
+        mock_cache.get.assert_called_once()
+
+    def test_no_device_id_returns_empty_row(self):
+        """Missing device_id: returns default empty formatted_row."""
+        view = self._make_view()
+        request = _make_request({"local_port_id": "42"})
+        response = view.post(request)
+
+        data = json.loads(response.content)
+        assert data["status"] == "success"
+        assert data["formatted_row"]["cable_status"] == "Missing Ports"
+
+
+# ---------------------------------------------------------------------------
+# SingleInterfaceVerifyView
+# ---------------------------------------------------------------------------
+class TestSingleInterfaceVerifyView:
+    """SingleInterfaceVerifyView.post() VC resolution and None guard."""
+
+    def _make_view(self):
+        from netbox_librenms_plugin.views.object_sync.devices import SingleInterfaceVerifyView
+
+        view = object.__new__(SingleInterfaceVerifyView)
+        return view
+
+    @patch("netbox_librenms_plugin.views.object_sync.devices.get_object_or_404")
+    @patch("netbox_librenms_plugin.views.object_sync.devices.get_librenms_sync_device")
+    @patch("netbox_librenms_plugin.views.object_sync.devices.cache")
+    def test_vc_device_no_sync_device_returns_404(self, mock_cache, mock_sync, mock_get_obj):
+        """VC with no sync device: returns 404 JSON error, no crash."""
+        device = _make_device(pk=1, has_vc=True)
+        mock_get_obj.return_value = device
+        mock_sync.return_value = None
+
+        view = self._make_view()
+        request = _make_request(
+            {
+                "device_id": 1,
+                "interface_name": "eth0",
+                "interface_name_field": "ifName",
+            }
+        )
+        response = view.post(request)
+
+        assert response.status_code == 404
+        data = json.loads(response.content)
+        assert data["status"] == "error"
+        assert "sync device" in data["message"].lower()
+        mock_cache.get.assert_not_called()
+
+    @patch("netbox_librenms_plugin.views.object_sync.devices.get_object_or_404")
+    @patch("netbox_librenms_plugin.views.object_sync.devices.get_librenms_sync_device")
+    @patch("netbox_librenms_plugin.views.object_sync.devices.cache")
+    def test_vc_device_with_sync_device_uses_cache(self, mock_cache, mock_sync, mock_get_obj):
+        """VC with valid sync device: cache is queried with the sync device's key."""
+        device = _make_device(pk=1, has_vc=True)
+        sync_device = _make_device(pk=3, name="sync-member")
+        mock_get_obj.return_value = device
+        mock_sync.return_value = sync_device
+        mock_cache.get.return_value = None
+
+        view = self._make_view()
+        request = _make_request(
+            {
+                "device_id": 1,
+                "interface_name": "eth0",
+                "interface_name_field": "ifName",
+            }
+        )
+        view.post(request)
+
+        mock_sync.assert_called_once_with(device)
+        mock_cache.get.assert_called_once()
+        cache_key = mock_cache.get.call_args[0][0]
+        assert "3" in cache_key
+
+    @patch("netbox_librenms_plugin.views.object_sync.devices.get_object_or_404")
+    @patch("netbox_librenms_plugin.views.object_sync.devices.get_librenms_sync_device")
+    @patch("netbox_librenms_plugin.views.object_sync.devices.cache")
+    def test_non_vc_device_skips_sync_device_lookup(self, mock_cache, mock_sync, mock_get_obj):
+        """Non-VC device: get_librenms_sync_device is NOT called."""
+        device = _make_device(pk=5, has_vc=False)
+        mock_get_obj.return_value = device
+        mock_cache.get.return_value = None
+
+        view = self._make_view()
+        request = _make_request(
+            {
+                "device_id": 5,
+                "interface_name": "eth0",
+                "interface_name_field": "ifName",
+            }
+        )
+        view.post(request)
+
+        mock_sync.assert_not_called()
+        mock_cache.get.assert_called_once()
+
+    def test_no_device_id_returns_400(self):
+        """Missing device_id: returns 400 error."""
+        view = self._make_view()
+        request = _make_request({"interface_name": "eth0"})
+        response = view.post(request)
+
+        assert response.status_code == 400
+        data = json.loads(response.content)
+        assert data["status"] == "error"

--- a/netbox_librenms_plugin/tests/test_verify_views.py
+++ b/netbox_librenms_plugin/tests/test_verify_views.py
@@ -1,8 +1,8 @@
 """Tests for SingleCableVerifyView and SingleInterfaceVerifyView VC resolution.
 
-Covers the fix for the NoneType crash when a VC device has no primary_ip
-on any member — both views must use get_librenms_sync_device() and guard
-against None.
+Verifies that both views delegate VC device resolution to
+get_librenms_sync_device() and handle the None return gracefully
+(e.g. empty VC members or vc_position type errors).
 """
 
 import json
@@ -17,14 +17,14 @@ def _make_request(body: dict) -> MagicMock:
     return request
 
 
-def _make_device(pk=1, has_vc=False, name="test-device"):
-    """Create a mock Device with optional virtual_chassis."""
+def _make_vc_device(pk=1, name="vc-device"):
+    """Create a mock Device that belongs to a virtual chassis."""
     device = MagicMock()
     device.pk = pk
     device.id = pk
     device.name = name
     device._meta.model_name = "device"
-    device.virtual_chassis = MagicMock() if has_vc else None
+    device.virtual_chassis = MagicMock()
     device.interfaces.filter.return_value.first.return_value = None
     return device
 
@@ -45,9 +45,9 @@ class TestSingleCableVerifyView:
     @patch("netbox_librenms_plugin.views.base.cables_view.get_object_or_404")
     @patch("netbox_librenms_plugin.views.base.cables_view.get_librenms_sync_device")
     @patch("netbox_librenms_plugin.views.base.cables_view.cache")
-    def test_vc_device_no_primary_ip_returns_empty_row(self, mock_cache, mock_sync, mock_get_obj):
-        """VC with no primary_ip: get_librenms_sync_device returns None → empty row, no crash."""
-        device = _make_device(pk=1, has_vc=True)
+    def test_vc_no_resolvable_sync_device_returns_empty_row(self, mock_cache, mock_sync, mock_get_obj):
+        """VC where get_librenms_sync_device returns None → empty row, no crash."""
+        device = _make_vc_device(pk=1)
         mock_get_obj.return_value = device
         mock_sync.return_value = None
 
@@ -63,10 +63,10 @@ class TestSingleCableVerifyView:
     @patch("netbox_librenms_plugin.views.base.cables_view.get_object_or_404")
     @patch("netbox_librenms_plugin.views.base.cables_view.get_librenms_sync_device")
     @patch("netbox_librenms_plugin.views.base.cables_view.cache")
-    def test_vc_device_with_sync_device_uses_cache(self, mock_cache, mock_sync, mock_get_obj):
-        """VC with valid sync device: cache is queried with the sync device's key."""
-        device = _make_device(pk=1, has_vc=True)
-        sync_device = _make_device(pk=2, name="sync-device")
+    def test_vc_resolved_sync_device_uses_cache(self, mock_cache, mock_sync, mock_get_obj):
+        """VC with resolved sync device: cache is queried with that device's key."""
+        device = _make_vc_device(pk=1)
+        sync_device = _make_vc_device(pk=2, name="sync-device")
         mock_get_obj.return_value = device
         mock_sync.return_value = sync_device
         mock_cache.get.return_value = None  # No cached data
@@ -84,10 +84,10 @@ class TestSingleCableVerifyView:
     @patch("netbox_librenms_plugin.views.base.cables_view.get_object_or_404")
     @patch("netbox_librenms_plugin.views.base.cables_view.get_librenms_sync_device")
     @patch("netbox_librenms_plugin.views.base.cables_view.cache")
-    def test_non_vc_device_skips_sync_device_lookup(self, mock_cache, mock_sync, mock_get_obj):
+    def test_non_vc_device_skips_sync_device_lookup(self, mock_cache, mock_sync, mock_get_obj, mock_netbox_device):
         """Non-VC device: get_librenms_sync_device is NOT called."""
-        device = _make_device(pk=5, has_vc=False)
-        mock_get_obj.return_value = device
+        mock_netbox_device.virtual_chassis = None
+        mock_get_obj.return_value = mock_netbox_device
         mock_cache.get.return_value = None
 
         view = self._make_view()
@@ -123,9 +123,9 @@ class TestSingleInterfaceVerifyView:
     @patch("netbox_librenms_plugin.views.object_sync.devices.get_object_or_404")
     @patch("netbox_librenms_plugin.views.object_sync.devices.get_librenms_sync_device")
     @patch("netbox_librenms_plugin.views.object_sync.devices.cache")
-    def test_vc_device_no_sync_device_returns_404(self, mock_cache, mock_sync, mock_get_obj):
-        """VC with no sync device: returns 404 JSON error, no crash."""
-        device = _make_device(pk=1, has_vc=True)
+    def test_vc_no_resolvable_sync_device_returns_404(self, mock_cache, mock_sync, mock_get_obj):
+        """VC where get_librenms_sync_device returns None → 404 JSON error, no crash."""
+        device = _make_vc_device(pk=1)
         mock_get_obj.return_value = device
         mock_sync.return_value = None
 
@@ -148,10 +148,10 @@ class TestSingleInterfaceVerifyView:
     @patch("netbox_librenms_plugin.views.object_sync.devices.get_object_or_404")
     @patch("netbox_librenms_plugin.views.object_sync.devices.get_librenms_sync_device")
     @patch("netbox_librenms_plugin.views.object_sync.devices.cache")
-    def test_vc_device_with_sync_device_uses_cache(self, mock_cache, mock_sync, mock_get_obj):
-        """VC with valid sync device: cache is queried with the sync device's key."""
-        device = _make_device(pk=1, has_vc=True)
-        sync_device = _make_device(pk=3, name="sync-member")
+    def test_vc_resolved_sync_device_uses_cache(self, mock_cache, mock_sync, mock_get_obj):
+        """VC with resolved sync device: cache is queried with that device's key."""
+        device = _make_vc_device(pk=1)
+        sync_device = _make_vc_device(pk=3, name="sync-member")
         mock_get_obj.return_value = device
         mock_sync.return_value = sync_device
         mock_cache.get.return_value = None
@@ -174,10 +174,10 @@ class TestSingleInterfaceVerifyView:
     @patch("netbox_librenms_plugin.views.object_sync.devices.get_object_or_404")
     @patch("netbox_librenms_plugin.views.object_sync.devices.get_librenms_sync_device")
     @patch("netbox_librenms_plugin.views.object_sync.devices.cache")
-    def test_non_vc_device_skips_sync_device_lookup(self, mock_cache, mock_sync, mock_get_obj):
+    def test_non_vc_device_skips_sync_device_lookup(self, mock_cache, mock_sync, mock_get_obj, mock_netbox_device):
         """Non-VC device: get_librenms_sync_device is NOT called."""
-        device = _make_device(pk=5, has_vc=False)
-        mock_get_obj.return_value = device
+        mock_netbox_device.virtual_chassis = None
+        mock_get_obj.return_value = mock_netbox_device
         mock_cache.get.return_value = None
 
         view = self._make_view()

--- a/netbox_librenms_plugin/views/base/cables_view.py
+++ b/netbox_librenms_plugin/views/base/cables_view.py
@@ -14,6 +14,7 @@ from django.views import View
 
 from netbox_librenms_plugin.utils import (
     get_interface_name_field,
+    get_librenms_sync_device,
     get_virtual_chassis_member,
 )
 from netbox_librenms_plugin.views.mixins import CacheMixin, LibreNMSAPIMixin, LibreNMSPermissionMixin
@@ -363,16 +364,14 @@ class SingleCableVerifyView(BaseCableTableView):
         if selected_device_id:
             selected_device = get_object_or_404(Device, pk=selected_device_id)
 
-            # Get the primary device (master or first with IP) if part of virtual chassis
+            # Resolve the VC device that holds cached LibreNMS data
             if selected_device.virtual_chassis:
-                primary_device = selected_device.virtual_chassis.master
-                if not primary_device or not primary_device.primary_ip:
-                    primary_device = next(
-                        (member for member in selected_device.virtual_chassis.members.all() if member.primary_ip),
-                        None,
-                    )
+                primary_device = get_librenms_sync_device(selected_device)
             else:
                 primary_device = selected_device
+
+            if not primary_device:
+                return JsonResponse({"status": "success", "formatted_row": formatted_row})
 
             cached_links = cache.get(self.get_cache_key(primary_device, "links"))
 

--- a/netbox_librenms_plugin/views/object_sync/devices.py
+++ b/netbox_librenms_plugin/views/object_sync/devices.py
@@ -19,6 +19,7 @@ from netbox_librenms_plugin.tables.interfaces import (
 )
 from netbox_librenms_plugin.utils import (
     get_interface_name_field,
+    get_librenms_sync_device,
     get_missing_vlan_warning,
     get_tagged_vlan_css_class,
     get_untagged_vlan_css_class,
@@ -106,15 +107,14 @@ class SingleInterfaceVerifyView(LibreNMSPermissionMixin, CacheMixin, View):
 
         selected_device = get_object_or_404(Device, pk=selected_device_id)
 
+        # Resolve the VC device that holds cached LibreNMS data
         if selected_device.virtual_chassis:
-            primary_device = selected_device.virtual_chassis.master
-            if not primary_device or not primary_device.primary_ip:
-                primary_device = next(
-                    (member for member in selected_device.virtual_chassis.members.all() if member.primary_ip),
-                    None,
-                )
+            primary_device = get_librenms_sync_device(selected_device)
         else:
             primary_device = selected_device
+
+        if not primary_device:
+            return JsonResponse({"status": "error", "message": "No sync device found for virtual chassis"}, status=404)
 
         cached_data = cache.get(self.get_cache_key(primary_device, "ports"))
 


### PR DESCRIPTION
## Summary
Fix 500 error in cable and interface verify views when changing the VC member dropdown on a virtual chassis device with no `primary_ip` on any member.

## Motivation / Problem
- Bug

`SingleCableVerifyView` and `SingleInterfaceVerifyView` used inline VC resolution that only checked `primary_ip`. When no member has one, `primary_device` is `None`, causing `AttributeError: 'NoneType' object has no attribute '_meta'` in `CacheMixin.get_cache_key()`.

## Scope of Change
- Sync/Import logic
- Tests

## How Was This Tested?
- Unit tests: 8 new tests covering VC resolution and None guard paths for both views
- Manual testing: verified cable and interface dropdown changes work on a VC device without primary_ip

## Risk Assessment
- Does this change affect existing users? No — only changes error path for VC devices
- Could this cause unintended imports / updates? No

## Backwards Compatibility
- No breaking changes

## Other Notes
The fix replaces duplicated inline VC logic with the existing `get_librenms_sync_device()` utility which has 4 priority levels (`librenms_id` → master with IP → any member with IP → lowest `vc_position`). This bug exists on both master and develop.