### PR TITLE
fix: generate slug when creating Platform via sync page

### DIFF
--- a/netbox_librenms_plugin/tests/test_coverage_device_fields.py
+++ b/netbox_librenms_plugin/tests/test_coverage_device_fields.py
@@ -717,6 +717,40 @@ class TestCreateAndAssignPlatformView:
         assert mock_locked.platform == mock_platform_instance
         mock_locked.save.assert_called_once()
 
+    def test_platform_constructor_includes_slug(self):
+        """Platform must be constructed with slug=slugify(name) — regression for #279."""
+        from django.utils.text import slugify
+
+        view = self._view()
+        platform_name = "Cisco IOS-XE 17.x"
+        req = _make_request({"platform_name": platform_name, "manufacturer": ""})
+
+        mock_platform_cls = MagicMock()
+        mock_platform_cls.objects.filter.return_value.exists.return_value = False
+        mock_platform_instance = MagicMock()
+        mock_platform_cls.return_value = mock_platform_instance
+
+        mock_device_cls = MagicMock()
+        mock_device_cls.DoesNotExist = type("DoesNotExist", (Exception,), {})
+        mock_locked = MagicMock()
+        mock_device_cls.objects.select_for_update.return_value.get.return_value = mock_locked
+
+        with (
+            patch("netbox_librenms_plugin.views.sync.device_fields.get_object_or_404", return_value=MagicMock()),
+            patch("netbox_librenms_plugin.views.sync.device_fields.Platform", mock_platform_cls),
+            patch("netbox_librenms_plugin.views.sync.device_fields.Device", mock_device_cls),
+            patch("netbox_librenms_plugin.views.sync.device_fields.transaction"),
+            patch("netbox_librenms_plugin.views.sync.device_fields.messages"),
+            patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
+        ):
+            view.post(req, pk=1)
+
+        mock_platform_cls.assert_called_once_with(
+            name=platform_name,
+            slug=slugify(platform_name),
+            manufacturer=None,
+        )
+
     def test_platform_validation_error(self):
         from django.core.exceptions import ValidationError
 

--- a/netbox_librenms_plugin/views/sync/device_fields.py
+++ b/netbox_librenms_plugin/views/sync/device_fields.py
@@ -4,6 +4,7 @@ from dcim.models import Device, Manufacturer, Platform
 from django.contrib import messages
 from django.core.exceptions import ValidationError
 from django.db import IntegrityError, transaction
+from django.utils.text import slugify
 
 from django.http import HttpResponse
 from django.shortcuts import get_object_or_404, redirect
@@ -331,6 +332,7 @@ class CreateAndAssignPlatformView(LibreNMSPermissionMixin, NetBoxObjectPermissio
             try:
                 platform = Platform(
                     name=platform_name,
+                    slug=slugify(platform_name),
                     manufacturer=manufacturer,
                 )
                 platform.full_clean()


### PR DESCRIPTION
## Summary
When using the \"Create & Sync\" button on the device sync page to create a new Platform, the Platform object was constructed without a `slug` field. NetBox's `full_clean()` raises a `ValidationError` for the missing slug

## Motivation / Problem
- Bug

Fixes #279.

## Scope of Change
- NetBox models / ORM
- Tests

## How Was This Tested?
- Unit tests: yes — added `test_platform_constructor_includes_slug` to `TestCreateAndAssignPlatformView` which asserts `Platform(name=..., slug=slugify(name), manufacturer=...)` is called. Uses a name with spaces and special characters to exercise `slugify` non-trivially.
- Manual testing: yes — verified Platform creation succeeds on the sync page after the fix.

## Risk Assessment
- No unintended imports or updates — only the slug field is now correctly populated on new Platform objects.

## Backwards Compatibility
- No breaking changes

## Other Notes
