### PR TITLE
Use naming preferences for device name matching on sync page

### DIFF
--- a/netbox_librenms_plugin/templates/netbox_librenms_plugin/librenms_sync_base.html
+++ b/netbox_librenms_plugin/templates/netbox_librenms_plugin/librenms_sync_base.html
@@ -329,23 +329,27 @@
 
                         <!-- Name Row -->
                         <tr>
-                            <td style="padding-left: 1rem;">Name</td>
+                            <td style="padding-left: 1rem;">Name
+                                <i class="mdi mdi-information-outline text-muted ms-1"
+                                   title="Name check uses your sysName and strip domain preferences. For virtual chassis members, the VC naming pattern is also applied."
+                                   style="cursor: help;"></i>
+                            </td>
                             <td>
                                 <div class="d-flex align-items-center">
                                     <div>{{ object.name }}</div>
                                     <div class="ms-3">
-                                        {% if sysName and sysName != "-" and sysName != object.name %}
+                                        {% if resolved_name and resolved_name != object.name %}
                                         <form method="post"
                                               action="{% url 'plugins:netbox_librenms_plugin:update_device_name' pk=object.pk %}"
                                               style="display: inline;">
                                             {% csrf_token %}
                                             <button type="submit" class="btn btn-sm btn-outline-primary"
-                                                    title="Sync name to {{ sysName }}">
+                                                    title="Sync name to {{ resolved_name }}">
                                                 <i class="mdi mdi-sync"></i> Sync to NetBox
                                             </button>
                                         </form>
-                                        {% elif sysName and sysName != "-" %}
-                                        <span class="text-success" title="Name matches LibreNMS">
+                                        {% elif resolved_name %}
+                                        <span class="text-success" title="Synced with LibreNMS">
                                             <i class="mdi mdi-check-circle"></i>
                                         </span>
                                         {% endif %}
@@ -403,9 +407,6 @@
                         <tr>
                             <td style="padding-left: 1rem;">
                                 Serial Number
-                                {% if object.virtual_chassis and vc_inventory_serials %}
-                                    <span class="badge bg-secondary text-white ms-2">{{ vc_inventory_serials|length }}</span>
-                                {% endif %}
                             </td>
                             <td>
                                 <div class="d-flex align-items-center">
@@ -421,7 +422,7 @@
                                             <button type="button" class="btn btn-sm btn-outline-info"
                                                     data-bs-toggle="modal" data-bs-target="#vc-serials-modal"
                                                     title="View VC member serials from inventory">
-                                                <i class="mdi mdi-server-network"></i> VC Serials
+                                                <i class="mdi mdi-server-network"></i> VC Serials ({{ vc_inventory_serials|length }})
                                             </button>
                                         {% else %}
                                             {% if librenms_device_serial != "-" %}

--- a/netbox_librenms_plugin/tests/test_coverage_actions.py
+++ b/netbox_librenms_plugin/tests/test_coverage_actions.py
@@ -88,7 +88,7 @@ class TestResolveNamingPreferences:
         from netbox_librenms_plugin.views.imports.actions import _resolve_naming_preferences
 
         request = _make_request(post={"use-sysname-toggle": "on"})
-        with patch("netbox_librenms_plugin.views.imports.actions.get_user_pref", return_value=None):
+        with patch("netbox_librenms_plugin.utils.get_user_pref", return_value=None):
             with patch("netbox_librenms_plugin.models.LibreNMSSettings", create=True) as MockSettings:
                 MockSettings.objects.first.return_value = None
                 use_sysname, strip_domain = _resolve_naming_preferences(request)
@@ -98,7 +98,7 @@ class TestResolveNamingPreferences:
         from netbox_librenms_plugin.views.imports.actions import _resolve_naming_preferences
 
         request = _make_request(post={"use_sysname-toggle": "on"})
-        with patch("netbox_librenms_plugin.views.imports.actions.get_user_pref", return_value=None):
+        with patch("netbox_librenms_plugin.utils.get_user_pref", return_value=None):
             with patch("netbox_librenms_plugin.models.LibreNMSSettings", create=True) as MockSettings:
                 MockSettings.objects.first.return_value = None
                 use_sysname, _ = _resolve_naming_preferences(request)
@@ -108,7 +108,7 @@ class TestResolveNamingPreferences:
         from netbox_librenms_plugin.views.imports.actions import _resolve_naming_preferences
 
         request = _make_request(post={"use_sysname": "true"})
-        with patch("netbox_librenms_plugin.views.imports.actions.get_user_pref", return_value=None):
+        with patch("netbox_librenms_plugin.utils.get_user_pref", return_value=None):
             with patch("netbox_librenms_plugin.models.LibreNMSSettings", create=True) as MockSettings:
                 MockSettings.objects.first.return_value = None
                 use_sysname, _ = _resolve_naming_preferences(request)
@@ -119,7 +119,7 @@ class TestResolveNamingPreferences:
 
         request = _make_request(get={"use_sysname": "on"})
         request.POST = {}
-        with patch("netbox_librenms_plugin.views.imports.actions.get_user_pref", return_value=None):
+        with patch("netbox_librenms_plugin.utils.get_user_pref", return_value=None):
             with patch("netbox_librenms_plugin.models.LibreNMSSettings", create=True) as MockSettings:
                 MockSettings.objects.first.return_value = None
                 use_sysname, _ = _resolve_naming_preferences(request)
@@ -129,7 +129,7 @@ class TestResolveNamingPreferences:
         from netbox_librenms_plugin.views.imports.actions import _resolve_naming_preferences
 
         request = _make_request()
-        with patch("netbox_librenms_plugin.views.imports.actions.get_user_pref") as mock_pref:
+        with patch("netbox_librenms_plugin.utils.get_user_pref") as mock_pref:
             mock_pref.return_value = False
             with patch("netbox_librenms_plugin.models.LibreNMSSettings", create=True) as MockSettings:
                 MockSettings.objects.first.return_value = None
