### PR TITLE
refactor(js): extract showModal/hideModal helpers

### DIFF
--- a/netbox_librenms_plugin/static/netbox_librenms_plugin/js/librenms_sync.js
+++ b/netbox_librenms_plugin/static/netbox_librenms_plugin/js/librenms_sync.js
@@ -122,13 +122,17 @@ function getDeviceIdFromUrl() {
     const pluginVMIndex = pathParts.indexOf('virtualmachine');
 
     if (deviceIndex !== -1 && deviceIndex + 1 < pathParts.length) {
-        return { id: pathParts[deviceIndex + 1], type: 'device' };
+        const id = pathParts[deviceIndex + 1];
+        if (/^\d+$/.test(id)) return { id, type: 'device' };
     } else if (vmIndex !== -1 && vmIndex + 1 < pathParts.length) {
-        return { id: pathParts[vmIndex + 1], type: 'virtualmachine' };
+        const id = pathParts[vmIndex + 1];
+        if (/^\d+$/.test(id)) return { id, type: 'virtualmachine' };
     } else if (pluginDeviceIndex !== -1 && pluginDeviceIndex + 1 < pathParts.length) {
-        return { id: pathParts[pluginDeviceIndex + 1], type: 'device' };
+        const id = pathParts[pluginDeviceIndex + 1];
+        if (/^\d+$/.test(id)) return { id, type: 'device' };
     } else if (pluginVMIndex !== -1 && pluginVMIndex + 1 < pathParts.length) {
-        return { id: pathParts[pluginVMIndex + 1], type: 'virtualmachine' };
+        const id = pathParts[pluginVMIndex + 1];
+        if (/^\d+$/.test(id)) return { id, type: 'virtualmachine' };
     }
 
     return null;
@@ -189,7 +193,6 @@ function initializeCountdowns() {
     if (window.vlanCountdownInterval) {
         clearInterval(window.vlanCountdownInterval);
     }
-
     window.interfaceCountdownInterval = initializeCountdown("countdown-timer");
     window.cableCountdownInterval = initializeCountdown("cable-countdown-timer");
     window.ipCountdownInterval = initializeCountdown("ip-countdown-timer");
@@ -554,7 +557,7 @@ function verifyVlanInGroup(select, deviceId, vid, vlanType, groupId) {
             }
         })
         .catch(err => {
-            console.error('VLAN group verify failed:', err);
+            console.error('VLAN group verify failed:', err && err.message ? err.message : String(err));
         })
         .finally(() => {
             const saveBtn = document.getElementById('saveVlanGroups');
@@ -687,11 +690,7 @@ function initializeVlanModalSave() {
                 })
             }).then(response => {
                 if (!response.ok) {
-                    return response.text().then(t => {
-                        let msg = `HTTP ${response.status}`;
-                        try { const data = JSON.parse(t); if (data.message) msg = data.message; } catch (_) {}
-                        throw new Error(msg);
-                    });
+                    return response.text().then(t => { throw new Error(`HTTP ${response.status}: ${t}`); });
                 }
                 // Apply DOM mutations only after the server has persisted the overrides
                 applyButtonUpdates();
@@ -825,7 +824,6 @@ function handleVRFChange(select, value) {
         return;
     }
     const deviceId = deviceInfo.id;
-    const row = select.closest('tr');
 
     fetch('/plugins/librenms_plugin/verify-ipaddress/', {
         method: 'POST',
@@ -847,6 +845,8 @@ function handleVRFChange(select, value) {
             return response.json();
         })
         .then(data => {
+            const row = document.querySelector(`tr[data-interface="${select.dataset.rowId}"]`);
+
             if (data.status === 'success' && row && data.formatted_row) {
                 const statusCell = row.querySelector('td[data-col="status"]');
                 if (statusCell) {
@@ -1273,6 +1273,7 @@ function setInterfaceNameFieldFromURL() {
     const urlParams = new URLSearchParams(window.location.search);
     const interfaceNameField = urlParams.get('interface_name_field');
     if (interfaceNameField) {
+        if (!['ifDescr', 'ifName'].includes(interfaceNameField)) return;
         const radio = document.querySelector(`input[name="interface_name_field"][value="${interfaceNameField}"]`);
         if (radio) {
             radio.checked = true;
@@ -1318,11 +1319,6 @@ function initializeNetBoxOnlyInterfaces() {
             if (selectedCheckboxes.length === 0) {
                 return;
             }
-
-            const interfaceNames = Array.from(selectedCheckboxes).map(cb => {
-                const row = cb.closest('tr');
-                return row.querySelector('td:nth-child(2) a').textContent;
-            });
 
             deleteSelectedInterfaces(selectedCheckboxes);
         });
@@ -1593,6 +1589,7 @@ function closeHtmxModal() {
  * Initialize all sync page functionality.
  * Called on DOMContentLoaded and after HTMX content swaps.
  */
+
 function initializeScripts() {
     initializeCheckboxes();
     initializeVCMemberSelect();
@@ -1630,4 +1627,19 @@ document.addEventListener('DOMContentLoaded', function () {
 // Initialize scripts after HTMX swaps content
 document.body.addEventListener('htmx:afterSwap', function (event) {
     initializeScripts();
+});
+
+// Update HTMX modal accessible label after content loads so screen readers
+// announce the actual dialog title rather than the static "Loading" placeholder.
+document.addEventListener('DOMContentLoaded', function () {
+    const htmxModal = document.getElementById('htmx-modal');
+    if (htmxModal) {
+        htmxModal.addEventListener('htmx:afterSettle', function () {
+            const header = htmxModal.querySelector('.modal-title, .modal-header h5, .modal-header h4');
+            const label = document.getElementById('htmx-modal-label');
+            if (header && label) {
+                label.textContent = header.textContent.trim();
+            }
+        });
+    }
 });

--- a/netbox_librenms_plugin/static/netbox_librenms_plugin/js/librenms_sync.js
+++ b/netbox_librenms_plugin/static/netbox_librenms_plugin/js/librenms_sync.js
@@ -18,6 +18,42 @@
 const TOMSELECT_INIT_DELAY_MS = 100;
 const COUNTDOWN_UPDATE_INTERVAL_MS = 1000;
 
+/**
+ * Show a Bootstrap-style modal using direct DOM manipulation.
+ * @param {HTMLElement} el - The modal element to show
+ */
+function showModal(el) {
+    if (!el) return;
+    el.classList.add('show');
+    el.style.display = 'block';
+    el.setAttribute('aria-modal', 'true');
+    el.removeAttribute('aria-hidden');
+    let backdrop = document.querySelector('.modal-backdrop');
+    if (!backdrop) {
+        backdrop = document.createElement('div');
+        backdrop.className = 'modal-backdrop fade show';
+        document.body.appendChild(backdrop);
+    }
+    document.body.classList.add('modal-open');
+}
+
+/**
+ * Hide a Bootstrap-style modal and clean up backdrop/body state.
+ * @param {HTMLElement} el - The modal element to hide
+ */
+function hideModal(el) {
+    if (!el) return;
+    el.classList.remove('show');
+    el.style.display = 'none';
+    el.setAttribute('aria-hidden', 'true');
+    el.removeAttribute('aria-modal');
+    const backdrop = document.querySelector('.modal-backdrop');
+    if (backdrop) backdrop.remove();
+    document.body.classList.remove('modal-open');
+    document.body.style.removeProperty('padding-right');
+    document.body.style.removeProperty('overflow');
+}
+
 // Helper to read CSRF token from cookies
 function getCookie(name) {
     let cookieValue = null;
@@ -401,17 +437,7 @@ function openVlanDetailModal(btn) {
         applyAllCheckbox.checked = false;
     }
 
-    // Show modal via hidden trigger (bootstrap not globally available in NetBox/Tabler)
-    let trigger = document.getElementById('vlanModalTrigger');
-    if (!trigger) {
-        trigger = document.createElement('button');
-        trigger.id = 'vlanModalTrigger';
-        trigger.setAttribute('data-bs-toggle', 'modal');
-        trigger.setAttribute('data-bs-target', '#vlanDetailModal');
-        trigger.style.display = 'none';
-        document.body.appendChild(trigger);
-    }
-    trigger.click();
+    showModal(document.getElementById('vlanDetailModal'));
 }
 
 /**
@@ -953,22 +979,7 @@ function initializeBulkEditApply() {
             });
 
             // Close the modal on 'Apply'
-            const bulkModal = document.getElementById('bulkVCMemberModal');
-            if (bulkModal) {
-                bulkModal.classList.remove('show');
-                bulkModal.style.display = 'none';
-                bulkModal.setAttribute('aria-hidden', 'true');
-                bulkModal.removeAttribute('aria-modal');
-
-                const backdrop = document.querySelector('.modal-backdrop');
-                if (backdrop) {
-                    backdrop.remove();
-                }
-
-                document.body.classList.remove('modal-open');
-                document.body.style.removeProperty('padding-right');
-                document.body.style.removeProperty('overflow');
-            }
+            hideModal(document.getElementById('bulkVCMemberModal'));
 
         });
     }
@@ -1220,20 +1231,7 @@ document.addEventListener('DOMContentLoaded', function () {
 
 // Function to open the bulk VC modal
 function openBulkVCModal() {
-    const modal = document.getElementById('bulkVCMemberModal');
-    if (modal) {
-        modal.classList.add('show');
-        modal.style.display = 'block';
-        modal.setAttribute('aria-modal', 'true');
-        modal.removeAttribute('aria-hidden');
-
-        // Add backdrop
-        const backdrop = document.createElement('div');
-        backdrop.className = 'modal-backdrop fade show';
-        document.body.appendChild(backdrop);
-
-        document.body.classList.add('modal-open');
-    }
+    showModal(document.getElementById('bulkVCMemberModal'));
 }
 
 // Function to update the interface_name_field radio button
@@ -1386,26 +1384,7 @@ function deleteSelectedInterfaces(selectedCheckboxes) {
         })
         .then(data => {
             if (data.status === 'success') {
-                // Close modal using native DOM methods
-                const modalElement = document.getElementById('netboxOnlyInterfacesModal');
-                if (modalElement) {
-                    // Hide the modal
-                    modalElement.classList.remove('show');
-                    modalElement.style.display = 'none';
-                    modalElement.setAttribute('aria-hidden', 'true');
-                    modalElement.removeAttribute('aria-modal');
-
-                    // Remove backdrop
-                    const backdrop = document.querySelector('.modal-backdrop');
-                    if (backdrop) {
-                        backdrop.remove();
-                    }
-
-                    // Clean up body classes and styles
-                    document.body.classList.remove('modal-open');
-                    document.body.style.removeProperty('padding-right');
-                    document.body.style.removeProperty('overflow');
-                }
+                hideModal(document.getElementById('netboxOnlyInterfacesModal'));
 
                 // Refresh the interface data by triggering the refresh button
                 const refreshButton = document.querySelector('[hx-post*="interface-sync"]');
@@ -1556,21 +1535,7 @@ function initializeModuleReplaceButtons() {
                     '</div>';
             }
 
-            // Show modal using direct class manipulation (consistent with openBulkVCModal)
-            const htmxModal = document.getElementById('htmx-modal');
-            if (htmxModal) {
-                htmxModal.classList.add('show');
-                htmxModal.style.display = 'block';
-                htmxModal.setAttribute('aria-modal', 'true');
-                htmxModal.removeAttribute('aria-hidden');
-                let backdrop = document.querySelector('.modal-backdrop');
-                if (!backdrop) {
-                    backdrop = document.createElement('div');
-                    backdrop.className = 'modal-backdrop fade show';
-                    document.body.appendChild(backdrop);
-                }
-                document.body.classList.add('modal-open');
-            }
+            showModal(document.getElementById('htmx-modal'));
 
             // Fetch preview content and inject into modal body
             const csrfToken = document.querySelector('[name=csrfmiddlewaretoken]')?.value || getCookie('csrftoken');
@@ -1617,16 +1582,7 @@ function closeHtmxModal() {
         _activeReplaceController.abort();
         _activeReplaceController = null;
     }
-    const htmxModal = document.getElementById('htmx-modal');
-    if (htmxModal) {
-        htmxModal.classList.remove('show');
-        htmxModal.style.display = 'none';
-        htmxModal.setAttribute('aria-hidden', 'true');
-        htmxModal.removeAttribute('aria-modal');
-        const backdrop = document.querySelector('.modal-backdrop');
-        if (backdrop) backdrop.remove();
-        document.body.classList.remove('modal-open');
-    }
+    hideModal(document.getElementById('htmx-modal'));
 }
 
 // ============================================


### PR DESCRIPTION
## Summary

Refactors modal handling in `librenms_sync.js` to remove reliance on hidden Bootstrap trigger buttons, and improves several JS utilities for correctness and robustness.

Key changes:
- Extract reusable `showModal`/`hideModal` helpers using direct DOM manipulation instead of fragile hidden trigger buttons
- Harden `getDeviceIdFromUrl` to validate numeric path segments
- Fix `handleVRFChange` row lookup to survive HTMX DOM swaps
- Guard `setInterfaceNameFieldFromURL` against unexpected URL-injected values
- Add HTMX `afterSettle` listener for accessible modal labels
- Remove dead code, improve error logging

## Motivation / Problem

- Refactor
- Maintenance / cleanup

Hidden Bootstrap trigger buttons left orphaned DOM elements and broke after HTMX content swaps. Several JS utilities had edge-case bugs around DOM replacement, input validation, and error formatting.

## Scope of Change

- Web UI / templates

## How Was This Tested?

- Manual testing: verified on the device sync page (modal open/close, VLAN detail, VRF change, interface name field)
- Not tested: no JS test infrastructure yet

## Risk Assessment

- Does not affect existing users beyond improved robustness
- No import/update logic changes — JS-only

## Backwards Compatibility

- No breaking changes

## Other Notes

All changes are in `librenms_sync.js` and `librenms_sync_base.html` (HTMX modal label).