### PR TITLE
docs: update instruction files for accuracy after v0.4.4-v0.4.6 changes

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -5,6 +5,7 @@
 > - [frontend.instructions.md](instructions/frontend.instructions.md) – applies to templates and static files
 > - [background-jobs.instructions.md](instructions/background-jobs.instructions.md) – applies to `jobs.py`, import views, and import utilities
 > - [sync.instructions.md](instructions/sync.instructions.md) – applies to sync views, base views, tables, and sync JS
+> - [release.instructions.md](instructions/release.instructions.md) – applies to changelog, pyproject.toml, and `__init__.py` version bumps
 
 ## Architecture & Key Modules
 - Plugin hooks into NetBox (Django 5) under `netbox_librenms_plugin/`; respect NetBox plugin APIs (`navigation.py`, `urls.py`, `api/`).
@@ -62,7 +63,7 @@
 - `_get_safe_redirect_url(request)` validates referrer URLs to prevent open-redirect attacks.
 
 ### Permission Helpers for Background Jobs
-- Background jobs run outside view context and cannot use view mixins. Use standalone helpers from `import_utils.py` (`check_user_permissions`, `require_permissions`). See `background-jobs.instructions.md` for details.
+- Background jobs run outside view context and cannot use view mixins. Use standalone helpers from `import_utils/permissions.py` (`check_user_permissions`, `require_permissions`). See `background-jobs.instructions.md` for details.
 
 ### API & Navigation Permissions
 - API endpoints use `LibreNMSPluginPermission` class in `api/views.py` (GET=view, others=change).

--- a/.github/instructions/background-jobs.instructions.md
+++ b/.github/instructions/background-jobs.instructions.md
@@ -1,5 +1,5 @@
 ---
-applyTo: "**/jobs.py,**/views/imports/**,**/import_utils.py,**/import_validation_helpers.py"
+applyTo: "**/jobs.py,**/views/imports/**,**/import_utils/**,**/import_validation_helpers.py"
 description: Background job architecture, import workflow, and task management patterns
 ---
 
