### PR TITLE
Release 0.4.5

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.4.5 (2026-04-16)
+
+### Fixes
+* Fix VLAN group modal not closing on dismiss button, cancel button, save button, or backdrop click on the interface sync page
+* Align `showModal()`/`hideModal()` with `ModalManager` pattern — try Bootstrap 5 native first, fall back to manual DOM manipulation
+* Prevent stacking backdrop click handlers on repeated `showModal()` calls
+
 ## 0.4.4 (2026-04-15)
 
 ### New Features

--- a/netbox_librenms_plugin/__init__.py
+++ b/netbox_librenms_plugin/__init__.py
@@ -2,7 +2,7 @@ from django.core.exceptions import ImproperlyConfigured
 from netbox.plugins import PluginConfig
 
 __author__ = "Andy Norwood"
-__version__ = "0.4.4"
+__version__ = "0.4.5"
 
 
 class LibreNMSSyncConfig(PluginConfig):

--- a/netbox_librenms_plugin/static/netbox_librenms_plugin/js/librenms_sync.js
+++ b/netbox_librenms_plugin/static/netbox_librenms_plugin/js/librenms_sync.js
@@ -19,11 +19,42 @@ const TOMSELECT_INIT_DELAY_MS = 100;
 const COUNTDOWN_UPDATE_INTERVAL_MS = 1000;
 
 /**
- * Show a Bootstrap-style modal using direct DOM manipulation.
+ * Show a Bootstrap modal, using native Bootstrap Modal when available,
+ * falling back to manual DOM manipulation otherwise.
+ * Matches the ModalManager pattern in librenms_import.js.
  * @param {HTMLElement} el - The modal element to show
  */
 function showModal(el) {
     if (!el) return;
+
+    // Register click-outside (backdrop) and dismiss-button handlers once per element.
+    // These are needed regardless of whether Bootstrap is available — Tabler/NetBox
+    // may not always wire up native Bootstrap backdrop-click behaviour for modals
+    // opened programmatically.  Matches the safety-net pattern in librenms_import.js.
+    if (!el._syncDismissHandlersBound) {
+        // Click on the modal overlay (outside .modal-dialog) → close
+        el.addEventListener('click', function (e) {
+            if (e.target === el) {
+                hideModal(el);
+            }
+        });
+        // data-bs-dismiss="modal" buttons → close
+        el.addEventListener('click', function (e) {
+            if (e.target.closest('[data-bs-dismiss="modal"]')) {
+                hideModal(el);
+            }
+        });
+        el._syncDismissHandlersBound = true;
+    }
+
+    // Try Bootstrap 5 native (preferred — handles dismiss, backdrop, keyboard)
+    if (typeof bootstrap !== 'undefined' && bootstrap.Modal) {
+        const instance = bootstrap.Modal.getInstance(el) || new bootstrap.Modal(el);
+        instance.show();
+        return;
+    }
+
+    // Fallback: manual DOM manipulation
     el.classList.add('show');
     el.style.display = 'block';
     el.setAttribute('aria-modal', 'true');
@@ -35,14 +66,31 @@ function showModal(el) {
         document.body.appendChild(backdrop);
     }
     document.body.classList.add('modal-open');
+
+    // Backdrop element click → close (only needed in manual fallback)
+    backdrop.addEventListener('click', function () {
+        hideModal(el);
+    });
 }
 
 /**
- * Hide a Bootstrap-style modal and clean up backdrop/body state.
+ * Hide a Bootstrap modal, using native Bootstrap Modal when available,
+ * falling back to manual DOM cleanup otherwise.
  * @param {HTMLElement} el - The modal element to hide
  */
 function hideModal(el) {
     if (!el) return;
+
+    // Try Bootstrap 5 native (preferred)
+    if (typeof bootstrap !== 'undefined' && bootstrap.Modal) {
+        const instance = bootstrap.Modal.getInstance(el);
+        if (instance) {
+            instance.hide();
+            return;
+        }
+    }
+
+    // Fallback: manual DOM cleanup
     el.classList.remove('show');
     el.style.display = 'none';
     el.setAttribute('aria-hidden', 'true');
@@ -694,11 +742,8 @@ function initializeVlanModalSave() {
                 }
                 // Apply DOM mutations only after the server has persisted the overrides
                 applyButtonUpdates();
-                // Close modal only on success
-                const closeBtn = modalEl.querySelector('[data-bs-dismiss="modal"]');
-                if (closeBtn) {
-                    closeBtn.click();
-                }
+                // Close modal on success
+                hideModal(modalEl);
             }).catch(error => {
                 console.error('Failed to persist VLAN group overrides:', error.message);
                 let alertEl = modalEl.querySelector('.vlan-override-error');
@@ -712,10 +757,7 @@ function initializeVlanModalSave() {
         } else {
             // No server persist needed — apply DOM mutations and close immediately
             applyButtonUpdates();
-            const closeBtn = modalEl.querySelector('[data-bs-dismiss="modal"]');
-            if (closeBtn) {
-                closeBtn.click();
-            }
+            hideModal(modalEl);
         }
     });
 }

--- a/netbox_librenms_plugin/static/netbox_librenms_plugin/js/librenms_sync.js
+++ b/netbox_librenms_plugin/static/netbox_librenms_plugin/js/librenms_sync.js
@@ -67,10 +67,17 @@ function showModal(el) {
     }
     document.body.classList.add('modal-open');
 
-    // Backdrop element click → close (only needed in manual fallback)
-    backdrop.addEventListener('click', function () {
-        hideModal(el);
-    });
+    // Backdrop element click → close (only needed in manual fallback).
+    // Bind once per backdrop so repeated showModal() calls do not stack handlers.
+    if (!backdrop._syncBackdropClickBound) {
+        backdrop.addEventListener('click', function () {
+            const activeModal = document.querySelector('.modal.show');
+            if (activeModal) {
+                hideModal(activeModal);
+            }
+        });
+        backdrop._syncBackdropClickBound = true;
+    }
 }
 
 /**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name =  "netbox-librenms-plugin"
-version = "0.4.4"
+version = "0.4.5"
 authors = [
     {name = "Andy Norwood"},
 ]


### PR DESCRIPTION
## Summary
Release 0.4.5 — merge develop into master for PyPI release.

## Motivation / Problem
- Maintenance / cleanup

Bug fix release containing the VLAN group modal close fix from PR #271.

## Scope of Change

- Web UI / templates

## Changes
- Fix VLAN group modal not closing on dismiss/backdrop click (#271)
- Align `showModal()`/`hideModal()` with `ModalManager` pattern from `librenms_import.js`
- Prevent stacking backdrop click handlers on repeated `showModal()` calls
- Bump version to 0.4.5

## How Was This Tested?

- Manual testing: VLAN group modal close via all paths (X button, Cancel, Save, backdrop click)

## Risk Assessment
- Low risk bug fix release
- No impact on sync/import logic

## Backwards Compatibility
- No breaking changes