@@ -140,7 +140,7 @@ class TestResolveNamingPreferences:
         from netbox_librenms_plugin.views.imports.actions import _resolve_naming_preferences
 
         request = _make_request()
-        with patch("netbox_librenms_plugin.views.imports.actions.get_user_pref", return_value=None):
+        with patch("netbox_librenms_plugin.utils.get_user_pref", return_value=None):
             with patch("netbox_librenms_plugin.models.LibreNMSSettings", create=True) as MockSettings:
                 settings_obj = MagicMock()
                 settings_obj.use_sysname_default = False
@@ -154,7 +154,7 @@ class TestResolveNamingPreferences:
         from netbox_librenms_plugin.views.imports.actions import _resolve_naming_preferences
 
         request = _make_request()
-        with patch("netbox_librenms_plugin.views.imports.actions.get_user_pref", return_value=None):
+        with patch("netbox_librenms_plugin.utils.get_user_pref", return_value=None):
             with patch("netbox_librenms_plugin.models.LibreNMSSettings", create=True) as MockSettings:
                 MockSettings.objects.first.return_value = None
                 use_sysname, strip_domain = _resolve_naming_preferences(request)
@@ -165,7 +165,7 @@ class TestResolveNamingPreferences:
         from netbox_librenms_plugin.views.imports.actions import _resolve_naming_preferences
 
         request = _make_request(post={"strip-domain-toggle": "on"})
-        with patch("netbox_librenms_plugin.views.imports.actions.get_user_pref", return_value=None):
+        with patch("netbox_librenms_plugin.utils.get_user_pref", return_value=None):
             with patch("netbox_librenms_plugin.models.LibreNMSSettings", create=True) as MockSettings:
                 MockSettings.objects.first.return_value = None
                 _, strip_domain = _resolve_naming_preferences(request)

--- a/netbox_librenms_plugin/tests/test_coverage_device_fields.py
+++ b/netbox_librenms_plugin/tests/test_coverage_device_fields.py
@@ -114,6 +114,7 @@ class TestUpdateDeviceNameView:
 
         mock_device = MagicMock()
         mock_device.name = "old-name"
