### PR TITLE
fix: hardening pass of sync/import paths

### DIFF
--- a/netbox_librenms_plugin/import_utils/bulk_import.py
+++ b/netbox_librenms_plugin/import_utils/bulk_import.py
@@ -8,7 +8,7 @@ from django.core.cache import cache
 
 from ..import_validation_helpers import apply_role_to_validation, recalculate_validation_status, remove_validation_issue
 from ..librenms_api import LibreNMSAPI
-from ..utils import find_by_librenms_id
+from ..utils import find_by_librenms_id, preload_normalization_rules
 from .cache import get_cache_metadata_key, get_import_device_cache_key, get_validated_device_cache_key
 from .device_operations import import_single_device, validate_device_for_import
 from .filters import _safe_disabled, get_librenms_devices_for_import
@@ -117,6 +117,10 @@ def bulk_import_devices_shared(
     # Initialize API client once for all devices to avoid repeated config parsing
     api = LibreNMSAPI(server_key=server_key)
 
+    # Preload the device_type NormalizationRule set once so the per-device hardware→device-type
+    # match doesn't re-query it for every device in the loop (issue #90 / N+1 avoidance, #92).
+    device_type_norm_rules = preload_normalization_rules("device_type")
+
     for idx, device_id in enumerate(device_ids, start=1):
         # Check for job cancellation on first iteration and every 5th thereafter.
         if job and (idx == 1 or idx % 5 == 0) and _is_job_cancelled(job):
@@ -156,6 +160,7 @@ def bulk_import_devices_shared(
                 # LibreNMS inventory so stack members are created even when preview
                 # flags are stale or omitted.
                 include_vc_detection=True,
+                preloaded_device_type_rules=device_type_norm_rules,
             )
 
             vc_data = validation.get("virtual_chassis", {})

--- a/netbox_librenms_plugin/import_utils/device_operations.py
+++ b/netbox_librenms_plugin/import_utils/device_operations.py
@@ -29,7 +29,7 @@ from .virtual_chassis import (
 logger = logging.getLogger(__name__)
 
 
-def _try_chassis_device_type_match(api, device_id):
+def _try_chassis_device_type_match(api, device_id, preloaded_device_type_rules: dict | None = None):
     """
     Attempt device type matching using chassis inventory fields.
 
@@ -56,7 +56,9 @@ def _try_chassis_device_type_match(api, device_id):
             for field in ("entPhysicalName", "entPhysicalModelName"):
                 value = item.get(field) or ""
                 if value and value not in skip_values:
-                    chassis_match = match_librenms_hardware_to_device_type(value)
+                    chassis_match = match_librenms_hardware_to_device_type(
+                        value, preloaded_rules=preloaded_device_type_rules
+                    )
                     if chassis_match is None:
                         continue
                     if chassis_match["matched"]:
@@ -556,7 +558,9 @@ def validate_device_for_import(
                 if not dt_match["matched"] and api:
                     device_id = libre_device.get("device_id")
                     if device_id:
-                        chassis_match = _try_chassis_device_type_match(api, device_id)
+                        chassis_match = _try_chassis_device_type_match(
+                            api, device_id, preloaded_device_type_rules=preloaded_device_type_rules
+                        )
                         if chassis_match and chassis_match["matched"]:
                             dt_match = chassis_match
 

--- a/netbox_librenms_plugin/import_utils/device_operations.py
+++ b/netbox_librenms_plugin/import_utils/device_operations.py
@@ -135,6 +135,7 @@ def validate_device_for_import(
     force_vc_refresh: bool = False,
     use_sysname: bool = True,
     strip_domain: bool = False,
+    preloaded_device_type_rules: dict | None = None,
 ) -> dict:
     """
     Validate if a LibreNMS device can be imported to NetBox.
@@ -539,7 +540,7 @@ def validate_device_for_import(
 
             # 3. Validate DeviceType (required)
             hardware = libre_device.get("hardware", "")
-            dt_match = match_librenms_hardware_to_device_type(hardware)
+            dt_match = match_librenms_hardware_to_device_type(hardware, preloaded_rules=preloaded_device_type_rules)
 
             if dt_match is None:
                 result["device_type"]["found"] = False

--- a/netbox_librenms_plugin/import_utils/device_operations.py
+++ b/netbox_librenms_plugin/import_utils/device_operations.py
@@ -443,7 +443,18 @@ def validate_device_for_import(
             if not result["existing_device"]:
                 serial = libre_device.get("serial") or ""
                 if serial and serial != "-" and not import_as_vm:
-                    existing_by_serial = Device.objects.filter(serial=serial).first()
+                    # Serial is not unique in NetBox, so .first() would bind an arbitrary row
+                    # and the downstream serial/OOB/merge flow would derive its guidance from a
+                    # random device. Require a unique match before binding, mirroring the
+                    # merge-peer [:2] guard (issue #101).
+                    serial_matches = list(Device.objects.filter(serial=serial)[:2])
+                    if len(serial_matches) > 1:
+                        result["warnings"].append(
+                            f"Multiple NetBox devices share serial '{serial}'; serial-based matching skipped."
+                        )
+                        existing_by_serial = None
+                    else:
+                        existing_by_serial = serial_matches[0] if serial_matches else None
                     if existing_by_serial:
                         logger.info(f"Found existing device by serial: {existing_by_serial.name} (serial={serial})")
                         result["existing_device"] = existing_by_serial

--- a/netbox_librenms_plugin/librenms_api.py
+++ b/netbox_librenms_plugin/librenms_api.py
@@ -24,6 +24,11 @@ class LibreNMSAPI:
         Args:
             server_key: Key for specific server configuration. If None, uses selected server or default.
         """
+        # Track whether the caller explicitly requested a specific server. A key auto-resolved
+        # from LibreNMSSettings.selected_server is NOT explicit, so a stale stored key falls back
+        # to the first available server rather than hard-failing (issue #110).
+        explicit_server_key = server_key is not None
+
         # If no server_key is provided, try to get the selected server from settings
         if not server_key:
             try:
@@ -46,19 +51,24 @@ class LibreNMSAPI:
         # If a specific (non-default) server_key was requested but not found, raise
         # immediately to avoid silently using the wrong LibreNMS instance.
         if servers_config and isinstance(servers_config, dict) and server_key not in servers_config:
-            if server_key != "default":
+            # Only fail closed for an *explicitly* requested non-default key (tampered or
+            # stale-page input). An auto-resolved/default key falls back instead (issue #110).
+            if explicit_server_key and server_key != "default":
                 available = list(servers_config.keys())
                 raise KeyError(
                     f"Server '{server_key}' not found in LibreNMS plugin configuration. Available servers: {available}"
                 )
-            first_key = next(iter(servers_config), None)
-            if first_key:
-                logger.info(
-                    "Server '%s' not found in config, falling back to '%s'",
-                    server_key,
-                    first_key,
-                )
-                server_key = first_key
+            # Pick the first *valid* mapping; a non-dict entry would otherwise raise later at the
+            # config read. If none are valid, fail with a clear error (issue #110).
+            first_key = next((key for key, config in servers_config.items() if isinstance(config, dict)), None)
+            if first_key is None:
+                raise ValueError("No valid LibreNMS server configuration entries found.")
+            logger.info(
+                "Server '%s' not found in config, falling back to '%s'",
+                server_key,
+                first_key,
+            )
+            server_key = first_key
 
         self.server_key = server_key
 

--- a/netbox_librenms_plugin/librenms_api.py
+++ b/netbox_librenms_plugin/librenms_api.py
@@ -75,6 +75,11 @@ class LibreNMSAPI:
         if servers_config and isinstance(servers_config, dict) and server_key in servers_config:
             # Multi-server configuration
             config = servers_config[server_key]
+            # The fallback above only guards the key-not-found case; a present-but-malformed
+            # entry (e.g. {"default": "not-a-dict"}) would otherwise raise an opaque TypeError
+            # at the key reads below. Fail with a clear configuration error instead (issue #110).
+            if not isinstance(config, dict):
+                raise ValueError(f"Invalid LibreNMS server configuration for '{server_key}': expected a mapping.")
             self.librenms_url = config["librenms_url"]
             self.api_token = config["api_token"]
             self.cache_timeout = config.get("cache_timeout", 300)

--- a/netbox_librenms_plugin/librenms_api.py
+++ b/netbox_librenms_plugin/librenms_api.py
@@ -175,8 +175,12 @@ class LibreNMSAPI:
             # Multi-server configuration
             result = {}
             for key, config in servers_config.items():
-                display_name = config.get("display_name", key)
-                result[key] = display_name
+                # Skip malformed (non-dict) entries. Otherwise config.get(...) raises and a sync
+                # POST that calls this for its server-key membership check 500s instead of
+                # degrading to the active server. A non-usable server must not be selectable.
+                if not isinstance(config, dict):
+                    continue
+                result[key] = config.get("display_name", key)
             return result
         else:
             # Legacy single-server configuration

--- a/netbox_librenms_plugin/tables/interfaces.py
+++ b/netbox_librenms_plugin/tables/interfaces.py
@@ -178,23 +178,31 @@ class LibreNMSInterfaceTable(tables.Table):
             else:
                 css = get_tagged_vlan_css_class(vid, netbox_tagged_vids, exists_in_netbox, missing_vlans, group_matches)
             warning = get_missing_vlan_warning(vid, missing_vlans)
-            inline_parts.append(f'<span class="{css}">{vid}({vlan_type}){warning}</span>')
+            # Escape the LibreNMS-sourced vid/vlan_type (XSS, issue #105 class). css is an
+            # internal class name; warning is the static icon HTML from get_missing_vlan_warning,
+            # so it is marked safe rather than escaped.
+            inline_parts.append(
+                format_html('<span class="{}">{}({}){}</span>', css, vid, vlan_type, mark_safe(warning))
+            )
 
-        summary = ", ".join(inline_parts)
+        # inline_parts are already escaped SafeStrings; join them and keep the result safe.
+        summary = mark_safe(", ".join(str(part) for part in inline_parts))
         if len(all_vlans) > MAX_INLINE:
             extra = len(all_vlans) - MAX_INLINE
-            summary += f' <span class="text-muted">+{extra} more</span>'
+            summary = format_html('{} <span class="text-muted">+{} more</span>', summary, extra)
 
-        # Build tooltip showing auto-selected VLAN group per VLAN
+        # Build tooltip showing auto-selected VLAN group per VLAN. Escape the LibreNMS-sourced
+        # vid/vlan_type and group_name; the "&#10;" separator is a literal newline entity for the
+        # title attribute, so join the escaped lines and mark the whole tooltip safe.
         tooltip_lines = []
         for vlan_type, vid in all_vlans:
             if vid in missing_vlans:
-                tooltip_lines.append(f"VLAN {vid}({vlan_type}) → ⚠ Not in NetBox")
+                tooltip_lines.append(format_html("VLAN {}({}) → ⚠ Not in NetBox", vid, vlan_type))
             else:
                 group_info = vlan_group_map.get(vid, {})
                 group_name = group_info.get("group_name", "Global")
-                tooltip_lines.append(f"VLAN {vid}({vlan_type}) → {escape(group_name)}")
-        tooltip_text = "&#10;".join(tooltip_lines)
+                tooltip_lines.append(format_html("VLAN {}({}) → {}", vid, vlan_type, group_name))
+        tooltip_text = mark_safe("&#10;".join(str(line) for line in tooltip_lines))
 
         # Build hidden inputs for per-VLAN group selections (submitted with form)
         hidden_inputs = []
@@ -282,8 +290,8 @@ class LibreNMSInterfaceTable(tables.Table):
 
         return format_html(
             '<span title="{}">{}</span>{}{}',
-            mark_safe(tooltip_text),
-            mark_safe(summary),
+            tooltip_text,
+            summary,
             edit_btn,
             hidden_inputs_html,
         )

--- a/netbox_librenms_plugin/tables/interfaces.py
+++ b/netbox_librenms_plugin/tables/interfaces.py
@@ -355,29 +355,31 @@ class LibreNMSInterfaceTable(tables.Table):
     def render_librenms_id(self, value, record):
         """Render the 'librenms_id' field with appropriate styling based on comparison with NetBox."""
 
+        # Same XSS guard as _render_field: value/netbox_librenms_id originate outside NetBox, so
+        # use format_html to auto-escape both the body and the title attribute (issue #105).
         if not record.get("exists_in_netbox"):
-            return mark_safe(f'<span class="text-danger">{value}</span>')
+            return format_html('<span class="text-danger">{}</span>', value)
 
         netbox_interface = record.get("netbox_interface")
         if not netbox_interface:
-            return mark_safe(f'<span class="text-danger">{value}</span>')
+            return format_html('<span class="text-danger">{}</span>', value)
 
         netbox_librenms_id = get_librenms_device_id(netbox_interface, self.server_key, auto_save=False)
 
         if netbox_librenms_id is None:
-            return mark_safe(
-                f'<span class="text-danger" title="No librenms_id custom field value found">{value}</span>'
+            return format_html(
+                '<span class="text-danger" title="No librenms_id custom field value found">{}</span>', value
             )
 
         # Compare the IDs
         if str(value) != str(netbox_librenms_id):
             # IDs do not match
-            return mark_safe(
-                f'<span class="text-warning" title="Existing LibreNMS ID: {netbox_librenms_id}">{value}</span>'
+            return format_html(
+                '<span class="text-warning" title="Existing LibreNMS ID: {}">{}</span>', netbox_librenms_id, value
             )
         else:
             # IDs match
-            return mark_safe(f'<span class="text-success">{value}</span>')
+            return format_html('<span class="text-success">{}</span>', value)
 
     def _compare_mac_addresses(self, librenms_mac, netbox_interface):
         """
@@ -399,17 +401,20 @@ class LibreNMSInterfaceTable(tables.Table):
     def _render_field(self, value, record, librenms_key, netbox_key):
         """Render a field value with appropriate styling based on the comparison with NetBox."""
 
+        # value is an untrusted LibreNMS field (ifName, description, MAC, …). Use format_html so
+        # it is auto-escaped — a device reporting e.g. ifName="<img src=x onerror=alert(1)>" must
+        # not render as live HTML (stored XSS, issue #105). The class names stay literal.
         if not record.get("exists_in_netbox"):
-            return mark_safe(f'<span class="text-danger">{value}</span>')
+            return format_html('<span class="text-danger">{}</span>', value)
 
         netbox_interface = record.get("netbox_interface")
         if not netbox_interface:
-            return mark_safe(f'<span class="text-danger">{value}</span>')
+            return format_html('<span class="text-danger">{}</span>', value)
 
         if librenms_key == "ifPhysAddress":
             mac_matches = self._compare_mac_addresses(value, netbox_interface)
             css_class = "text-success" if mac_matches else "text-warning"
-            return mark_safe(f'<span class="{css_class}">{value}</span>')
+            return format_html('<span class="{}">{}</span>', css_class, value)
 
         netbox_value = getattr(netbox_interface, netbox_key, None)
         librenms_value = record.get(librenms_key)
@@ -418,9 +423,9 @@ class LibreNMSInterfaceTable(tables.Table):
             librenms_value = convert_speed_to_kbps(librenms_value)
 
         if librenms_value != netbox_value:
-            return mark_safe(f'<span class="text-warning">{value}</span>')
+            return format_html('<span class="text-warning">{}</span>', value)
 
-        return mark_safe(f'<span class="text-success">{value}</span>')
+        return format_html('<span class="text-success">{}</span>', value)
 
     def render_type(self, value, record):
         """Render interface type with appropriate styling based on comparison with NetBox"""

--- a/netbox_librenms_plugin/templates/netbox_librenms_plugin/_interface_sync_content.html
+++ b/netbox_librenms_plugin/templates/netbox_librenms_plugin/_interface_sync_content.html
@@ -305,7 +305,8 @@
                                 <tr>
                                     <th>
                                         <input type="checkbox" id="select-all-netbox-interfaces"
-                                            class="form-check-input">
+                                            class="form-check-input"
+                                            aria-label="Select all NetBox-only interfaces">
                                     </th>
                                     <th>Interface Name</th>
                                     <th>Type</th>
@@ -318,7 +319,8 @@
                                 <tr>
                                     <td>
                                         <input type="checkbox" name="interface_ids" value="{{ interface.id }}"
-                                            class="form-check-input netbox-interface-checkbox">
+                                            class="form-check-input netbox-interface-checkbox"
+                                            aria-label="Select interface {{ interface.name }}">
                                     </td>
                                     <td>
                                         <a href="{{ interface.url }}" target="_blank">{{ interface.name }}</a>

--- a/netbox_librenms_plugin/templates/netbox_librenms_plugin/htmx/device_validation_details.html
+++ b/netbox_librenms_plugin/templates/netbox_librenms_plugin/htmx/device_validation_details.html
@@ -497,6 +497,8 @@
               hx-swap="none"
               hx-include="#use-sysname-toggle, #strip-domain-toggle">
           {% csrf_token %}
+          {# server_key keeps the action scoped to the active LibreNMS server (issue #106). #}
+          <input type="hidden" name="server_key" value="{{ server_key }}">
           <input type="hidden" name="existing_device_id" value="{{ validation.existing_device.pk }}">
           <input type="hidden" name="existing_device_type" value="{{ existing_device_model_name|default:'device' }}">
           {% if validation.device_type_mismatch %}
@@ -546,6 +548,8 @@
               hx-swap="none"
               hx-include="#use-sysname-toggle, #strip-domain-toggle">
           {% csrf_token %}
+          {# server_key keeps the action scoped to the active LibreNMS server (issue #106). #}
+          <input type="hidden" name="server_key" value="{{ server_key }}">
           <input type="hidden" name="existing_device_id" value="{{ validation.existing_device.pk }}">
           <input type="hidden" name="existing_device_type" value="{{ existing_device_model_name|default:'device' }}">
           {% if validation.device_type_mismatch %}

--- a/netbox_librenms_plugin/tests/test_coverage_actions.py
+++ b/netbox_librenms_plugin/tests/test_coverage_actions.py
@@ -4177,3 +4177,56 @@ class TestAddDeviceTypeMappingNoSecondRoundTrip:
         # ...and the cached device is still present (repopulated, not cleared).
         assert cache.get(cache_key) is not None
         assert response.status_code == 200
+
+    def test_mapping_persisted_under_normalised_hardware_key(self):
+        """The mapping must be keyed on the NORMALISED hardware string. The matcher normalises via
+        the device_type rules before the DeviceTypeMapping lookup, so a mapping saved under the raw
+        value would never be found by the immediate revalidation (the modal would report no match)."""
+        from django.contrib.auth import get_user_model
+        from django.core.cache import cache
+        from django.test import RequestFactory
+
+        from netbox_librenms_plugin.import_utils.cache import get_import_device_cache_key
+        from netbox_librenms_plugin.models import DeviceTypeMapping, NormalizationRule
+
+        device_id = 4343
+        dt = self._make_device_type()
+        view = self._make_view()
+
+        # A device_type rule strips the "WS-" prefix the raw LibreNMS string carries.
+        NormalizationRule.objects.create(
+            scope="device_type", match_pattern=r"^WS-(.+)$", replacement=r"\1", priority=10
+        )
+
+        libre_device = {
+            "device_id": device_id,
+            "hardware": "WS-C9300-66",  # normalises to "C9300-66"
+            "sysName": "switch-43",
+            "hostname": "switch-43",
+            "os": "ios",
+            "serial": "SN43",
+        }
+        cache.set(get_import_device_cache_key(device_id, "default"), libre_device, timeout=300)
+
+        User = get_user_model()
+        user = User.objects.create_user(username="u43", password="x")
+        user.is_superuser = True
+        user.save()
+
+        request = RequestFactory().post(
+            f"/device-import/add-device-type-mapping/{device_id}/",
+            data={"device_type_id": str(dt.pk)},
+        )
+        request.user = user
+
+        with (
+            patch("netbox_librenms_plugin.import_utils.device_operations.get_librenms_device_by_id", return_value=None),
+            patch.object(view, "require_write_permission", return_value=None),
+            patch.object(view, "require_object_permissions", return_value=None),
+            patch.object(view, "_should_enable_vc_detection", return_value=False),
+        ):
+            view.post(request, device_id=device_id)
+
+        # Saved under the normalised, lowercased key — NOT the raw "ws-c9300-66".
+        assert DeviceTypeMapping.objects.filter(librenms_hardware="c9300-66").exists()
+        assert not DeviceTypeMapping.objects.filter(librenms_hardware="ws-c9300-66").exists()

--- a/netbox_librenms_plugin/tests/test_coverage_actions.py
+++ b/netbox_librenms_plugin/tests/test_coverage_actions.py
@@ -4230,3 +4230,64 @@ class TestAddDeviceTypeMappingNoSecondRoundTrip:
         # Saved under the normalised, lowercased key — NOT the raw "ws-c9300-66".
         assert DeviceTypeMapping.objects.filter(librenms_hardware="c9300-66").exists()
         assert not DeviceTypeMapping.objects.filter(librenms_hardware="ws-c9300-66").exists()
+
+    def test_normalised_hardware_is_trimmed_before_lookup(self):
+        """The normalised key must be trimmed. DeviceTypeMapping.clean() strips on save, so a rule
+        that emits surrounding whitespace would make the untrimmed lookup miss the stored mapping,
+        take the add path, and then fail uniqueness validation generically. With trimming, the
+        existing mapping is found and updated instead."""
+        from django.contrib.auth import get_user_model
+        from django.core.cache import cache
+        from django.test import RequestFactory
+
+        from dcim.models import DeviceType, Manufacturer
+        from netbox_librenms_plugin.import_utils.cache import get_import_device_cache_key
+        from netbox_librenms_plugin.models import DeviceTypeMapping, NormalizationRule
+
+        device_id = 4444
+        mfr = Manufacturer.objects.create(name="Cisco-trim", slug="cisco-trim")
+        dt_old = DeviceType.objects.create(manufacturer=mfr, model="C9300-old", slug="c9300-old")
+        dt_new = DeviceType.objects.create(manufacturer=mfr, model="C9300-new", slug="c9300-new")
+        view = self._make_view()
+
+        # A pre-existing mapping (stored stripped+lowercased by clean()).
+        existing = DeviceTypeMapping.objects.create(librenms_hardware="c9300-44", netbox_device_type=dt_old)
+
+        # A rule that pads the value with spaces — the untrimmed output is " C9300-44 ".
+        NormalizationRule.objects.create(
+            scope="device_type", match_pattern=r"^WS-(.+)$", replacement=r" \1 ", priority=10
+        )
+
+        libre_device = {
+            "device_id": device_id,
+            "hardware": "WS-C9300-44",
+            "sysName": "switch-44",
+            "hostname": "switch-44",
+            "os": "ios",
+            "serial": "SN44",
+        }
+        cache.set(get_import_device_cache_key(device_id, "default"), libre_device, timeout=300)
+
+        User = get_user_model()
+        user = User.objects.create_user(username="u44", password="x")
+        user.is_superuser = True
+        user.save()
+
+        request = RequestFactory().post(
+            f"/device-import/add-device-type-mapping/{device_id}/",
+            data={"device_type_id": str(dt_new.pk)},
+        )
+        request.user = user
+
+        with (
+            patch("netbox_librenms_plugin.import_utils.device_operations.get_librenms_device_by_id", return_value=None),
+            patch.object(view, "require_write_permission", return_value=None),
+            patch.object(view, "require_object_permissions", return_value=None),
+            patch.object(view, "_should_enable_vc_detection", return_value=False),
+        ):
+            view.post(request, device_id=device_id)
+
+        # The trimmed key matched the existing mapping → it was UPDATED, not duplicated.
+        assert DeviceTypeMapping.objects.filter(librenms_hardware="c9300-44").count() == 1
+        existing.refresh_from_db()
+        assert existing.netbox_device_type_id == dt_new.pk

--- a/netbox_librenms_plugin/tests/test_coverage_actions.py
+++ b/netbox_librenms_plugin/tests/test_coverage_actions.py
@@ -2,6 +2,8 @@
 
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 
 def _make_request(post=None, get=None, headers=None, user_is_superuser=False):
     """Build a mock request object with QueryDict-like POST/GET."""
@@ -4094,3 +4096,84 @@ class TestBulkImportEdgePaths:
                                     view.post(request)
 
         mock_redirect.assert_called()
+
+
+@pytest.mark.django_db
+class TestAddDeviceTypeMappingNoSecondRoundTrip:
+    """Issue #66: AddDeviceTypeMappingView.post must reuse the LibreNMS device it already fetched
+    for the modal/row refresh, never issuing a second LibreNMS round-trip after the DB write.
+
+    This drives the real view end-to-end: real Django cache, a real DeviceTypeMapping write,
+    real validate_device_for_import + template render. Only the true external boundaries are
+    mocked — the LibreNMS HTTP fetch (get_librenms_device_by_id) and the auth gates (covered by
+    their own tests). The discriminator is that the HTTP boundary is never called after the write;
+    the previous cache-clear path forced a fresh lookup that a transient LibreNMS outage could
+    downgrade to a stale/"not found" refresh.
+    """
+
+    def _make_view(self):
+        from netbox_librenms_plugin.views.imports.actions import AddDeviceTypeMappingView
+
+        view = object.__new__(AddDeviceTypeMappingView)
+        view._librenms_api = _make_api()
+        return view
+
+    def _make_device_type(self):
+        from dcim.models import DeviceType, Manufacturer
+
+        mfr = Manufacturer.objects.create(name="Cisco-66", slug="cisco-66")
+        return DeviceType.objects.create(manufacturer=mfr, model="C9300-66", slug="c9300-66")
+
+    def test_post_reuses_cached_device_no_second_librenms_call(self):
+        from django.contrib.auth import get_user_model
+        from django.core.cache import cache
+        from django.test import RequestFactory
+
+        from netbox_librenms_plugin.import_utils.cache import get_import_device_cache_key
+        from netbox_librenms_plugin.models import DeviceTypeMapping
+
+        device_id = 4242
+        dt = self._make_device_type()
+        view = self._make_view()
+
+        # Pre-seed the cache exactly as the table load would (so the first fetch is a cache hit).
+        libre_device = {
+            "device_id": device_id,
+            "hardware": "WS-C9300-66",
+            "sysName": "switch-66",
+            "hostname": "switch-66",
+            "os": "ios",
+            "serial": "SN66",
+        }
+        cache_key = get_import_device_cache_key(device_id, "default")
+        cache.set(cache_key, libre_device, timeout=300)
+
+        User = get_user_model()
+        user = User.objects.create_user(username="u66", password="x")
+        user.is_superuser = True
+        user.save()
+
+        request = RequestFactory().post(
+            f"/device-import/add-device-type-mapping/{device_id}/",
+            data={"device_type_id": str(dt.pk)},
+        )
+        request.user = user
+
+        # Mock ONLY the LibreNMS HTTP boundary; have it raise if ever called after the cache hit,
+        # so a second round-trip would be unmistakable. Also stub the auth gates and VC detection.
+        with (
+            patch("netbox_librenms_plugin.import_utils.device_operations.get_librenms_device_by_id") as mock_http,
+            patch.object(view, "require_write_permission", return_value=None),
+            patch.object(view, "require_object_permissions", return_value=None),
+            patch.object(view, "_should_enable_vc_detection", return_value=False),
+        ):
+            mock_http.return_value = None  # simulate LibreNMS unavailable on any fresh fetch
+            response = view.post(request, device_id=device_id)
+
+        # The mapping was actually written to the DB...
+        assert DeviceTypeMapping.objects.filter(librenms_hardware="ws-c9300-66").exists()
+        # ...the refresh succeeded without ever touching the LibreNMS HTTP boundary...
+        assert mock_http.call_count == 0
+        # ...and the cached device is still present (repopulated, not cleared).
+        assert cache.get(cache_key) is not None
+        assert response.status_code == 200

--- a/netbox_librenms_plugin/tests/test_coverage_actions.py
+++ b/netbox_librenms_plugin/tests/test_coverage_actions.py
@@ -2299,6 +2299,9 @@ class TestBulkImportConfirmViewVMRole:
             "status": "importable",
             "resolved_name": "vm01",
             "virtual_chassis": {},
+            # is_vm is recomputed from import_as_vm; set it so the VM cluster path actually runs
+            # (the prior weak assertion masked that this branch was never exercised).
+            "import_as_vm": True,
         }
         mock_cluster = MagicMock()
         mock_role = MagicMock()
@@ -2321,7 +2324,10 @@ class TestBulkImportConfirmViewVMRole:
                         ):
                             with patch(
                                 "netbox_librenms_plugin.views.imports.actions.fetch_model_by_id",
-                                side_effect=[mock_role, mock_cluster, MagicMock()],
+                                # Issue #112: key the stub by the submitted id (cluster_id=1,
+                                # role_id=2), not call order — so a wrong-id fetch returns the
+                                # wrong mock and the swap asserts below fail.
+                                side_effect=lambda _model, id_: {"1": mock_cluster, "2": mock_role}.get(str(id_)),
                             ):
                                 with patch(
                                     "netbox_librenms_plugin.views.imports.actions.apply_cluster_to_validation"
@@ -2335,8 +2341,10 @@ class TestBulkImportConfirmViewVMRole:
                                         ):
                                             response = view.post(request)
 
-        # Cluster and role should have been applied
-        assert mock_apply_c.called or mock_apply_r.called or response is not None
+        assert response is not None
+        # The cluster (id 1) and role (id 2) each reached the correct apply_* helper.
+        assert mock_apply_c.call_args.args[1] is mock_cluster
+        assert mock_apply_r.call_args.args[1] is mock_role
 
     def test_device_with_role_and_rack_applies_both(self):
         """Lines 390, 393: Device with role + rack applies both."""
@@ -2373,19 +2381,25 @@ class TestBulkImportConfirmViewVMRole:
                         ):
                             with patch(
                                 "netbox_librenms_plugin.views.imports.actions.fetch_model_by_id",
-                                side_effect=[mock_role, mock_rack],
+                                # Issue #112: key by submitted id (role_id=1, rack_id=2), not call order.
+                                side_effect=lambda _model, id_: {"1": mock_role, "2": mock_rack}.get(str(id_)),
                             ):
                                 with patch(
                                     "netbox_librenms_plugin.views.imports.actions.apply_role_to_validation"
                                 ) as mock_apply_r:
-                                    with patch("netbox_librenms_plugin.views.imports.actions.apply_rack_to_validation"):
+                                    with patch(
+                                        "netbox_librenms_plugin.views.imports.actions.apply_rack_to_validation"
+                                    ) as mock_apply_rack:
                                         with patch(
                                             "netbox_librenms_plugin.views.imports.actions.render",
                                             return_value=MagicMock(status_code=200),
                                         ):
                                             response = view.post(request)
 
-        assert mock_apply_r.called or response is not None
+        assert response is not None
+        # The role (id 1) and rack (id 2) each reached the correct apply_* helper.
+        assert mock_apply_r.call_args.args[1] is mock_role
+        assert mock_apply_rack.call_args.args[1] is mock_rack
 
 
 class TestSaveDevicePath:

--- a/netbox_librenms_plugin/tests/test_coverage_base_views2.py
+++ b/netbox_librenms_plugin/tests/test_coverage_base_views2.py
@@ -106,6 +106,25 @@ class TestLibreNMSIdQ:
         result = _librenms_id_q("default", None)
         assert result is not None
 
+    def test_float_value_returns_match_nothing_q(self):
+        """Issue #103: a float like 1.9 must NOT int()-truncate to 1 and match device id 1.
+        A non-int/str value matches nothing, mirroring find_by_librenms_id's strict contract."""
+        from django.db.models import Q
+        from netbox_librenms_plugin.views.base.cables_view import _librenms_id_q
+
+        result = _librenms_id_q("default", 1.9)
+        expected = Q(pk__isnull=True) & Q(pk__isnull=False)
+        assert str(result) == str(expected)
+
+    def test_non_positive_int_returns_match_nothing_q(self):
+        """Zero / negative values can't be a valid librenms_id, so they match nothing."""
+        from django.db.models import Q
+        from netbox_librenms_plugin.views.base.cables_view import _librenms_id_q
+
+        expected = str(Q(pk__isnull=True) & Q(pk__isnull=False))
+        assert str(_librenms_id_q("default", 0)) == expected
+        assert str(_librenms_id_q("default", -5)) == expected
+
 
 # =============================================================================
 # TestGetObjectAndIpAddress  — BaseCableTableView trivial wrappers

--- a/netbox_librenms_plugin/tests/test_coverage_base_views2.py
+++ b/netbox_librenms_plugin/tests/test_coverage_base_views2.py
@@ -14,6 +14,8 @@ All tests follow strict project conventions:
 
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 
 # =============================================================================
 # Helpers
@@ -965,6 +967,33 @@ class TestIpAddressViewMethods:
         view._librenms_api.server_key = "default"
         view.model = MagicMock()
         return view
+
+    @pytest.mark.parametrize(
+        "payload",
+        [None, {"port": []}, {"port": ["bad"]}, "not-a-dict", {"port": "x"}],
+    )
+    def test_get_port_info_caches_none_for_malformed_payload(self, payload):
+        """Issue #111: a truthy success with a malformed get_port_by_id payload must cache None
+        without raising (None -> 'port' in None TypeError; ['bad'] -> non-dict row that later
+        crashes at port_info.get())."""
+        view = self._make_view()
+        view._librenms_api.get_port_by_id.return_value = (True, payload)
+        cache = {}
+
+        result = view._get_port_info(7, cache, "ifName")
+
+        assert result is None
+        assert cache[7] is None
+
+    def test_get_port_info_caches_first_dict_row(self):
+        """A well-formed payload caches the first port dict."""
+        view = self._make_view()
+        row = {"ifName": "eth0", "port_id": 7}
+        view._librenms_api.get_port_by_id.return_value = (True, {"port": [row]})
+        cache = {}
+
+        assert view._get_port_info(7, cache, "ifName") == row
+        assert cache[7] == row
 
     def test_get_object_calls_get_object_or_404(self):
         """get_object delegates to get_object_or_404 with the view's model."""

--- a/netbox_librenms_plugin/tests/test_coverage_bulk_import.py
+++ b/netbox_librenms_plugin/tests/test_coverage_bulk_import.py
@@ -942,7 +942,10 @@ class TestRefreshExistingDevice:
             _refresh_existing_device(validation)  # must not raise
 
         mock_logger.error.assert_called_once()
-        assert "99" in mock_logger.error.call_args[0][0]
+        # Inspect every positional arg, not just the format string, so this still passes if the
+        # production call switches to parameterized logging (logger.error("... %s", pk)) — the
+        # id would then land in a separate arg (issue #98).
+        assert any("99" in str(a) for a in mock_logger.error.call_args.args)
 
     # ------------------------------------------------------------------
     # Line 373: no existing_device, no libre_device → early return

--- a/netbox_librenms_plugin/tests/test_coverage_bulk_import.py
+++ b/netbox_librenms_plugin/tests/test_coverage_bulk_import.py
@@ -129,6 +129,16 @@ class TestBulkImportDevices:
 class TestBulkImportDevicesShared:
     """Tests for ``bulk_import_devices_shared``."""
 
+    @pytest.fixture(autouse=True)
+    def _stub_norm_preload(self):
+        """bulk_import_devices_shared preloads device_type NormalizationRule once (issue #90);
+        these are mock-based (no DB), so stub the preload to avoid real DB access."""
+        with patch(
+            "netbox_librenms_plugin.import_utils.bulk_import.preload_normalization_rules",
+            return_value={},
+        ):
+            yield
+
     # ------------------------------------------------------------------
     # Lines 129 & 140 – "else: logger.warning(...)" when job.logger=None
     # ------------------------------------------------------------------

--- a/netbox_librenms_plugin/tests/test_coverage_device_operations.py
+++ b/netbox_librenms_plugin/tests/test_coverage_device_operations.py
@@ -78,7 +78,8 @@ class TestTryChassisDeviceTypeMatch:
 
         call_count = [0]
 
-        def match_side_effect(value):
+        def match_side_effect(value, **kwargs):
+            # **kwargs accepts the preloaded_rules the chassis fallback now threads through (#90 N+1).
             call_count[0] += 1
             if value == "Unrecognized":
                 return {"matched": False}

--- a/netbox_librenms_plugin/tests/test_coverage_sync_interfaces.py
+++ b/netbox_librenms_plugin/tests/test_coverage_sync_interfaces.py
@@ -316,6 +316,54 @@ class TestSyncInterfacesViewPost:
         mock_redirect.assert_called_once()
 
 
+class TestSyncInterfacesViewServerKeyAndRedirect:
+    """Issues #107/#108/#109: the POST server_key must be validated against configured servers
+    before it scopes cache/CF lookups, and interface_name_field must be URL-escaped in the
+    post-sync redirect."""
+
+    def _make_view(self, configured_servers):
+        from netbox_librenms_plugin.views.sync.interfaces import SyncInterfacesView
+
+        view = object.__new__(SyncInterfacesView)
+        view.require_all_permissions = MagicMock(return_value=None)
+        view.get_required_permissions_for_object_type = MagicMock(return_value=[])
+        mock_api = MagicMock(server_key="default")
+        mock_api.get_available_servers.return_value = configured_servers
+        return view, mock_api
+
+    def _run_no_selection(self, view, mock_api, post_data, name_field="ifName"):
+        """Drive post() down the no-selection redirect path (server_key + redirect_url are set
+        before that), returning the redirect call mock."""
+        with (
+            patch("netbox_librenms_plugin.views.sync.interfaces.get_object_or_404", return_value=MagicMock(pk=1)),
+            patch("netbox_librenms_plugin.views.sync.interfaces.get_interface_name_field", return_value=name_field),
+            patch("netbox_librenms_plugin.views.sync.interfaces.messages"),
+            patch("netbox_librenms_plugin.views.sync.interfaces.redirect") as mock_redirect,
+            patch("netbox_librenms_plugin.views.sync.interfaces.reverse", return_value="/sync/"),
+            patch.object(type(view), "librenms_api", new_callable=lambda: property(lambda s: mock_api)),
+        ):
+            view.post(_make_request(post_data=post_data), "device", 1)
+        return mock_redirect
+
+    def test_unconfigured_server_key_falls_back_to_active(self):
+        view, mock_api = self._make_view({"default": "Default", "secondary": "Secondary"})
+        self._run_no_selection(view, mock_api, {"server_key": "evil-server"})
+        # The forged key is not configured, so it is dropped in favour of the active server.
+        assert view._post_server_key == "default"
+
+    def test_configured_server_key_is_honoured(self):
+        view, mock_api = self._make_view({"default": "Default", "secondary": "Secondary"})
+        self._run_no_selection(view, mock_api, {"server_key": "secondary"})
+        assert view._post_server_key == "secondary"
+
+    def test_interface_name_field_is_url_escaped_in_redirect(self):
+        view, mock_api = self._make_view({"default": "Default"})
+        mock_redirect = self._run_no_selection(view, mock_api, {}, name_field="ifName&injected=1")
+        url = mock_redirect.call_args.args[0]
+        assert "ifName%26injected%3D1" in url
+        assert "ifName&injected=1" not in url
+
+
 # ===========================================================================
 # SyncInterfacesView.sync_interface — Device paths
 # ===========================================================================

--- a/netbox_librenms_plugin/tests/test_coverage_tables.py
+++ b/netbox_librenms_plugin/tests/test_coverage_tables.py
@@ -2675,3 +2675,20 @@ class TestInterfaceTableXSSEscaping:
         rendered = str(table.render_librenms_id(self.XSS, {"exists_in_netbox": False}))
         assert "<img" not in rendered
         assert "&lt;img" in rendered
+
+    def test_render_vlans_escapes_malicious_vid(self):
+        """Sibling sink to #105: a malicious VLAN id from LibreNMS must be escaped in both the
+        inline summary and the tooltip rather than rendered as live HTML."""
+        table = _make_interface_table()
+        record = {
+            "untagged_vlan": self.XSS,
+            "tagged_vlans": [],
+            "missing_vlans": [],
+            "exists_in_netbox": False,
+            "netbox_interface": None,
+            "vlan_group_map": {},
+            "ifName": "eth0",
+        }
+        rendered = str(table.render_vlans(value=None, record=record))
+        assert "<img" not in rendered
+        assert "&lt;img" in rendered

--- a/netbox_librenms_plugin/tests/test_coverage_tables.py
+++ b/netbox_librenms_plugin/tests/test_coverage_tables.py
@@ -2647,3 +2647,31 @@ class TestRenderVlansTaggedVlansIteration:
 
         assert "200" in result
         assert "300" in result
+
+
+class TestInterfaceTableXSSEscaping:
+    """Issue #105: _render_field / render_librenms_id must escape untrusted LibreNMS values
+    (ifName, description, MAC, …) instead of rendering them as live HTML (stored XSS)."""
+
+    XSS = "<img src=x onerror=alert(1)>"
+
+    def test_render_field_escapes_value_when_not_in_netbox(self):
+        table = _make_interface_table()
+        rendered = str(table._render_field(self.XSS, {"exists_in_netbox": False}, "ifName", "name"))
+        assert "<img" not in rendered
+        assert "&lt;img" in rendered
+
+    def test_render_field_escapes_value_on_mismatch(self):
+        table = _make_interface_table()
+        nb = MagicMock()
+        nb.name = "eth0"
+        record = {"exists_in_netbox": True, "netbox_interface": nb, "ifName": self.XSS}
+        rendered = str(table._render_field(self.XSS, record, "ifName", "name"))
+        assert "<img" not in rendered
+        assert "&lt;img" in rendered
+
+    def test_render_librenms_id_escapes_value(self):
+        table = _make_interface_table()
+        rendered = str(table.render_librenms_id(self.XSS, {"exists_in_netbox": False}))
+        assert "<img" not in rendered
+        assert "&lt;img" in rendered

--- a/netbox_librenms_plugin/tests/test_coverage_utils.py
+++ b/netbox_librenms_plugin/tests/test_coverage_utils.py
@@ -2,6 +2,8 @@
 
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 
 class TestConvertSpeedToKbps:
     """Boundary and type tests for convert_speed_to_kbps."""
@@ -33,7 +35,6 @@ class TestConvertSpeedToKbps:
         assert convert_speed_to_kbps(1_000_000_000) == 1_000_000
 
     def test_string_input_raises_type_error(self):
-        import pytest
         from netbox_librenms_plugin.utils import convert_speed_to_kbps
 
         with pytest.raises(TypeError):
@@ -321,6 +322,9 @@ class TestMatchLibrenmsHardwareImportError:
         assert result["matched"] is False
 
 
+# match_librenms_hardware_to_device_type runs the device_type NormalizationRule query (issue
+# #90); django_db lets that real (empty) query run while the lookups stay mocked below.
+@pytest.mark.django_db
 class TestMatchLibrenmsHardwareDeviceTypeMappingPaths:
     """Tests for DeviceTypeMapping paths (lines 251-261)."""
 
@@ -372,6 +376,59 @@ class TestMatchLibrenmsHardwareDeviceTypeMappingPaths:
         assert result is None  # multiple DeviceTypeMapping matches returns None (ambiguous)
 
 
+@pytest.mark.django_db
+class TestMatchLibrenmsHardwareDeviceTypeNormalization:
+    """Issue #90: the documented ``device_type`` NormalizationRule scope must clean the raw
+    LibreNMS hardware string before the DeviceTypeMapping / part_number / model lookups
+    (docs/usage_tips/mapping_rules.md).
+
+    Real DB: a NormalizationRule rewrites the raw string and a DeviceTypeMapping keyed on the
+    *normalized* value must then match. Without the normalization step the raw string matches
+    nothing — so the first test is a genuine red→green regression."""
+
+    def _make_device_type(self):
+        from dcim.models import DeviceType, Manufacturer
+
+        mfr = Manufacturer.objects.create(name="Cisco-90", slug="cisco-90")
+        return DeviceType.objects.create(manufacturer=mfr, model="C9300-48P", slug="c9300-48p-90")
+
+    def test_device_type_scope_rule_normalizes_before_mapping_lookup(self):
+        from netbox_librenms_plugin.models import DeviceTypeMapping, NormalizationRule
+        from netbox_librenms_plugin.utils import match_librenms_hardware_to_device_type
+
+        dt = self._make_device_type()
+        # Mapping is keyed on the normalized hardware string (model lowercases on save).
+        DeviceTypeMapping.objects.create(librenms_hardware="C9300-48P", netbox_device_type=dt)
+        # A device_type-scoped rule strips the "WS-" prefix the raw LibreNMS string carries.
+        NormalizationRule.objects.create(
+            scope="device_type", match_pattern=r"^WS-(.+)$", replacement=r"\1", priority=10
+        )
+
+        result = match_librenms_hardware_to_device_type("WS-C9300-48P")
+
+        assert result is not None
+        assert result["matched"] is True
+        assert result["device_type"] == dt
+        assert result["match_type"] == "mapping"
+
+    def test_wrong_scope_rule_does_not_affect_device_type_matching(self):
+        """A module_type-scoped rule must NOT normalize device-type lookups: the raw string is
+        used unchanged, so a WS-prefixed string does not match while the bare string does."""
+        from netbox_librenms_plugin.models import DeviceTypeMapping, NormalizationRule
+        from netbox_librenms_plugin.utils import match_librenms_hardware_to_device_type
+
+        dt = self._make_device_type()
+        DeviceTypeMapping.objects.create(librenms_hardware="C9300-48P", netbox_device_type=dt)
+        NormalizationRule.objects.create(
+            scope="module_type", match_pattern=r"^WS-(.+)$", replacement=r"\1", priority=10
+        )
+
+        # Bare string matches the mapping directly; the wrong-scope WS- rule is not applied.
+        assert match_librenms_hardware_to_device_type("C9300-48P")["matched"] is True
+        assert match_librenms_hardware_to_device_type("WS-C9300-48P")["matched"] is False
+
+
+@pytest.mark.django_db
 class TestMatchLibrenmsHardwareDeviceTypeMultipleReturned:
     """Tests for DeviceType MultipleObjectsReturned — ambiguity surfaces as None."""
 

--- a/netbox_librenms_plugin/tests/test_coverage_utils.py
+++ b/netbox_librenms_plugin/tests/test_coverage_utils.py
@@ -427,6 +427,32 @@ class TestMatchLibrenmsHardwareDeviceTypeNormalization:
         assert match_librenms_hardware_to_device_type("C9300-48P")["matched"] is True
         assert match_librenms_hardware_to_device_type("WS-C9300-48P")["matched"] is False
 
+    def test_preloaded_rules_skip_the_per_call_normalization_query(self):
+        """Perf (issue #90 / N+1): passing preloaded_rules must avoid the per-call device_type
+        NormalizationRule query — the bulk-import loop preloads it once instead of per device."""
+        from django.db import connection
+        from django.test.utils import CaptureQueriesContext
+
+        from netbox_librenms_plugin.models import NormalizationRule
+        from netbox_librenms_plugin.utils import (
+            match_librenms_hardware_to_device_type,
+            preload_normalization_rules,
+        )
+
+        NormalizationRule.objects.create(
+            scope="device_type", match_pattern=r"^WS-(.+)$", replacement=r"\1", priority=10
+        )
+        preloaded = preload_normalization_rules("device_type")
+
+        with CaptureQueriesContext(connection) as preloaded_ctx:
+            match_librenms_hardware_to_device_type("WS-C9300-48P", preloaded_rules=preloaded)
+        assert not any("normalizationrule" in q["sql"].lower() for q in preloaded_ctx.captured_queries)
+
+        # Without preloading, the match does hit NormalizationRule (the per-device cost).
+        with CaptureQueriesContext(connection) as unpreloaded_ctx:
+            match_librenms_hardware_to_device_type("WS-C9300-48P")
+        assert any("normalizationrule" in q["sql"].lower() for q in unpreloaded_ctx.captured_queries)
+
 
 @pytest.mark.django_db
 class TestMatchLibrenmsHardwareDeviceTypeMultipleReturned:

--- a/netbox_librenms_plugin/tests/test_coverage_utils.py
+++ b/netbox_librenms_plugin/tests/test_coverage_utils.py
@@ -427,6 +427,47 @@ class TestMatchLibrenmsHardwareDeviceTypeNormalization:
         assert match_librenms_hardware_to_device_type("C9300-48P")["matched"] is True
         assert match_librenms_hardware_to_device_type("WS-C9300-48P")["matched"] is False
 
+
+@pytest.mark.django_db
+class TestChassisFallbackHonorsPreloadedRules:
+    """Issue #90 / N+1: the chassis inventory fallback (_try_chassis_device_type_match) must
+    thread the preloaded device_type rules into its own match call. Otherwise an unmatched
+    hardware string in a bulk import still triggers a per-device NormalizationRule query through
+    the fallback, partially reintroducing the N+1 cost the preload was meant to remove."""
+
+    def test_chassis_fallback_uses_preloaded_rules_no_per_call_query(self):
+        from unittest.mock import MagicMock
+
+        from django.db import connection
+        from django.test.utils import CaptureQueriesContext
+
+        from dcim.models import DeviceType, Manufacturer
+        from netbox_librenms_plugin.import_utils.device_operations import _try_chassis_device_type_match
+        from netbox_librenms_plugin.models import DeviceTypeMapping, NormalizationRule
+        from netbox_librenms_plugin.utils import preload_normalization_rules
+
+        mfr = Manufacturer.objects.create(name="Cisco-chassis", slug="cisco-chassis")
+        dt = DeviceType.objects.create(manufacturer=mfr, model="C9300-48P", slug="c9300-48p-chassis")
+        DeviceTypeMapping.objects.create(librenms_hardware="C9300-48P", netbox_device_type=dt)
+        NormalizationRule.objects.create(
+            scope="device_type", match_pattern=r"^WS-(.+)$", replacement=r"\1", priority=10
+        )
+        preloaded = preload_normalization_rules("device_type")
+
+        # api is a true external boundary (LibreNMS HTTP): stub only the inventory call.
+        api = MagicMock()
+        api.get_inventory_filtered.return_value = (True, [{"entPhysicalName": "WS-C9300-48P"}])
+
+        with CaptureQueriesContext(connection) as ctx:
+            result = _try_chassis_device_type_match(api, 123, preloaded_device_type_rules=preloaded)
+
+        assert result is not None
+        assert result["matched"] is True
+        assert result["device_type"] == dt
+        assert result["match_type"] == "chassis"
+        # The preloaded rules must reach the inner matcher, so no NormalizationRule query fires here.
+        assert not any("normalizationrule" in q["sql"].lower() for q in ctx.captured_queries)
+
     def test_preloaded_rules_skip_the_per_call_normalization_query(self):
         """Perf (issue #90 / N+1): passing preloaded_rules must avoid the per-call device_type
         NormalizationRule query — the bulk-import loop preloads it once instead of per device."""

--- a/netbox_librenms_plugin/tests/test_enrich_remote_port_realdb.py
+++ b/netbox_librenms_plugin/tests/test_enrich_remote_port_realdb.py
@@ -1,0 +1,107 @@
+"""Real-DB coverage for BaseCableTableView.enrich_remote_port librenms_id lookup.
+
+Issue #113 (CodeRabbit): the mock-based enrich_remote_port tests in test_coverage_base_views2.py
+use a reported remote_port equal to the interface name, so they still pass if the librenms_id
+branch is broken and the method falls back to ``name=remote_port`` — the mocked queryset returns
+the same interface for *every* filter call.
+
+These tests exercise the real ORM with the reported port name deliberately DIFFERENT from the
+interface name, so a match can only come from the librenms_id custom-field lookup
+(``_librenms_id_q``). If the id branch regresses, the name fallback finds nothing and the
+assertions fail — a genuine red→green guard.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+
+def _make_view():
+    from netbox_librenms_plugin.views.base.cables_view import BaseCableTableView
+
+    view = object.__new__(BaseCableTableView)
+    view._librenms_api = MagicMock()
+    view._librenms_api.server_key = "default"
+    return view
+
+
+def _make_device(name, slug_suffix):
+    from dcim.models import Device, DeviceRole, DeviceType, Manufacturer, Site
+
+    mfr, _ = Manufacturer.objects.get_or_create(name="ACME-113", slug="acme-113")
+    dt, _ = DeviceType.objects.get_or_create(manufacturer=mfr, model="DT-113", slug="dt-113")
+    role, _ = DeviceRole.objects.get_or_create(name="Role-113", slug="role-113")
+    site, _ = Site.objects.get_or_create(name="Site-113", slug="site-113")
+    return Device.objects.create(name=name, device_type=dt, role=role, site=site, status="active")
+
+
+@pytest.mark.django_db
+class TestEnrichRemotePortLibrenmsIdRealDB:
+    def test_non_vc_finds_by_librenms_id_when_name_differs(self):
+        """Non-VC: interface name differs from the reported remote_port, so only the librenms_id
+        lookup can match. Proves the id path resolves and isn't masked by the name fallback."""
+        from dcim.models import Interface
+
+        device = _make_device("switch-a", "a")
+        iface = Interface.objects.create(
+            device=device,
+            name="ge-0/0/77",
+            type="1000base-t",
+            custom_field_data={"librenms_id": {"default": 20}},
+        )
+
+        view = _make_view()
+        # Reported port name deliberately != iface.name; match must come from remote_port_id.
+        link = {"remote_port": "reported-different-name", "remote_port_id": 20}
+
+        result = view.enrich_remote_port(link, device)
+
+        assert result["netbox_remote_interface_id"] == iface.pk
+        assert result["remote_port_name"] == "ge-0/0/77"
+
+    def test_non_vc_returns_no_interface_when_id_misses_and_name_differs(self):
+        """When the librenms_id misses and the name differs, nothing matches — confirms the
+        positive test above is genuinely driven by the id lookup, not an unconditional return."""
+        from dcim.models import Interface
+
+        device = _make_device("switch-a", "a")
+        Interface.objects.create(
+            device=device,
+            name="ge-0/0/77",
+            type="1000base-t",
+            custom_field_data={"librenms_id": {"default": 20}},
+        )
+
+        view = _make_view()
+        link = {"remote_port": "reported-different-name", "remote_port_id": 999}
+
+        result = view.enrich_remote_port(link, device)
+
+        assert "netbox_remote_interface_id" not in result
+
+    def test_vc_member_finds_by_librenms_id_when_name_differs(self):
+        """VC: the reported port keeps the slot prefix (Gi1/...) so member selection resolves
+        vc_position=1, but the interface name differs — so only the librenms_id lookup can match."""
+        from dcim.models import Interface, VirtualChassis
+
+        member = _make_device("vc-member", "vc")
+        vc = VirtualChassis.objects.create(name="vc-113")
+        member.virtual_chassis = vc
+        member.vc_position = 1
+        member.save()
+
+        iface = Interface.objects.create(
+            device=member,
+            name="xe-1/0/5",
+            type="10gbase-x-sfpp",
+            custom_field_data={"librenms_id": {"default": 21}},
+        )
+
+        view = _make_view()
+        # "Gi1/0/99" → slot 1 (member_pos), but != iface.name "xe-1/0/5".
+        link = {"remote_port": "Gi1/0/99", "remote_port_id": 21}
+
+        result = view.enrich_remote_port(link, member)
+
+        assert result["netbox_remote_interface_id"] == iface.pk
+        assert result["remote_port_name"] == "xe-1/0/5"

--- a/netbox_librenms_plugin/tests/test_import_utils.py
+++ b/netbox_librenms_plugin/tests/test_import_utils.py
@@ -1624,6 +1624,56 @@ class TestNameMatchesWithNamingPreferencesLegacy:
         assert result["name_sync_available"] is False
 
 
+@pytest.mark.django_db
+class TestSerialNumberMatchingRealDB:
+    """Real-DB coverage for the serial-match path (issue #101): serial is not unique in NetBox,
+    so the match must run against real rows. Exercises the actual Device.objects.filter(serial=…)
+    queryset rather than a mocked manager with a hand-stubbed slice."""
+
+    @staticmethod
+    def _make_device(name, serial):
+        from dcim.models import Device, DeviceRole, DeviceType, Manufacturer, Site
+
+        mfr, _ = Manufacturer.objects.get_or_create(name="ACME-101", slug="acme-101")
+        dt, _ = DeviceType.objects.get_or_create(manufacturer=mfr, model="DT-101", slug="dt-101")
+        role, _ = DeviceRole.objects.get_or_create(name="Role-101", slug="role-101")
+        site, _ = Site.objects.get_or_create(name="Site-101", slug="site-101")
+        return Device.objects.create(name=name, device_type=dt, role=role, site=site, status="active", serial=serial)
+
+    def test_duplicate_serials_skip_matching_with_warning(self):
+        """Two real devices share the incoming serial → serial matching is skipped (no arbitrary
+        bind) and a warning is added. Red against the old .first() which bound a random row."""
+        from netbox_librenms_plugin.import_utils import validate_device_for_import
+
+        self._make_device("dup-a-101", "DUP123")
+        self._make_device("dup-b-101", "DUP123")
+
+        result = validate_device_for_import(
+            # device_id matches no NetBox librenms_id, so the flow reaches the serial block.
+            {"device_id": 99999, "hostname": "new-host-101", "serial": "DUP123"},
+            include_vc_detection=False,
+        )
+
+        assert result["existing_device"] is None
+        assert result.get("existing_match_type") != "serial"
+        assert any("share serial" in w for w in result["warnings"])
+
+    def test_unique_serial_still_binds(self):
+        """A single device with the serial still binds via the serial path (guards against the
+        unique guard over-rejecting)."""
+        from netbox_librenms_plugin.import_utils import validate_device_for_import
+
+        dev = self._make_device("solo-101", "SOLO123")
+
+        result = validate_device_for_import(
+            {"device_id": 99998, "hostname": "new-host-101b", "serial": "SOLO123"},
+            include_vc_detection=False,
+        )
+
+        assert result["existing_device"] == dev
+        assert result["existing_match_type"] == "serial"
+
+
 class TestSerialNumberMatching:
     """Test serial number matching in device validation."""
 
@@ -1702,39 +1752,6 @@ class TestSerialNumberMatching:
         assert result["can_import"] is False
         assert result["existing_match_type"] == "serial"
         assert result["existing_device"] == existing
-
-    def test_duplicate_serials_skip_matching_with_warning(self):
-        """Issue #101: when multiple NetBox devices share the incoming serial, serial-based
-        matching must be skipped (no arbitrary .first() bind) and a warning added. The guard's
-        len() check runs on the real list returned by the [:2] slice."""
-        dev_a = MagicMock(name="dev-a", pk=1)
-        dev_b = MagicMock(name="dev-b", pk=2)
-
-        self.mock_vm.objects.filter.return_value.first.return_value = None
-
-        def device_filter(*args, **kwargs):
-            result = MagicMock()
-            if "serial" in kwargs:
-                result.first.return_value = dev_a
-                result.__getitem__.return_value = [dev_a, dev_b]  # two devices share the serial
-            else:
-                result.first.return_value = None
-                result.__getitem__.return_value = []
-            return result
-
-        self.mock_device.objects.filter.side_effect = device_filter
-
-        from netbox_librenms_plugin.import_utils import validate_device_for_import
-
-        result = validate_device_for_import(
-            {"device_id": 1, "hostname": "new-host", "serial": "DUP123"},
-            include_vc_detection=False,
-        )
-
-        # No arbitrary device bound, and the serial path did not claim a match.
-        assert result["existing_device"] is None
-        assert result.get("existing_match_type") != "serial"
-        assert any("share serial" in w for w in result["warnings"])
 
     def test_serial_match_same_hostname_offers_link(self):
         """Serial + hostname match offers link action."""

--- a/netbox_librenms_plugin/tests/test_import_utils.py
+++ b/netbox_librenms_plugin/tests/test_import_utils.py
@@ -1679,6 +1679,11 @@ class TestSerialNumberMatching:
 
         def device_filter(*args, **kwargs):
             result = MagicMock()
+            # Support the unique-serial guard's [:2] slice: derive the slice from the
+            # .first() stub so a single match -> [match], no match -> [] (issue #101).
+            result.__getitem__.side_effect = lambda _s: (
+                [result.first.return_value] if result.first.return_value is not None else []
+            )
             if "serial" in kwargs:
                 result.first.return_value = existing
             else:
@@ -1696,6 +1701,39 @@ class TestSerialNumberMatching:
         assert result["existing_match_type"] == "serial"
         assert result["existing_device"] == existing
 
+    def test_duplicate_serials_skip_matching_with_warning(self):
+        """Issue #101: when multiple NetBox devices share the incoming serial, serial-based
+        matching must be skipped (no arbitrary .first() bind) and a warning added. The guard's
+        len() check runs on the real list returned by the [:2] slice."""
+        dev_a = MagicMock(name="dev-a", pk=1)
+        dev_b = MagicMock(name="dev-b", pk=2)
+
+        self.mock_vm.objects.filter.return_value.first.return_value = None
+
+        def device_filter(*args, **kwargs):
+            result = MagicMock()
+            if "serial" in kwargs:
+                result.first.return_value = dev_a
+                result.__getitem__.return_value = [dev_a, dev_b]  # two devices share the serial
+            else:
+                result.first.return_value = None
+                result.__getitem__.return_value = []
+            return result
+
+        self.mock_device.objects.filter.side_effect = device_filter
+
+        from netbox_librenms_plugin.import_utils import validate_device_for_import
+
+        result = validate_device_for_import(
+            {"device_id": 1, "hostname": "new-host", "serial": "DUP123"},
+            include_vc_detection=False,
+        )
+
+        # No arbitrary device bound, and the serial path did not claim a match.
+        assert result["existing_device"] is None
+        assert result.get("existing_match_type") != "serial"
+        assert any("share serial" in w for w in result["warnings"])
+
     def test_serial_match_same_hostname_offers_link(self):
         """Serial + hostname match offers link action."""
         existing = MagicMock()
@@ -1706,6 +1744,11 @@ class TestSerialNumberMatching:
 
         def device_filter(*args, **kwargs):
             result = MagicMock()
+            # Support the unique-serial guard's [:2] slice: derive the slice from the
+            # .first() stub so a single match -> [match], no match -> [] (issue #101).
+            result.__getitem__.side_effect = lambda _s: (
+                [result.first.return_value] if result.first.return_value is not None else []
+            )
             if "serial" in kwargs:
                 result.first.return_value = existing
             else:
@@ -1733,6 +1776,11 @@ class TestSerialNumberMatching:
 
         def device_filter(*args, **kwargs):
             result = MagicMock()
+            # Support the unique-serial guard's [:2] slice: derive the slice from the
+            # .first() stub so a single match -> [match], no match -> [] (issue #101).
+            result.__getitem__.side_effect = lambda _s: (
+                [result.first.return_value] if result.first.return_value is not None else []
+            )
             if "serial" in kwargs:
                 result.first.return_value = existing
             else:
@@ -1760,6 +1808,11 @@ class TestSerialNumberMatching:
 
         def device_filter(*args, **kwargs):
             result = MagicMock()
+            # Support the unique-serial guard's [:2] slice: derive the slice from the
+            # .first() stub so a single match -> [match], no match -> [] (issue #101).
+            result.__getitem__.side_effect = lambda _s: (
+                [result.first.return_value] if result.first.return_value is not None else []
+            )
             if "name__iexact" in kwargs:
                 result.first.return_value = existing
             elif "serial" in kwargs:
@@ -1840,6 +1893,11 @@ class TestSerialNumberMatching:
 
         def device_filter(*args, **kwargs):
             result = MagicMock()
+            # Support the unique-serial guard's [:2] slice: derive the slice from the
+            # .first() stub so a single match -> [match], no match -> [] (issue #101).
+            result.__getitem__.side_effect = lambda _s: (
+                [result.first.return_value] if result.first.return_value is not None else []
+            )
             if "name__iexact" in kwargs:
                 result.first.return_value = hostname_device
             elif "serial" in kwargs:
@@ -1871,6 +1929,11 @@ class TestSerialNumberMatching:
 
         def device_filter(*args, **kwargs):
             result = MagicMock()
+            # Support the unique-serial guard's [:2] slice: derive the slice from the
+            # .first() stub so a single match -> [match], no match -> [] (issue #101).
+            result.__getitem__.side_effect = lambda _s: (
+                [result.first.return_value] if result.first.return_value is not None else []
+            )
             q_has_librenms = any("librenms_id" in str(arg) for arg in args) or any(
                 k.startswith("custom_field_data__librenms_id") for k in kwargs
             )
@@ -1915,6 +1978,11 @@ class TestSerialNumberMatching:
 
         def device_filter(*args, **kwargs):
             result = MagicMock()
+            # Support the unique-serial guard's [:2] slice: derive the slice from the
+            # .first() stub so a single match -> [match], no match -> [] (issue #101).
+            result.__getitem__.side_effect = lambda _s: (
+                [result.first.return_value] if result.first.return_value is not None else []
+            )
             q_has_librenms = any("librenms_id" in str(arg) for arg in args) or any(
                 k.startswith("custom_field_data__librenms_id") for k in kwargs
             )
@@ -1961,6 +2029,11 @@ class TestSerialNumberMatching:
 
         def device_filter(*args, **kwargs):
             result = MagicMock()
+            # Support the unique-serial guard's [:2] slice: derive the slice from the
+            # .first() stub so a single match -> [match], no match -> [] (issue #101).
+            result.__getitem__.side_effect = lambda _s: (
+                [result.first.return_value] if result.first.return_value is not None else []
+            )
             q_has_librenms = any("librenms_id" in str(arg) for arg in args) or any(
                 k.startswith("custom_field_data__librenms_id") for k in kwargs
             )
@@ -2008,6 +2081,11 @@ class TestSerialNumberMatching:
 
         def device_filter(*args, **kwargs):
             result = MagicMock()
+            # Support the unique-serial guard's [:2] slice: derive the slice from the
+            # .first() stub so a single match -> [match], no match -> [] (issue #101).
+            result.__getitem__.side_effect = lambda _s: (
+                [result.first.return_value] if result.first.return_value is not None else []
+            )
             if "serial" in kwargs:
                 result.first.return_value = existing
             else:
@@ -2061,6 +2139,11 @@ class TestSerialNumberMatching:
 
         def device_filter(*args, **kwargs):
             result = MagicMock()
+            # Support the unique-serial guard's [:2] slice: derive the slice from the
+            # .first() stub so a single match -> [match], no match -> [] (issue #101).
+            result.__getitem__.side_effect = lambda _s: (
+                [result.first.return_value] if result.first.return_value is not None else []
+            )
             if "serial" in kwargs:
                 result.first.return_value = existing
             else:
@@ -2112,6 +2195,11 @@ class TestSerialNumberMatching:
 
         def device_filter(*args, **kwargs):
             result = MagicMock()
+            # Support the unique-serial guard's [:2] slice: derive the slice from the
+            # .first() stub so a single match -> [match], no match -> [] (issue #101).
+            result.__getitem__.side_effect = lambda _s: (
+                [result.first.return_value] if result.first.return_value is not None else []
+            )
             if "serial" in kwargs:
                 result.first.return_value = existing
             else:
@@ -2204,6 +2292,11 @@ class TestNameMatchesWithNamingPreferences:
     def _setup_librenms_id_filter(self, existing):
         def device_filter(*args, **kwargs):
             result = MagicMock()
+            # Support the unique-serial guard's [:2] slice: derive the slice from the
+            # .first() stub so a single match -> [match], no match -> [] (issue #101).
+            result.__getitem__.side_effect = lambda _s: (
+                [result.first.return_value] if result.first.return_value is not None else []
+            )
             q_has_librenms = any("librenms_id" in str(arg) for arg in args) or any(
                 k.startswith("custom_field_data__librenms_id") for k in kwargs
             )

--- a/netbox_librenms_plugin/tests/test_import_utils.py
+++ b/netbox_librenms_plugin/tests/test_import_utils.py
@@ -7,6 +7,8 @@ device retrieval, and device validation functions.
 
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 # =============================================================================
 # TestCacheKeyGeneration - 4 tests
 # =============================================================================
@@ -3674,6 +3676,16 @@ class TestDeviceNamingPreferences:
 class TestProcessDeviceFilters:
     """Tests for process_device_filters and related bulk_import utilities."""
 
+    @pytest.fixture(autouse=True)
+    def _stub_norm_preload(self):
+        # bulk_import_devices_shared preloads device_type NormalizationRule once (issue #90);
+        # these are mock-based (no DB), so stub the preload to avoid real DB access.
+        with patch(
+            "netbox_librenms_plugin.import_utils.bulk_import.preload_normalization_rules",
+            return_value={},
+        ):
+            yield
+
     def test_show_disabled_filters_integer_disabled_1(self):
         """show_disabled=False should exclude devices with disabled==1 (int)."""
         from unittest.mock import MagicMock, patch
@@ -4879,6 +4891,14 @@ class TestSyncModuleBayCounter:
 class TestBulkImportCancellation:
     """Test that bulk_import_devices_shared respects RQ and DB cancellation."""
 
+    @pytest.fixture(autouse=True)
+    def _stub_norm_preload(self):
+        with patch(
+            "netbox_librenms_plugin.import_utils.bulk_import.preload_normalization_rules",
+            return_value={},
+        ):
+            yield
+
     def _run_bulk_import(self, mock_rq_job=None, db_status="running", device_ids=None):
         """Helper: run bulk_import with provided mocks, return import call count."""
         from unittest.mock import MagicMock, patch
@@ -4974,6 +4994,14 @@ class TestBulkImportCancellation:
 
 class TestBulkImportVCPermission:
     """Test VC creation behavior during bulk import."""
+
+    @pytest.fixture(autouse=True)
+    def _stub_norm_preload(self):
+        with patch(
+            "netbox_librenms_plugin.import_utils.bulk_import.preload_normalization_rules",
+            return_value={},
+        ):
+            yield
 
     def _make_stack_validation(self):
         from unittest.mock import MagicMock

--- a/netbox_librenms_plugin/tests/test_librenms_api.py
+++ b/netbox_librenms_plugin/tests/test_librenms_api.py
@@ -90,6 +90,48 @@ class TestLibreNMSAPIInit:
         assert api.server_key == "primary"
         assert api.librenms_url == "https://primary.example.com"
 
+    def test_init_stale_auto_selected_server_falls_back(self, mock_librenms_config):
+        """Issue #110: a stale LibreNMSSettings.selected_server (no longer configured) must fall
+        back to the first server rather than hard-fail — it was auto-resolved, not explicitly
+        requested, so the KeyError guard must not fire."""
+        mock_config = mock_librenms_config["mock_config"]
+        mock_config.return_value = {
+            "primary": {"librenms_url": "https://primary.example.com", "api_token": "t"},
+        }
+        mock_settings = mock_librenms_config["mock_settings"]
+        mock_settings.objects.first.return_value.selected_server = "gone-server"
+
+        from netbox_librenms_plugin.librenms_api import LibreNMSAPI
+
+        api = LibreNMSAPI()  # server_key=None -> auto-resolved from (stale) settings
+        assert api.server_key == "primary"
+
+    def test_init_skips_leading_malformed_server_entry(self, mock_librenms_config):
+        """Issue #110: the first-entry fallback must pick the first *valid* mapping, skipping a
+        malformed (non-dict) leading entry that would otherwise raise at the config read."""
+        mock_config = mock_librenms_config["mock_config"]
+        mock_config.return_value = {
+            "broken": "not-a-dict",
+            "good": {"librenms_url": "https://good.example.com", "api_token": "t"},
+        }
+
+        from netbox_librenms_plugin.librenms_api import LibreNMSAPI
+
+        api = LibreNMSAPI(server_key="default")
+        assert api.server_key == "good"
+        assert api.librenms_url == "https://good.example.com"
+
+    def test_init_all_malformed_server_entries_raise_valueerror(self, mock_librenms_config):
+        """Issue #110: when no configured entry is a valid mapping, raise a clear ValueError
+        instead of crashing on the malformed entry's config read."""
+        mock_config = mock_librenms_config["mock_config"]
+        mock_config.return_value = {"broken": "not-a-dict", "also-bad": 123}
+
+        from netbox_librenms_plugin.librenms_api import LibreNMSAPI
+
+        with pytest.raises(ValueError):
+            LibreNMSAPI(server_key="default")
+
 
 # =============================================================================
 # Test Class 2: Connection Testing (4 tests)

--- a/netbox_librenms_plugin/tests/test_librenms_api.py
+++ b/netbox_librenms_plugin/tests/test_librenms_api.py
@@ -146,6 +146,23 @@ class TestLibreNMSAPIInit:
         with pytest.raises(ValueError, match="expected a mapping"):
             LibreNMSAPI(server_key="broken")
 
+    def test_get_available_servers_skips_malformed_entry(self, mock_librenms_config):
+        """get_available_servers() powers the sync-POST server-key membership check. A malformed
+        (non-dict) server entry must be skipped, not raise — otherwise config.get(...) throws and
+        the sync POST 500s instead of degrading to the active server."""
+        mock_config = mock_librenms_config["mock_config"]
+        mock_config.return_value = {
+            "good": {"librenms_url": "https://good.example.com", "api_token": "t", "display_name": "Good"},
+            "broken": "not-a-dict",
+        }
+
+        from netbox_librenms_plugin.librenms_api import LibreNMSAPI
+
+        servers = LibreNMSAPI.get_available_servers()
+
+        assert servers == {"good": "Good"}
+        assert "broken" not in servers
+
 
 # =============================================================================
 # Test Class 2: Connection Testing (4 tests)

--- a/netbox_librenms_plugin/tests/test_librenms_api.py
+++ b/netbox_librenms_plugin/tests/test_librenms_api.py
@@ -132,6 +132,20 @@ class TestLibreNMSAPIInit:
         with pytest.raises(ValueError):
             LibreNMSAPI(server_key="default")
 
+    def test_init_selected_key_malformed_raises_valueerror_not_typeerror(self, mock_librenms_config):
+        """Issue #110: an explicitly requested key that *exists* but maps to a non-dict must raise a
+        clear ValueError, not an opaque TypeError from indexing the string at the config read.
+
+        The not-found fallback only guards the missing-key case; this exercises the present-but-
+        malformed branch."""
+        mock_config = mock_librenms_config["mock_config"]
+        mock_config.return_value = {"broken": "not-a-dict"}
+
+        from netbox_librenms_plugin.librenms_api import LibreNMSAPI
+
+        with pytest.raises(ValueError, match="expected a mapping"):
+            LibreNMSAPI(server_key="broken")
+
 
 # =============================================================================
 # Test Class 2: Connection Testing (4 tests)

--- a/netbox_librenms_plugin/tests/test_payload_hardening.py
+++ b/netbox_librenms_plugin/tests/test_payload_hardening.py
@@ -1,0 +1,137 @@
+"""Issue #100: base views must fail closed on malformed-but-truthy LibreNMS payloads.
+
+A LibreNMS ``success=True`` response can still carry a non-well-shaped body (a string, a
+list of scalars, a dict with a non-list ``ports``). Dereferencing it turned a refresh into a
+500 instead of the existing error/fallback path. These tests cover the shared
+``is_list_of_dicts`` guard and the three develop-owned sites that adopt it.
+"""
+
+from unittest.mock import MagicMock, patch
+
+
+class TestIsListOfDicts:
+    """Unit tests for the shared payload-shape guard."""
+
+    def test_list_of_dicts_is_true(self):
+        from netbox_librenms_plugin.utils import is_list_of_dicts
+
+        assert is_list_of_dicts([{"a": 1}, {"b": 2}]) is True
+
+    def test_empty_list_is_true(self):
+        """A device legitimately with no rows is valid."""
+        from netbox_librenms_plugin.utils import is_list_of_dicts
+
+        assert is_list_of_dicts([]) is True
+
+    def test_non_list_is_false(self):
+        from netbox_librenms_plugin.utils import is_list_of_dicts
+
+        assert is_list_of_dicts("oops") is False
+        assert is_list_of_dicts({"a": 1}) is False
+        assert is_list_of_dicts(None) is False
+
+    def test_list_with_a_scalar_row_is_false(self):
+        from netbox_librenms_plugin.utils import is_list_of_dicts
+
+        assert is_list_of_dicts([{"a": 1}, "scalar"]) is False
+
+
+class TestInterfacePostMalformedPorts:
+    """Site 1: BaseInterfaceTableView.post must fail closed when get_ports returns a
+    truthy-but-malformed payload, redirecting with an error instead of 500ing."""
+
+    def _make_view(self):
+        from netbox_librenms_plugin.views.base.interfaces_view import BaseInterfaceTableView
+
+        view = object.__new__(BaseInterfaceTableView)
+        view._librenms_api = MagicMock()
+        view._librenms_api.server_key = "default"
+        view._librenms_api.cache_timeout = 300
+        return view
+
+    def test_non_dict_ports_payload_redirects_without_500(self):
+        view = self._make_view()
+        view._librenms_api.get_librenms_id.return_value = 1
+        # success=True but the body is a bare string (malformed).
+        view._librenms_api.get_ports.return_value = (True, "garbage-string")
+        view.get_object = MagicMock(return_value=MagicMock())
+        view.get_redirect_url = MagicMock(return_value="/redirect")
+
+        with (
+            patch(
+                "netbox_librenms_plugin.views.base.interfaces_view.get_interface_name_field",
+                return_value="ifName",
+            ),
+            patch("netbox_librenms_plugin.views.base.interfaces_view.messages") as mock_messages,
+            patch(
+                "netbox_librenms_plugin.views.base.interfaces_view.redirect",
+                return_value="REDIRECT",
+            ) as mock_redirect,
+        ):
+            result = view.post(MagicMock(), pk=1)
+
+        assert result == "REDIRECT"
+        mock_redirect.assert_called_once_with("/redirect")
+        assert mock_messages.error.called  # error surfaced, not a 500
+
+
+class TestSyncViewDeviceInfoMalformed:
+    """Site 2: get_librenms_device_info must fall back to default details when get_device_info
+    returns a truthy non-dict payload."""
+
+    def test_non_dict_device_info_falls_back_to_defaults(self):
+        from netbox_librenms_plugin.views.base.librenms_sync_view import BaseLibreNMSSyncView
+
+        view = object.__new__(BaseLibreNMSSyncView)
+        view._librenms_api = MagicMock()
+        view._librenms_api.server_key = "default"
+        view.librenms_id = 1
+        view._librenms_api.get_device_info.return_value = (True, "garbage-string")
+
+        obj = MagicMock()
+        obj.name = "dev1"
+        obj.primary_ip = None
+
+        result = view.get_librenms_device_info(obj)
+
+        assert result["found_in_librenms"] is False
+        # Default details block (no fields read off the malformed payload).
+        assert result["librenms_device_details"]["librenms_device_hardware"] == "-"
+        assert result["librenms_device_details"]["librenms_device_serial"] == "-"
+
+
+class TestVLANFetchMalformedPayload:
+    """Site 3: _fetch_and_cache_vlan_data must reject a truthy non-list-of-dicts payload and
+    not cache it (compare_vlans would later 500 on vlan.get(...))."""
+
+    def _make_view(self):
+        from netbox_librenms_plugin.views.base.vlan_table_view import BaseVLANTableView
+
+        view = object.__new__(BaseVLANTableView)
+        view._librenms_api = MagicMock()
+        view._librenms_api.server_key = "default"
+        view._librenms_api.cache_timeout = 300
+        view.librenms_id = 1
+        return view
+
+    def test_malformed_vlan_payload_fails_closed_without_caching(self):
+        view = self._make_view()
+        view._librenms_api.get_device_vlans.return_value = (True, "garbage-string")
+
+        with patch("netbox_librenms_plugin.views.base.vlan_table_view.cache") as mock_cache:
+            success, msg = view._fetch_and_cache_vlan_data(MagicMock())
+
+        assert success is False
+        assert "malformed" in msg.lower()
+        mock_cache.set.assert_not_called()
+
+    def test_valid_vlan_payload_is_cached(self):
+        view = self._make_view()
+        view._librenms_api.get_device_vlans.return_value = (True, [{"vlan_vlan": 10}])
+
+        with patch("netbox_librenms_plugin.views.base.vlan_table_view.cache") as mock_cache:
+            success, msg = view._fetch_and_cache_vlan_data(MagicMock())
+
+        assert success is True
+        assert msg is None
+        assert mock_cache.set.called

--- a/netbox_librenms_plugin/tests/test_permissions.py
+++ b/netbox_librenms_plugin/tests/test_permissions.py
@@ -633,6 +633,18 @@ class TestNetBoxObjectPermissionMixin:
 class TestBulkImportPermissions:
     """Tests for permission checks in bulk import functions."""
 
+    def setup_method(self):
+        # bulk_import_devices_shared preloads device_type NormalizationRule once (issue #90);
+        # these are mock-based (no DB), so stub the preload to avoid real DB access.
+        self._norm_patcher = patch(
+            "netbox_librenms_plugin.import_utils.bulk_import.preload_normalization_rules",
+            return_value={},
+        )
+        self._norm_patcher.start()
+
+    def teardown_method(self):
+        self._norm_patcher.stop()
+
     @patch("netbox_librenms_plugin.import_utils.bulk_import.require_permissions")
     @patch("netbox_librenms_plugin.import_utils.bulk_import.LibreNMSAPI")
     def test_bulk_import_devices_checks_permissions(self, mock_api_class, mock_require):
@@ -873,6 +885,16 @@ class TestSafeRedirectUrl:
 
 class TestBulkImportVCPermission:
     """Tests that bulk import checks virtualchassis permission."""
+
+    def setup_method(self):
+        self._norm_patcher = patch(
+            "netbox_librenms_plugin.import_utils.bulk_import.preload_normalization_rules",
+            return_value={},
+        )
+        self._norm_patcher.start()
+
+    def teardown_method(self):
+        self._norm_patcher.stop()
 
     @patch("netbox_librenms_plugin.import_utils.bulk_import.require_permissions")
     @patch("netbox_librenms_plugin.import_utils.bulk_import.LibreNMSAPI")

--- a/netbox_librenms_plugin/tests/test_sync_view_mismatch.py
+++ b/netbox_librenms_plugin/tests/test_sync_view_mismatch.py
@@ -364,6 +364,24 @@ class TestBuildAllServerMappings:
         assert entry["is_active"] is True
         assert entry["device_url"] == "https://librenms.example.com/device/device=42/"
 
+    def test_whitespace_padded_string_id_is_included(self, mock_netbox_device, mock_plugins_config_single_server):
+        """Issue #99: a per-server id stored as a whitespace-padded string (" 42 ") resolves
+        fine elsewhere (int() strips whitespace) but str.isdigit() wrongly rejected it here,
+        hiding a valid link from the mappings UI. It must now appear, coerced to 42."""
+        from unittest.mock import patch
+
+        from netbox_librenms_plugin.views.base.librenms_sync_view import BaseLibreNMSSyncView
+
+        mock_netbox_device.custom_field_data = {"librenms_id": {"production": " 42 "}}
+        with patch("netbox_librenms_plugin.views.base.librenms_sync_view.django_settings") as mock_settings:
+            mock_settings.PLUGINS_CONFIG = mock_plugins_config_single_server
+            result = BaseLibreNMSSyncView._build_all_server_mappings(mock_netbox_device, "production")
+
+        assert result is not None
+        assert len(result) == 1
+        assert result[0]["server_key"] == "production"
+        assert result[0]["device_id"] == 42
+
     def test_orphaned_server_is_not_configured(self, mock_netbox_device, mock_plugins_config_empty_servers):
         from unittest.mock import patch
 

--- a/netbox_librenms_plugin/tests/test_sync_view_mismatch.py
+++ b/netbox_librenms_plugin/tests/test_sync_view_mismatch.py
@@ -382,6 +382,24 @@ class TestBuildAllServerMappings:
         assert result[0]["server_key"] == "production"
         assert result[0]["device_id"] == 42
 
+    def test_float_id_is_rejected_not_truncated(self, mock_netbox_device, mock_plugins_config_single_server):
+        """Issue #99: a float id must be rejected, never silently truncated. Coercing 1.9 → 1 with
+        a bare int() would surface a mapping to the *wrong* device, diverging from
+        get_librenms_device_id()'s str/int-only contract. The valid sibling entry still resolves."""
+        from unittest.mock import patch
+
+        from netbox_librenms_plugin.views.base.librenms_sync_view import BaseLibreNMSSyncView
+
+        mock_netbox_device.custom_field_data = {"librenms_id": {"production": 42, "staging": 1.9}}
+        with patch("netbox_librenms_plugin.views.base.librenms_sync_view.django_settings") as mock_settings:
+            mock_settings.PLUGINS_CONFIG = mock_plugins_config_single_server
+            result = BaseLibreNMSSyncView._build_all_server_mappings(mock_netbox_device, "production")
+
+        assert result is not None
+        # Only the valid int entry survives; the float is dropped, not coerced to 1.
+        assert [e["server_key"] for e in result] == ["production"]
+        assert all(e["device_id"] != 1 for e in result)
+
     def test_orphaned_server_is_not_configured(self, mock_netbox_device, mock_plugins_config_empty_servers):
         from unittest.mock import patch
 

--- a/netbox_librenms_plugin/tests/test_utils.py
+++ b/netbox_librenms_plugin/tests/test_utils.py
@@ -8,11 +8,17 @@ platform matching, and conversion helper functions.
 import json
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 # =============================================================================
 # TestDeviceTypeMatching - 5 tests
 # =============================================================================
 
 
+# match_librenms_hardware_to_device_type now runs the device_type NormalizationRule query
+# (issue #90); enabling django_db lets that real (empty) query run while the lookups below
+# stay mocked, so the matching assertions are unaffected.
+@pytest.mark.django_db
 class TestDeviceTypeMatching:
     """Test device type matching logic."""
 

--- a/netbox_librenms_plugin/tests/test_validation_template_server_key.py
+++ b/netbox_librenms_plugin/tests/test_validation_template_server_key.py
@@ -1,0 +1,37 @@
+"""Issue #106: device_conflict_action forms that write a server-scoped LibreNMS mapping
+(link / update / update_serial — the serial/hostname-match forms) must carry a server_key
+hidden input, or on a non-default server the POST rebind silently falls back to "default" and
+writes the wrong mapping/cache scope. Field-sync actions (sync_name, sync_device_type,
+sync_platform, …) only touch NetBox fields and need no server_key, so they are exempt.
+
+A structural check of the real template source (the htmx fragment is too branch-heavy to render
+standalone under the strict test template settings).
+"""
+
+import pathlib
+import re
+
+from django.template.loader import get_template
+
+TEMPLATE = "netbox_librenms_plugin/htmx/device_validation_details.html"
+
+# Actions that persist a server-scoped librenms_id mapping (need the active server_key).
+MAPPING_ACTIONS = {"link", "update", "update_serial", "migrate_librenms_id"}
+
+
+def _form_actions(form_html):
+    return set(
+        re.findall(r'name="action"\s+value="([^"]+)"', form_html)
+        + re.findall(r'value="([^"]+)"\s+name="action"', form_html)
+    )
+
+
+def test_mapping_writing_conflict_forms_include_server_key():
+    src = pathlib.Path(get_template(TEMPLATE).origin.name).read_text()
+    forms = [f for f in re.findall(r"<form\b.*?</form>", src, re.DOTALL) if "device_conflict_action" in f]
+
+    mapping_forms = [f for f in forms if _form_actions(f) & MAPPING_ACTIONS]
+    assert mapping_forms, "expected mapping-writing device_conflict_action forms in the template"
+
+    missing = [sorted(_form_actions(f)) for f in mapping_forms if 'name="server_key"' not in f]
+    assert not missing, f"mapping-writing forms missing a server_key hidden input: {missing}"

--- a/netbox_librenms_plugin/utils.py
+++ b/netbox_librenms_plugin/utils.py
@@ -13,6 +13,17 @@ from utilities.paginator import get_paginate_count as netbox_get_paginate_count
 logger = logging.getLogger(__name__)
 
 
+def is_list_of_dicts(value) -> bool:
+    """Return True only when *value* is a list whose every element is a dict.
+
+    Used to validate LibreNMS payloads at the API boundary: a ``success=True`` response can
+    still carry a malformed-but-truthy body (a string, a list of scalars, etc.), and blindly
+    dereferencing it turns a refresh into a 500 instead of the graceful error/fallback path.
+    An empty list is considered valid (a device legitimately with no rows).
+    """
+    return isinstance(value, list) and all(isinstance(item, dict) for item in value)
+
+
 _VC_MEMBER_INTERFACE_PATTERN = re.compile(r"^(?P<prefix>[A-Za-z][A-Za-z0-9]*)(?P<member>\d+)(?P<suffix>[/:].+)$")
 
 

--- a/netbox_librenms_plugin/utils.py
+++ b/netbox_librenms_plugin/utils.py
@@ -613,10 +613,17 @@ def match_librenms_hardware_to_device_type(hardware_name: str) -> dict | None:
     if not hardware_name or hardware_name == "-":
         return {"matched": False, "device_type": None, "match_type": None}
 
+    # Normalize the raw LibreNMS hardware string per the documented ``device_type``
+    # NormalizationRule scope before matching (docs/usage_tips/mapping_rules.md: "normalizes
+    # LibreNMS hardware string before DeviceTypeMapping lookup"). With no device_type rules
+    # configured this returns the input unchanged, so existing exact-match behavior is
+    # preserved; when rules exist they clean the string once and all lookups use the result.
+    search_name = apply_normalization_rules(value=hardware_name, scope="device_type")
+
     # Check DeviceTypeMapping table first (when available)
     if _has_device_type_mapping:
         try:
-            mapping = DeviceTypeMapping.objects.get(librenms_hardware__iexact=hardware_name)
+            mapping = DeviceTypeMapping.objects.get(librenms_hardware__iexact=search_name)
             return {
                 "matched": True,
                 "device_type": mapping.netbox_device_type,
@@ -628,13 +635,13 @@ def match_librenms_hardware_to_device_type(hardware_name: str) -> dict | None:
             logger.warning(
                 "Multiple DeviceTypeMapping entries match hardware %r — skipping mapping lookup; "
                 "resolve the ambiguity by removing duplicate mappings.",
-                hardware_name,
+                search_name,
             )
             return None
 
     # Try part number exact match
     try:
-        device_type = DeviceType.objects.get(part_number__iexact=hardware_name)
+        device_type = DeviceType.objects.get(part_number__iexact=search_name)
         return {
             "matched": True,
             "device_type": device_type,
@@ -646,13 +653,13 @@ def match_librenms_hardware_to_device_type(hardware_name: str) -> dict | None:
         logger.warning(
             "Multiple DeviceType entries match part_number %r — cannot auto-select; "
             "resolve the ambiguity by ensuring part numbers are unique across manufacturers.",
-            hardware_name,
+            search_name,
         )
         return None
 
     # Try exact model match (case-insensitive)
     try:
-        device_type = DeviceType.objects.get(model__iexact=hardware_name)
+        device_type = DeviceType.objects.get(model__iexact=search_name)
         return {"matched": True, "device_type": device_type, "match_type": "exact"}
     except DeviceType.DoesNotExist:
         pass
@@ -660,7 +667,7 @@ def match_librenms_hardware_to_device_type(hardware_name: str) -> dict | None:
         logger.warning(
             "Multiple DeviceType entries match model %r — cannot auto-select; "
             "resolve the ambiguity by ensuring model names are unique across manufacturers.",
-            hardware_name,
+            search_name,
         )
         return None
 

--- a/netbox_librenms_plugin/utils.py
+++ b/netbox_librenms_plugin/utils.py
@@ -591,7 +591,7 @@ def get_interface_name_field(request: Optional[HttpRequest] = None) -> str:
     return get_plugin_config("netbox_librenms_plugin", "interface_name_field")
 
 
-def match_librenms_hardware_to_device_type(hardware_name: str) -> dict | None:
+def match_librenms_hardware_to_device_type(hardware_name: str, *, preloaded_rules: dict | None = None) -> dict | None:
     """
     Match LibreNMS hardware string to a NetBox DeviceType.
 
@@ -600,6 +600,9 @@ def match_librenms_hardware_to_device_type(hardware_name: str) -> dict | None:
 
     Args:
         hardware_name (str): Hardware string from LibreNMS API (e.g., 'C9200L-48P-4X')
+        preloaded_rules: Optional dict from :func:`preload_normalization_rules` for the
+            ``device_type`` scope. When matching many devices in a loop (bulk import), pass it
+            so the device_type NormalizationRule set is fetched once instead of per device.
 
     Returns:
         dict | None: Dictionary containing:
@@ -629,7 +632,7 @@ def match_librenms_hardware_to_device_type(hardware_name: str) -> dict | None:
     # LibreNMS hardware string before DeviceTypeMapping lookup"). With no device_type rules
     # configured this returns the input unchanged, so existing exact-match behavior is
     # preserved; when rules exist they clean the string once and all lookups use the result.
-    search_name = apply_normalization_rules(value=hardware_name, scope="device_type")
+    search_name = apply_normalization_rules(value=hardware_name, scope="device_type", preloaded_rules=preloaded_rules)
 
     # Check DeviceTypeMapping table first (when available)
     if _has_device_type_mapping:

--- a/netbox_librenms_plugin/views/base/cables_view.py
+++ b/netbox_librenms_plugin/views/base/cables_view.py
@@ -30,8 +30,22 @@ def _librenms_id_q(server_key: str, value) -> Q:
 
     Matches both integer and string representations to handle any stored format.
     """
-    if isinstance(value, bool):
-        return Q(pk__isnull=True) & Q(pk__isnull=False)  # match nothing
+    # Match nothing for values that can't be a valid librenms_id. Reject bools (an int subclass)
+    # and any non-int/str type up front: int() would truncate a float like 1.9 to 1 and match the
+    # wrong device/interface — looser than find_by_librenms_id's int/str-only contract (issue
+    # #103). Also reject blank strings and non-positive ids.
+    _match_nothing = Q(pk__isnull=True) & Q(pk__isnull=False)
+    if isinstance(value, bool) or not isinstance(value, (int, str)):
+        return _match_nothing
+    if isinstance(value, str) and not value.strip():
+        return _match_nothing
+    try:
+        if int(value) <= 0:
+            return _match_nothing
+    except (TypeError, ValueError):
+        # Non-numeric string: it can't equal a numeric id, but keep the literal match below
+        # rather than failing closed (no behaviour change for that case).
+        pass
 
     q = Q(**{f"custom_field_data__librenms_id__{server_key}": value}) | Q(custom_field_data__librenms_id=value)
     try:

--- a/netbox_librenms_plugin/views/base/interfaces_view.py
+++ b/netbox_librenms_plugin/views/base/interfaces_view.py
@@ -7,6 +7,7 @@ from django.views import View
 from netbox_librenms_plugin.utils import (
     get_interface_name_field,
     get_virtual_chassis_member,
+    is_list_of_dicts,
     normalize_librenms_port_id,
 )
 from netbox_librenms_plugin.views.mixins import (
@@ -120,8 +121,15 @@ class BaseInterfaceTableView(VlanAssignmentMixin, LibreNMSAPIMixin, LibreNMSPerm
             messages.error(request, librenms_data)
             return redirect(self.get_redirect_url(obj))
 
+        # A success=True response can still carry a malformed-but-truthy body (string/list/
+        # dict-with-non-list "ports"); dereferencing it would 500 the refresh. Fail closed like
+        # the not-success path instead (issue #100). An empty ports list stays valid.
+        ports = librenms_data.get("ports", []) if isinstance(librenms_data, dict) else None
+        if not is_list_of_dicts(ports):
+            messages.error(request, "Unexpected response from LibreNMS (malformed ports payload).")
+            return redirect(self.get_redirect_url(obj))
+
         # Enrich ports with VLAN data for trunk ports
-        ports = librenms_data.get("ports", [])
         enriched_ports = self._enrich_ports_with_vlan_data(ports, interface_name_field)
         librenms_data["ports"] = enriched_ports
 

--- a/netbox_librenms_plugin/views/base/ip_addresses_view.py
+++ b/netbox_librenms_plugin/views/base/ip_addresses_view.py
@@ -167,8 +167,8 @@ class BaseIPAddressTableView(LibreNMSPermissionMixin, LibreNMSAPIMixin, CacheMix
         """Get port info from LibreNMS with caching to minimize API calls"""
         if port_id not in port_data_cache:
             success, port_data = self.librenms_api.get_port_by_id(port_id)
-            # A truthy success can still carry a malformed payload: port_data=None (\"port\" in
-            # None raises), {\"port\": [\"bad\"]} (a non-dict row that later crashes at
+            # A truthy success can still carry a malformed payload: port_data=None ("port" in
+            # None raises), {"port": ["bad"]} (a non-dict row that later crashes at
             # port_info.get(...)). Validate the shape and cache only a real dict row, else None
             # (issue #111, same class as #100).
             ports = port_data.get("port") if success and isinstance(port_data, dict) else None

--- a/netbox_librenms_plugin/views/base/ip_addresses_view.py
+++ b/netbox_librenms_plugin/views/base/ip_addresses_view.py
@@ -167,10 +167,13 @@ class BaseIPAddressTableView(LibreNMSPermissionMixin, LibreNMSAPIMixin, CacheMix
         """Get port info from LibreNMS with caching to minimize API calls"""
         if port_id not in port_data_cache:
             success, port_data = self.librenms_api.get_port_by_id(port_id)
-            if success and "port" in port_data and port_data["port"]:
-                port_data_cache[port_id] = port_data["port"][0]
-            else:
-                port_data_cache[port_id] = None
+            # A truthy success can still carry a malformed payload: port_data=None (\"port\" in
+            # None raises), {\"port\": [\"bad\"]} (a non-dict row that later crashes at
+            # port_info.get(...)). Validate the shape and cache only a real dict row, else None
+            # (issue #111, same class as #100).
+            ports = port_data.get("port") if success and isinstance(port_data, dict) else None
+            first_port = ports[0] if isinstance(ports, list) and ports else None
+            port_data_cache[port_id] = first_port if isinstance(first_port, dict) else None
 
         return port_data_cache[port_id]
 

--- a/netbox_librenms_plugin/views/base/librenms_sync_view.py
+++ b/netbox_librenms_plugin/views/base/librenms_sync_view.py
@@ -197,9 +197,15 @@ class BaseLibreNMSSyncView(LibreNMSPermissionMixin, LibreNMSAPIMixin, generic.Ob
             # non-positive ids.
             if isinstance(did, bool) or did is None:
                 continue
-            try:
-                did = int(did)
-            except (TypeError, ValueError):
+            # Only str/int are valid stored shapes; coercing a float here would silently
+            # truncate (1.9 → 1) and surface a link to the wrong device. This mirrors
+            # get_librenms_device_id() in utils.py, which rejects non-str/int before int() (#99).
+            if isinstance(did, str):
+                try:
+                    did = int(did)
+                except (TypeError, ValueError):
+                    continue
+            elif not isinstance(did, int):
                 continue
             if did <= 0:
                 continue

--- a/netbox_librenms_plugin/views/base/librenms_sync_view.py
+++ b/netbox_librenms_plugin/views/base/librenms_sync_view.py
@@ -255,7 +255,10 @@ class BaseLibreNMSSyncView(LibreNMSPermissionMixin, LibreNMSAPIMixin, generic.Ob
 
         if self.librenms_id:
             success, device_info = self.librenms_api.get_device_info(self.librenms_id)
-            if success and device_info:
+            # isinstance(dict) guard: a truthy non-dict payload (string/list) would 500 on the
+            # device_info.get(...) calls below; fall back to the default details block instead
+            # of trusting success=True alone (issue #100).
+            if success and isinstance(device_info, dict):
                 # Get NetBox device details
                 netbox_ip = str(obj.primary_ip.address.ip).lower() if obj.primary_ip else None
                 netbox_name = obj.name

--- a/netbox_librenms_plugin/views/base/librenms_sync_view.py
+++ b/netbox_librenms_plugin/views/base/librenms_sync_view.py
@@ -189,14 +189,19 @@ class BaseLibreNMSSyncView(LibreNMSPermissionMixin, LibreNMSAPIMixin, generic.Ob
 
         result = []
         for sk, did in cf_value.items():
-            # Validate device ID — accept int or digit-string, skip bool/None/junk.
+            # Validate device ID consistently with the int()-based coercion used everywhere
+            # else for librenms_id: int() strips surrounding whitespace, so a value written as
+            # " 42 " (hand-edited, or from a path that doesn't normalize) resolves fine in the
+            # rest of the app but str.isdigit() wrongly rejected it here, hiding a valid link
+            # from the per-server mappings UI (issue #99). Reject bool/None/non-numeric and
+            # non-positive ids.
             if isinstance(did, bool) or did is None:
                 continue
-            if isinstance(did, str):
-                if not did.isdigit():
-                    continue
+            try:
                 did = int(did)
-            elif not isinstance(did, int):
+            except (TypeError, ValueError):
+                continue
+            if did <= 0:
                 continue
             srv_cfg = servers_config.get(sk)
             # Legacy single-server config: "default" key with no matching servers entry —

--- a/netbox_librenms_plugin/views/base/vlan_table_view.py
+++ b/netbox_librenms_plugin/views/base/vlan_table_view.py
@@ -6,6 +6,7 @@ from django.views import View
 
 from netbox_librenms_plugin.constants import LIBRENMS_VLAN_STATE_ACTIVE
 from netbox_librenms_plugin.tables.vlans import LibreNMSVLANTable
+from netbox_librenms_plugin.utils import is_list_of_dicts
 from netbox_librenms_plugin.views.mixins import (
     CacheMixin,
     LibreNMSAPIMixin,
@@ -62,6 +63,13 @@ class BaseVLANTableView(VlanAssignmentMixin, LibreNMSAPIMixin, LibreNMSPermissio
         success, vlans_data = self.librenms_api.get_device_vlans(self.librenms_id)
         if not success:
             return False, f"Failed to fetch VLANs: {vlans_data}"
+
+        # A success=True response can still carry a malformed-but-truthy payload (string, list
+        # of scalars, etc.); caching it would later 500 in compare_vlans() on vlan.get(...).
+        # Reject anything that isn't a list of dict rows before caching (issue #100). An empty
+        # list is valid (a device with no VLANs).
+        if not is_list_of_dicts(vlans_data):
+            return False, "Unexpected response from LibreNMS (malformed VLAN payload)."
 
         # Cache VLANs
         server_key = self.librenms_api.server_key

--- a/netbox_librenms_plugin/views/imports/actions.py
+++ b/netbox_librenms_plugin/views/imports/actions.py
@@ -1502,6 +1502,16 @@ class AddDeviceTypeMappingView(
         if not hardware or hardware == "-":
             return _htmx_error_response("Device has no hardware string — cannot create mapping.")
 
+        # Key the mapping on the NORMALISED hardware string. match_librenms_hardware_to_device_type
+        # normalises via the device_type rules before the DeviceTypeMapping lookup, so a mapping
+        # saved under the raw value (e.g. "WS-C9300" when a rule strips it to "C9300") would never
+        # be found by the revalidation below.
+        from netbox_librenms_plugin.utils import apply_normalization_rules
+
+        mapping_hardware = apply_normalization_rules(value=hardware, scope="device_type")
+        if not mapping_hardware or mapping_hardware == "-":
+            return _htmx_error_response("Device hardware normalised to an empty value — cannot create mapping.")
+
         device_type_id = request.POST.get("device_type_id", "").strip()
         if not device_type_id:
             return _htmx_error_response("Please select a device type before submitting.")
@@ -1518,7 +1528,7 @@ class AddDeviceTypeMappingView(
 
         # Resolve the existing mapping first so we only require the permission
         # actually needed: "add" for a new mapping, "change" for an update.
-        existing_mapping = DeviceTypeMapping.objects.filter(librenms_hardware__iexact=hardware).first()
+        existing_mapping = DeviceTypeMapping.objects.filter(librenms_hardware__iexact=mapping_hardware).first()
         if existing_mapping:
             self.required_object_permissions = {"POST": [("change", DeviceTypeMapping)]}
         else:
@@ -1532,7 +1542,9 @@ class AddDeviceTypeMappingView(
                 # check and the actual write (select_for_update prevents a concurrent
                 # INSERT from slipping through undetected).
                 locked = (
-                    DeviceTypeMapping.objects.select_for_update().filter(librenms_hardware__iexact=hardware).first()
+                    DeviceTypeMapping.objects.select_for_update()
+                    .filter(librenms_hardware__iexact=mapping_hardware)
+                    .first()
                 )
                 if locked and not existing_mapping:
                     # A concurrent request created the mapping after our upfront read.
@@ -1557,7 +1569,7 @@ class AddDeviceTypeMappingView(
                 else:
                     try:
                         DeviceTypeMapping.objects.create(
-                            librenms_hardware=hardware.lower(),
+                            librenms_hardware=mapping_hardware.lower(),
                             netbox_device_type=device_type,
                         )
                     except IntegrityError:

--- a/netbox_librenms_plugin/views/imports/actions.py
+++ b/netbox_librenms_plugin/views/imports/actions.py
@@ -230,15 +230,37 @@ class DeviceImportHelperMixin:
             Tuple of (libre_device, validation, selections)
             Returns (None, None, selections) if device not found
         """
-        selections = extract_device_selections(request, device_id)
-        cluster_id = selections["cluster_id"]
-        is_vm = bool(cluster_id)
-
         # Try to use cached device data from table load (eliminates redundant API calls)
         libre_device = fetch_device_with_cache(device_id, self.librenms_api)
 
         if not libre_device:
-            return None, None, selections
+            return None, None, extract_device_selections(request, device_id)
+
+        validation, selections = self.validate_and_apply_selections(device_id, request, libre_device)
+        return libre_device, validation, selections
+
+    def validate_and_apply_selections(self, device_id: int, request, libre_device: dict) -> tuple[dict, dict]:
+        """
+        Validate an already-fetched LibreNMS device and apply user selections.
+
+        Split out of :meth:`get_validated_device_with_selections` so callers that already hold
+        the LibreNMS device dict (e.g. ``AddDeviceTypeMappingView.post`` right after a mapping
+        write) can re-validate without a second LibreNMS round-trip (issue #66). Re-validation
+        still reflects NetBox-side changes — a freshly created ``DeviceTypeMapping``, role, etc.
+        — because :func:`validate_device_for_import` reads those from the database, not from the
+        cached ``libre_device``.
+
+        Args:
+            device_id: LibreNMS device ID
+            request: Django request object
+            libre_device: Already-fetched LibreNMS device dict
+
+        Returns:
+            Tuple of (validation, selections)
+        """
+        selections = extract_device_selections(request, device_id)
+        cluster_id = selections["cluster_id"]
+        is_vm = bool(cluster_id)
 
         # Determine if we should enable VC detection for this request
         # This checks: user preference, cache status, and VM vs Device
@@ -263,7 +285,7 @@ class DeviceImportHelperMixin:
         # Apply user selections (cluster, role, rack) to validation
         _apply_user_selections_to_validation(validation, selections, is_vm)
 
-        return libre_device, validation, selections
+        return validation, selections
 
     def render_device_row(self, request, libre_device: dict, validation: dict, selections: dict):
         """
@@ -1548,14 +1570,20 @@ class AddDeviceTypeMappingView(
             logger.exception("AddDeviceTypeMappingView: failed to save mapping: %s", exc)
             return _htmx_error_response("Error saving mapping. Please try again.")
 
-        # Clear cached LibreNMS device data so re-validation picks up the new mapping
+        # Repopulate (rather than clear) the cache with the LibreNMS device we already fetched
+        # at the top of this request. Re-validation reads the new mapping from the NetBox DB, so
+        # the cached LibreNMS payload stays correct; keeping it means the modal/row refresh below
+        # never issues a second LibreNMS round-trip — and a transient LibreNMS outage after the
+        # commit can no longer downgrade the refresh to a stale/"not found" state (issue #66).
         cache_key = get_import_device_cache_key(device_id, self.librenms_api.server_key)
-        cache.delete(cache_key)
+        cache.set(cache_key, libre_device, timeout=self.librenms_api.cache_timeout)
 
         # Re-render the modal content as an OOB swap so it updates in place.
         # The inner views render via Django templates (auto-escaped), so the
         # decoded content is already safe HTML; wrap with format_html + mark_safe
         # to compose the OOB envelope without introducing new escape boundaries.
+        # The cache repopulation above keeps DeviceValidationDetailsView.get's
+        # fetch_device_with_cache a cache hit, so no extra LibreNMS call is made.
         detail_view = DeviceValidationDetailsView()
         detail_view._librenms_api = self._librenms_api
         modal_html = detail_view.get(request, device_id).content.decode("utf-8")
@@ -1566,7 +1594,8 @@ class AddDeviceTypeMappingView(
 
         # Re-validate and include the background table row as a second OOB swap so the
         # row reflects the new mapping immediately without a secondary JS-triggered request.
-        libre_device, validation, selections = self.get_validated_device_with_selections(device_id, request)
+        # Reuse the in-memory libre_device directly (no re-fetch) via validate_and_apply_selections.
+        validation, selections = self.validate_and_apply_selections(device_id, request, libre_device)
         if libre_device is not None and validation is not None:
             row_response = self.render_device_row(request, libre_device, validation, selections)
             row_html = row_response.content.decode("utf-8")

--- a/netbox_librenms_plugin/views/imports/actions.py
+++ b/netbox_librenms_plugin/views/imports/actions.py
@@ -1505,10 +1505,12 @@ class AddDeviceTypeMappingView(
         # Key the mapping on the NORMALISED hardware string. match_librenms_hardware_to_device_type
         # normalises via the device_type rules before the DeviceTypeMapping lookup, so a mapping
         # saved under the raw value (e.g. "WS-C9300" when a rule strips it to "C9300") would never
-        # be found by the revalidation below.
+        # be found by the revalidation below. Strip the rule output too: DeviceTypeMapping.clean()
+        # strips before save, so an untrimmed key (e.g. " C9300 ") would miss the stored "c9300"
+        # mapping and take the add path, then fail uniqueness validation generically on save.
         from netbox_librenms_plugin.utils import apply_normalization_rules
 
-        mapping_hardware = apply_normalization_rules(value=hardware, scope="device_type")
+        mapping_hardware = (apply_normalization_rules(value=hardware, scope="device_type") or "").strip()
         if not mapping_hardware or mapping_hardware == "-":
             return _htmx_error_response("Device hardware normalised to an empty value — cannot create mapping.")
 

--- a/netbox_librenms_plugin/views/sync/interfaces.py
+++ b/netbox_librenms_plugin/views/sync/interfaces.py
@@ -65,8 +65,16 @@ class SyncInterfacesView(
         obj = self.get_object(object_type, object_id)
         self.object = obj  # Store for use in sync methods
 
-        # Read server_key from POST so we use the exact server the user was viewing
-        server_key = request.POST.get("server_key") or self.librenms_api.server_key
+        # Read server_key from POST so we use the exact server the user was viewing, but only
+        # honour it when it names a configured server: the raw value scopes cache entries and
+        # librenms_id custom-field reads/writes (find_by_librenms_id / set_librenms_device_id),
+        # so a forged/unconfigured key must not address another server's namespace (issues
+        # #108/#109). Fall back to the active server when the POSTed key isn't configured.
+        requested_server_key = request.POST.get("server_key")
+        if requested_server_key and requested_server_key in self.librenms_api.get_available_servers():
+            server_key = requested_server_key
+        else:
+            server_key = self.librenms_api.server_key
         self._post_server_key = server_key
 
         interface_name_field = get_interface_name_field(request)
@@ -76,7 +84,9 @@ class SyncInterfacesView(
 
         redirect_url = (
             reverse(url_name, kwargs={"pk": object_id})
-            + f"?tab=interfaces&interface_name_field={interface_name_field}"
+            # quote_plus the field too: it comes from the request, so unescaped special chars
+            # could corrupt the redirect or inject extra query params (issue #107).
+            + f"?tab=interfaces&interface_name_field={quote_plus(interface_name_field)}"
             + (f"&server_key={quote_plus(server_key)}" if server_key else "")
         )
 


### PR DESCRIPTION
## Summary
A hardening pass over the sync/import paths: escape untrusted LibreNMS-sourced values rendered into HTML, fail closed on malformed API payloads, tighten `librenms_id` and server-config validation, remove a per-device query in bulk import, and add/strengthen tests.

## Motivation / Problem
Maintenance / bug fixes. Latent issues in the sync/import code:
- LibreNMS-sourced strings (interface/VLAN labels, names) rendered into HTML without escaping.
- View code that proceeded on malformed-but-truthy LibreNMS payloads instead of failing closed.
- `librenms_id` lookups that truncated floats and rejected valid whitespace-padded ids.
- A stale or malformed `servers` config key raising an opaque `TypeError` at client init.
- A per-device `NormalizationRule` query during bulk import (N+1).

## Scope of Change
- Sync/Import logic
- LibreNMS API interaction
- Config / settings
- Web UI / templates
- Tests

## How Was This Tested?
- Unit tests: yes — new and updated tests; several converted from mocks to real-DB coverage. Full plugin test suite passes.
- Manual testing: no

## Risk Assessment
- Affects existing users: only through stricter input handling; no behaviour change for well-formed data.
- Unintended imports/updates: no. The serial-match change makes binding to an existing device stricter (requires a unique serial match), not looser.

## Backwards Compatibility
- No breaking changes

## Other Notes
- Device-type matching now normalizes the LibreNMS hardware string via the `device_type` normalization rules before lookup; those rules are preloaded once per bulk import.
- The API client now raises a clear configuration error for a malformed selected server entry, and falls back to the first valid server when an auto-selected key is stale.
