### PR TITLE
feat: UI improvements

### DIFF
--- a/netbox_librenms_plugin/static/netbox_librenms_plugin/js/librenms_import.js
+++ b/netbox_librenms_plugin/static/netbox_librenms_plugin/js/librenms_import.js
@@ -349,8 +349,8 @@
      * Persists toggle state to user preferences on change.
      */
     function initializeTogglePrefs() {
-        const sysname = document.getElementById('use-sysname-toggle');
-        const strip = document.getElementById('strip-domain-toggle');
+        const sysname = document.getElementById('use-sysname-toggle-cb');
+        const strip = document.getElementById('strip-domain-toggle-cb');
         if (sysname) sysname.addEventListener('change', function () { savePref('use_sysname', this.checked); });
         if (strip) strip.addEventListener('change', function () { savePref('strip_domain', this.checked); });
     }
@@ -1199,10 +1199,14 @@
 
             const dismissTrigger = event.target.closest('[data-bs-dismiss="modal"]');
             if (dismissTrigger) {
-                event.preventDefault();
-
-                // Check if it's in the HTMX modal
-                if (modalElement.contains(dismissTrigger)) {
+                // Only handle dismiss triggers whose nearest .modal ancestor IS
+                // the outer HTMX modal. Buttons inside nested modals (e.g. the
+                // Promote-to-host modal rendered inside #htmx-modal-content)
+                // must be left for Bootstrap's own dismiss handler so they
+                // close the inner modal, not the outer one.
+                const nearestModal = dismissTrigger.closest('.modal');
+                if (nearestModal === modalElement) {
+                    event.preventDefault();
                     hideModal(modalElement, fallbackBackdropRef);
                 }
             }

--- a/netbox_librenms_plugin/templates/netbox_librenms_plugin/htmx/_dt_mapping_form.html
+++ b/netbox_librenms_plugin/templates/netbox_librenms_plugin/htmx/_dt_mapping_form.html
@@ -15,6 +15,7 @@ Optional context:
       class="mt-1"
       id="dt-mapping-form-{{ libre_device.device_id }}">
   {% csrf_token %}
+  {% if server_key %}<input type="hidden" name="server_key" value="{{ server_key }}">{% endif %}
   <div class="position-relative">
     <label for="dt-search-{{ libre_device.device_id }}" class="visually-hidden">
       Search device types

--- a/netbox_librenms_plugin/templates/netbox_librenms_plugin/htmx/_dt_mapping_form.html
+++ b/netbox_librenms_plugin/templates/netbox_librenms_plugin/htmx/_dt_mapping_form.html
@@ -1,0 +1,112 @@
+{% comment %}
+Reusable "Add Device Type Mapping" form for the import validation modal.
+
+Required context:
+  - libre_device (dict-like with device_id, hardware)
+Optional context:
+  - preselect_device_type: a DeviceType instance to pre-fill the typeahead
+    (used in the existing-device + mismatch branch so a single click maps
+    `libre_device.hardware` → `existing_device.device_type`).
+  - submit_label (defaults to "Add Mapping")
+{% endcomment %}
+<form hx-post="{% url 'plugins:netbox_librenms_plugin:add_device_type_mapping' device_id=libre_device.device_id %}"
+      hx-swap="none"
+      hx-include="[name=role_{{ libre_device.device_id }}], [name=rack_{{ libre_device.device_id }}], [name=cluster_{{ libre_device.device_id }}], #use-sysname-toggle, #strip-domain-toggle"
+      class="mt-1"
+      id="dt-mapping-form-{{ libre_device.device_id }}">
+  {% csrf_token %}
+  <div class="position-relative">
+    <label for="dt-search-{{ libre_device.device_id }}" class="visually-hidden">
+      Search device types
+    </label>
+    <input type="text"
+           class="form-control form-control-sm"
+           id="dt-search-{{ libre_device.device_id }}"
+           placeholder="Search device types…"
+           autocomplete="off"
+           {% if preselect_device_type %}value="{% if preselect_device_type.manufacturer %}{{ preselect_device_type.manufacturer.name }} — {% endif %}{{ preselect_device_type.display }}"{% endif %}>
+    <input type="hidden"
+           name="device_type_id"
+           id="dt-id-{{ libre_device.device_id }}"
+           value="{% if preselect_device_type %}{{ preselect_device_type.pk }}{% endif %}">
+    <div id="dt-dropdown-{{ libre_device.device_id }}"
+         class="dropdown-menu w-100 shadow"
+         style="z-index:1050; max-height:200px; overflow-y:auto; display:none;"></div>
+  </div>
+  {# Disabled until a typeahead item is chosen (or a preselect value is present). #}
+  <button type="submit"
+          id="dt-submit-{{ libre_device.device_id }}"
+          class="btn btn-sm btn-primary mt-1 w-100"
+          {% if not preselect_device_type %}disabled{% endif %}>{{ submit_label|default:"Add Mapping" }}</button>
+</form>
+<script>
+  (function () {
+    var searchEl = document.getElementById("dt-search-{{ libre_device.device_id }}");
+    var dropdownEl = document.getElementById("dt-dropdown-{{ libre_device.device_id }}");
+    var hiddenEl = document.getElementById("dt-id-{{ libre_device.device_id }}");
+    var submitBtn = document.getElementById("dt-submit-{{ libre_device.device_id }}");
+    if (!searchEl) return;
+    var timer = null;
+    var requestSeq = 0;
+
+    searchEl.addEventListener("input", function () {
+      clearTimeout(timer);
+      hiddenEl.value = "";
+      submitBtn.disabled = true;
+      var q = this.value.trim();
+      if (q.length < 2) { dropdownEl.style.display = "none"; dropdownEl.innerHTML = ""; return; }
+      timer = setTimeout(function () {
+        var seq = ++requestSeq;
+        var csrfToken = (document.querySelector('[name=csrfmiddlewaretoken]') || {}).value || "";
+        fetch("{% url 'dcim-api:devicetype-list' %}?q=" + encodeURIComponent(q) + "&limit=20", {
+          headers: { "X-CSRFToken": csrfToken }
+        })
+          .then(function (r) {
+            if (!r.ok) { throw new Error("HTTP " + r.status); }
+            return r.json();
+          })
+          .then(function (data) {
+            if (seq !== requestSeq) return;
+            dropdownEl.innerHTML = "";
+            if (!data.results || data.results.length === 0) {
+              dropdownEl.innerHTML = '<a class="dropdown-item small py-1 text-muted disabled">No results</a>';
+            } else {
+              data.results.forEach(function (dt) {
+                var a = document.createElement("a");
+                a.className = "dropdown-item small py-1";
+                a.href = "#";
+                a.textContent = (dt.manufacturer ? dt.manufacturer.display + " — " : "") + dt.display;
+                a.addEventListener("click", function (e) {
+                  e.preventDefault();
+                  searchEl.value = (dt.manufacturer ? dt.manufacturer.display + " — " : "") + dt.display;
+                  hiddenEl.value = dt.id;
+                  submitBtn.disabled = false;
+                  dropdownEl.style.display = "none";
+                });
+                dropdownEl.appendChild(a);
+              });
+            }
+            dropdownEl.style.display = "block";
+          })
+          .catch(function (error) {
+            console.debug("Device type lookup failed:", error.message);
+            dropdownEl.style.display = "none";
+          });
+      }, 300);
+    });
+
+    // Outside-click hides the dropdown. The listener self-removes once the
+    // form leaves the DOM (HTMX swap, modal teardown) so handlers don't
+    // accumulate on document each time this template re-renders.
+    function onDocClick(e) {
+      if (!document.body.contains(searchEl)) {
+        document.removeEventListener("click", onDocClick);
+        return;
+      }
+      if (!searchEl.contains(e.target) && !dropdownEl.contains(e.target)) {
+        dropdownEl.style.display = "none";
+      }
+    }
+    document.addEventListener("click", onDocClick);
+  })();
+</script>

--- a/netbox_librenms_plugin/templates/netbox_librenms_plugin/htmx/_platform_manage_icon.html
+++ b/netbox_librenms_plugin/templates/netbox_librenms_plugin/htmx/_platform_manage_icon.html
@@ -1,0 +1,13 @@
+{# Compact pencil icon that opens the combined "manage platform" modal
+   (map LibreNMS OS to an existing platform, or create a new one). Keeps the
+   platform cell uncluttered. Requires: libre_device, server_key. #}
+{% if libre_device.os and libre_device.os != "-" %}
+<button type="button" class="btn btn-sm btn-outline-secondary py-0 px-1 ms-1"
+        hx-get="{% url 'plugins:netbox_librenms_plugin:create_platform_from_import' device_id=libre_device.device_id %}?server_key={{ server_key|urlencode }}"
+        hx-target="#htmx-modal-content"
+        hx-swap="innerHTML"
+        title="Map or create platform for '{{ libre_device.os }}'"
+        aria-label="Map or create platform">
+  <i class="mdi mdi-pencil"></i>
+</button>
+{% endif %}

--- a/netbox_librenms_plugin/templates/netbox_librenms_plugin/htmx/_platform_manage_icon.html
+++ b/netbox_librenms_plugin/templates/netbox_librenms_plugin/htmx/_platform_manage_icon.html
@@ -1,6 +1,8 @@
-{# Compact pencil icon that opens the combined "manage platform" modal
-   (map LibreNMS OS to an existing platform, or create a new one). Keeps the
-   platform cell uncluttered. Requires: libre_device, server_key. #}
+{% comment %}
+Compact pencil icon that opens the combined "manage platform" modal (map
+LibreNMS OS to an existing platform, or create a new one). Keeps the platform
+cell uncluttered. Requires: libre_device, server_key.
+{% endcomment %}
 {% if libre_device.os and libre_device.os != "-" %}
 <button type="button" class="btn btn-sm btn-outline-secondary py-0 px-1 ms-1"
         hx-get="{% url 'plugins:netbox_librenms_plugin:create_platform_from_import' device_id=libre_device.device_id %}?server_key={{ server_key|urlencode }}"

--- a/netbox_librenms_plugin/templates/netbox_librenms_plugin/htmx/_platform_mapping_form.html
+++ b/netbox_librenms_plugin/templates/netbox_librenms_plugin/htmx/_platform_mapping_form.html
@@ -1,0 +1,110 @@
+{% comment %}
+Reusable "Add Platform Mapping" form for the import validation modal.
+
+Required context:
+  - libre_device (dict-like with device_id, os)
+Optional:
+  - preselect_platform: a Platform instance to pre-fill the typeahead.
+  - submit_label
+{% endcomment %}
+<form hx-post="{% url 'plugins:netbox_librenms_plugin:add_platform_mapping' device_id=libre_device.device_id %}"
+      hx-swap="none"
+      hx-include="[name=role_{{ libre_device.device_id }}], [name=rack_{{ libre_device.device_id }}], [name=cluster_{{ libre_device.device_id }}], #use-sysname-toggle, #strip-domain-toggle"
+      class="mt-1"
+      id="plat-mapping-form-{{ libre_device.device_id }}">
+  {% csrf_token %}
+  <div class="position-relative">
+    <label for="plat-search-{{ libre_device.device_id }}" class="visually-hidden">
+      Search platforms
+    </label>
+    <input type="text"
+           class="form-control form-control-sm"
+           id="plat-search-{{ libre_device.device_id }}"
+           placeholder="Search platforms…"
+           autocomplete="off"
+           {% if preselect_platform %}value="{{ preselect_platform.name }}"{% endif %}>
+    <input type="hidden"
+           name="platform_id"
+           id="plat-id-{{ libre_device.device_id }}"
+           value="{% if preselect_platform %}{{ preselect_platform.pk }}{% endif %}">
+    <div id="plat-dropdown-{{ libre_device.device_id }}"
+         class="dropdown-menu w-100 shadow"
+         style="z-index:1050; max-height:200px; overflow-y:auto; display:none;"></div>
+  </div>
+  {# Disabled until a typeahead item is chosen (or a preselect value is present). #}
+  <button type="submit"
+          id="plat-submit-{{ libre_device.device_id }}"
+          class="btn btn-sm btn-primary mt-1 w-100"
+          {% if not preselect_platform %}disabled{% endif %}>{{ submit_label|default:"Add Mapping" }}</button>
+</form>
+<script>
+  (function () {
+    var searchEl = document.getElementById("plat-search-{{ libre_device.device_id }}");
+    var dropdownEl = document.getElementById("plat-dropdown-{{ libre_device.device_id }}");
+    var hiddenEl = document.getElementById("plat-id-{{ libre_device.device_id }}");
+    var submitBtn = document.getElementById("plat-submit-{{ libre_device.device_id }}");
+    if (!searchEl) return;
+    var timer = null;
+    var requestSeq = 0;
+
+    searchEl.addEventListener("input", function () {
+      clearTimeout(timer);
+      hiddenEl.value = "";
+      submitBtn.disabled = true;
+      var q = this.value.trim();
+      if (q.length < 2) { dropdownEl.style.display = "none"; dropdownEl.innerHTML = ""; return; }
+      timer = setTimeout(function () {
+        var seq = ++requestSeq;
+        var csrfToken = (document.querySelector('[name=csrfmiddlewaretoken]') || {}).value || "";
+        fetch("{% url 'dcim-api:platform-list' %}?q=" + encodeURIComponent(q) + "&limit=20", {
+          headers: { "X-CSRFToken": csrfToken }
+        })
+          .then(function (r) {
+            if (!r.ok) { throw new Error("HTTP " + r.status); }
+            return r.json();
+          })
+          .then(function (data) {
+            if (seq !== requestSeq) return;
+            dropdownEl.innerHTML = "";
+            if (!data.results || data.results.length === 0) {
+              dropdownEl.innerHTML = '<a class="dropdown-item small py-1 text-muted disabled">No results</a>';
+            } else {
+              data.results.forEach(function (p) {
+                var a = document.createElement("a");
+                a.className = "dropdown-item small py-1";
+                a.href = "#";
+                a.textContent = p.display || p.name;
+                a.addEventListener("click", function (e) {
+                  e.preventDefault();
+                  searchEl.value = p.display || p.name;
+                  hiddenEl.value = p.id;
+                  submitBtn.disabled = false;
+                  dropdownEl.style.display = "none";
+                });
+                dropdownEl.appendChild(a);
+              });
+            }
+            dropdownEl.style.display = "block";
+          })
+          .catch(function (error) {
+            console.debug("Platform lookup failed:", error.message);
+            dropdownEl.style.display = "none";
+          });
+      }, 300);
+    });
+
+    // Outside-click hides the dropdown. The listener self-removes once the
+    // form leaves the DOM (HTMX swap, modal teardown) so handlers don't
+    // accumulate on document each time this template re-renders.
+    function onDocClick(e) {
+      if (!document.body.contains(searchEl)) {
+        document.removeEventListener("click", onDocClick);
+        return;
+      }
+      if (!searchEl.contains(e.target) && !dropdownEl.contains(e.target)) {
+        dropdownEl.style.display = "none";
+      }
+    }
+    document.addEventListener("click", onDocClick);
+  })();
+</script>

--- a/netbox_librenms_plugin/templates/netbox_librenms_plugin/htmx/_platform_mapping_form.html
+++ b/netbox_librenms_plugin/templates/netbox_librenms_plugin/htmx/_platform_mapping_form.html
@@ -13,6 +13,7 @@ Optional:
       class="mt-1"
       id="plat-mapping-form-{{ libre_device.device_id }}">
   {% csrf_token %}
+  {% if server_key %}<input type="hidden" name="server_key" value="{{ server_key }}">{% endif %}
   <div class="position-relative">
     <label for="plat-search-{{ libre_device.device_id }}" class="visually-hidden">
       Search platforms

--- a/netbox_librenms_plugin/templates/netbox_librenms_plugin/htmx/create_platform_modal.html
+++ b/netbox_librenms_plugin/templates/netbox_librenms_plugin/htmx/create_platform_modal.html
@@ -13,10 +13,19 @@
 {#   server_key              - (optional) LibreNMS server key, forwarded as hidden field #}
 <div class="modal-header">
     <h5 class="modal-title" id="createPlatformModalLabel">
-        <i class="mdi mdi-alert"></i> Create New Platform
+        {% if libre_device %}<i class="mdi mdi-cog-outline"></i> Manage platform — <code>{{ librenms_os }}</code>{% else %}<i class="mdi mdi-alert"></i> Create New Platform{% endif %}
     </h5>
     <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
 </div>
+{% if libre_device %}
+{# Map the LibreNMS OS to an EXISTING platform (separate form -> add_platform_mapping). #}
+<div class="modal-body pb-2">
+    <h6 class="mb-2">Map <code>{{ librenms_os }}</code> to an existing platform</h6>
+    {% include "netbox_librenms_plugin/htmx/_platform_mapping_form.html" with preselect_platform=current_platform submit_label="Map to this platform" %}
+    <div class="text-center text-muted small mt-3">— or create a new platform below —</div>
+</div>
+<hr class="my-0">
+{% endif %}
 <form{% if use_htmx %} hx-post="{{ form_action }}" hx-swap="none"{% if htmx_include %} hx-include="{{ htmx_include }}"{% endif %}{% else %} method="post" action="{{ form_action }}"{% endif %}>
     {% csrf_token %}
     <input type="hidden" name="librenms_os" value="{{ librenms_os }}">
@@ -27,9 +36,9 @@
     <input type="hidden" name="device_pk" value="{{ device_pk }}">
     {% endif %}
     <div class="modal-body">
-        <div class="alert alert-warning">
+        <div class="alert alert-info py-2">
             <i class="mdi mdi-information"></i>
-            No NetBox platform matches LibreNMS OS <strong>{{ librenms_os }}</strong>.
+            Create a new NetBox platform for LibreNMS OS <strong>{{ librenms_os }}</strong>.
         </div>
         <p>This will:</p>
         <ol>

--- a/netbox_librenms_plugin/templates/netbox_librenms_plugin/htmx/device_validation_details.html
+++ b/netbox_librenms_plugin/templates/netbox_librenms_plugin/htmx/device_validation_details.html
@@ -363,9 +363,10 @@
                     {% else %}
                     <span class="text-muted">Optional</span>
                     {% endif %}
-                    {% if libre_device.os and libre_device.os != "-" and sync_info and not sync_info.platform_info.platform_exists %}
-                      {% include "netbox_librenms_plugin/htmx/_platform_mapping_form.html" with preselect_platform=validation.existing_device.platform %}
+                    {% if libre_device.os and libre_device.os != "-" %}
+                      {% include "netbox_librenms_plugin/htmx/_platform_mapping_form.html" %}
                     {% endif %}
+                  {% endif %}
                   </td>
                   <td>{{ libre_device.os|default:"—" }}</td>
               </tr>

--- a/netbox_librenms_plugin/templates/netbox_librenms_plugin/htmx/device_validation_details.html
+++ b/netbox_librenms_plugin/templates/netbox_librenms_plugin/htmx/device_validation_details.html
@@ -309,26 +309,13 @@
                         <span class="text-muted ms-1" title="Platform '{{ sync_info.platform_info.librenms_os }}' not in NetBox">
                           <i class="mdi mdi-alert-outline"></i>
                         </span>
-                        {% if libre_device.os and libre_device.os != "-" %}
-                        <button type="button" class="btn btn-sm btn-warning py-0 px-1 ms-1"
-                                hx-get="{% url 'plugins:netbox_librenms_plugin:create_platform_from_import' device_id=libre_device.device_id %}?server_key={{ server_key|urlencode }}"
-                                hx-target="#htmx-modal-content"
-                                hx-swap="innerHTML"
-                                title="Create platform for {{ libre_device.os }}"
-                                aria-label="Create platform for {{ libre_device.os }}">
-                          <i class="mdi mdi-plus"></i>
-                        </button>
-                        {# Let the user map the LibreNMS OS to the device's current platform instead of creating a duplicate (mirrors the device-type flow). #}
-                        <div class="mt-1">
-                          {% include "netbox_librenms_plugin/htmx/_platform_mapping_form.html" with preselect_platform=validation.existing_device.platform submit_label="Map LibreNMS OS to current platform" %}
-                        </div>
-                        {% endif %}
                       {% endif %}
                     {% elif sync_info and sync_info.platform_synced %}
                       <span class="text-success"><i class="mdi mdi-check-circle"></i></span>
                     {% endif %}
+                    {% include "netbox_librenms_plugin/htmx/_platform_manage_icon.html" %}
                   {% elif validation.existing_device %}
-                    {# Existing device with no platform assigned — show Not set + sync button #}
+                    {# Existing device with no platform assigned #}
                     <span class="text-muted">Not set</span>
                     {% if validation.platform.platform or sync_info and sync_info.platform_info.platform_exists %}
                     <form style="display:inline" class="ms-1"
@@ -342,38 +329,18 @@
                         <i class="mdi mdi-sync"></i>
                       </button>
                     </form>
-                    {% elif libre_device.os and libre_device.os != "-" %}
-                    <button type="button" class="btn btn-sm btn-outline-warning py-0 px-1"
-                            hx-get="{% url 'plugins:netbox_librenms_plugin:create_platform_from_import' device_id=libre_device.device_id %}?server_key={{ server_key|urlencode }}"
-                            hx-target="#htmx-modal-content"
-                            hx-swap="innerHTML"
-                            title="Create platform for {{ libre_device.os }}">
-                      <i class="mdi mdi-plus"></i> Create Platform
-                    </button>
-                    {# No current platform to preselect, but still let the user map the OS to an existing platform rather than create one. #}
-                    <div class="mt-1">
-                      {% include "netbox_librenms_plugin/htmx/_platform_mapping_form.html" with submit_label="Map LibreNMS OS to a platform" %}
-                    </div>
                     {% endif %}
+                    {% include "netbox_librenms_plugin/htmx/_platform_manage_icon.html" %}
                   {% elif validation.platform.platform %}
                     {# New import — platform will be assigned on import #}
                     {{ validation.platform.platform.name }}
                     <span class="text-success"><i class="mdi mdi-check-circle"></i></span>
+                    {% include "netbox_librenms_plugin/htmx/_platform_manage_icon.html" %}
                   {% else %}
-                    {% if libre_device.os and libre_device.os != "-" %}
-                    <button type="button" class="btn btn-sm btn-outline-warning py-0 px-1"
-                            hx-get="{% url 'plugins:netbox_librenms_plugin:create_platform_from_import' device_id=libre_device.device_id %}?server_key={{ server_key|urlencode }}"
-                            hx-target="#htmx-modal-content"
-                            hx-swap="innerHTML"
-                            title="Create platform for {{ libre_device.os }}">
-                      <i class="mdi mdi-plus"></i> Create Platform
-                    </button>
-                    {% else %}
+                    {% if not libre_device.os or libre_device.os == "-" %}
                     <span class="text-muted">Optional</span>
                     {% endif %}
-                    {% if libre_device.os and libre_device.os != "-" %}
-                      {% include "netbox_librenms_plugin/htmx/_platform_mapping_form.html" %}
-                    {% endif %}
+                    {% include "netbox_librenms_plugin/htmx/_platform_manage_icon.html" %}
                   {% endif %}
                   </td>
                   <td>{{ libre_device.os|default:"—" }}</td>

--- a/netbox_librenms_plugin/templates/netbox_librenms_plugin/htmx/device_validation_details.html
+++ b/netbox_librenms_plugin/templates/netbox_librenms_plugin/htmx/device_validation_details.html
@@ -318,6 +318,10 @@
                                 aria-label="Create platform for {{ libre_device.os }}">
                           <i class="mdi mdi-plus"></i>
                         </button>
+                        {# Let the user map the LibreNMS OS to the device's current platform instead of creating a duplicate (mirrors the device-type flow). #}
+                        <div class="mt-1">
+                          {% include "netbox_librenms_plugin/htmx/_platform_mapping_form.html" with preselect_platform=validation.existing_device.platform submit_label="Map LibreNMS OS to current platform" %}
+                        </div>
                         {% endif %}
                       {% endif %}
                     {% elif sync_info and sync_info.platform_synced %}
@@ -346,6 +350,10 @@
                             title="Create platform for {{ libre_device.os }}">
                       <i class="mdi mdi-plus"></i> Create Platform
                     </button>
+                    {# No current platform to preselect, but still let the user map the OS to an existing platform rather than create one. #}
+                    <div class="mt-1">
+                      {% include "netbox_librenms_plugin/htmx/_platform_mapping_form.html" with submit_label="Map LibreNMS OS to a platform" %}
+                    </div>
                     {% endif %}
                   {% elif validation.platform.platform %}
                     {# New import — platform will be assigned on import #}

--- a/netbox_librenms_plugin/templates/netbox_librenms_plugin/htmx/device_validation_details.html
+++ b/netbox_librenms_plugin/templates/netbox_librenms_plugin/htmx/device_validation_details.html
@@ -175,6 +175,9 @@
                         <i class="mdi mdi-sync"></i>
                       </button>
                     </form>
+                    {% if libre_device.hardware and libre_device.hardware != "-" %}
+                      {% include "netbox_librenms_plugin/htmx/_dt_mapping_form.html" with preselect_device_type=validation.existing_device.device_type submit_label="Map LibreNMS hardware to current type" %}
+                    {% endif %}
                   {% elif validation.existing_device and validation.existing_device.device_type %}
                     {{ validation.existing_device.device_type }}
                     {% if sync_info and not sync_info.device_type_synced and sync_info.librenms_device_type %}
@@ -189,6 +192,12 @@
                           <i class="mdi mdi-sync"></i>
                         </button>
                       </form>
+                    {% elif sync_info and not sync_info.device_type_synced and not sync_info.librenms_device_type and libre_device.hardware and libre_device.hardware != "-" %}
+                      {# LibreNMS hardware has no NetBox mapping yet -- let the user create one, pre-selected to the existing device type so the common case is one click. #}
+                      <div class="mt-1">
+                        <span class="text-warning small d-block"><i class="mdi mdi-alert"></i> No mapping for LibreNMS hardware</span>
+                        {% include "netbox_librenms_plugin/htmx/_dt_mapping_form.html" with preselect_device_type=validation.existing_device.device_type submit_label="Map LibreNMS hardware to current type" %}
+                      </div>
                     {% elif validation.device_type.device_type %}
                       <span class="text-success"><i class="mdi mdi-check-circle"></i></span>
                     {% endif %}
@@ -201,106 +210,8 @@
                     {% if libre_device.hardware and libre_device.hardware != "-" %}
                       <div>
                         <span class="text-danger d-block"><i class="mdi mdi-close-circle"></i> No matching type</span>
-                        <form hx-post="{% url 'plugins:netbox_librenms_plugin:add_device_type_mapping' device_id=libre_device.device_id %}"
-                              hx-swap="none"
-                              hx-include="[name=role_{{ libre_device.device_id }}], [name=rack_{{ libre_device.device_id }}], [name=cluster_{{ libre_device.device_id }}], #use-sysname-toggle, #strip-domain-toggle"
-                              class="mt-1"
-                              id="dt-mapping-form-{{ libre_device.device_id }}">
-                          {% csrf_token %}
-                          <input type="hidden" name="server_key" value="{{ server_key }}">
-                          <div class="position-relative">
-                            <label for="dt-search-{{ libre_device.device_id }}" class="visually-hidden">
-                              Search device types
-                            </label>
-                            <input type="text"
-                                   class="form-control form-control-sm"
-                                   id="dt-search-{{ libre_device.device_id }}"
-                                   placeholder="Search device types…"
-                                   autocomplete="off">
-                            <input type="hidden"
-                                   name="device_type_id"
-                                   id="dt-id-{{ libre_device.device_id }}">
-                            <div id="dt-dropdown-{{ libre_device.device_id }}"
-                                 class="dropdown-menu w-100 shadow"
-                                 style="z-index:1050; max-height:200px; overflow-y:auto; display:none;"></div>
-                          </div>
-                          <button type="submit"
-                                  id="dt-submit-{{ libre_device.device_id }}"
-                                  class="btn btn-sm btn-primary mt-1 w-100"
-                                  disabled>Add Mapping</button>
-                        </form>
+                        {% include "netbox_librenms_plugin/htmx/_dt_mapping_form.html" %}
                       </div>
-                      <script>
-                        (function () {
-                          var searchEl = document.getElementById("dt-search-{{ libre_device.device_id }}");
-                          var dropdownEl = document.getElementById("dt-dropdown-{{ libre_device.device_id }}");
-                          var hiddenEl = document.getElementById("dt-id-{{ libre_device.device_id }}");
-                          var submitBtn = document.getElementById("dt-submit-{{ libre_device.device_id }}");
-                          if (!searchEl) return;
-                          var timer = null;
-                          var requestSeq = 0;
-
-                          searchEl.addEventListener("input", function () {
-                            clearTimeout(timer);
-                            hiddenEl.value = "";
-                            submitBtn.disabled = true;
-                            var q = this.value.trim();
-                            if (q.length < 2) { dropdownEl.style.display = "none"; dropdownEl.innerHTML = ""; return; }
-                            timer = setTimeout(function () {
-                              var seq = ++requestSeq;
-                              fetch("{% url 'dcim-api:devicetype-list' %}?q=" + encodeURIComponent(q) + "&limit=20")
-                                .then(function (r) {
-                                  if (!r.ok) {
-                                    throw new Error("DeviceType search failed: HTTP " + r.status);
-                                  }
-                                  return r.json();
-                                })
-                                .then(function (data) {
-                                  if (seq !== requestSeq) return;
-                                  dropdownEl.innerHTML = "";
-                                  if (!data.results || data.results.length === 0) {
-                                    dropdownEl.innerHTML = '<a class="dropdown-item small py-1 text-muted disabled">No results</a>';
-                                  } else {
-                                    data.results.forEach(function (dt) {
-                                      var a = document.createElement("a");
-                                      a.className = "dropdown-item small py-1";
-                                      a.href = "#";
-                                      // dt.display already includes the manufacturer
-                                      // (e.g. "Cisco ISR4321"), so don't prepend it again.
-                                      a.textContent = dt.display;
-                                      a.addEventListener("click", function (e) {
-                                        e.preventDefault();
-                                        searchEl.value = dt.display;
-                                        hiddenEl.value = dt.id;
-                                        submitBtn.disabled = false;
-                                        dropdownEl.style.display = "none";
-                                      });
-                                      dropdownEl.appendChild(a);
-                                    });
-                                  }
-                                  dropdownEl.style.display = "block";
-                                })
-                                .catch(function (err) {
-                                  if (window.console && console.warn) {
-                                    console.warn("DeviceType autocomplete failed:", err);
-                                  }
-                                  dropdownEl.style.display = "none";
-                                });
-                            }, 300);
-                          });
-
-                          function handleDocumentClick(e) {
-                            if (!document.body.contains(dropdownEl)) {
-                              document.removeEventListener("click", handleDocumentClick);
-                              return;
-                            }
-                            if (!searchEl.contains(e.target) && !dropdownEl.contains(e.target)) {
-                              dropdownEl.style.display = "none";
-                            }
-                          }
-                          document.addEventListener("click", handleDocumentClick);
-                        })();
-                      </script>
                     {% else %}
                       <span class="text-danger"><i class="mdi mdi-close-circle"></i> No matching type</span>
                     {% endif %}
@@ -452,9 +363,11 @@
                     {% else %}
                     <span class="text-muted">Optional</span>
                     {% endif %}
-                  {% endif %}
-                </td>
-                <td>{{ libre_device.os|default:"—" }}</td>
+                    {% if libre_device.os and libre_device.os != "-" and sync_info and not sync_info.platform_info.platform_exists %}
+                      {% include "netbox_librenms_plugin/htmx/_platform_mapping_form.html" with preselect_platform=validation.existing_device.platform %}
+                    {% endif %}
+                  </td>
+                  <td>{{ libre_device.os|default:"—" }}</td>
               </tr>
 
               {% if validation.import_as_vm and not validation.existing_device or validation.existing_device and existing_device_model_name == "virtualmachine" %}

--- a/netbox_librenms_plugin/templates/netbox_librenms_plugin/librenms_import.html
+++ b/netbox_librenms_plugin/templates/netbox_librenms_plugin/librenms_import.html
@@ -348,18 +348,24 @@
              data-save-pref-url="{% url 'plugins:netbox_librenms_plugin:save_user_pref' %}">
             <strong class="small">Settings:</strong>
             <div class="form-check form-switch mb-0">
-                <input class="form-check-input" type="checkbox" id="use-sysname-toggle" name="use-sysname-toggle" {% if use_sysname %}checked{% endif %}
-                       data-bs-toggle="tooltip"
-                       title="Use SNMP sysName instead of LibreNMS hostname">
-                <label class="form-check-label small" for="use-sysname-toggle">
+                <span id="use-sysname-toggle">
+                    <input type="hidden" name="use-sysname-toggle" value="off">
+                    <input class="form-check-input" type="checkbox" id="use-sysname-toggle-cb" name="use-sysname-toggle" {% if use_sysname %}checked{% endif %}
+                           data-bs-toggle="tooltip"
+                           title="Use SNMP sysName instead of LibreNMS hostname">
+                </span>
+                <label class="form-check-label small" for="use-sysname-toggle-cb">
                     Use sysName
                 </label>
             </div>
             <div class="form-check form-switch mb-0">
-                <input class="form-check-input" type="checkbox" id="strip-domain-toggle" name="strip-domain-toggle" {% if strip_domain %}checked{% endif %}
-                       data-bs-toggle="tooltip"
-                       title="Remove domain suffix (e.g., 'switch01.example.com' → 'switch01'). IP addresses preserved.">
-                <label class="form-check-label small" for="strip-domain-toggle">
+                <span id="strip-domain-toggle">
+                    <input type="hidden" name="strip-domain-toggle" value="off">
+                    <input class="form-check-input" type="checkbox" id="strip-domain-toggle-cb" name="strip-domain-toggle" {% if strip_domain %}checked{% endif %}
+                           data-bs-toggle="tooltip"
+                           title="Remove domain suffix (e.g., 'switch01.example.com' -> 'switch01'). IP addresses preserved.">
+                </span>
+                <label class="form-check-label small" for="strip-domain-toggle-cb">
                     Strip domain
                 </label>
             </div>

--- a/netbox_librenms_plugin/tests/test_template_comments.py
+++ b/netbox_librenms_plugin/tests/test_template_comments.py
@@ -1,0 +1,36 @@
+"""Guard against multi-line Django ``{# #}`` comments.
+
+Django's ``{# #}`` comment syntax must stay on a single line. A multi-line
+``{# ... #}`` is NOT recognised as a comment and renders as literal text in the
+page (e.g. the platform-cell pencil-icon partial once leaked its header comment
+into the import modal). ``get_template()`` only *parses* templates, so this slips
+past template-compile checks — hence this static scan. Use ``{% comment %}`` for
+multi-line comments instead.
+"""
+
+import pathlib
+
+import netbox_librenms_plugin
+
+TEMPLATES_DIR = pathlib.Path(netbox_librenms_plugin.__file__).parent / "templates"
+
+
+def _html_templates():
+    return sorted(TEMPLATES_DIR.rglob("*.html"))
+
+
+def test_templates_found():
+    """Sanity check that the scan actually has templates to look at."""
+    assert _html_templates(), f"No .html templates found under {TEMPLATES_DIR}"
+
+
+def test_no_multiline_single_hash_comments():
+    """No line may contain an unbalanced ``{#`` / ``#}`` (a multi-line ``{# #}``)."""
+    offenders = []
+    for path in _html_templates():
+        for lineno, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+            if line.count("{#") != line.count("#}"):
+                offenders.append(f"{path.relative_to(TEMPLATES_DIR)}:{lineno}: {line.strip()}")
+    assert not offenders, "Multi-line `{# #}` comments render as literal text — use `{% comment %}`:\n" + "\n".join(
+        offenders
+    )

--- a/netbox_librenms_plugin/urls.py
+++ b/netbox_librenms_plugin/urls.py
@@ -13,6 +13,7 @@ from .models import (
 from .views import (
     AddDeviceToLibreNMSView,
     AddDeviceTypeMappingView,
+    AddPlatformMappingView,
     AssignVCSerialView,
     BulkImportConfirmView,
     BulkImportDevicesView,
@@ -428,6 +429,11 @@ urlpatterns = [
         "device-import/add-device-type-mapping/<int:device_id>/",
         AddDeviceTypeMappingView.as_view(),
         name="add_device_type_mapping",
+    ),
+    path(
+        "device-import/add-platform-mapping/<int:device_id>/",
+        AddPlatformMappingView.as_view(),
+        name="add_platform_mapping",
     ),
     path(
         "device-import/create-platform/<int:device_id>/",

--- a/netbox_librenms_plugin/views/__init__.py
+++ b/netbox_librenms_plugin/views/__init__.py
@@ -110,6 +110,7 @@ from .mapping_views import (  # noqa: F401
     PlatformMappingView,
 )
 from .imports.actions import AddDeviceTypeMappingView  # noqa: F401
+from .imports.actions import AddPlatformMappingView  # noqa: F401
 from .object_sync import (  # noqa: F401
     DeviceCableTableView,
     DeviceInterfaceTableView,

--- a/netbox_librenms_plugin/views/imports/actions.py
+++ b/netbox_librenms_plugin/views/imports/actions.py
@@ -1578,10 +1578,12 @@ class CreatePlatformFromImportView(
         _, validation, _ = self.get_validated_device_with_selections(device_id, request)
         device_pk = None
         selected_manufacturer_pk = None
+        current_platform = None
         if validation:
             existing = validation.get("existing_device")
             if existing:
                 device_pk = existing.pk
+                current_platform = getattr(existing, "platform", None)
                 device_type = getattr(existing, "device_type", None)
                 if device_type:
                     selected_manufacturer_pk = device_type.manufacturer_id
@@ -1604,6 +1606,9 @@ class CreatePlatformFromImportView(
                 "server_key": self.librenms_api.server_key,
                 "use_htmx": True,
                 "htmx_include": htmx_include,
+                # Enable the "map to existing platform" section of the combined modal.
+                "libre_device": libre_device,
+                "current_platform": current_platform,
             },
         )
 

--- a/netbox_librenms_plugin/views/imports/actions.py
+++ b/netbox_librenms_plugin/views/imports/actions.py
@@ -1889,7 +1889,7 @@ class AddPlatformMappingView(
                     except IntegrityError:
                         return _htmx_error_response("Mapping was created concurrently. Please try again.")
         except Exception as exc:
-            logger.warning("AddPlatformMappingView: failed to save mapping: %s", exc)
+            logger.exception("AddPlatformMappingView: failed to save mapping: %s", exc)
             return _htmx_error_response("Error saving mapping. Please try again.")
 
         cache_key = get_import_device_cache_key(device_id, self.librenms_api.server_key)

--- a/netbox_librenms_plugin/views/imports/actions.py
+++ b/netbox_librenms_plugin/views/imports/actions.py
@@ -1831,6 +1831,10 @@ class AddPlatformMappingView(
         except Platform.DoesNotExist:
             return _htmx_error_response("Selected platform not found.")
 
+        if PlatformMapping.objects.filter(librenms_os__iexact=librenms_os).count() > 1:
+            return _htmx_error_response(
+                "Multiple mappings exist for this OS string. Remove duplicates before updating."
+            )
         existing_mapping = PlatformMapping.objects.filter(librenms_os__iexact=librenms_os).first()
         self.required_object_permissions = {
             "POST": [("change", PlatformMapping) if existing_mapping else ("add", PlatformMapping)]
@@ -1843,7 +1847,16 @@ class AddPlatformMappingView(
                 # Lock the row to close the TOCTOU window between the upfront
                 # permission check and the actual write. select_for_update cannot
                 # lock absent rows, so the create branch handles IntegrityError.
-                locked = PlatformMapping.objects.select_for_update().filter(librenms_os__iexact=librenms_os).first()
+                # Materialise the locked rows in one query — count() would drop
+                # the FOR UPDATE clause, leaving the rows unlocked.
+                locked_rows = list(
+                    PlatformMapping.objects.select_for_update().filter(librenms_os__iexact=librenms_os)[:2]
+                )
+                if len(locked_rows) > 1:
+                    return _htmx_error_response(
+                        "Multiple mappings exist for this OS string. Remove duplicates before updating."
+                    )
+                locked = locked_rows[0] if locked_rows else None
                 if locked and not existing_mapping:
                     # Concurrent request created the mapping after our upfront read.
                     # Only escalate to change permission if we would actually mutate.

--- a/netbox_librenms_plugin/views/imports/actions.py
+++ b/netbox_librenms_plugin/views/imports/actions.py
@@ -1789,3 +1789,107 @@ class SaveUserPrefView(LibreNMSPermissionMixin, View):
 
         save_user_pref(request, self.ALLOWED_PREFS[key], value)
         return JsonResponse({"status": "ok"})
+
+
+class AddPlatformMappingView(
+    LibreNMSPermissionMixin, NetBoxObjectPermissionMixin, LibreNMSAPIMixin, DeviceImportHelperMixin, View
+):
+    """HTMX view to create a PlatformMapping from the import validation modal."""
+
+    def post(self, request, device_id):
+        """Create a PlatformMapping linking the LibreNMS OS string to a NetBox Platform."""
+        if error := self.require_write_permission():
+            return error
+
+        from dcim.models import Platform
+        from netbox_librenms_plugin.librenms_api import LibreNMSAPI
+        from netbox_librenms_plugin.models import PlatformMapping
+
+        post_server_key = (request.POST.get("server_key") or "").strip()
+        if post_server_key:
+            self._librenms_api = LibreNMSAPI(server_key=post_server_key)
+
+        libre_device = fetch_device_with_cache(device_id, self.librenms_api)
+        if not libre_device:
+            return HttpResponse(
+                '<span class="text-danger small">Device not found in LibreNMS.</span>',
+                status=404,
+            )
+
+        librenms_os = (libre_device.get("os") or "").strip()
+        if not librenms_os:
+            return HttpResponse(
+                '<span class="text-danger small">Device has no OS string -- cannot create mapping.</span>',
+                status=400,
+            )
+
+        platform_id = request.POST.get("platform_id", "").strip()
+        if not platform_id:
+            return HttpResponse(
+                '<span class="text-danger small">Please select a platform before submitting.</span>',
+                status=400,
+            )
+
+        try:
+            platform_id = int(platform_id)
+        except (ValueError, TypeError):
+            return HttpResponse(
+                '<span class="text-danger small">Invalid platform selection.</span>',
+                status=400,
+            )
+
+        try:
+            platform = Platform.objects.get(pk=platform_id)
+        except Platform.DoesNotExist:
+            return HttpResponse(
+                '<span class="text-danger small">Selected platform not found.</span>',
+                status=404,
+            )
+
+        existing_mapping = PlatformMapping.objects.filter(librenms_os__iexact=librenms_os).first()
+        self.required_object_permissions = {
+            "POST": [("change", PlatformMapping) if existing_mapping else ("add", PlatformMapping)]
+        }
+        if error := self.require_object_permissions("POST"):
+            return error
+
+        try:
+            with transaction.atomic():
+                mapping, created = PlatformMapping.objects.get_or_create(
+                    librenms_os=librenms_os.lower(),
+                    defaults={"netbox_platform": platform},
+                )
+                if not created and existing_mapping is None and mapping.netbox_platform_id != platform_id:
+                    self.required_object_permissions = {"POST": [("change", PlatformMapping)]}
+                    if error := self.require_object_permissions("POST"):
+                        return error
+                if not created and mapping.netbox_platform_id != platform_id:
+                    mapping.netbox_platform = platform
+                    mapping.save()
+        except Exception as exc:
+            logger.warning("AddPlatformMappingView: failed to save mapping: %s", exc)
+            return HttpResponse(
+                f'<span class="text-danger small">Error saving mapping: {escape(str(exc))}</span>',
+                status=500,
+            )
+
+        cache_key = get_import_device_cache_key(device_id, self.librenms_api.server_key)
+        cache.delete(cache_key)
+
+        detail_view = DeviceValidationDetailsView()
+        detail_view._librenms_api = self._librenms_api
+        modal_html = detail_view.get(request, device_id).content.decode("utf-8")
+        oob_modal = format_html(
+            '<div id="htmx-modal-content" hx-swap-oob="innerHTML">{}</div>',
+            mark_safe(modal_html),
+        )
+
+        libre_device, validation, selections = self.get_validated_device_with_selections(device_id, request)
+        if libre_device is not None and validation is not None:
+            row_response = self.render_device_row(request, libre_device, validation, selections)
+            row_html = row_response.content.decode("utf-8")
+            row_html = format_html("<table><tbody>{}</tbody></table>", mark_safe(row_html))
+        else:
+            row_html = mark_safe("")
+
+        return HttpResponse(oob_modal + row_html, content_type="text/html")

--- a/netbox_librenms_plugin/views/imports/actions.py
+++ b/netbox_librenms_plugin/views/imports/actions.py
@@ -1811,40 +1811,25 @@ class AddPlatformMappingView(
 
         libre_device = fetch_device_with_cache(device_id, self.librenms_api)
         if not libre_device:
-            return HttpResponse(
-                '<span class="text-danger small">Device not found in LibreNMS.</span>',
-                status=404,
-            )
+            return _htmx_error_response("Device not found in LibreNMS.")
 
         librenms_os = (libre_device.get("os") or "").strip()
-        if not librenms_os:
-            return HttpResponse(
-                '<span class="text-danger small">Device has no OS string -- cannot create mapping.</span>',
-                status=400,
-            )
+        if not librenms_os or librenms_os == "-":
+            return _htmx_error_response("Device has no OS string — cannot create mapping.")
 
         platform_id = request.POST.get("platform_id", "").strip()
         if not platform_id:
-            return HttpResponse(
-                '<span class="text-danger small">Please select a platform before submitting.</span>',
-                status=400,
-            )
+            return _htmx_error_response("Please select a platform before submitting.")
 
         try:
             platform_id = int(platform_id)
         except (ValueError, TypeError):
-            return HttpResponse(
-                '<span class="text-danger small">Invalid platform selection.</span>',
-                status=400,
-            )
+            return _htmx_error_response("Invalid platform selection.")
 
         try:
             platform = Platform.objects.get(pk=platform_id)
         except Platform.DoesNotExist:
-            return HttpResponse(
-                '<span class="text-danger small">Selected platform not found.</span>',
-                status=404,
-            )
+            return _htmx_error_response("Selected platform not found.")
 
         existing_mapping = PlatformMapping.objects.filter(librenms_os__iexact=librenms_os).first()
         self.required_object_permissions = {

--- a/netbox_librenms_plugin/views/imports/actions.py
+++ b/netbox_librenms_plugin/views/imports/actions.py
@@ -1855,23 +1855,39 @@ class AddPlatformMappingView(
 
         try:
             with transaction.atomic():
-                mapping, created = PlatformMapping.objects.get_or_create(
-                    librenms_os=librenms_os.lower(),
-                    defaults={"netbox_platform": platform},
-                )
-                if not created and existing_mapping is None and mapping.netbox_platform_id != platform_id:
-                    self.required_object_permissions = {"POST": [("change", PlatformMapping)]}
+                # Lock the row to close the TOCTOU window between the upfront
+                # permission check and the actual write. select_for_update cannot
+                # lock absent rows, so the create branch handles IntegrityError.
+                locked = PlatformMapping.objects.select_for_update().filter(librenms_os__iexact=librenms_os).first()
+                if locked and not existing_mapping:
+                    # Concurrent request created the mapping after our upfront read.
+                    # Only escalate to change permission if we would actually mutate.
+                    if locked.netbox_platform_id != platform_id:
+                        self.required_object_permissions = {"POST": [("change", PlatformMapping)]}
+                        if error := self.require_object_permissions("POST"):
+                            return error
+                if existing_mapping and not locked:
+                    # Mapping was deleted between our upfront read and the lock.
+                    # We are about to CREATE a new row, so require add permission.
+                    self.required_object_permissions = {"POST": [("add", PlatformMapping)]}
                     if error := self.require_object_permissions("POST"):
                         return error
-                if not created and mapping.netbox_platform_id != platform_id:
-                    mapping.netbox_platform = platform
-                    mapping.save()
+                if locked:
+                    if locked.netbox_platform_id != platform_id:
+                        locked.netbox_platform = platform
+                        locked.full_clean()
+                        locked.save()
+                else:
+                    try:
+                        PlatformMapping.objects.create(
+                            librenms_os=librenms_os.lower(),
+                            netbox_platform=platform,
+                        )
+                    except IntegrityError:
+                        return _htmx_error_response("Mapping was created concurrently. Please try again.")
         except Exception as exc:
             logger.warning("AddPlatformMappingView: failed to save mapping: %s", exc)
-            return HttpResponse(
-                f'<span class="text-danger small">Error saving mapping: {escape(str(exc))}</span>',
-                status=500,
-            )
+            return _htmx_error_response("Error saving mapping. Please try again.")
 
         cache_key = get_import_device_cache_key(device_id, self.librenms_api.server_key)
         cache.delete(cache_key)


### PR DESCRIPTION
follows  #288 

## Summary
Improves the import / validation UI. The device-type and platform mapping forms in the validation modal are extracted into reusable partials, a new **Add Platform Mapping** flow lets users create a `PlatformMapping` directly from the import modal, and several template/JS bugs around the import toggles and nested modals are fixed.

## Motivation / Problem
- **Feature** — Allow creating a `PlatformMapping` from the import validation modal (`AddPlatformMappingView`) so users can resolve unmatched platforms without leaving the import flow.
- **Refactor** — The device-type and platform mapping forms were ~100 lines of inline markup in `device_validation_details.html`; extract them into reusable partials.
- **Bug** — Import toggles did not submit a value when unchecked; nested modals (e.g. Promote-to-host picker) were dismissed incorrectly; a missing `{% endif %}` broke template compilation and the platform mapping form never rendered for new imports.

## Scope of Change
- LibreNMS API interaction
- Web UI / templates

Specifically:
- **Views** — `AddPlatformMappingView` added to `views/imports/actions.py`, registered in `urls.py` and exported from `views/__init__.py`.
- **Templates** — new `_dt_mapping_form.html` and `_platform_mapping_form.html` partials; `device_validation_details.html`, `librenms_import.html`, `librenms_sync_base.html` updated.
- **JS** — `librenms_import.js` toggle ID renames (`-cb` suffix) and nested-modal dismiss fix.

## How Was This Tested?
- **Manual testing**: yes — exercised the import/validation modal, created platform and device-type mappings from the modal, verified toggle values submit when unchecked and nested modals dismiss correctly.
- **Unit tests**: existing suite run; the new view mirrors the established `AddDeviceTypeMappingView` pattern.

### Manual Test Steps
1. Open a device import with an unmatched platform/device type and trigger validation.
2. From the validation modal, use the **Add Platform Mapping** / device-type mapping forms to create a mapping; confirm the HTMX toast on success and on validation error (empty / `-` OS rejected).
3. Toggle the import options off and submit; confirm the unchecked value is submitted.
4. Open a nested modal (e.g. Promote-to-host picker) and dismiss it; confirm the outer modal stays open.

## Risk Assessment
- **Affects existing users?** UI-only changes plus a new optional view; no migrations. Existing import flows are unchanged apart from the toggle/modal fixes.
- **Unintended imports / updates?** No. The new view only creates a `PlatformMapping`; `AddPlatformMappingView` uses `select_for_update` to re-derive the required permission from the locked row and surfaces `IntegrityError` on concurrent inserts, closing a TOCTOU window.

## Backwards Compatibility
- No breaking changes. No database migrations.

## Other Notes
- `AddPlatformMappingView` deliberately mirrors `AddDeviceTypeMappingView` (permission handling, `_htmx_error_response`, `-` placeholder OS rejection) for consistency — worth reviewing the two side by side.
