### PR TITLE
fix(modules): don't render 'No matching bay' on Integrated rows

### DIFF
--- a/netbox_librenms_plugin/tables/modules.py
+++ b/netbox_librenms_plugin/tables/modules.py
@@ -198,7 +198,12 @@ class LibreNMSModuleTable(tables.Table):
 
     def render_module_bay(self, value, record):
         """Render module bay with link if found in NetBox."""
-        if not value or value == "-":
+        if record.get("status") == "Integrated":
+            # Informational rows for components fused into a parent module have
+            # no bay of their own; show a plain placeholder, not a red warning,
+            # to match the muted status badge and absent actions on these rows.
+            rendered_value = "-"
+        elif not value or value == "-":
             rendered_value = format_html('<span class="text-danger">{}</span>', "No matching bay")
         elif url := record.get("module_bay_url"):
             rendered_value = format_html('<a href="{}">{}</a>', url, value)

--- a/netbox_librenms_plugin/tests/test_tables_modules.py
+++ b/netbox_librenms_plugin/tests/test_tables_modules.py
@@ -245,6 +245,14 @@ class TestLibreNMSModuleTable:
         result = str(table.render_module_bay("", {}))
         assert "text-danger" in result
 
+    def test_render_module_bay_integrated_row_shows_plain_dash(self):
+        """Integrated rows have no bay of their own; show '-' not a red warning."""
+        table = self._make_table()
+        result = str(table.render_module_bay("-", {"status": "Integrated"}))
+        assert "text-danger" not in result
+        assert "No matching bay" not in result
+        assert result == "-"
+
     def test_render_module_bay_with_url_renders_link(self):
         """When module_bay_url is present, a hyperlink is rendered."""
         table = self._make_table()


### PR DESCRIPTION
## Summary
`render_module_bay` no longer shows a red "No matching bay" warning on `Integrated` rows.

## Motivation / Problem
**Bug.** Integrated rows (a component fused into a parent module — `_build_row` emits them with `module_bay == "-"`, `status == "Integrated"`) are informational: `render_status` gives them a muted badge and `render_actions` returns no actions. But `render_module_bay` still painted a red "No matching bay", contradicting the badge and making a non-actionable row look broken.

## Scope of Change
- Web UI / templates (table render method)
- Tests

## How Was This Tested?
- Unit tests: added `test_render_module_bay_integrated_row_shows_plain_dash`; full `test_tables_modules.py` passes (162).

## Risk Assessment
- Display-only; no DB writes, no migrations. Only `status == "Integrated"` rows change (now render plain `-`).

## Backwards Compatibility
- No breaking changes.

## Other Notes
- Guard mirrors the existing `status == "Integrated"` check in `render_actions`. Addresses a CodeRabbit comment on #83.