@@ -69,13 +69,15 @@ Filter fields: `librenms_location`, `librenms_type`, `librenms_os`, `librenms_ho
 - **`DeviceVCDetailsView`** (GET) — renders VC member details via `htmx/device_vc_details.html`.
 - **`DeviceRoleUpdateView`**, **`DeviceClusterUpdateView`**, **`DeviceRackUpdateView`** (POST) — per-device dropdown updates. Apply selection to validation state and return re-rendered row via `render_device_row()`.
 
-## Key Import Utilities (`import_utils.py`)
-- `process_device_filters(filters, ...)` — fetches and validates devices from LibreNMS, returns list.
-- `validate_device_for_import(device, ...)` — core validation function, produces validation state dict.
-- `bulk_import_devices_shared(devices, user, ...)` — shared implementation between sync and background import.
-- `bulk_import_vms(vm_imports, user, ...)` — VM import implementation.
-- `fetch_device_with_cache(device_id, ...)` — retrieves/caches individual device data.
-- Cache key functions: `get_validated_device_cache_key()`, `get_cache_metadata_key()`, `get_active_cached_searches()`, `get_import_device_cache_key()`.
+## Key Import Utilities (`import_utils/` package)
+`import_utils/` is a package; the `__init__.py` re-exports key functions so callers can still use `from import_utils import ...`.
+
+- `filters.py` — `process_device_filters(filters, ...)`, `fetch_device_with_cache(device_id, ...)`.
+- `device_operations.py` — `validate_device_for_import(device, ...)`, `bulk_import_devices_shared(devices, user, ...)`.
+- `vm_operations.py` — `bulk_import_vms(vm_imports, user, ...)`.
+- `cache.py` — `get_validated_device_cache_key()`, `get_cache_metadata_key()`, `get_active_cached_searches()`, `get_import_device_cache_key()`.
+- `permissions.py` — `check_user_permissions(user, permissions)`, `require_permissions(user, permissions, action_description)`.
+- `virtual_chassis.py` — `create_virtual_chassis_with_members()`, `_sync_module_bay_counter()`.
 
 ## Validation Helpers (`import_validation_helpers.py`)
 Centralizes validation state mutation used by the role/cluster/rack update views:

--- a/.github/instructions/frontend.instructions.md
+++ b/.github/instructions/frontend.instructions.md
@@ -11,10 +11,11 @@ description: Frontend patterns for templates, HTMX, and static assets
 - All HTMX requests and `fetch()` calls must include a CSRF token. The standard pattern is `document.querySelector('[name=csrfmiddlewaretoken]').value` (from a hidden form input). The import JS also uses `getCookie('csrftoken')` as a fallback — prefer the hidden input approach for consistency.
 
 ## Modal Implementation
-- Modals use Tabler (Bootstrap-like) but **without** `bootstrap.Modal` helpers.
+- Modals try Bootstrap 5 native (`bootstrap.Modal`) first, falling back to manual DOM manipulation if unavailable. Both `librenms_sync.js` and `librenms_import.js` follow this pattern via `showModal()`/`hideModal()` helpers.
 - Buttons target the `htmx-modal-content` element and JavaScript in `librenms_import.html` toggles the wrapper.
 - Do not reintroduce `data-bs-toggle` or duplicate modal IDs.
 - The import page uses `ModalManager` class and `filterModalManager` instance—always use this reference in fetch callbacks, not undefined `modalInstance` variables.
+- Dismiss handlers (backdrop click, `data-bs-dismiss` buttons) are bound once per element to prevent stacking on repeated `showModal()` calls.
 
 ## JavaScript Fetch Patterns
 - Always check `response.ok` before processing fetch responses to catch HTTP errors.

--- a/.github/instructions/release.instructions.md
+++ b/.github/instructions/release.instructions.md
@@ -1,0 +1,149 @@
+---
+applyTo: "**/changelog.md,**/pyproject.toml,**/__init__.py"
+---
+
+# Release Workflow
+
+This describes the standard release process for the NetBox LibreNMS Plugin. Follow these steps exactly when asked to create a new release.
+
+## Branch Strategy
+
+> **Both `develop` and `master` have branch protection.** All changes must go through pull requests — never push directly.
+
+### Standard Flow (used for all releases)
+
+1. **Create `release/X.Y.Z` branch** from develop
+2. **Version bump commit** on the release branch
+3. **PR `release/X.Y.Z` → develop** (version bump PR)
+4. **PR `develop` → master** (release PR) — GitHub will auto-include any commits master is missing
+5. **Tag `vX.Y.Z`** on master and create GitHub release
+6. **Post-release:** master may now be ahead of develop (e.g. the merge commit). This resolves naturally — step 1 of the next release starts from the current develop, and the release PR (step 4) will reconcile any divergence.
+
+## Files to Update
+
+Three files must be updated in a single commit with message `Bump version to X.Y.Z and update changelog`:
+
+### `netbox_librenms_plugin/__init__.py`
+```python
+__version__ = "X.Y.Z"
+```
+
+### `pyproject.toml`
+```toml
+version = "X.Y.Z"
+```
+
+### `docs/changelog.md`
+Prepend a new section at the top (after `# Changelog`). Use the current date in `YYYY-MM-DD` format. Categories used (pick only those that apply):
+- `### New Features`
+- `### Improvements`
+- `### Fixes`
+- `### Development`
+- `### Documentation`
+
+Example:
+```markdown
+## X.Y.Z (YYYY-MM-DD)
+
+### Fixes
+* Description of fix (#PR_NUMBER)
+```
+
+## Version Bump PR (release/X.Y.Z → develop)
+
+**Title:** `Bump version to X.Y.Z and update changelog`
+
+**Body template:**
+```markdown
+## Summary
+Bump version to X.Y.Z and update changelog for release.
+
+## Motivation / Problem
+- Maintenance / cleanup
+
+Prepare release X.Y.Z with <brief description of what's included>.
+
+## Scope of Change
+
+- Config / settings
+- Docs only
+
+## How Was This Tested?
+
+- Not tested: version bump and changelog only
+
+## Risk Assessment
+- No impact on existing users
+- No code logic changes
+
+## Backwards Compatibility
+- No breaking changes
+```
+
+## Release PR (develop → master)
+
+**Title:** `Release X.Y.Z`
+
+**Body template:**
+```markdown
+## Summary
+Release X.Y.Z — merge develop into master for PyPI release.
+
+## Motivation / Problem
+- <Bug | Feature | Maintenance / cleanup>
+
+<One-line description of what this release contains, referencing PR numbers.>
+
+## Scope of Change
+
+<List applicable scopes from the PR template>
+
+## Changes
+<Bullet list of changes, each referencing PR numbers>
+- Bump version to X.Y.Z
+
+## How Was This Tested?
+
+<Summarize testing from the included PRs>
+
+## Risk Assessment
+<Brief risk assessment>
+
+## Backwards Compatibility
+- No breaking changes
+```
+
+## GitHub Release Text
+
+**Tag:** `vX.Y.Z` (create on master)
+**Release title:** `vX.Y.Z`
+
+**Body template:**
+```markdown
+## <Bug Fix Release | Feature Release | Maintenance Release>
+
+<One-paragraph summary of the release. Explain what was wrong and what changed.>
+
+### <Fixes | New Features | Improvements>
+
+- <Change description> (#PR_NUMBER)
+
+> ### Upgrade note
+> - <Migration/collectstatic notes, or "No database migrations in this release."> Standard [update process](https://github.com/bonzo81/netbox-librenms-plugin#update) applies.
+
+---
+
+## All Changes
+* <commit title> by @<author> in https://github.com/bonzo81/netbox-librenms-plugin/pull/<PR_NUMBER>
+```
+
+The "All Changes" section lists only the feature/fix PRs included in the release — not version bump or merge PRs.
+
+## Checklist
+
+- [ ] Version bumped in `__init__.py` and `pyproject.toml`
+- [ ] Changelog updated in `docs/changelog.md`
+- [ ] Version bump PR merged to develop
+- [ ] Release PR merged to master
+- [ ] Tag created on master
+- [ ] GitHub release published

