### PR TITLE
fix: localise open-redirect guard to redirect sink

### DIFF
--- a/netbox_librenms_plugin/views/mixins.py
+++ b/netbox_librenms_plugin/views/mixins.py
@@ -43,26 +43,31 @@ def _safe_redirect_response(request):
     """
     Build a permission-denied redirect response to a validated URL.
 
-    Resolves a safe target via ``_get_safe_redirect_url`` and then re-applies
-    the ``url_has_allowed_host_and_scheme`` guard inline, in the same scope as
-    the ``redirect()`` sink, before redirecting. Keeping the open-redirect
-    guard local to the sink prevents open-redirect attacks and lets static
-    analysers trace the sanitizer barrier.
+    Resolves a candidate target via ``_get_safe_redirect_url`` and then
+    re-applies the ``url_has_allowed_host_and_scheme`` guard inline as a
+    positive guard, with the redirect sink inside the validated branch and a
+    hard-coded ``"/"`` fallback otherwise. Keeping the open-redirect guard
+    local to the sink (rather than in a helper) prevents open-redirect attacks
+    and lets static analysers trace the sanitizer barrier.
 
     Returns an HTMX ``HX-Redirect`` response for HTMX requests, otherwise a
     standard redirect.
     """
     target = _get_safe_redirect_url(request)
