### PR TITLE
Fix VLAN group modal not closing on dismiss/backdrop click

### DIFF
--- a/netbox_librenms_plugin/static/netbox_librenms_plugin/js/librenms_sync.js
+++ b/netbox_librenms_plugin/static/netbox_librenms_plugin/js/librenms_sync.js
@@ -19,11 +19,42 @@ const TOMSELECT_INIT_DELAY_MS = 100;
 const COUNTDOWN_UPDATE_INTERVAL_MS = 1000;
 
 /**
- * Show a Bootstrap-style modal using direct DOM manipulation.
+ * Show a Bootstrap modal, using native Bootstrap Modal when available,
+ * falling back to manual DOM manipulation otherwise.
+ * Matches the ModalManager pattern in librenms_import.js.
  * @param {HTMLElement} el - The modal element to show
  */
 function showModal(el) {
     if (!el) return;
+
+    // Register click-outside (backdrop) and dismiss-button handlers once per element.
+    // These are needed regardless of whether Bootstrap is available — Tabler/NetBox
+    // may not always wire up native Bootstrap backdrop-click behaviour for modals
+    // opened programmatically.  Matches the safety-net pattern in librenms_import.js.
+    if (!el._syncDismissHandlersBound) {
+        // Click on the modal overlay (outside .modal-dialog) → close
+        el.addEventListener('click', function (e) {
+            if (e.target === el) {
+                hideModal(el);
+            }
+        });
+        // data-bs-dismiss="modal" buttons → close
+        el.addEventListener('click', function (e) {
+            if (e.target.closest('[data-bs-dismiss="modal"]')) {
+                hideModal(el);
+            }
+        });
+        el._syncDismissHandlersBound = true;
+    }
+
+    // Try Bootstrap 5 native (preferred — handles dismiss, backdrop, keyboard)
+    if (typeof bootstrap !== 'undefined' && bootstrap.Modal) {
+        const instance = bootstrap.Modal.getInstance(el) || new bootstrap.Modal(el);
+        instance.show();
+        return;
+    }
+
+    // Fallback: manual DOM manipulation
     el.classList.add('show');
     el.style.display = 'block';
     el.setAttribute('aria-modal', 'true');
@@ -35,14 +66,31 @@ function showModal(el) {
         document.body.appendChild(backdrop);
     }
     document.body.classList.add('modal-open');
+
+    // Backdrop element click → close (only needed in manual fallback)
+    backdrop.addEventListener('click', function () {
+        hideModal(el);
+    });
 }
 
 /**
- * Hide a Bootstrap-style modal and clean up backdrop/body state.
+ * Hide a Bootstrap modal, using native Bootstrap Modal when available,
+ * falling back to manual DOM cleanup otherwise.
  * @param {HTMLElement} el - The modal element to hide
  */
 function hideModal(el) {
     if (!el) return;
+
+    // Try Bootstrap 5 native (preferred)
+    if (typeof bootstrap !== 'undefined' && bootstrap.Modal) {
+        const instance = bootstrap.Modal.getInstance(el);
+        if (instance) {
+            instance.hide();
+            return;
+        }
+    }
+
+    // Fallback: manual DOM cleanup
     el.classList.remove('show');
     el.style.display = 'none';
     el.setAttribute('aria-hidden', 'true');
@@ -694,11 +742,8 @@ function initializeVlanModalSave() {
                 }
                 // Apply DOM mutations only after the server has persisted the overrides
                 applyButtonUpdates();
-                // Close modal only on success
-                const closeBtn = modalEl.querySelector('[data-bs-dismiss="modal"]');
-                if (closeBtn) {
-                    closeBtn.click();
-                }
+                // Close modal on success
+                hideModal(modalEl);
             }).catch(error => {
                 console.error('Failed to persist VLAN group overrides:', error.message);
                 let alertEl = modalEl.querySelector('.vlan-override-error');
@@ -712,10 +757,7 @@ function initializeVlanModalSave() {
         } else {
             // No server persist needed — apply DOM mutations and close immediately
             applyButtonUpdates();
-            const closeBtn = modalEl.querySelector('[data-bs-dismiss="modal"]');
-            if (closeBtn) {
-                closeBtn.click();
-            }
+            hideModal(modalEl);
         }
     });
 }

--- a/netbox_librenms_plugin/static/netbox_librenms_plugin/js/librenms_sync.js
+++ b/netbox_librenms_plugin/static/netbox_librenms_plugin/js/librenms_sync.js
@@ -67,10 +67,17 @@ function showModal(el) {
     }
     document.body.classList.add('modal-open');
 
-    // Backdrop element click → close (only needed in manual fallback)
-    backdrop.addEventListener('click', function () {
-        hideModal(el);
-    });
+    // Backdrop element click → close (only needed in manual fallback).
+    // Bind once per backdrop so repeated showModal() calls do not stack handlers.
+    if (!backdrop._syncBackdropClickBound) {
+        backdrop.addEventListener('click', function () {
+            const activeModal = document.querySelector('.modal.show');
+            if (activeModal) {
+                hideModal(activeModal);
+            }
+        });
+        backdrop._syncBackdropClickBound = true;
+    }
 }
 
 /**


### PR DESCRIPTION
## Summary
Fix the VLAN group selection modal on the interface sync page not closing when clicking the close button, cancel button, save button, or clicking outside the modal.

## Motivation / Problem
- Bug

After the PR #258 modal JS refactor, the VLAN detail modal was the only modal opened purely via the custom `showModal()` function. The previous implementation used manual DOM manipulation that bypassed Bootstrap entirely, so `data-bs-dismiss` buttons, backdrop clicks, and close/cancel buttons all failed to close it. Other modals worked because they were opened via Bootstrap's native `data-bs-toggle="modal"` attribute.

## Scope of Change

- Web UI / templates

## How Was This Tested?

- Manual testing: Verified VLAN group modal closes correctly via close button, cancel button, save button, and clicking outside. Confirmed other modals (bulk VC member, interface type help, NetBox-only interfaces) still work correctly.

### Manual Test Steps (if applicable)
1. Navigate to a device's interface sync page with VLAN data
2. Click the edit (pencil) icon on a VLAN column to open the VLAN group modal
3. Verify the modal closes when clicking: the X button, the Cancel button, the Save button, or clicking outside the modal
4. Verify other modals on the page still open/close correctly

## Risk Assessment
- Does not affect existing users beyond fixing the broken modal
- Cannot cause unintended imports / updates — JS-only change to modal show/hide logic

## Backwards Compatibility
- No breaking changes

## Other Notes
Aligns `showModal()`/`hideModal()` in `librenms_sync.js` with the `ModalManager` pattern from `librenms_import.js`: tries Bootstrap 5 native first, falls back to manual DOM manipulation. Safety-net dismiss and click-outside handlers are registered unconditionally to handle cases where Tabler/NetBox doesn't wire up native Bootstrap backdrop-click for programmatically-opened modals.