### PR TITLE
Fix device location showing as dict on LibreNMS sync page (#280)

### DIFF
--- a/netbox_librenms_plugin/librenms_api.py
+++ b/netbox_librenms_plugin/librenms_api.py
@@ -368,9 +368,9 @@ class LibreNMSAPI:
             device_data = response.json()["devices"][0]
             if not isinstance(device_data, dict):
                 return False, None
-            # Newer LibreNMS versions return the full location relationship
-            # object (e.g. {"id": 33, "location": "CYP", "lat": ...}) instead
-            # of a flat location name string. Normalise to the name so
+            # LibreNMS 26.5.0 returns the full location relationship object
+            # (keys: id, location, lat, lng, timestamp, fixed_coordinates)
+            # instead of a flat location name string. Normalise to the name so
             # downstream consumers receive a consistent value.
             location = device_data.get("location")
             if isinstance(location, dict):

--- a/netbox_librenms_plugin/librenms_api.py
+++ b/netbox_librenms_plugin/librenms_api.py
@@ -368,6 +368,13 @@ class LibreNMSAPI:
             device_data = response.json()["devices"][0]
             if not isinstance(device_data, dict):
                 return False, None
+            # Newer LibreNMS versions return the full location relationship
+            # object (e.g. {"id": 33, "location": "CYP", "lat": ...}) instead
+            # of a flat location name string. Normalise to the name so
+            # downstream consumers receive a consistent value.
+            location = device_data.get("location")
+            if isinstance(location, dict):
+                device_data["location"] = location.get("location")
             return True, device_data
         except (requests.exceptions.RequestException, ValueError, IndexError, KeyError, TypeError):
             return False, None


### PR DESCRIPTION
## Summary
Fixes the LibreNMS sync page showing a raw object (e.g. `{'id': 33, 'location': 'NYC', 'lat': ..., 'lng': ...}`) in the Location field of the Device Information card instead of the location name.

## Motivation / Problem
Resolves #280.

- Bug

The issue originally surfaced because a LibreNMS regression (PR #19434) dropped the flattened `location`/`lat`/`lng` fields from `GET /api/v0/devices/{id}`, leaving the field blank. The upstream fix (PR #19622, now merged) restored the data — but as the full `location` **relationship object** rather than the previous flat name string. As a result `get_device_info` now returns a dict under `location`, which leaked into the sync page UI and the import flow (wiping location to `-`).

## Scope of Change

- LibreNMS API interaction

## How Was This Tested?

- Unit tests: yes — existing `test_librenms_api.py` (96 tests), `test_sync_view_mismatch.py`, and `test_coverage_device_fields.py` all pass.
- Manual testing: confirmed by reporter that the upstream LibreNMS fix returns the nested dict; normalisation extracts the name.

### Manual Test Steps (if applicable)
1. Open a device's LibreNMS Sync page on a LibreNMS version that returns the nested location object.
2. Confirm the Device Information card shows the location **name** (e.g. `NYC`) rather than a dict.

## Risk Assessment
- Affects existing users only positively (restores correct display).
- No unintended imports/updates — normalisation is read-only and applied at the API client boundary in `get_device_info`, so all downstream consumers (sync page, import flow, forms) receive a consistent location-name string regardless of LibreNMS version.

## Backwards Compatibility
- No breaking changes — handles both the old flat-string shape and the new dict shape.

## Other Notes
The new nested object also carries `lat`/`lng`/`location_id`, which could be leveraged later for the "Location Mapping" feature discussed in #280.