### PR TITLE
Release 0.4.6

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.4.6 (2026-04-20)
+
+### Fixes
+* Fix VC master device showing 0 module bays after import by preventing stale counter overwrites during virtual chassis creation (#275)
+* Defer VC master assignment until after all members are attached
+* Add `_sync_module_bay_counter()` safety net to reconcile counter after master assignment
+
 ## 0.4.5 (2026-04-16)
 
 ### Fixes

--- a/netbox_librenms_plugin/__init__.py
+++ b/netbox_librenms_plugin/__init__.py
@@ -2,7 +2,7 @@ from django.core.exceptions import ImproperlyConfigured
 from netbox.plugins import PluginConfig
 
 __author__ = "Andy Norwood"
-__version__ = "0.4.5"
+__version__ = "0.4.6"
 
 
 class LibreNMSSyncConfig(PluginConfig):

--- a/netbox_librenms_plugin/import_utils/virtual_chassis.py
+++ b/netbox_librenms_plugin/import_utils/virtual_chassis.py
@@ -406,6 +406,21 @@ def _norm_serial(s) -> str:
     return "" if s == "-" else s
 
 
+def _sync_module_bay_counter(device: Device) -> None:
+    """Reconcile device module_bay_count with actual ModuleBay rows in the DB."""
+    try:
+        actual_count = device.modulebays.count()
+        if getattr(device, "module_bay_count", None) != actual_count:
+            Device.objects.filter(pk=device.pk).update(module_bay_count=actual_count)
+            device.module_bay_count = actual_count
+    except Exception as e:
+        logger.warning(
+            "Could not sync module_bay_count for device '%s': %s",
+            getattr(device, "name", "unknown"),
+            e,
+        )
+
+
 def create_virtual_chassis_with_members(
     master_device: Device, members_info: list, libre_device: dict, server_key: str | None = None
 ) -> VirtualChassis:
@@ -473,9 +488,11 @@ def create_virtual_chassis_with_members(
                     f"Keeping original name '{original_master_name}'"
                 )
                 master_base_name = original_master_name
+                rename_master = False
             else:
                 master_device.name = master_device_new_name
                 master_base_name = original_master_name
+                rename_master = True
 
             # Create VC using original base name
             vc_name = master_base_name
@@ -483,14 +500,16 @@ def create_virtual_chassis_with_members(
             _domain_prefix = f"librenms-{server_key}" if server_key else "librenms"
             vc = VirtualChassis.objects.create(
                 name=vc_name,
-                master=master_device,
                 domain=f"{_domain_prefix}-{_device_id}",
             )
 
             # Update master device
             master_device.virtual_chassis = vc
             master_device.vc_position = _master_pos
-            master_device.save()
+            save_fields = ["virtual_chassis", "vc_position"]
+            if rename_master:
+                save_fields.append("name")
+            master_device.save(update_fields=save_fields)
 
             # Create member devices for remaining positions
             position = _master_pos + 1  # Start after master position
@@ -596,6 +615,12 @@ def create_virtual_chassis_with_members(
                     f"Created {members_created} members but expected {expected_members}. "
                     "Some members may have been skipped due to duplicates."
                 )
+
+            # Assign VC master only after all members are attached to avoid
+            # NetBox's create-time auto-master signal changing order/state.
+            vc.master = master_device
+            vc.save(update_fields=["master"])
+            _sync_module_bay_counter(master_device)
 
             logger.info(
                 f"Created Virtual Chassis '{vc.name}' with {vc.members.count()} total members "

--- a/netbox_librenms_plugin/tests/test_import_utils.py
+++ b/netbox_librenms_plugin/tests/test_import_utils.py
@@ -4655,6 +4655,130 @@ class TestCreateVirtualChassisWithMembers:
         assert result == mock_vc
         mock_vc_cls.objects.create.assert_called_once()
 
+    def test_calls_module_bay_counter_sync(self):
+        """VC creation calls counter sync helper after assigning master."""
+        from contextlib import contextmanager
+        from unittest.mock import patch
+
+        from netbox_librenms_plugin.import_utils.virtual_chassis import create_virtual_chassis_with_members
+
+        master_device = MagicMock()
+        master_device.name = "sw1"
+        master_device.pk = 1
+        master_device.serial = ""
+
+        mock_vc = MagicMock()
+        mock_vc.members.count.return_value = 1
+
+        @contextmanager
+        def mock_atomic():
+            yield
+
+        with (
+            patch(
+                "netbox_librenms_plugin.import_utils.virtual_chassis.transaction.atomic",
+                mock_atomic,
+            ),
+            patch(
+                "netbox_librenms_plugin.import_utils.virtual_chassis._generate_vc_member_name",
+                return_value="sw1-M1",
+            ),
+            patch("netbox_librenms_plugin.import_utils.virtual_chassis.Device") as mock_device_cls,
+            patch("netbox_librenms_plugin.import_utils.virtual_chassis.VirtualChassis") as mock_vc_cls,
+            patch(
+                "netbox_librenms_plugin.import_utils.virtual_chassis._load_vc_member_name_pattern",
+                return_value="-M{position}",
+            ),
+            patch("netbox_librenms_plugin.import_utils.virtual_chassis._sync_module_bay_counter") as mock_sync,
+        ):
+            mock_device_cls.objects.filter.return_value.exclude.return_value.exists.return_value = False
+            mock_vc_cls.objects.create.return_value = mock_vc
+
+            create_virtual_chassis_with_members(master_device, [], {"device_id": 1})
+
+        mock_sync.assert_called_once_with(master_device)
+
+    def test_master_save_uses_update_fields(self):
+        """Master save should update only VC/name fields, not stale counter fields."""
+        from contextlib import contextmanager
+        from unittest.mock import patch
+
+        from netbox_librenms_plugin.import_utils.virtual_chassis import create_virtual_chassis_with_members
+
+        master_device = MagicMock()
+        master_device.name = "sw1"
+        master_device.pk = 1
+        master_device.serial = ""
+
+        mock_vc = MagicMock()
+        mock_vc.members.count.return_value = 1
+
+        @contextmanager
+        def mock_atomic():
+            yield
+
+        with (
+            patch(
+                "netbox_librenms_plugin.import_utils.virtual_chassis.transaction.atomic",
+                mock_atomic,
+            ),
+            patch(
+                "netbox_librenms_plugin.import_utils.virtual_chassis._generate_vc_member_name",
+                return_value="sw1-M1",
+            ),
+            patch("netbox_librenms_plugin.import_utils.virtual_chassis.Device") as mock_device_cls,
+            patch("netbox_librenms_plugin.import_utils.virtual_chassis.VirtualChassis") as mock_vc_cls,
+            patch(
+                "netbox_librenms_plugin.import_utils.virtual_chassis._load_vc_member_name_pattern",
+                return_value="-M{position}",
+            ),
+            patch("netbox_librenms_plugin.import_utils.virtual_chassis._sync_module_bay_counter"),
+        ):
+            mock_device_cls.objects.filter.return_value.exclude.return_value.exists.return_value = False
+            mock_vc_cls.objects.create.return_value = mock_vc
+
+            create_virtual_chassis_with_members(master_device, [], {"device_id": 1})
+
+        master_device.save.assert_called_once_with(update_fields=["virtual_chassis", "vc_position", "name"])
+
+
+class TestSyncModuleBayCounter:
+    """Tests for module_bay_count synchronization helper."""
+
+    def test_syncs_counter_when_actual_differs(self):
+        from unittest.mock import patch
+
+        from netbox_librenms_plugin.import_utils.virtual_chassis import _sync_module_bay_counter
+
+        device = MagicMock()
+        device.pk = 42
+        device.name = "sw1"
+        device.module_bay_count = 0
+        device.modulebays.count.return_value = 2
+
+        with patch("netbox_librenms_plugin.import_utils.virtual_chassis.Device") as mock_device_cls:
+            _sync_module_bay_counter(device)
+
+        mock_device_cls.objects.filter.assert_called_once_with(pk=42)
+        mock_device_cls.objects.filter.return_value.update.assert_called_once_with(module_bay_count=2)
+        assert device.module_bay_count == 2
+
+    def test_no_op_when_counter_matches(self):
+        from unittest.mock import patch
+
+        from netbox_librenms_plugin.import_utils.virtual_chassis import _sync_module_bay_counter
+
+        device = MagicMock()
+        device.pk = 42
+        device.name = "sw1"
+        device.module_bay_count = 3
+        device.modulebays.count.return_value = 3
+
+        with patch("netbox_librenms_plugin.import_utils.virtual_chassis.Device") as mock_device_cls:
+            _sync_module_bay_counter(device)
+
+        mock_device_cls.objects.filter.assert_not_called()
+
 
 class TestBulkImportCancellation:
     """Test that bulk_import_devices_shared respects RQ and DB cancellation."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name =  "netbox-librenms-plugin"
-version = "0.4.5"
+version = "0.4.6"
 authors = [
     {name = "Andy Norwood"},
 ]


### PR DESCRIPTION
## Summary
Release 0.4.6 — merge develop into master for PyPI release.

## Motivation / Problem
- Bug

Bug fix release for virtual chassis master device showing 0 module bays after import (#275).

## Scope of Change

- Sync/Import logic
- Tests

## Changes
- Fix VC master device showing 0 module bays after import by preventing stale counter overwrites during VC creation (#275)
- Defer VC master assignment until after all members are attached
- Add `_sync_module_bay_counter()` safety net to reconcile counter after master assignment
- Bump version to 0.4.6

## How Was This Tested?

- Unit tests: 4 new/updated tests covering `update_fields` save, counter sync, and deferred master assignment
- Manual testing: imported VC stack devices and confirmed module bays display correctly on master

## Risk Assessment
- Low risk bug fix release
- Scoped to VC creation path only; no impact on non-VC imports

## Backwards Compatibility
- No breaking changes