-    if not url_has_allowed_host_and_scheme(
+    is_htmx = bool(request.headers.get("HX-Request"))
+
+    if url_has_allowed_host_and_scheme(
         target,
         allowed_hosts={request.get_host()},
         require_https=request.is_secure(),
     ):
-        target = "/"
+        if is_htmx:
+            return HttpResponse("", headers={"HX-Redirect": target})
+        return redirect(target)
 
-    if request.headers.get("HX-Request"):
-        return HttpResponse("", headers={"HX-Redirect": target})
-    return redirect(target)
+    if is_htmx:
+        return HttpResponse("", headers={"HX-Redirect": "/"})
+    return redirect("/")
 
 
 class LibreNMSPermissionMixin(PermissionRequiredMixin):

--- a/netbox_librenms_plugin/views/mixins.py
+++ b/netbox_librenms_plugin/views/mixins.py
@@ -39,6 +39,32 @@ def _get_safe_redirect_url(request):
     return getattr(request, "path", "/")
 
 
+def _safe_redirect_response(request):
+    """
+    Build a permission-denied redirect response to a validated URL.
+
+    Resolves a safe target via ``_get_safe_redirect_url`` and then re-applies
+    the ``url_has_allowed_host_and_scheme`` guard inline, in the same scope as
+    the ``redirect()`` sink, before redirecting. Keeping the open-redirect
+    guard local to the sink prevents open-redirect attacks and lets static
+    analysers trace the sanitizer barrier.
+
+    Returns an HTMX ``HX-Redirect`` response for HTMX requests, otherwise a
+    standard redirect.
+    """
+    target = _get_safe_redirect_url(request)
+    if not url_has_allowed_host_and_scheme(
+        target,
+        allowed_hosts={request.get_host()},
+        require_https=request.is_secure(),
+    ):
+        target = "/"
+
+    if request.headers.get("HX-Request"):
+        return HttpResponse("", headers={"HX-Redirect": target})
+    return redirect(target)
+
+
 class LibreNMSPermissionMixin(PermissionRequiredMixin):
     """
     Mixin for views requiring LibreNMS plugin permissions.
@@ -69,14 +95,7 @@ class LibreNMSPermissionMixin(PermissionRequiredMixin):
             msg = error_message or "You do not have permission to perform this action."
             messages.error(self.request, msg)
 
-            referrer = _get_safe_redirect_url(self.request)
-
-            # Check if this is an HTMX request
-            if self.request.headers.get("HX-Request"):
-                return HttpResponse("", headers={"HX-Redirect": referrer})
-
-            # referrer is safe: validated by _get_safe_redirect_url via url_has_allowed_host_and_scheme
-            return redirect(referrer)
+            return _safe_redirect_response(self.request)
         return None
 
     def require_write_permission_json(self, error_message=None):
@@ -164,14 +183,7 @@ class NetBoxObjectPermissionMixin:
             msg = f"Missing permissions: {missing_str}"
             messages.error(self.request, msg)
 
-            referrer = _get_safe_redirect_url(self.request)
-
-            # Check if this is an HTMX request
-            if self.request.headers.get("HX-Request"):
-                return HttpResponse("", headers={"HX-Redirect": referrer})
-
-            # referrer is safe: validated by _get_safe_redirect_url via url_has_allowed_host_and_scheme
-            return redirect(referrer)
+            return _safe_redirect_response(self.request)
         return None
 
     def require_object_permissions_json(self, method):


### PR DESCRIPTION
## Summary
Resolves the two CodeQL `py/url-redirection` alerts (#6, #7) in `views/mixins.py` by moving the open-redirect guard into the same scope as the `redirect()` sink, using the canonical positive-guard pattern. No behavioural change — the redirect targets were already validated, but the guard lived in a helper (`_get_safe_redirect_url`) that CodeQL could not trace across the function boundary.

## Motivation / Problem
- Maintenance / cleanup (security hardening)

CodeQL flagged `return redirect(referrer)` in `require_write_permission` and `require_object_permissions` as untrusted URL redirection. The referrer was in fact already validated via `_get_safe_redirect_url` using Django's `url_has_allowed_host_and_scheme`, but because that guard runs in a separate helper function, the static analyser's taint tracking did not recognise the sanitizer barrier.

## Scope of Change
- Web UI / templates (redirect behaviour on permission-denied)

Files changed:
- `netbox_librenms_plugin/views/mixins.py`

Details:
- Added `_safe_redirect_response(request)` which resolves a candidate target via `_get_safe_redirect_url`, then re-applies `url_has_allowed_host_and_scheme` inline as a **positive guard**: the `redirect()` / `HX-Redirect` sinks live inside the validated `if` branch, with a hard-coded `/` fallback otherwise.
- Routed both permission-denied paths (`require_write_permission`, `require_object_permissions`) through the new helper, removing the duplicated HTMX/redirect blocks.
- `_get_safe_redirect_url` is retained unchanged (still covered by existing tests).

> Note: an initial revision of this PR used a *negative* guard (`if not url_has_allowed_host_and_scheme(...): target = "/"`), which CodeQL's Django taint model did not recognise as a sanitizer barrier and which raised a fresh `py/url-redirection` alert (#29) on the helper itself. The current revision uses the positive-guard pattern (sink inside the validated branch) so the barrier is recognised.

## How Was This Tested?
- Unit tests: yes — `netbox_librenms_plugin/tests/test_permissions.py` (59 tests) all pass, including the `_get_safe_redirect_url` cases.
- Manual testing: yes — as a user without write permission:
  - Interface Sync button (HTMX path) correctly redirected back with the "You do not have permission…" notification.
  - Plugin Settings save (standard redirect path) correctly redirected back with the "You do not have permission…" notification.

### Manual Test Steps
1. `python -m pytest netbox_librenms_plugin/tests/test_permissions.py -q` → 59 passed.
2. As a read-only user, click "Sync Interfaces" on a Device's LibreNMS sync tab → redirected to same-host page with permission-denied toast.
3. As a read-only user, save Plugin Settings → redirected to same-host page with permission-denied flash message.

## Risk Assessment
- Affects existing users? No — a user denied a write/object action is still redirected back to a validated safe URL (Referer when same-host, otherwise the request path / `/`), with the same flash/HTMX behaviour. A relative `request.path` fallback still passes validation; only genuinely unsafe targets now redirect to `/`.
- Could this cause unintended imports / updates? No.

## Backwards Compatibility
- No breaking changes

## Other Notes
The redirect target validation is now strictly stronger: it is validated twice (once in the resolver, once inline at the sink using the positive-guard pattern). The CodeQL alerts will clear once analysis runs on this branch / after merge.
