### PR TITLE
ci: restrict GITHUB_TOKEN permissions in workflows

### DIFF
--- a/.github/workflows/lint-format.yaml
+++ b/.github/workflows/lint-format.yaml
@@ -10,6 +10,9 @@ on:
       - master
       - develop
 
+permissions:
+  contents: read
+
 jobs:
   format-and-lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-pypi.yaml
+++ b/.github/workflows/publish-pypi.yaml
@@ -8,6 +8,11 @@ on:
     tags:
       - '*'
 
+# Default to read-only token; the publish-to-pypi job overrides this with the
+# id-token: write permission required for PyPI trusted publishing.
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build distribution 📦

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -10,6 +10,9 @@ on:
       - master
       - develop
 
+permissions:
+  contents: read
+
 jobs:
   test-netbox:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
Adds a minimal top-level `permissions: contents: read` block to the three GitHub Actions workflows so the `GITHUB_TOKEN` follows least-privilege. This resolves the CodeQL `actions/missing-workflow-permissions` code scanning alerts (#1, #2, #3).

## Motivation / Problem
- Maintenance / cleanup (security hardening)

CodeQL flagged that the `test`, `lint-format`, and `publish-pypi` workflows do not limit the permissions of the default `GITHUB_TOKEN`, which means they run with the broad repository default scope.

## Scope of Change
- Config / settings (CI workflows only)

Files changed:
- `.github/workflows/test.yaml`
- `.github/workflows/lint-format.yaml`
- `.github/workflows/publish-pypi.yaml`

## How Was This Tested?
- Manual testing: yes — validated all three workflow files parse as valid YAML.
- Unit tests: n/a (no application code changed)

### Manual Test Steps
1. Confirmed each job only reads code, runs tests/lint, or up/downloads build artifacts — none require write scopes.
2. Verified the `publish-to-pypi` job retains its own job-level `permissions: id-token: write` (required for PyPI trusted publishing).
3. Parsed all three YAML files successfully.

## Risk Assessment
- Affects existing users? No — CI configuration only, no runtime/plugin behaviour change.
- Could this cause unintended imports / updates? No.

Key safety note: a job-level `permissions` block fully overrides the workflow-level default (it does not merge). The `publish-to-pypi` job already declares `id-token: write`, so adding a top-level `contents: read` default does not weaken or alter the publish job — trusted publishing to PyPI continues to work.

## Backwards Compatibility
- No breaking changes

## Other Notes
The CodeQL alerts will only show as resolved once the workflows run on this branch / after merge.
