### PR TITLE
Bump version to 0.4.6 and update changelog

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.4.6 (2026-04-20)
+
+### Fixes
+* Fix VC master device showing 0 module bays after import by preventing stale counter overwrites during virtual chassis creation (#275)
+* Defer VC master assignment until after all members are attached
+* Add `_sync_module_bay_counter()` safety net to reconcile counter after master assignment
+
 ## 0.4.5 (2026-04-16)
 
 ### Fixes

--- a/netbox_librenms_plugin/__init__.py
+++ b/netbox_librenms_plugin/__init__.py
@@ -2,7 +2,7 @@ from django.core.exceptions import ImproperlyConfigured
 from netbox.plugins import PluginConfig
 
 __author__ = "Andy Norwood"
-__version__ = "0.4.5"
+__version__ = "0.4.6"
 
 
 class LibreNMSSyncConfig(PluginConfig):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name =  "netbox-librenms-plugin"
-version = "0.4.5"
+version = "0.4.6"
 authors = [
     {name = "Andy Norwood"},
 ]


### PR DESCRIPTION
## Summary
Bump version to 0.4.6 and update changelog for release.

## Motivation / Problem
- Maintenance / cleanup

Prepare release 0.4.6 with the VC master module bay counter fix from PR #275.

## Scope of Change

- Config / settings
- Docs only

## How Was This Tested?

- Not tested: version bump and changelog only

## Risk Assessment
- No impact on existing users
- No code logic changes

## Backwards Compatibility
- No breaking changes