### PR TITLE
fix(import): guard VirtualMachine.cluster access (#284)

### DIFF
--- a/netbox_librenms_plugin/tables/device_status.py
+++ b/netbox_librenms_plugin/tables/device_status.py
@@ -236,9 +236,13 @@ class DeviceImportTable(tables.Table):
 
         # Check if existing object is a VM
         if existing and isinstance(existing, VirtualMachine):
-            # VM already exists - show its cluster (cluster is required for VMs)
+            # VM already exists - show its cluster. NetBox has allowed
+            # VirtualMachine.cluster to be NULL since 3.3 (VMs can be assigned
+            # directly to a site/device), so guard against the cluster-less case.
             cluster = existing.cluster
-            return mark_safe(f'<span class="badge bg-info text-white">{cluster.name}</span>')
+            if cluster is not None:
+                return mark_safe(f'<span class="badge bg-info text-white">{cluster.name}</span>')
+            return mark_safe('<span class="text-muted small">VM (no cluster)</span>')
 
         # If Device already exists (not VM), show it's not a VM
         if existing:

--- a/netbox_librenms_plugin/templates/netbox_librenms_plugin/librenms_sync_base.html
+++ b/netbox_librenms_plugin/templates/netbox_librenms_plugin/librenms_sync_base.html
@@ -20,7 +20,14 @@
 </li>
 {% elif model_name == "virtualmachine" %}
 <li class="breadcrumb-item">
+    {# VirtualMachine.cluster has been nullable since NetBox 3.3 #}
+    {% if object.cluster %}
     <a href="{% url 'virtualization:virtualmachine_list' %}?cluster_id={{ object.cluster.pk }}">{{ object.cluster }}</a>
+    {% elif object.site %}
+    <a href="{% url 'dcim:site' pk=object.site.pk %}">{{ object.site }}</a>
+    {% else %}
+    <span class="text-muted">No cluster</span>
+    {% endif %}
 </li>
 {% endif %}
 {% endwith %}


### PR DESCRIPTION
## Summary
Small fix for #284 — the import page was crashing on VMs without a cluster.

## Motivation / Problem
Opening the LibreNMS Import view (filter by Device Type, Apply Filters) crashed with `AttributeError: 'NoneType' object has no attribute 'name'`.  `render_netbox_cluster()` was doing `vm.cluster.name` without a guard. The inline comment said "cluster is required for VMs" — but that hasn't been true since NetBox 3.3 made `VirtualMachine.cluster` nullable (so VMs can live directly on a site/device).

Found the same unguarded `.cluster.pk` in the VM's LibreNMS Sync breadcrumb — same root cause, didn't crash but rendered a broken link.

- Bug

Fixes #284.

## Scope of Change
- Sync/Import logic
- Web UI / templates

## How Was This Tested?
- Manual testing: VM with `cluster=None`, repro'd the crash on the import page on 4.4.10, confirmed it now shows a `VM (no cluster)` badge. Opened the VM's LibreNMS tab — breadcrumb falls back to the site link instead of an empty `?cluster_id=`.
- Existing tests still pass.

### Manual Test Steps
1. Pick or create a VM in NetBox with no cluster (assign it to a site/device instead).
2. Make sure it's in LibreNMS under the same hostname.
3. Go to Import, filter so that VM is in the result set, click Apply Filters — page should load.
4. Open the LibreNMS tab on the VM detail page — breadcrumb should render fine.

## Risk Assessment
Display-only guard, doesn't touch import/create logic. Users who always set a cluster on VMs won't see any difference. The "new VM import requires a cluster" policy is unchanged.

## Backwards Compatibility
- No breaking changes

## Other Notes
Also replaced the misleading "cluster is required for VMs" comment with a note about the NetBox 3.3 change, so it doesn't get reintroduced.