+        mock_device.virtual_chassis = None
         with (
             patch("netbox_librenms_plugin.views.sync.device_fields.get_object_or_404", return_value=mock_device),
             patch("netbox_librenms_plugin.views.sync.device_fields.messages") as mock_msg,
@@ -136,6 +137,7 @@ class TestUpdateDeviceNameView:
 
         mock_device = MagicMock()
         mock_device.name = "old-name"
+        mock_device.virtual_chassis = None
         exc = ValidationError({"name": ["duplicate"]})
         mock_device.full_clean.side_effect = exc
 
@@ -159,6 +161,7 @@ class TestUpdateDeviceNameView:
 
         mock_device = MagicMock()
         mock_device.name = "old-name"
+        mock_device.virtual_chassis = None
         mock_device.full_clean.side_effect = IntegrityError("duplicate key")
 
         with (

--- a/netbox_librenms_plugin/tests/test_import_utils.py
+++ b/netbox_librenms_plugin/tests/test_import_utils.py
@@ -5089,7 +5089,7 @@ class TestResolveNamingPreferencesKeys:
         from netbox_librenms_plugin.views.imports.actions import _resolve_naming_preferences
 
         request = self._make_request(post={"use-sysname-toggle": "on", "strip-domain-toggle": "off"})
-        with patch("netbox_librenms_plugin.views.imports.actions.get_user_pref", return_value=None):
+        with patch("netbox_librenms_plugin.utils.get_user_pref", return_value=None):
             use_sysname, strip_domain = _resolve_naming_preferences(request)
         assert use_sysname is True
         assert strip_domain is False
@@ -5101,7 +5101,7 @@ class TestResolveNamingPreferencesKeys:
         from netbox_librenms_plugin.views.imports.actions import _resolve_naming_preferences
 
         request = self._make_request(post={"use_sysname-toggle": "on", "strip_domain-toggle": "on"})
-        with patch("netbox_librenms_plugin.views.imports.actions.get_user_pref", return_value=None):
+        with patch("netbox_librenms_plugin.utils.get_user_pref", return_value=None):
             use_sysname, strip_domain = _resolve_naming_preferences(request)
         assert use_sysname is True
         assert strip_domain is True
@@ -5112,7 +5112,7 @@ class TestResolveNamingPreferencesKeys:
         from netbox_librenms_plugin.views.imports.actions import _resolve_naming_preferences
 
         request = self._make_request(get={"use-sysname-toggle": "off", "strip-domain-toggle": "on"})
-        with patch("netbox_librenms_plugin.views.imports.actions.get_user_pref", return_value=None):
+        with patch("netbox_librenms_plugin.utils.get_user_pref", return_value=None):
             use_sysname, strip_domain = _resolve_naming_preferences(request)
         assert use_sysname is False
         assert strip_domain is True
@@ -5123,7 +5123,7 @@ class TestResolveNamingPreferencesKeys:
         from netbox_librenms_plugin.views.imports.actions import _resolve_naming_preferences
 
         request = self._make_request()
-        with patch("netbox_librenms_plugin.views.imports.actions.get_user_pref") as mock_pref:
+        with patch("netbox_librenms_plugin.utils.get_user_pref") as mock_pref:
             mock_pref.side_effect = lambda req, key: False if "use_sysname" in key else True
             use_sysname, strip_domain = _resolve_naming_preferences(request)
         assert use_sysname is False
@@ -5136,7 +5136,7 @@ class TestResolveNamingPreferencesKeys:
 
         request = self._make_request(post={"use-sysname-toggle": "off"})
         # user_pref would say True — POST should win
-        with patch("netbox_librenms_plugin.views.imports.actions.get_user_pref", return_value=True):
+        with patch("netbox_librenms_plugin.utils.get_user_pref", return_value=True):
             use_sysname, _ = _resolve_naming_preferences(request)
         assert use_sysname is False
 
@@ -5148,7 +5148,7 @@ class TestResolveNamingPreferencesKeys:
 
         for truthy_val in ("true", "True", "TRUE", "1"):
             request = self._make_request(post={"use-sysname-toggle": truthy_val, "strip-domain-toggle": "off"})
-            with patch("netbox_librenms_plugin.views.imports.actions.get_user_pref", return_value=None):
+            with patch("netbox_librenms_plugin.utils.get_user_pref", return_value=None):
                 use_sysname, _ = _resolve_naming_preferences(request)
             assert use_sysname is True, f"Expected True for value {truthy_val!r}"
 
@@ -5160,7 +5160,7 @@ class TestResolveNamingPreferencesKeys:
 
         for falsy_val in ("off", "false", "0", "", "no"):
             request = self._make_request(post={"use-sysname-toggle": falsy_val, "strip-domain-toggle": "off"})
-            with patch("netbox_librenms_plugin.views.imports.actions.get_user_pref", return_value=None):
+            with patch("netbox_librenms_plugin.utils.get_user_pref", return_value=None):
                 use_sysname, _ = _resolve_naming_preferences(request)
             assert use_sysname is False, f"Expected False for value {falsy_val!r}"
 

--- a/netbox_librenms_plugin/tests/test_sync_view_mismatch.py
+++ b/netbox_librenms_plugin/tests/test_sync_view_mismatch.py
@@ -1,7 +1,9 @@
 """Tests for device mismatch detection in get_librenms_device_info.
 
 Covers the identity cross-matching logic that determines whether a
-mismatched_device warning banner is shown on the LibreNMS Sync page.
+mismatched_device warning banner is shown on the LibreNMS Sync page,
+as well as the resolved_name computation that drives the name-match
+icon and sync button.
 
 Match rule: mismatch is False when ANY NetBox identity (device name,
 primary IP, DNS name) matches ANY LibreNMS identity (sysName, hostname, ip).
@@ -24,7 +26,7 @@ def _make_view(librenms_id, device_info, librenms_url="https://librenms.example.
     return view
 
 
-def _make_obj(name, primary_ip=None, dns_name=None, virtual_chassis=None, cf=None):
+def _make_obj(name, primary_ip=None, dns_name=None, virtual_chassis=None, cf=None, vc_position=None, serial=None):
     """Create a mock NetBox device object."""
     obj = MagicMock()
     obj.name = name
@@ -36,7 +38,23 @@ def _make_obj(name, primary_ip=None, dns_name=None, virtual_chassis=None, cf=Non
     else:
         obj.primary_ip = None
     obj.virtual_chassis = virtual_chassis
+    obj.vc_position = vc_position
+    obj.serial = serial
     return obj
+
+
+def _make_request(use_sysname=None, strip_domain=None):
+    """Create a mock request with user preferences for naming settings."""
+    request = MagicMock()
+    request.POST = {}
+    request.GET = {}
+    config = {}
+    if use_sysname is not None:
+        config["plugins.netbox_librenms_plugin.use_sysname"] = use_sysname
+    if strip_domain is not None:
+        config["plugins.netbox_librenms_plugin.strip_domain"] = strip_domain
+    request.user.config.get = lambda path, default=None: config.get(path, default)
+    return request
 
 
 class TestMismatchDetection:
@@ -482,3 +500,88 @@ class TestBuildAllServerMappings:
         # Orphaned last
         assert result[2]["server_key"] == "old-server"
         assert result[2]["is_configured"] is False
+
+
+class TestResolvedName:
+    """Tests for resolved_name computation using naming preferences."""
+
+    @patch("netbox_librenms_plugin.views.base.librenms_sync_view.match_librenms_hardware_to_device_type")
+    @patch("netbox_librenms_plugin.views.base.librenms_sync_view.resolve_naming_preferences")
+    def test_resolved_name_uses_sysname_by_default(self, mock_prefs, mock_hw):
+        """resolved_name defaults to sysName when use_sysname=True."""
+        mock_prefs.return_value = (True, False)
+        view = _make_view(42, {"sysName": "sw01.example.com", "hostname": "10.0.0.2", "ip": "10.0.0.2"})
+        obj = _make_obj("sw01.example.com", primary_ip="10.0.0.2")
+        request = _make_request(use_sysname=True, strip_domain=False)
+
+        result = view.get_librenms_device_info(obj, request)
+
+        assert result["librenms_device_details"]["resolved_name"] == "sw01.example.com"
+
+    @patch("netbox_librenms_plugin.views.base.librenms_sync_view.match_librenms_hardware_to_device_type")
+    @patch("netbox_librenms_plugin.views.base.librenms_sync_view.resolve_naming_preferences")
+    def test_resolved_name_with_strip_domain(self, mock_prefs, mock_hw):
+        """resolved_name strips domain when strip_domain=True."""
+        mock_prefs.return_value = (True, True)
+        view = _make_view(42, {"sysName": "sw01.example.com", "hostname": "10.0.0.2", "ip": "10.0.0.2"})
+        obj = _make_obj("sw01", primary_ip="10.0.0.2")
+        request = _make_request(use_sysname=True, strip_domain=True)
+
+        result = view.get_librenms_device_info(obj, request)
+
+        assert result["librenms_device_details"]["resolved_name"] == "sw01"
+
+    @patch("netbox_librenms_plugin.views.base.librenms_sync_view.match_librenms_hardware_to_device_type")
+    @patch("netbox_librenms_plugin.views.base.librenms_sync_view.resolve_naming_preferences")
+    def test_resolved_name_use_hostname(self, mock_prefs, mock_hw):
+        """resolved_name uses hostname when use_sysname=False."""
+        mock_prefs.return_value = (False, False)
+        view = _make_view(42, {"sysName": "sw01.example.com", "hostname": "sw01-mgmt", "ip": "10.0.0.2"})
+        obj = _make_obj("sw01-mgmt", primary_ip="10.0.0.2")
+        request = _make_request(use_sysname=False, strip_domain=False)
+
+        result = view.get_librenms_device_info(obj, request)
+
+        assert result["librenms_device_details"]["resolved_name"] == "sw01-mgmt"
+
+    @patch("netbox_librenms_plugin.views.base.librenms_sync_view.match_librenms_hardware_to_device_type")
+    @patch("netbox_librenms_plugin.views.base.librenms_sync_view.resolve_naming_preferences")
+    @patch("netbox_librenms_plugin.views.base.librenms_sync_view._generate_vc_member_name")
+    def test_resolved_name_vc_member(self, mock_vc_name, mock_prefs, mock_hw):
+        """resolved_name applies VC member naming pattern for VC members."""
+        mock_prefs.return_value = (True, True)
+        mock_vc_name.return_value = "sw01-M2"
+        vc = MagicMock()
+        view = _make_view(42, {"sysName": "sw01.example.com", "hostname": "10.0.0.2", "ip": "10.0.0.2"})
+        obj = _make_obj("sw01-M2", primary_ip="10.0.0.2", virtual_chassis=vc, vc_position=2, serial="ABC123")
+        request = _make_request(use_sysname=True, strip_domain=True)
+
+        result = view.get_librenms_device_info(obj, request)
+
+        assert result["librenms_device_details"]["resolved_name"] == "sw01-M2"
+        mock_vc_name.assert_called_once_with("sw01", 2, serial="ABC123")
+
+    @patch("netbox_librenms_plugin.views.base.librenms_sync_view.match_librenms_hardware_to_device_type")
+    def test_resolved_name_falls_back_to_sysname_without_request(self, mock_hw):
+        """Without request, resolved_name falls back to raw sysName."""
+        view = _make_view(42, {"sysName": "sw01.example.com", "ip": "10.0.0.2"})
+        obj = _make_obj("sw01", primary_ip="10.0.0.2")
+
+        result = view.get_librenms_device_info(obj)
+
+        assert result["librenms_device_details"]["resolved_name"] == "sw01.example.com"
+
+    @patch("netbox_librenms_plugin.views.base.librenms_sync_view.match_librenms_hardware_to_device_type")
+    @patch("netbox_librenms_plugin.views.base.librenms_sync_view.resolve_naming_preferences")
+    def test_resolved_name_non_vc_device_no_vc_pattern(self, mock_prefs, mock_hw):
+        """Non-VC device does not apply VC member naming."""
+        mock_prefs.return_value = (True, True)
+        view = _make_view(42, {"sysName": "sw01.example.com", "hostname": "10.0.0.2", "ip": "10.0.0.2"})
+        obj = _make_obj("sw01", primary_ip="10.0.0.2")
+        obj.virtual_chassis = None
+        obj.vc_position = None
+        request = _make_request(use_sysname=True, strip_domain=True)
+
+        result = view.get_librenms_device_info(obj, request)
+
+        assert result["librenms_device_details"]["resolved_name"] == "sw01"

--- a/netbox_librenms_plugin/tests/test_sync_view_mismatch.py
+++ b/netbox_librenms_plugin/tests/test_sync_view_mismatch.py
@@ -1,4 +1,5 @@
-"""Tests for device mismatch detection in get_librenms_device_info.
+"""
+Tests for device mismatch detection in get_librenms_device_info.
 
 Covers the identity cross-matching logic that determines whether a
 mismatched_device warning banner is shown on the LibreNMS Sync page,
@@ -181,7 +182,8 @@ class TestMismatchDetection:
 
     @patch("netbox_librenms_plugin.views.base.librenms_sync_view.match_librenms_hardware_to_device_type")
     def test_fqdn_domain_differs_matches_via_domain_strip(self, mock_hw):
-        """Different FQDN domains -- matches because domain-stripped
+        """
+        Different FQDN domains -- matches because domain-stripped
         LibreNMS short name 'sw01' matches NetBox FQDN split 'sw01'.
 
         NetBox name 'sw01.example.net' is compared as-is (no stripping),

--- a/netbox_librenms_plugin/utils.py
+++ b/netbox_librenms_plugin/utils.py
@@ -200,12 +200,21 @@ def resolve_naming_preferences(request) -> tuple[bool, bool]:
     from netbox_librenms_plugin.models import LibreNMSSettings
 
     settings = None
+    _TRUTHY = frozenset({"on", "true", "1"})
+    _USE_SYSNAME_KEYS = ("use-sysname-toggle", "use_sysname-toggle", "use_sysname")
+    _STRIP_DOMAIN_KEYS = ("strip-domain-toggle", "strip_domain-toggle", "strip_domain")
+
+    def _is_truthy(val):
+        return val.lower() in _TRUTHY if val is not None else False
 
     # Check POST first (import form submissions), then GET (HTMX hx-include)
-    if "use-sysname-toggle" in request.POST:
-        use_sysname = request.POST.get("use-sysname-toggle") == "on"
-    elif "use-sysname-toggle" in request.GET:
-        use_sysname = request.GET.get("use-sysname-toggle") == "on"
+    _use_sysname_post = next((request.POST.get(k) for k in _USE_SYSNAME_KEYS if k in request.POST), None)
+    _use_sysname_get = next((request.GET.get(k) for k in _USE_SYSNAME_KEYS if k in request.GET), None)
+
+    if _use_sysname_post is not None:
+        use_sysname = _is_truthy(_use_sysname_post)
+    elif _use_sysname_get is not None:
+        use_sysname = _is_truthy(_use_sysname_get)
     else:
         pref = get_user_pref(request, "plugins.netbox_librenms_plugin.use_sysname")
         if pref is not None:
@@ -214,10 +223,13 @@ def resolve_naming_preferences(request) -> tuple[bool, bool]:
             settings = LibreNMSSettings.objects.first()
             use_sysname = getattr(settings, "use_sysname_default", True) if settings else True
 
-    if "strip-domain-toggle" in request.POST:
-        strip_domain = request.POST.get("strip-domain-toggle") == "on"
-    elif "strip-domain-toggle" in request.GET:
-        strip_domain = request.GET.get("strip-domain-toggle") == "on"
+    _strip_domain_post = next((request.POST.get(k) for k in _STRIP_DOMAIN_KEYS if k in request.POST), None)
+    _strip_domain_get = next((request.GET.get(k) for k in _STRIP_DOMAIN_KEYS if k in request.GET), None)
+
+    if _strip_domain_post is not None:
+        strip_domain = _is_truthy(_strip_domain_post)
+    elif _strip_domain_get is not None:
+        strip_domain = _is_truthy(_strip_domain_get)
     else:
         pref = get_user_pref(request, "plugins.netbox_librenms_plugin.strip_domain")
         if pref is not None:

--- a/netbox_librenms_plugin/utils.py
+++ b/netbox_librenms_plugin/utils.py
@@ -188,6 +188,48 @@ def save_user_pref(request, path, value):
             pass
 
 
+def resolve_naming_preferences(request) -> tuple[bool, bool]:
+    """Resolve use_sysname/strip_domain: POST/GET toggle → user pref → plugin settings.
+
+    This is the single source of truth for naming preference resolution,
+    used by the import page, sync page, and sync action views.
+
+    Returns:
+        (use_sysname, strip_domain) booleans.
+    """
+    from netbox_librenms_plugin.models import LibreNMSSettings
+
+    settings = None
+
+    # Check POST first (import form submissions), then GET (HTMX hx-include)
+    if "use-sysname-toggle" in request.POST:
+        use_sysname = request.POST.get("use-sysname-toggle") == "on"
+    elif "use-sysname-toggle" in request.GET:
+        use_sysname = request.GET.get("use-sysname-toggle") == "on"
+    else:
+        pref = get_user_pref(request, "plugins.netbox_librenms_plugin.use_sysname")
+        if pref is not None:
+            use_sysname = pref
+        else:
+            settings = LibreNMSSettings.objects.first()
+            use_sysname = getattr(settings, "use_sysname_default", True) if settings else True
+
+    if "strip-domain-toggle" in request.POST:
+        strip_domain = request.POST.get("strip-domain-toggle") == "on"
+    elif "strip-domain-toggle" in request.GET:
+        strip_domain = request.GET.get("strip-domain-toggle") == "on"
+    else:
+        pref = get_user_pref(request, "plugins.netbox_librenms_plugin.strip_domain")
+        if pref is not None:
+            strip_domain = pref
+        else:
+            if settings is None:
+                settings = LibreNMSSettings.objects.first()
+            strip_domain = getattr(settings, "strip_domain_default", False) if settings else False
+
+    return use_sysname, strip_domain
+
+
 def get_interface_name_field(request: Optional[HttpRequest] = None) -> str:
     """
     Get interface name field with request override support.

--- a/netbox_librenms_plugin/views/base/librenms_sync_view.py
+++ b/netbox_librenms_plugin/views/base/librenms_sync_view.py
@@ -7,13 +7,12 @@ from netbox.views import generic
 from netbox_librenms_plugin.forms import AddToLIbreSNMPV1V2, AddToLIbreSNMPV3
 from netbox_librenms_plugin.import_utils import _determine_device_name
 from netbox_librenms_plugin.import_utils.virtual_chassis import _generate_vc_member_name
-from netbox_librenms_plugin.models import LibreNMSSettings
 from netbox_librenms_plugin.utils import (
     get_interface_name_field,
     get_librenms_device_id,
     get_librenms_sync_device,
-    get_user_pref,
     match_librenms_hardware_to_device_type,
+    resolve_naming_preferences,
 )
 from netbox_librenms_plugin.views.mixins import LibreNMSAPIMixin, LibreNMSPermissionMixin
 
@@ -231,22 +230,6 @@ class BaseLibreNMSSyncView(LibreNMSPermissionMixin, LibreNMSAPIMixin, generic.Ob
         result.sort(key=lambda e: 0 if e["is_active"] else (1 if e["is_configured"] else 2))
         return result or None
 
-    def _resolve_naming_preferences(self, request):
-        """Resolve use_sysname/strip_domain from user prefs or plugin settings."""
-        use_sysname_pref = get_user_pref(request, "plugins.netbox_librenms_plugin.use_sysname")
-        strip_domain_pref = get_user_pref(request, "plugins.netbox_librenms_plugin.strip_domain")
-
-        if use_sysname_pref is not None and strip_domain_pref is not None:
-            return use_sysname_pref, strip_domain_pref
-
-        settings = LibreNMSSettings.objects.first()
-        if use_sysname_pref is None:
-            use_sysname_pref = getattr(settings, "use_sysname_default", True) if settings else True
-        if strip_domain_pref is None:
-            strip_domain_pref = getattr(settings, "strip_domain_default", False) if settings else False
-
-        return use_sysname_pref, strip_domain_pref
-
     def get_librenms_device_info(self, obj, request=None):
         """Get the LibreNMS device information for the given object."""
         found_in_librenms = False
@@ -287,7 +270,7 @@ class BaseLibreNMSSyncView(LibreNMSPermissionMixin, LibreNMSAPIMixin, generic.Ob
                 # Compute resolved name using naming preferences
                 resolved_name = None
                 if request:
-                    use_sysname, strip_domain = self._resolve_naming_preferences(request)
+                    use_sysname, strip_domain = resolve_naming_preferences(request)
                     resolved_name = _determine_device_name(
                         device_info,
                         use_sysname=use_sysname,

--- a/netbox_librenms_plugin/views/base/librenms_sync_view.py
+++ b/netbox_librenms_plugin/views/base/librenms_sync_view.py
@@ -5,10 +5,14 @@ from django.shortcuts import get_object_or_404, render
 from netbox.views import generic
 
 from netbox_librenms_plugin.forms import AddToLIbreSNMPV1V2, AddToLIbreSNMPV3
+from netbox_librenms_plugin.import_utils import _determine_device_name
+from netbox_librenms_plugin.import_utils.virtual_chassis import _generate_vc_member_name
+from netbox_librenms_plugin.models import LibreNMSSettings
 from netbox_librenms_plugin.utils import (
     get_interface_name_field,
     get_librenms_device_id,
     get_librenms_sync_device,
+    get_user_pref,
     match_librenms_hardware_to_device_type,
 )
 from netbox_librenms_plugin.views.mixins import LibreNMSAPIMixin, LibreNMSPermissionMixin
@@ -87,7 +91,7 @@ class BaseLibreNMSSyncView(LibreNMSPermissionMixin, LibreNMSAPIMixin, generic.Ob
                 }
             )
 
-        librenms_info = self.get_librenms_device_info(obj)
+        librenms_info = self.get_librenms_device_info(obj, request)
 
         interface_context = self.get_interface_context(request, obj)
         cable_context = self.get_cable_context(request, obj)
@@ -227,7 +231,23 @@ class BaseLibreNMSSyncView(LibreNMSPermissionMixin, LibreNMSAPIMixin, generic.Ob
         result.sort(key=lambda e: 0 if e["is_active"] else (1 if e["is_configured"] else 2))
         return result or None
 
-    def get_librenms_device_info(self, obj):
+    def _resolve_naming_preferences(self, request):
+        """Resolve use_sysname/strip_domain from user prefs or plugin settings."""
+        use_sysname_pref = get_user_pref(request, "plugins.netbox_librenms_plugin.use_sysname")
+        strip_domain_pref = get_user_pref(request, "plugins.netbox_librenms_plugin.strip_domain")
+
+        if use_sysname_pref is not None and strip_domain_pref is not None:
+            return use_sysname_pref, strip_domain_pref
+
+        settings = LibreNMSSettings.objects.first()
+        if use_sysname_pref is None:
+            use_sysname_pref = getattr(settings, "use_sysname_default", True) if settings else True
+        if strip_domain_pref is None:
+            strip_domain_pref = getattr(settings, "strip_domain_default", False) if settings else False
+
+        return use_sysname_pref, strip_domain_pref
+
+    def get_librenms_device_info(self, obj, request=None):
         """Get the LibreNMS device information for the given object."""
         found_in_librenms = False
         mismatched_device = False
@@ -264,6 +284,30 @@ class BaseLibreNMSSyncView(LibreNMSPermissionMixin, LibreNMSAPIMixin, generic.Ob
                 # Try to match hardware to NetBox DeviceType
                 hardware_match = match_librenms_hardware_to_device_type(hardware)
 
+                # Compute resolved name using naming preferences
+                resolved_name = None
+                if request:
+                    use_sysname, strip_domain = self._resolve_naming_preferences(request)
+                    resolved_name = _determine_device_name(
+                        device_info,
+                        use_sysname=use_sysname,
+                        strip_domain=strip_domain,
+                        device_id=self.librenms_id,
+                    )
+
+                    # For VC members, generate the expected VC member name
+                    if (
+                        resolved_name
+                        and hasattr(obj, "virtual_chassis")
+                        and obj.virtual_chassis is not None
+                        and obj.vc_position is not None
+                    ):
+                        resolved_name = _generate_vc_member_name(
+                            resolved_name,
+                            obj.vc_position,
+                            serial=getattr(obj, "serial", None),
+                        )
+
                 # Update device details regardless of match
                 librenms_device_details.update(
                     {
@@ -276,6 +320,7 @@ class BaseLibreNMSSyncView(LibreNMSPermissionMixin, LibreNMSAPIMixin, generic.Ob
                         "librenms_device_location": device_info.get("location", "-"),
                         "librenms_device_ip": librenms_ip,
                         "sysName": librenms_sysname,
+                        "resolved_name": resolved_name or librenms_sysname,
                         "librenms_device_hostname": device_info.get("hostname", "-"),
                         "librenms_device_hardware_match": hardware_match,
                     }

--- a/netbox_librenms_plugin/views/imports/actions.py
+++ b/netbox_librenms_plugin/views/imports/actions.py
@@ -32,7 +32,11 @@ from netbox_librenms_plugin.import_validation_helpers import (
     fetch_model_by_id,
 )
 from netbox_librenms_plugin.tables.device_status import DeviceImportTable
-from netbox_librenms_plugin.utils import get_user_pref, save_user_pref, set_librenms_device_id
+from netbox_librenms_plugin.utils import (
+    resolve_naming_preferences as _resolve_naming_preferences,
+    save_user_pref,
+    set_librenms_device_id,
+)
 from netbox_librenms_plugin.views.mixins import LibreNMSAPIMixin, LibreNMSPermissionMixin, NetBoxObjectPermissionMixin
 
 logger = logging.getLogger(__name__)
@@ -55,57 +59,6 @@ def _save_device(device) -> HttpResponse | None:
     except IntegrityError as exc:
         return HttpResponse(f"Integrity error: {escape(str(exc))}", status=409)
     return None
-
-
-def _resolve_naming_preferences(request) -> tuple[bool, bool]:
-    """Resolve use_sysname/strip_domain: POST/GET data → user pref → plugin settings."""
-    from netbox_librenms_plugin.models import LibreNMSSettings
-
-    settings = None
-
-    # Check POST first (form submissions), then GET (HTMX hx-include on hx-get).
-    # Support hyphenated ("use-sysname-toggle"), underscored ("use_sysname-toggle"),
-    # and plain canonical ("use_sysname") key variants for compatibility across
-    # different form/hidden-input implementations.
-    _USE_SYSNAME_KEYS = ("use-sysname-toggle", "use_sysname-toggle", "use_sysname")
-    _STRIP_DOMAIN_KEYS = ("strip-domain-toggle", "strip_domain-toggle", "strip_domain")
-    _TRUTHY = frozenset({"on", "true", "1"})
-
-    def _is_truthy(val):
-        return val.lower() in _TRUTHY if val is not None else False
-
-    _use_sysname_post = next((request.POST.get(k) for k in _USE_SYSNAME_KEYS if k in request.POST), None)
-    _use_sysname_get = next((request.GET.get(k) for k in _USE_SYSNAME_KEYS if k in request.GET), None)
-
-    if _use_sysname_post is not None:
-        use_sysname = _is_truthy(_use_sysname_post)
-    elif _use_sysname_get is not None:
-        use_sysname = _is_truthy(_use_sysname_get)
-    else:
-        pref = get_user_pref(request, "plugins.netbox_librenms_plugin.use_sysname")
-        if pref is not None:
-            use_sysname = pref
-        else:
-            settings = LibreNMSSettings.objects.first()
-            use_sysname = getattr(settings, "use_sysname_default", True) if settings else True
-
-    _strip_domain_post = next((request.POST.get(k) for k in _STRIP_DOMAIN_KEYS if k in request.POST), None)
-    _strip_domain_get = next((request.GET.get(k) for k in _STRIP_DOMAIN_KEYS if k in request.GET), None)
-
-    if _strip_domain_post is not None:
-        strip_domain = _is_truthy(_strip_domain_post)
-    elif _strip_domain_get is not None:
-        strip_domain = _is_truthy(_strip_domain_get)
-    else:
-        pref = get_user_pref(request, "plugins.netbox_librenms_plugin.strip_domain")
-        if pref is not None:
-            strip_domain = pref
-        else:
-            if settings is None:
-                settings = LibreNMSSettings.objects.first()
-            strip_domain = getattr(settings, "strip_domain_default", False) if settings else False
-
-    return use_sysname, strip_domain
 
 
 def _get_hostname_for_action(request, validation: dict, libre_device: dict) -> str:

--- a/netbox_librenms_plugin/views/sync/device_fields.py
+++ b/netbox_librenms_plugin/views/sync/device_fields.py
@@ -58,13 +58,19 @@ class UpdateDeviceNameView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixin,
             messages.error(request, "Failed to retrieve device info from LibreNMS")
             return redirect("plugins:netbox_librenms_plugin:device_librenms_sync", pk=pk)
 
+        # Bail out early when LibreNMS has no usable name – the fallback
+        # names that _determine_device_name generates (e.g. "device-42")
+        # are only useful during import, not for renaming an existing device.
+        if not (device_info.get("sysName") or device_info.get("hostname")):
+            messages.warning(request, "No name could be determined from LibreNMS")
+            return redirect("plugins:netbox_librenms_plugin:device_librenms_sync", pk=pk)
+
         use_sysname, strip_domain = resolve_naming_preferences(request)
 
         resolved_name = _determine_device_name(
             device_info,
             use_sysname=use_sysname,
             strip_domain=strip_domain,
-            device_id=self.librenms_id,
         )
 
         # For VC members, generate the expected VC member name

--- a/netbox_librenms_plugin/views/sync/device_fields.py
+++ b/netbox_librenms_plugin/views/sync/device_fields.py
@@ -10,8 +10,12 @@ from django.shortcuts import get_object_or_404, redirect
 from django.views import View
 from virtualization.models import VirtualMachine
 
+from netbox_librenms_plugin.import_utils import _determine_device_name
+from netbox_librenms_plugin.import_utils.virtual_chassis import _generate_vc_member_name
+from netbox_librenms_plugin.models import LibreNMSSettings
 from netbox_librenms_plugin.utils import (
     find_by_librenms_id,
+    get_user_pref,
     match_librenms_hardware_to_device_type,
     migrate_legacy_librenms_id,
 )
@@ -45,24 +49,54 @@ class UpdateDeviceNameView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixin,
             messages.error(request, "Failed to retrieve device info from LibreNMS")
             return redirect("plugins:netbox_librenms_plugin:device_librenms_sync", pk=pk)
 
-        sys_name = device_info.get("sysName")
+        # Resolve naming preferences (user pref → plugin settings)
+        use_sysname_pref = get_user_pref(request, "plugins.netbox_librenms_plugin.use_sysname")
+        strip_domain_pref = get_user_pref(request, "plugins.netbox_librenms_plugin.strip_domain")
+        settings = None
+        if use_sysname_pref is None:
+            settings = LibreNMSSettings.objects.first()
+            use_sysname_pref = getattr(settings, "use_sysname_default", True) if settings else True
+        if strip_domain_pref is None:
+            if settings is None:
+                settings = LibreNMSSettings.objects.first()
+            strip_domain_pref = getattr(settings, "strip_domain_default", False) if settings else False
 
-        if not sys_name:
-            messages.warning(request, "No sysName available in LibreNMS")
+        resolved_name = _determine_device_name(
+            device_info,
+            use_sysname=use_sysname_pref,
+            strip_domain=strip_domain_pref,
+            device_id=self.librenms_id,
+        )
+
+        # For VC members, generate the expected VC member name
+        if (
+            resolved_name
+            and hasattr(device, "virtual_chassis")
+            and device.virtual_chassis is not None
+            and device.vc_position is not None
+        ):
+            resolved_name = _generate_vc_member_name(
+                resolved_name,
+                device.vc_position,
+                serial=getattr(device, "serial", None),
+            )
+
+        if not resolved_name:
+            messages.warning(request, "No name could be determined from LibreNMS")
             return redirect("plugins:netbox_librenms_plugin:device_librenms_sync", pk=pk)
 
         old_name = device.name
-        device.name = sys_name
+        device.name = resolved_name
         try:
             device.full_clean()
             device.save()
         except (ValidationError, IntegrityError) as e:
             device.name = old_name
             error_msg = e.message_dict if hasattr(e, "message_dict") else str(e)
-            messages.error(request, f"Failed to update device name to '{sys_name}': {error_msg}")
+            messages.error(request, f"Failed to update device name to '{resolved_name}': {error_msg}")
             return redirect("plugins:netbox_librenms_plugin:device_librenms_sync", pk=pk)
 
-        messages.success(request, f"Device name updated from '{old_name}' to '{sys_name}'")
+        messages.success(request, f"Device name updated from '{old_name}' to '{resolved_name}'")
 
         return redirect("plugins:netbox_librenms_plugin:device_librenms_sync", pk=pk)
 

--- a/netbox_librenms_plugin/views/sync/device_fields.py
+++ b/netbox_librenms_plugin/views/sync/device_fields.py
@@ -12,12 +12,12 @@ from virtualization.models import VirtualMachine
 
 from netbox_librenms_plugin.import_utils import _determine_device_name
 from netbox_librenms_plugin.import_utils.virtual_chassis import _generate_vc_member_name
-from netbox_librenms_plugin.models import LibreNMSSettings
 from netbox_librenms_plugin.utils import (
     find_by_librenms_id,
-    get_user_pref,
+    get_librenms_sync_device,
     match_librenms_hardware_to_device_type,
     migrate_legacy_librenms_id,
+    resolve_naming_preferences,
 )
 from netbox_librenms_plugin.views.mixins import LibreNMSAPIMixin, LibreNMSPermissionMixin, NetBoxObjectPermissionMixin
 
@@ -37,7 +37,16 @@ class UpdateDeviceNameView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixin,
             return error
 
         device = get_object_or_404(Device, pk=pk)
-        self.librenms_id = self.librenms_api.get_librenms_id(device)
+
+        # For VC members without their own librenms_id, use the VC sync device
+        librenms_lookup_device = device
+        if hasattr(device, "virtual_chassis") and device.virtual_chassis:
+            if not device.cf.get("librenms_id"):
+                sync_device = get_librenms_sync_device(device)
+                if sync_device:
+                    librenms_lookup_device = sync_device
+
+        self.librenms_id = self.librenms_api.get_librenms_id(librenms_lookup_device)
 
         if not self.librenms_id:
             messages.error(request, "Device not found in LibreNMS")
@@ -49,22 +58,12 @@ class UpdateDeviceNameView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixin,
             messages.error(request, "Failed to retrieve device info from LibreNMS")
             return redirect("plugins:netbox_librenms_plugin:device_librenms_sync", pk=pk)
 
-        # Resolve naming preferences (user pref → plugin settings)
-        use_sysname_pref = get_user_pref(request, "plugins.netbox_librenms_plugin.use_sysname")
-        strip_domain_pref = get_user_pref(request, "plugins.netbox_librenms_plugin.strip_domain")
-        settings = None
-        if use_sysname_pref is None:
-            settings = LibreNMSSettings.objects.first()
-            use_sysname_pref = getattr(settings, "use_sysname_default", True) if settings else True
-        if strip_domain_pref is None:
-            if settings is None:
-                settings = LibreNMSSettings.objects.first()
-            strip_domain_pref = getattr(settings, "strip_domain_default", False) if settings else False
+        use_sysname, strip_domain = resolve_naming_preferences(request)
 
         resolved_name = _determine_device_name(
             device_info,
-            use_sysname=use_sysname_pref,
-            strip_domain=strip_domain_pref,
+            use_sysname=use_sysname,
+            strip_domain=strip_domain,
             device_id=self.librenms_id,
         )
 


### PR DESCRIPTION
## Summary
The device information card on the sync page now uses the same naming logic as the import/validation flow when checking whether the device name matches LibreNMS. Previously it compared raw `sysName` directly against `object.name`, ignoring user preferences for `use_sysname`, `strip_domain`, and virtual chassis member naming patterns. This caused the sync icon to incorrectly show a mismatch.

## Motivation / Problem
- Bug

When a user had `strip_domain` enabled (e.g. LibreNMS sysName `switch01.example.com`, NetBox name `switch01`), the sync page incorrectly showed a sync button instead of a green checkmark. Similarly, virtual chassis members named using the VC naming pattern (e.g. `switch01-M2`) were shown as mismatched because the comparison only used the base sysName.

## Scope of Change
- Sync/Import logic
- Web UI / templates

## How Was This Tested?
- Unit tests: yes — all 428 existing tests pass with no regressions

## Risk Assessment
- Does this change affect existing users?
  Yes — users who have `strip_domain` or `use_sysname` preferences set will now see correct match/mismatch indicators on the sync page. Previously incorrect sync buttons will now show green checkmarks where names actually match.
- Could this cause unintended imports / updates?
  No — this only changes the display logic (which icon is shown) and ensures the sync action applies the same name transformation. No automatic imports or updates are triggered.

## Backwards Compatibility
- No breaking changes

## Other Notes
**Changes:**

**`views/base/librenms_sync_view.py`**
- Added `_resolve_naming_preferences(request)` method to resolve `use_sysname`/`strip_domain` from user prefs → plugin settings (same fallback chain as import page)
- `get_librenms_device_info()` now computes `resolved_name` using `_determine_device_name()` with resolved preferences
- For VC members, applies `_generate_vc_member_name()` to produce the expected member name
- Passes `resolved_name` in template context alongside raw `sysName`

**`views/sync/device_fields.py`**
- `UpdateDeviceNameView.post()` now resolves naming preferences and uses `_determine_device_name()` + `_generate_vc_member_name()` to compute the target name, so clicking "Sync to NetBox" applies the correct transformation

**`templates/netbox_librenms_plugin/librenms_sync_base.html`**
- Name row comparison uses `resolved_name` instead of raw `sysName` for match/mismatch logic and sync button target
- LibreNMS Value column still shows raw `sysName`
- Added info icon on the Name field label explaining how the name check works
- Moved VC serial count from badge on field label into the "VC Serials" button text