--- a/.github/instructions/testing.instructions.md
+++ b/.github/instructions/testing.instructions.md
@@ -27,7 +27,7 @@ description: Testing patterns and conventions for the NetBox LibreNMS plugin
 
 ## Test Coverage by Module
 - `librenms_api.py` → `test_librenms_api.py`, `test_librenms_api_helpers.py`
-- `import_utils.py`, `import_validation_helpers.py`, `utils.py` → `test_import_utils.py`, `test_import_validation_helpers.py`, `test_utils.py`
+- `import_utils/` package (`filters.py`, `device_operations.py`, `vm_operations.py`, `cache.py`, `permissions.py`, `virtual_chassis.py`), `import_validation_helpers.py`, `utils.py` → `test_import_utils.py`, `test_import_validation_helpers.py`, `test_utils.py`
 - `jobs.py`, `views/imports/list.py` → `test_background_jobs.py`
 - Permission mixins, API permissions, constants → `test_permissions.py`
 - VLAN API, mode detection, comparison, sync → `test_vlan_sync.py`


### PR DESCRIPTION
## Summary
Update Copilot instruction files to reflect codebase changes from v0.4.4–v0.4.6 and add a new release workflow instruction file.

## Motivation / Problem
- Maintenance / cleanup

Several instruction files had stale or inaccurate content after the v0.4.4 `import_utils` package refactor, v0.4.5 modal pattern changes, and v0.4.6 VC virtual chassis test additions.

## Scope of Change

- Docs only

## Changes

### `frontend.instructions.md`
- Modal section now documents Bootstrap 5 native-first pattern with manual DOM fallback (was incorrectly stating no `bootstrap.Modal` usage)
- Added dismiss handler deduplication note

### `background-jobs.instructions.md`
- Fixed `applyTo` glob from `**/import_utils.py` to `**/import_utils/**` to match the package structure
- Restructured key utilities section to reflect per-module breakdown in the package

### `copilot-instructions.md`
- Updated permission helpers path from `import_utils.py` to `import_utils/permissions.py`

### `testing.instructions.md`
- Updated test coverage mapping to reflect `import_utils/` package structure

### New: `release.instructions.md`
- Standardized release workflow with branch strategy, version bump locations, PR templates, and GitHub release text format
- Documents branch protection constraints

## How Was This Tested?

- Not tested: documentation only

## Risk Assessment
- No impact on existing users
- No code logic changes

## Backwards Compatibility
- No breaking changes