### PR TITLE
fix: avoid exposing exception details in IP address sync responses

### DIFF
--- a/netbox_librenms_plugin/views/base/ip_addresses_view.py
+++ b/netbox_librenms_plugin/views/base/ip_addresses_view.py
@@ -444,8 +444,8 @@ class SingleIPAddressVerifyView(LibreNMSPermissionMixin, CacheMixin, View):
         try:
             try:
                 data = json.loads(request.body)
-            except json.JSONDecodeError as e:
-                return JsonResponse({"status": "error", "message": f"Invalid JSON: {e}"}, status=400)
+            except json.JSONDecodeError:
+                return JsonResponse({"status": "error", "message": "Invalid JSON payload"}, status=400)
             ip_address = data.get("ip_address")
             vrf_id = data.get("vrf_id")
             object_id = data.get("device_id")
@@ -461,14 +461,17 @@ class SingleIPAddressVerifyView(LibreNMSPermissionMixin, CacheMixin, View):
             # Get the object (Device or VirtualMachine)
             try:
                 obj = self._get_object(object_id, object_type)
-            except Http404 as e:
-                return JsonResponse({"status": "error", "message": str(e)}, status=404)
+            except Http404:
+                return JsonResponse({"status": "error", "message": f"Object with ID {object_id} not found"}, status=404)
 
             # Parse IP address
             try:
                 address_no_mask, prefix_len = self._parse_ip_address(ip_address)
-            except ValueError as e:
-                return JsonResponse({"status": "error", "message": str(e)}, status=400)
+            except ValueError:
+                return JsonResponse(
+                    {"status": "error", "message": "Invalid IP address: prefix length is missing or invalid"},
+                    status=400,
+                )
 
             cache_key = self.get_cache_key(obj, "ip_addresses", server_key)
             cached_data = cache.get(cache_key)


### PR DESCRIPTION
## Summary
Resolves the three CodeQL `py/stack-trace-exposure` alerts that are **open on the `develop` branch** (alerts 10, 11, 12) in `views/base/ip_addresses_view.py`. The IP address sync POST handler returned `str(exception)` directly to the client; this replaces those with safe, fixed messages.

## Motivation / Problem
- Maintenance / cleanup (security hardening)

CodeQL flagged `SingleIPAddressVerifyView.post` for returning exception text to the client (`Invalid JSON: {e}`, `str(Http404)`, `str(ValueError)`), which can disclose internal details.

> Scope note: the Security tab baseline is computed on `master` (the default branch), which is ~225 commits behind `develop`. This PR is deliberately scoped to only the alerts that CodeQL reports as **open on `develop`** (the active development branch). Other stack-trace alerts shown against `master` (8, 9, 13) point at code that has already changed on `develop` and are not reproduced there.

## Scope of Change
- Web UI / templates (JSON error responses)

Files changed:
- `netbox_librenms_plugin/views/base/ip_addresses_view.py`

Details (in `SingleIPAddressVerifyView.post`):
- `json.JSONDecodeError` → returns fixed `"Invalid JSON payload"` (400) instead of echoing the decoder error.
- `Http404` → returns reconstructed `"Object with ID <id> not found"` (404) instead of the raised exception text.
- `ValueError` from `_parse_ip_address` → returns fixed `"Invalid IP address: prefix length is missing or invalid"` (400) instead of the exception text.

Validation logic and HTTP status codes are unchanged.

## How Was This Tested?
- Unit tests: yes — `python -m pytest netbox_librenms_plugin/tests/ -k ip_address` → 12 passed. Existing tests assert on status codes, not message text.
- Manual testing: not required — only the wording of error messages changed.

## Risk Assessment
- Affects existing users? No — clients still receive the same status codes; only the human-readable error text is generic now.
- Could this cause unintended imports / updates? No.

## Backwards Compatibility
- No breaking changes

## Other Notes
The CodeQL alerts will clear once analysis runs on this branch / after merge to `develop`.
