### PR TITLE
Bump version to 0.4.5 and update changelog

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.4.5 (2026-04-16)
+
+### Fixes
+* Fix VLAN group modal not closing on dismiss button, cancel button, save button, or backdrop click on the interface sync page
+* Align `showModal()`/`hideModal()` with `ModalManager` pattern — try Bootstrap 5 native first, fall back to manual DOM manipulation
+* Prevent stacking backdrop click handlers on repeated `showModal()` calls
+
 ## 0.4.4 (2026-04-15)
 
 ### New Features

--- a/netbox_librenms_plugin/__init__.py
+++ b/netbox_librenms_plugin/__init__.py
@@ -2,7 +2,7 @@ from django.core.exceptions import ImproperlyConfigured
 from netbox.plugins import PluginConfig
 
 __author__ = "Andy Norwood"
-__version__ = "0.4.4"
+__version__ = "0.4.5"
 
 
 class LibreNMSSyncConfig(PluginConfig):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name =  "netbox-librenms-plugin"
-version = "0.4.4"
+version = "0.4.5"
 authors = [
     {name = "Andy Norwood"},
 ]


### PR DESCRIPTION
## Summary
Bump version to 0.4.5 and update changelog for release.

## Motivation / Problem
- Maintenance / cleanup

Prepare release 0.4.5 with the VLAN group modal fix from PR #271.

## Scope of Change

- Config / settings
- Docs only

## How Was This Tested?

- Not tested: version bump and changelog only

## Risk Assessment
- No impact on existing users
- No code logic changes

## Backwards Compatibility
- No breaking changes