### PR TITLE
feat: device merge for OOB consolidation

### DIFF
--- a/netbox_librenms_plugin/import_utils/bulk_import.py
+++ b/netbox_librenms_plugin/import_utils/bulk_import.py
@@ -691,34 +691,20 @@ def _refresh_existing_device(validation: dict, libre_device: dict = None, server
         match_type = None
         found_as_cross_model = False
 
-        def _lookup_in_model(m):
+        def _lookup_value(m, value):
             """
-            Return (device, match_type, ambiguous) by NAME for model m.
-
-            The librenms_id match is resolved up-front by the cross-model collision check below
-            and short-circuits (sets ``new_device``) before this is ever reached, so re-running
-            ``find_by_librenms_id(m, ...)`` here would just repeat that query for no result. This
-            does only the name/hostname/sysName fallbacks.
+            Return (device, ambiguous) for the single NAME *value* in model m.
 
             NetBox device names are unique only per-site, so a name can resolve to MORE THAN ONE
             device. Fail closed exactly like the serial/IP fallback below (and the full
-            validate_device_for_import() path): when a name matches >1 device, return
-            ``(None, None, True)`` so the caller blocks the row instead of binding ``.first()``
-            to an arbitrary one.
+            validate_device_for_import() path): when a value matches >1 object, return
+            ``(None, True)`` so the caller blocks the row instead of binding ``.first()`` to an
+            arbitrary one.
             """
-            for value, mt in (
-                (validation.get("resolved_name"), "resolved_name"),
-                (hostname, "hostname"),
-                (sys_name, "sysname"),
-            ):
-                if not value:
-                    continue
-                matches = list(m.objects.filter(name__iexact=value)[:2])
-                if len(matches) > 1:
-                    return None, None, True
-                if matches:
-                    return matches[0], mt, False
-            return None, None, False
+            matches = list(m.objects.filter(name__iexact=value)[:2])
+            if len(matches) > 1:
+                return None, True
+            return (matches[0] if matches else None), False
 
         # Fail closed on a CROSS-MODEL librenms_id collision before selecting a match — i.e.
         # the same (server_key, librenms_id) bound to BOTH a Device and a VirtualMachine. A
@@ -751,38 +737,54 @@ def _refresh_existing_device(validation: dict, libre_device: dict = None, server
 
         name_ambiguous = False
         if not new_device:
-            # Look up BOTH models by name, not preferred-first. The old code returned on the
-            # first Model name hit and never consulted CrossModel, so a cached row whose
-            # resolved name/hostname/sysName exists as BOTH a Device and a VirtualMachine was
-            # pinned to the preferred model. validate_device_for_import()'s hostname path treats
-            # that cross-model case as ambiguous and binds NEITHER (it warns and lets the user
-            # import as new, then set librenms_id on the correct object), so the refresh re-check
-            # must do the same or it drifts and renders/links the wrong target.
-            model_match, model_mt, model_amb = _lookup_in_model(Model)
-            cross_match, cross_mt, cross_amb = _lookup_in_model(CrossModel)
-            if model_amb or cross_amb:
-                # >1 match within a single model — terminal ambiguity, fail closed below.
-                name_ambiguous = True
-            elif model_match and cross_match:
-                # Same name resolves in BOTH models: warn and leave unmatched (do NOT block),
-                # exactly like the validator's cross-model hostname branch. A serial/IP match can
-                # still bind below (a stronger identity), mirroring the validator's fall-through.
-                # setdefault (not a plain get + isinstance guard) so the warning is surfaced even
-                # when the caller built a minimal validation dict without "warnings", matching the
-                # AmbiguousLibreNMSIdError handler below.
-                validation.setdefault("warnings", []).append(
-                    f"Both a VM and Device exist with hostname '{hostname}' in NetBox. Cannot "
-                    "determine which to match. Please set the librenms_id custom field on the "
-                    "correct object."
-                )
-            elif model_match:
-                new_device, match_type = model_match, model_mt
-            elif cross_match:
-                # Cross-model import that happened after the cache was built (e.g. a LibreNMS
-                # device imported as a VM): the preferred model has no name match, the opposite
-                # one does.
-                new_device, match_type = cross_match, cross_mt
-                found_as_cross_model = True
+            # Compare BOTH models against the SAME name candidate before advancing to the next
+            # fallback. Two INDEPENDENT per-model searches (the old _lookup_in_model, which returned
+            # on the first hit within each model) could match a Device by one candidate (e.g.
+            # resolved_name) and an UNRELATED VM by a *different* one (e.g. raw hostname), then
+            # treat that as a cross-model collision — leaving the real preferred-name match unbound
+            # and letting a duplicate import slip through. Iterate the candidates in priority order
+            # and, per value, query both models: a same-value hit in BOTH is the genuine cross-model
+            # ambiguity (warn + leave unmatched, exactly like validate_device_for_import()'s
+            # hostname path); a single-model hit binds and wins over any lower-priority candidate.
+            # The librenms_id match above already short-circuited, so this only does the
+            # name/hostname/sysName fallbacks.
+            for value, mt in (
+                (validation.get("resolved_name"), "resolved_name"),
+                (hostname, "hostname"),
+                (sys_name, "sysname"),
+            ):
+                if not value:
+                    continue
+                model_match, model_amb = _lookup_value(Model, value)
+                cross_match, cross_amb = _lookup_value(CrossModel, value)
+                if model_amb or cross_amb:
+                    # >1 match within a single model for this value — terminal ambiguity, fail
+                    # closed below.
+                    name_ambiguous = True
+                    break
+                if model_match and cross_match:
+                    # Same value resolves in BOTH models: warn and leave unmatched (do NOT block),
+                    # exactly like the validator's cross-model hostname branch. A serial/IP match
+                    # can still bind below (a stronger identity), mirroring the validator's
+                    # fall-through. setdefault (not a plain get + isinstance guard) so the warning
+                    # is surfaced even when the caller built a minimal validation dict without
+                    # "warnings", matching the AmbiguousLibreNMSIdError handler below.
+                    validation.setdefault("warnings", []).append(
+                        f"Both a VM and Device exist with hostname '{value}' in NetBox. Cannot "
+                        "determine which to match. Please set the librenms_id custom field on the "
+                        "correct object."
+                    )
+                    break
+                if model_match:
+                    new_device, match_type = model_match, mt
+                    break
+                if cross_match:
+                    # Cross-model import that happened after the cache was built (e.g. a LibreNMS
+                    # device imported as a VM): the preferred model has no match on this value, the
+                    # opposite one does.
+                    new_device, match_type = cross_match, mt
+                    found_as_cross_model = True
+                    break
 
         if not new_device and name_ambiguous:
             # A hostname/sysName resolved to MORE THAN ONE NetBox device (names are unique only
@@ -799,6 +801,11 @@ def _refresh_existing_device(validation: dict, libre_device: dict = None, server
             validation["existing_match_type"] = "ambiguous_hostname_or_serial"
             validation["can_import"] = False
             validation["is_ready"] = False
+            # Terminal: this row is blocked pending duplicate resolution. Return before the
+            # no-match `else` below re-adds create-time role/cluster blockers via
+            # _reassert_new_import_blockers — the cached row must show ONLY the
+            # duplicate-resolution blocker, not stale new-import ones.
+            return
 
         if not new_device and not name_ambiguous and not import_as_vm:
             # Serial- and IP-based matches: validate_device_for_import() catches these, so the
@@ -848,6 +855,10 @@ def _refresh_existing_device(validation: dict, libre_device: dict = None, server
                 validation["existing_match_type"] = "ambiguous_hostname_or_serial"
                 validation["can_import"] = False
                 validation["is_ready"] = False
+                # Terminal, same as the name-ambiguous branch above: block on the serial/IP
+                # duplicate and return before the no-match `else` re-adds create-time
+                # role/cluster blockers.
+                return
 
         if new_device:
             validation["existing_device"] = new_device

--- a/netbox_librenms_plugin/import_utils/bulk_import.py
+++ b/netbox_librenms_plugin/import_utils/bulk_import.py
@@ -54,6 +54,12 @@ _AMBIGUOUS_SERIAL_IP_MARKERS = (
     "serial or management IP",
     "hostname/serial",
 )
+# Stable fragment of the cross-model (VM + Device share the name) warning. Shared by the
+# writer (the both-models name branch in _refresh_existing_device, wording-matched to
+# validate_device_for_import's hostname branch) and the pre-lookup cleaner, so a refresh
+# neither stacks a duplicate copy on a persisting collision nor leaves a stale warning
+# behind once the collision is resolved.
+_CROSS_MODEL_HOSTNAME_MARKER = "Both a VM and Device exist with hostname"
 
 
 def _is_job_cancelled(job) -> bool:
@@ -653,6 +659,14 @@ def _refresh_existing_device(validation: dict, libre_device: dict = None, server
                         for m in msgs
                         if not (isinstance(m, str) and any(marker in m for marker in _AMBIGUOUS_SERIAL_IP_MARKERS))
                     ]
+
+        # Same for the cross-model (VM + Device) name warning: the both-models branch below
+        # re-adds it while the collision persists, so stripping it here both prevents a
+        # duplicate copy per refresh and drops the stale warning once the collision is
+        # resolved. Unconditional (no match_type gate) — this warning never binds a match.
+        msgs = validation.get("warnings")
+        if isinstance(msgs, list):
+            validation["warnings"] = [m for m in msgs if not (isinstance(m, str) and _CROSS_MODEL_HOSTNAME_MARKER in m)]
 
         new_device = None
         match_type = None

--- a/netbox_librenms_plugin/import_utils/bulk_import.py
+++ b/netbox_librenms_plugin/import_utils/bulk_import.py
@@ -461,7 +461,10 @@ def _clear_existing_match_derived_fields(validation: dict) -> None:
     validation["device_type_mismatch"] = False
     # promote_to_host follows the "absent otherwise" contract (see apply_oob_detection_result).
     validation.pop("promote_to_host", None)
-    validation.pop("merge_candidates", None)
+    # merge_candidates, by contrast, is always present (validate_device_for_import's
+    # baseline and apply_oob_detection_result both keep it set, defaulting to None),
+    # so reset it rather than removing the key.
+    validation["merge_candidates"] = None
 
 
 def _reassert_new_import_blockers(validation: dict) -> None:

--- a/netbox_librenms_plugin/import_utils/bulk_import.py
+++ b/netbox_librenms_plugin/import_utils/bulk_import.py
@@ -9,6 +9,7 @@ from django.core.cache import cache
 from ..import_validation_helpers import (
     apply_cluster_to_validation,
     apply_role_to_validation,
+    clear_match_derived_action_fields,
     recalculate_validation_status,
     remove_validation_issue,
 )
@@ -446,25 +447,13 @@ def _clear_existing_match_derived_fields(validation: dict) -> None:
     Returns:
         None
     """
-    validation["serial_action"] = None
-    validation["oob_candidate"] = None
-    validation["serial_confirmed"] = False
-    validation["serial_duplicate"] = False
-    validation["serial_role_choice_available"] = False
-    # Name-sync / migration / device-type state is also derived from the (now dropped) match;
+    clear_match_derived_action_fields(validation)
+    # Migration / device-type state is also derived from the (now dropped) match;
     # leaving it set would render a migrate/name-sync action for the old object. The fresh
-    # lookup below re-derives these only on a re-match, so reset them here.
+    # lookup below re-derives these only on a re-match, so reset them here (they are
+    # refresh-specific, so they stay out of the shared helper).
     validation["librenms_id_needs_migration"] = False
-    validation["name_matches"] = False
-    validation["name_sync_available"] = False
-    validation["suggested_name"] = None
     validation["device_type_mismatch"] = False
-    # promote_to_host follows the "absent otherwise" contract (see apply_oob_detection_result).
-    validation.pop("promote_to_host", None)
-    # merge_candidates, by contrast, is always present (validate_device_for_import's
-    # baseline and apply_oob_detection_result both keep it set, defaulting to None),
-    # so reset it rather than removing the key.
-    validation["merge_candidates"] = None
 
 
 def _reassert_new_import_blockers(validation: dict) -> None:

--- a/netbox_librenms_plugin/import_utils/bulk_import.py
+++ b/netbox_librenms_plugin/import_utils/bulk_import.py
@@ -861,6 +861,15 @@ def _refresh_existing_device(validation: dict, libre_device: dict = None, server
                 return
 
         if new_device:
+            # A stronger identity (serial / management IP) uniquely bound this row after the
+            # name fallback flagged a cross-model (VM + Device) hostname collision. That warning
+            # said "cannot determine which to match" — now moot, since new_device IS the match.
+            # Drop it so the resolved row doesn't keep showing a stale "ambiguous" warning.
+            msgs = validation.get("warnings")
+            if isinstance(msgs, list):
+                validation["warnings"] = [
+                    m for m in msgs if not (isinstance(m, str) and _CROSS_MODEL_HOSTNAME_MARKER in m)
+                ]
             validation["existing_device"] = new_device
             validation["existing_match_type"] = match_type
             # Re-derive linkage so a librenms_id match is correctly shown as the

--- a/netbox_librenms_plugin/import_utils/bulk_import.py
+++ b/netbox_librenms_plugin/import_utils/bulk_import.py
@@ -462,6 +462,45 @@ def _clear_existing_match_derived_fields(validation: dict) -> None:
     validation["device_type_mismatch"] = False
 
 
+def _reset_device_role(validation: dict) -> None:
+    """
+    Reset the row's role selection to "not found", preserving available_roles.
+
+    One shape shared by every refresh branch that drops a device match (deleted device,
+    vanished link, late cross-model rebind), so the copies can't drift on a future edit.
+
+    Args:
+        validation (dict): The import-row validation dict, mutated in place.
+
+    Returns:
+        None
+    """
+    validation["device_role"] = {
+        "found": False,
+        "role": None,
+        "available_roles": validation.get("device_role", {}).get("available_roles", []),
+    }
+
+
+def _reset_cluster(validation: dict) -> None:
+    """
+    Reset the row's cluster selection to "not found", preserving available_clusters.
+
+    The VM twin of :func:`_reset_device_role` — VM rows are gated on cluster, not role.
+
+    Args:
+        validation (dict): The import-row validation dict, mutated in place.
+
+    Returns:
+        None
+    """
+    validation["cluster"] = {
+        "found": False,
+        "cluster": None,
+        "available_clusters": validation.get("cluster", {}).get("available_clusters", []),
+    }
+
+
 def _reassert_new_import_blockers(validation: dict) -> None:
     """
     Re-add the create-time role/cluster blocker for unmatched rows.
@@ -532,21 +571,13 @@ def _refresh_existing_device(validation: dict, libre_device: dict = None, server
                     validation["existing_librenms_link"] = None
                     _clear_existing_match_derived_fields(validation)
                     if not validation.get("import_as_vm"):
-                        validation["device_role"] = {
-                            "found": False,
-                            "role": None,
-                            "available_roles": validation.get("device_role", {}).get("available_roles", []),
-                        }
+                        _reset_device_role(validation)
                     else:
                         # VM rows are gated on cluster, not role: a dropped match must also clear
                         # the stale cluster selection (preserving available_clusters), or
                         # _reassert_new_import_blockers() sees found/cluster still set and lets
                         # the row re-enter the new-import path without a fresh cluster choice.
-                        validation["cluster"] = {
-                            "found": False,
-                            "cluster": None,
-                            "available_clusters": validation.get("cluster", {}).get("available_clusters", []),
-                        }
+                        _reset_cluster(validation)
                     # Fail-closed: this branch drops the vanished-link match and recomputes
                     # readiness, then falls through to the fresh lookup that would normally re-add
                     # the create-time role/cluster blocker. But the fresh lookup early-returns when
@@ -558,11 +589,7 @@ def _refresh_existing_device(validation: dict, libre_device: dict = None, server
                     if hasattr(refreshed, "role") and refreshed.role:
                         apply_role_to_validation(validation, refreshed.role, is_vm=bool(validation.get("import_as_vm")))
                     elif not validation.get("import_as_vm"):
-                        validation["device_role"] = {
-                            "found": False,
-                            "role": None,
-                            "available_roles": validation.get("device_role", {}).get("available_roles", []),
-                        }
+                        _reset_device_role(validation)
                         remove_validation_issue(validation, "role")
                     recalculate_validation_status(validation, is_vm=bool(validation.get("import_as_vm")))
                     # Re-assert non-importable state: recalculate bases can_import on
@@ -584,20 +611,12 @@ def _refresh_existing_device(validation: dict, libre_device: dict = None, server
                 # Guard: VMs don't use device_role for readiness, so preserve any
                 # user-selected role rather than silently dropping it.
                 if not validation.get("import_as_vm"):
-                    validation["device_role"] = {
-                        "found": False,
-                        "role": None,
-                        "available_roles": validation.get("device_role", {}).get("available_roles", []),
-                    }
+                    _reset_device_role(validation)
                 else:
                     # Mirror the stale-match branch: a deleted cached VM match must drop the
                     # stale cluster selection (keeping available_clusters) so the row returns to
                     # the same create-time state as a brand-new VM import row.
-                    validation["cluster"] = {
-                        "found": False,
-                        "cluster": None,
-                        "available_clusters": validation.get("cluster", {}).get("available_clusters", []),
-                    }
+                    _reset_cluster(validation)
                 # Same fail-closed reasoning as the vanished-link branch above: re-assert the
                 # create-time blocker before recompute so a deleted-match row can't stay importable
                 # if the fresh lookup early-returns (libre_device None) or its except swallows.
@@ -860,21 +879,13 @@ def _refresh_existing_device(validation: dict, libre_device: dict = None, server
             if not actual_is_vm and hasattr(new_device, "role") and new_device.role:
                 apply_role_to_validation(validation, new_device.role, is_vm=False)
             elif not actual_is_vm:
-                validation["device_role"] = {
-                    "found": False,
-                    "role": None,
-                    "available_roles": validation.get("device_role", {}).get("available_roles", []),
-                }
+                _reset_device_role(validation)
             elif hasattr(new_device, "cluster") and new_device.cluster:
                 # VM match: mirror the device-role display above — show the matched
                 # VM's actual cluster rather than leaving the cached selection stale.
                 apply_cluster_to_validation(validation, new_device.cluster)
             else:
-                validation["cluster"] = {
-                    "found": False,
-                    "cluster": None,
-                    "available_clusters": validation.get("cluster", {}).get("available_clusters", []),
-                }
+                _reset_cluster(validation)
             recalculate_validation_status(validation, is_vm=actual_is_vm)
             # Re-assert non-importable: recalculate sets can_import from issues list,
             # but a late-found existing match must never be import-ready.

--- a/netbox_librenms_plugin/import_utils/device_operations.py
+++ b/netbox_librenms_plugin/import_utils/device_operations.py
@@ -25,7 +25,11 @@ from ..utils import (
     set_librenms_device_id,
 )
 from ..constants import normalize_oob_type
-from ..import_validation_helpers import apply_merge_candidates, apply_oob_detection_result
+from ..import_validation_helpers import (
+    apply_merge_candidates,
+    apply_oob_detection_result,
+    clear_match_derived_action_fields,
+)
 from .cache import get_import_device_cache_key
 from .virtual_chassis import (
     _generate_vc_member_name,
@@ -955,20 +959,12 @@ def validate_device_for_import(
                     # wrong device. Only existing_match_type carries the ambiguity forward.
                     result["existing_device"] = None
                     result["existing_librenms_link"] = None
-                    result["name_matches"] = False
-                    result["name_sync_available"] = False
-                    result["suggested_name"] = None
-                    result["serial_confirmed"] = False
-                    result["serial_duplicate"] = False
+                    clear_match_derived_action_fields(result)
                     # Demote the match_type off "hostname"/"serial" so neither the device_status
                     # table (has_actions) nor device_validation_details.html renders a "Link to
                     # LibreNMS" action — otherwise the arbitrary row could be linked to the wrong
                     # NetBox device. Mirrors the "ambiguous_librenms_id" terminal-state pattern.
                     result["existing_match_type"] = "ambiguous_hostname_or_serial"
-                    result["serial_action"] = None
-                    result["oob_candidate"] = None
-                    result.pop("promote_to_host", None)
-                    result["serial_role_choice_available"] = False
                     result["can_import"] = False
                     result["is_ready"] = False
                     # Both wordings keep the "hostname/serial" substring the refresh-path

--- a/netbox_librenms_plugin/import_utils/device_operations.py
+++ b/netbox_librenms_plugin/import_utils/device_operations.py
@@ -919,11 +919,14 @@ def validate_device_for_import(
             # for the matched type, so share the result instead of issuing it twice per device.
             _match_type = result.get("existing_match_type")
             _serial_now = normalize_serial(libre_device.get("serial"))
-            _dup_eligible = (
-                not import_as_vm and result.get("existing_device") is not None and _match_type in ("hostname", "serial")
-            )
+            _dup_eligible = result.get("existing_device") is not None and _match_type in ("hostname", "serial")
+            # VM matches are just as vulnerable: NetBox only enforces VM-name uniqueness per
+            # cluster, so the VM hostname match above binds .first() among cross-cluster
+            # duplicates. Pick the peer model by the side that actually matched (a VM match
+            # forced import_as_vm=True above; the serial path is device-only).
+            _PeerModel = VirtualMachine if import_as_vm else Device
             _hostname_peers = (
-                list(Device.objects.filter(name__iexact=hostname)[:2])
+                list(_PeerModel.objects.filter(name__iexact=hostname)[:2])
                 if _dup_eligible and _match_type == "hostname" and hostname
                 else []
             )
@@ -968,8 +971,11 @@ def validate_device_for_import(
                     result["serial_role_choice_available"] = False
                     result["can_import"] = False
                     result["is_ready"] = False
+                    # Both wordings keep the "hostname/serial" substring the refresh-path
+                    # blocker cleanup keys on (_AMBIGUOUS_SERIAL_IP_MARKERS in bulk_import).
+                    _dup_kind = "virtual machines" if import_as_vm else "devices"
                     _dup_msg = (
-                        "Multiple NetBox devices share this device's hostname/serial; resolve the "
+                        f"Multiple NetBox {_dup_kind} share this device's hostname/serial; resolve the "
                         "duplicate before importing or linking."
                     )
                     if _dup_msg not in result.setdefault("issues", []):

--- a/netbox_librenms_plugin/import_utils/device_operations.py
+++ b/netbox_librenms_plugin/import_utils/device_operations.py
@@ -926,9 +926,13 @@ def validate_device_for_import(
             _dup_eligible = result.get("existing_device") is not None and _match_type in ("hostname", "serial")
             # VM matches are just as vulnerable: NetBox only enforces VM-name uniqueness per
             # cluster, so the VM hostname match above binds .first() among cross-cluster
-            # duplicates. Pick the peer model by the side that actually matched (a VM match
-            # forced import_as_vm=True above; the serial path is device-only).
-            _PeerModel = VirtualMachine if import_as_vm else Device
+            # duplicates. Pick the peer model from the object that ACTUALLY matched, not from
+            # import_as_vm: the hostname fallback can bind a Device even when the caller requested
+            # a VM import (import_as_vm=True passed by vm_operations), so keying on import_as_vm
+            # would query the wrong table and miss same-name duplicates on the matched side. The
+            # serial path is device-only.
+            _matched_is_vm = isinstance(result.get("existing_device"), VirtualMachine)
+            _PeerModel = VirtualMachine if _matched_is_vm else Device
             _hostname_peers = (
                 list(_PeerModel.objects.filter(name__iexact=hostname)[:2])
                 if _dup_eligible and _match_type == "hostname" and hostname
@@ -969,7 +973,7 @@ def validate_device_for_import(
                     result["is_ready"] = False
                     # Both wordings keep the "hostname/serial" substring the refresh-path
                     # blocker cleanup keys on (_AMBIGUOUS_SERIAL_IP_MARKERS in bulk_import).
-                    _dup_kind = "virtual machines" if import_as_vm else "devices"
+                    _dup_kind = "virtual machines" if _matched_is_vm else "devices"
                     _dup_msg = (
                         f"Multiple NetBox {_dup_kind} share this device's hostname/serial; resolve the "
                         "duplicate before importing or linking."

--- a/netbox_librenms_plugin/import_utils/device_operations.py
+++ b/netbox_librenms_plugin/import_utils/device_operations.py
@@ -507,12 +507,36 @@ def validate_device_for_import(
         strip_domain: If True, strip domain suffix from device name
 
     Returns:
-        dict: Validation result with structure:
+        dict: Validation result with structure (the key set is pinned by
+        ``test_validation_result_key_contract``; extend both together):
             {
                 'is_ready': bool,  # Can import without user intervention
                 'can_import': bool,  # Can import (possibly after configuration)
-                'import_as_vm': bool,  # Whether importing as VM
+                'import_as_vm': bool,  # Whether importing as VM (may be flipped True by a VM hostname match)
+                'resolved_name': str or None,  # Final device name after applying naming preferences
                 'existing_device': Device or VirtualMachine or None,
+                'existing_match_type': str or None,  # How it matched: 'librenms_id', 'librenms_oob',
+                    # 'hostname', 'serial', 'primary_ip', or the terminal blockers
+                    # 'ambiguous_librenms_id' / 'ambiguous_hostname_or_serial'
+                'ambiguous_librenms_id': bool,  # librenms_id matches >1 NetBox object (import blocked)
+                'existing_librenms_link': dict or None,  # {host_id, oob_id, oob_type} current linkage
+                    # of the matched object (devices; VMs get a host_id-only variant)
+                'serial_action': str or None,  # None, 'link', 'conflict', 'update_serial',
+                    # 'hostname_differs', 'oob_candidate', 'promote_to_host', 'merge_netbox_devices'
+                'serial_confirmed': bool,  # librenms_id match and serial matches
+                'serial_duplicate': bool,  # Incoming serial already on a different device
+                'serial_role_choice_available': bool,  # Both oob_candidate and promote_to_host valid
+                'oob_candidate': dict or None,  # {device, type, version, ip} when detected (devices only)
+                # 'promote_to_host': dict — CONDITIONAL, present only when host promotion is available
+                'merge_candidates': dict or None,  # {host_named: {...}, oob_named: {...}} when two
+                    # NetBox devices look like the same physical box (devices only)
+                'librenms_id_needs_migration': bool,  # Existing object carries a legacy bare-int id
+                'name_matches': bool,  # Existing object's name matches the resolved name
+                'name_sync_available': bool,  # Existing object's name differs (sync offered)
+                'suggested_name': str or None,  # Name to suggest when name_sync_available
+                'device_type_mismatch': bool,  # Existing device's type differs from LibreNMS (devices only)
+                'naming_criteria': dict or None,  # How resolved_name was derived (use_sysname/strip_domain)
+                'virtual_chassis': dict,  # VC detection state, empty_virtual_chassis_data() shape
                 'issues': List[str],  # Blocking issues
                 'warnings': List[str],  # Non-blocking warnings
                 'site': {  # Only for devices
@@ -541,6 +565,11 @@ def validate_device_for_import(
                     'found': bool,
                     'platform': Platform or None,
                     'match_type': str  # 'exact' or None
+                },
+                'rack': {  # Only for devices
+                    'found': bool,
+                    'rack': Rack or None,
+                    'available_racks': List[Rack]
                 }
             }
 

--- a/netbox_librenms_plugin/import_utils/device_operations.py
+++ b/netbox_librenms_plugin/import_utils/device_operations.py
@@ -800,6 +800,28 @@ def validate_device_for_import(
                     f"Both a VM and Device exist with hostname '{hostname}' in NetBox. "
                     f"Cannot determine which to match. Please set the librenms_id custom field on the correct object."
                 )
+                # Fail closed when EITHER side ALSO has same-model duplicates. Nothing binds in
+                # this branch, so the Stage-1 duplicate guard below (keyed on a bound
+                # existing_device) never sees them — without this, two Devices plus one VM on a
+                # hostname would sail through as a new import, i.e. the VM's presence would
+                # RELAX the terminal protection the 2-Devices-no-VM case gets. Mirrors that
+                # guard's terminal state (message keeps the "hostname/serial" substring the
+                # refresh-path blocker cleanup keys on), including its early return: a
+                # hostname-bound duplicate never falls through to serial/IP re-binding either.
+                _device_peers = list(Device.objects.filter(name__iexact=hostname)[:2])
+                _vm_peers = list(VirtualMachine.objects.filter(name__iexact=hostname)[:2])
+                if len(_device_peers) > 1 or len(_vm_peers) > 1:
+                    _dup_kind = "devices" if len(_device_peers) > 1 else "virtual machines"
+                    _dup_msg = (
+                        f"Multiple NetBox {_dup_kind} share this device's hostname/serial; resolve the "
+                        "duplicate before importing or linking."
+                    )
+                    if _dup_msg not in result.setdefault("issues", []):
+                        result["issues"].append(_dup_msg)
+                    result["existing_match_type"] = "ambiguous_hostname_or_serial"
+                    result["can_import"] = False
+                    result["is_ready"] = False
+                    return result
                 # Don't set existing_device, don't block import - let user proceed as new
                 # This allows them to import and then resolve the conflict manually
             elif existing_vm:

--- a/netbox_librenms_plugin/import_validation_helpers.py
+++ b/netbox_librenms_plugin/import_validation_helpers.py
@@ -233,6 +233,32 @@ def apply_merge_candidates(
     result["warnings"] = [warning]
 
 
+def clear_match_derived_action_fields(validation: dict) -> None:
+    """
+    Reset the action/name fields derived from a hostname/serial match.
+
+    Shared by ``device_operations``' terminal-ambiguity teardown and
+    ``bulk_import._clear_existing_match_derived_fields`` so the two clearing
+    paths can't drift on the common field set. Context-specific state
+    (match-type demotion, linkage, migration/device-type flags) stays with
+    the callers.
+
+    ``promote_to_host`` follows the "absent otherwise" contract (see
+    :func:`apply_oob_detection_result`) and is popped; ``merge_candidates``
+    is always present, defaulting to ``None``, and is reset in place.
+    """
+    validation["serial_action"] = None
+    validation["oob_candidate"] = None
+    validation["serial_confirmed"] = False
+    validation["serial_duplicate"] = False
+    validation["serial_role_choice_available"] = False
+    validation["name_matches"] = False
+    validation["name_sync_available"] = False
+    validation["suggested_name"] = None
+    validation.pop("promote_to_host", None)
+    validation["merge_candidates"] = None
+
+
 def recalculate_validation_status(validation: dict, is_vm: bool = False) -> None:
     """
     Recalculate can_import and is_ready flags based on current validation state.

--- a/netbox_librenms_plugin/librenms_api.py
+++ b/netbox_librenms_plugin/librenms_api.py
@@ -800,13 +800,17 @@ class LibreNMSAPI:
                 return False, message or "Unexpected response format: 'addresses' must be a list"
             return True, addresses
         except requests.exceptions.HTTPError as e:
-            # LibreNMS returns HTTP 404 from /devices/{id}/ip for a device that simply has no IP
-            # addresses (same as /links for a device with no LLDP neighbours). That is a successful
-            # empty result, not a fetch failure — surfacing it as one shows a red "Failed to fetch
-            # IP addresses" error and an empty table instead of just the empty table. Mirror
-            # get_device_links; any other HTTP status is a genuine failure.
+            # LibreNMS returns this specific HTTP 404 for an existing device with no IP
+            # addresses. Other 404s (for example a stale device id) remain real failures.
             if e.response is not None and e.response.status_code == 404:
-                return True, []
+                try:
+                    error_data = e.response.json()
+                except ValueError:
+                    error_data = None
+                message = error_data.get("message") if isinstance(error_data, dict) else None
+                if message == f"Device {device_id} does not have any IP addresses":
+                    return True, []
+                return False, message or str(e)
             return False, str(e)
         except (requests.exceptions.RequestException, ValueError) as e:
             return False, str(e)

--- a/netbox_librenms_plugin/librenms_api.py
+++ b/netbox_librenms_plugin/librenms_api.py
@@ -808,7 +808,7 @@ class LibreNMSAPI:
                 except ValueError:
                     error_data = None
                 message = error_data.get("message") if isinstance(error_data, dict) else None
-                if message == f"Device {device_id} does not have any IP addresses":
+                if isinstance(message, str) and "does not have any ip addresses" in message.lower():
                     return True, []
                 return False, message or str(e)
             return False, str(e)

--- a/netbox_librenms_plugin/migrations/0012_normalize_device_serials.py
+++ b/netbox_librenms_plugin/migrations/0012_normalize_device_serials.py
@@ -101,8 +101,8 @@ def drop_device_serial_index(apps, schema_editor):
 
 
 class Migration(migrations.Migration):
-    # CREATE INDEX CONCURRENTLY cannot run inside a transaction. Keep the data rewrite
-    # atomic via RunPython.atomic while leaving the index operation outside it.
+    # CREATE INDEX CONCURRENTLY cannot run inside a transaction. Leave both operations
+    # non-atomic so every rewrite batch commits independently before the concurrent DDL.
     atomic = False
 
     dependencies = [
@@ -114,7 +114,7 @@ class Migration(migrations.Migration):
         migrations.RunPython(
             normalize_device_serials,
             migrations.RunPython.noop,
-            atomic=True,
+            atomic=False,
         ),
         # Device is owned by NetBox's dcim app, so the plugin cannot declare this index
         # through its model state. NetBox does not otherwise index Device.serial.

--- a/netbox_librenms_plugin/tables/cables.py
+++ b/netbox_librenms_plugin/tables/cables.py
@@ -1,7 +1,7 @@
 import re
 
 import django_tables2 as tables
-from django.utils.html import escape, format_html
+from django.utils.html import format_html
 from django.utils.safestring import mark_safe
 from netbox.tables.columns import ToggleColumn
 from utilities.paginator import EnhancedPaginator
@@ -9,6 +9,7 @@ from utilities.paginator import EnhancedPaginator
 from netbox_librenms_plugin.constants import OOB_BADGE_HTML
 from netbox_librenms_plugin.utils import (
     get_table_paginate_count,
+    render_vc_member_options,
 )
 
 
@@ -164,15 +165,10 @@ class VCCableTable(LibreNMSCableTable):
         selected_member_id = self._selected_member_id(record["local_port"])
         port_id = record["local_port_id"]
 
-        options = [
-            f'<option value="{member.id}"{" selected" if member.id == selected_member_id else ""}>{escape(member.name)}</option>'
-            for member in self._vc_members
-        ]
-
         return format_html(
             '<select name="device_selection_{0}" id="device_selection_{0}" class="form-select" data-interface="{0}" data-row-id="{0}">{1}</select>',
             port_id,
-            mark_safe("".join(options)),
+            render_vc_member_options(self._vc_members, selected_member_id),
         )
 
     class Meta(LibreNMSCableTable.Meta):

--- a/netbox_librenms_plugin/tables/cables.py
+++ b/netbox_librenms_plugin/tables/cables.py
@@ -2,13 +2,12 @@ import re
 
 import django_tables2 as tables
 from django.utils.html import format_html
-from django.utils.safestring import mark_safe
 from netbox.tables.columns import ToggleColumn
 from utilities.paginator import EnhancedPaginator
 
-from netbox_librenms_plugin.constants import OOB_BADGE_HTML
 from netbox_librenms_plugin.utils import (
     get_table_paginate_count,
+    oob_badge_html,
     render_vc_member_options,
 )
 
@@ -64,13 +63,8 @@ class LibreNMSCableTable(tables.Table):
 
     def render_local_port(self, value, record):
         """Render local port name as a link if URL is available."""
-        # Static trusted markup — use mark_safe, not format_html (which requires
-        # interpolation args and raises TypeError when given a bare string in Django 6+).
-        oob_badge = (
-            mark_safe(" " + OOB_BADGE_HTML)  # noqa: S308  (leading space: it follows the port name)
-            if record.get("_source") == "oob"
-            else ""
-        )
+        # Leading space: the badge follows the port name.
+        oob_badge = oob_badge_html(record, leading_space=True)
         # Normalize None to "" in both branches; otherwise the linked branch
         # renders the literal "None" as the link text when value is missing.
         display_value = value or ""

--- a/netbox_librenms_plugin/tables/interfaces.py
+++ b/netbox_librenms_plugin/tables/interfaces.py
@@ -7,7 +7,6 @@ from netbox.tables.columns import BooleanColumn, ToggleColumn
 from utilities.paginator import EnhancedPaginator
 from utilities.templatetags.helpers import humanize_speed
 
-from netbox_librenms_plugin.constants import OOB_BADGE_HTML
 from netbox_librenms_plugin.models import InterfaceTypeMapping
 from netbox_librenms_plugin.utils import (
     check_vlan_group_matches,
@@ -20,6 +19,7 @@ from netbox_librenms_plugin.utils import (
     get_tagged_vlan_css_class,
     get_untagged_vlan_css_class,
     get_virtual_chassis_member,
+    oob_badge_html,
     render_vc_member_options,
 )
 
@@ -316,9 +316,7 @@ class LibreNMSInterfaceTable(tables.Table):
     def render_name(self, value, record):
         """Render interface name with appropriate styling based on comparison with NetBox"""
         rendered = self._render_field(value, record, self.interface_name_field, "name")
-        badges = ""
-        if record.get("_source") == "oob":
-            badges += OOB_BADGE_HTML
+        badges = oob_badge_html(record)
         if record.get("_dedup_conflict"):
             badges += '<span class="badge bg-warning text-dark ms-1" title="Same MAC seen on both main and OOB">Shared LOM</span>'
         if badges:

--- a/netbox_librenms_plugin/tables/interfaces.py
+++ b/netbox_librenms_plugin/tables/interfaces.py
@@ -20,6 +20,7 @@ from netbox_librenms_plugin.utils import (
     get_tagged_vlan_css_class,
     get_untagged_vlan_css_class,
     get_virtual_chassis_member,
+    render_vc_member_options,
 )
 
 
@@ -591,16 +592,11 @@ class VCInterfaceTable(LibreNMSInterfaceTable):
         # Create unique base ID for TomSelect components
         base_id = f"device_selection_{interface_name}_{hash(interface_name)}"
 
-        options = [
-            f'<option value="{member.id}"{" selected" if member.id == selected_member_id else ""}>{escape(member.name)}</option>'
-            for member in members
-        ]
-
         return format_html(
             '<select name="device_selection_{0}" id="{1}" class="form-select vc-member-select" data-interface="{0}" data-row-id="{0}">{2}</select>',
             interface_name,
             base_id,
-            mark_safe("".join(options)),
+            render_vc_member_options(members, selected_member_id),
         )
 
     def format_interface_data(self, port_data, device):

--- a/netbox_librenms_plugin/tables/modules.py
+++ b/netbox_librenms_plugin/tables/modules.py
@@ -3,12 +3,12 @@ from urllib.parse import urlencode, urlparse
 
 import django_tables2 as tables
 from django.urls import reverse
-from django.utils.html import escape, format_html, mark_safe
+from django.utils.html import format_html, mark_safe
 from netbox.tables.columns import ToggleColumn
 from utilities.paginator import EnhancedPaginator
 
 from netbox_librenms_plugin.constants import OOB_BADGE_HTML
-from netbox_librenms_plugin.utils import get_table_paginate_count
+from netbox_librenms_plugin.utils import get_table_paginate_count, render_vc_member_options
 
 
 class LibreNMSModuleTable(tables.Table):
@@ -966,21 +966,11 @@ class VCModuleTable(LibreNMSModuleTable):
         selected_device_id = record.get("selected_device_id") or self.device.id
         ent_index = record.get("ent_physical_index", "")
 
-        options = [
-            (
-                f'<option value="{member.id}"'
-                f"{' selected' if str(member.id) == str(selected_device_id) else ''}>"
-                f"{escape(member.name)}"
-                "</option>"
-            )
-            for member in self._vc_members
-        ]
-
         return format_html(
             '<select name="device_selection_{0}" id="device_selection_{0}" '
             'class="form-select vc-member-select" data-module="{0}" data-row-id="{0}">{1}</select>',
             ent_index,
-            mark_safe("".join(options)),
+            render_vc_member_options(self._vc_members, selected_device_id),
         )
 
     def format_module_data(self, record):

--- a/netbox_librenms_plugin/tables/modules.py
+++ b/netbox_librenms_plugin/tables/modules.py
@@ -7,8 +7,7 @@ from django.utils.html import format_html, mark_safe
 from netbox.tables.columns import ToggleColumn
 from utilities.paginator import EnhancedPaginator
 
-from netbox_librenms_plugin.constants import OOB_BADGE_HTML
-from netbox_librenms_plugin.utils import get_table_paginate_count, render_vc_member_options
+from netbox_librenms_plugin.utils import get_table_paginate_count, oob_badge_html, render_vc_member_options
 
 
 class LibreNMSModuleTable(tables.Table):
@@ -182,13 +181,7 @@ class LibreNMSModuleTable(tables.Table):
             rendered_name = display_name
 
         depth = record.get("depth", 0)
-        # Static trusted markup — use mark_safe, not format_html (which requires
-        # interpolation args and raises TypeError when given a bare string).
-        oob_badge = (
-            mark_safe(OOB_BADGE_HTML)  # noqa: S308
-            if record.get("_source") == "oob"
-            else ""
-        )
+        oob_badge = oob_badge_html(record)
         if depth == 0:
             return format_html("{}{}", rendered_name, oob_badge)
         # Build visual tree prefix based on nesting depth

--- a/netbox_librenms_plugin/templates/netbox_librenms_plugin/_interface_sync_content.html
+++ b/netbox_librenms_plugin/templates/netbox_librenms_plugin/_interface_sync_content.html
@@ -11,13 +11,6 @@
 </div>
 {% endif %}
 
-{% if interface_sync.relationship_data_incomplete %}
-<div class="alert alert-warning d-flex align-items-center noprint" role="alert">
-    <i class="mdi mdi-alert me-2"></i>
-    <div>LAG / sub-interface relationship data could not be fetched from LibreNMS on the last refresh, so the Parent / LAG column may be incomplete. Refresh again to retry.</div>
-</div>
-{% endif %}
-
 {# Migrated donors must not sync: hiding only the button leaves the POST form live (Enter in a filter still submits), so drop the form in migrated mode. #}
 {% with model_name=interface_sync.object|meta:"model_name" %}
 {% if migrated_to_marker %}

--- a/netbox_librenms_plugin/templates/netbox_librenms_plugin/_interface_sync_content.html
+++ b/netbox_librenms_plugin/templates/netbox_librenms_plugin/_interface_sync_content.html
@@ -376,7 +376,7 @@
                                     <td>{{ interface.description|default:"-" }}</td>
                                     {% if migrated_to_marker %}
                                     <td class="text-end">
-                                        {% include "netbox_librenms_plugin/inc/_migrate_move_button.html" with move_url_name="plugins:netbox_librenms_plugin:interface_move_to_winner" obj_id=interface.id obj_label=interface.name entity_word="interface" winner=migrated_to_winner server_key=migrated_to_marker.server_key %}
+                                        {% include "netbox_librenms_plugin/inc/_migrate_move_button.html" with move_url_name="plugins:netbox_librenms_plugin:interface_move_to_winner" obj_id=interface.id obj_label=interface.name entity_word="interface" winner=migrated_to_winner server_key=migrated_to_marker.server_key|default:interface_sync.server_key %}
                                     </td>
                                     {% endif %}
                                 </tr>

--- a/netbox_librenms_plugin/templates/netbox_librenms_plugin/_interface_sync_content.html
+++ b/netbox_librenms_plugin/templates/netbox_librenms_plugin/_interface_sync_content.html
@@ -23,6 +23,14 @@
     auto-submits, so it doesn't reintroduce the live-form problem flagged above.
     {% endcomment %}
     <input type="hidden" name="csrfmiddlewaretoken" value="{{ csrf_token }}">
+    {% comment %}
+    Prefer the marker-scoped server_key (the server the donor was migrated under), falling back
+    to the active interface_sync.server_key — the same precedence the migrated Move button uses,
+    so JS handlers reading this input target the right LibreNMS server in either case.
+    {% endcomment %}
+    {% with effective_server_key=migrated_to_marker.server_key|default:interface_sync.server_key %}
+    {% if effective_server_key %}<input type="hidden" name="server_key" value="{{ effective_server_key }}">{% endif %}
+    {% endwith %}
 {% else %}
 <form method="post"
     action="{% url 'plugins:netbox_librenms_plugin:sync_selected_interfaces' object_type=model_name object_id=interface_sync.object.pk %}?interface_name_field={{ interface_name_field }}">

--- a/netbox_librenms_plugin/templates/netbox_librenms_plugin/_interface_sync_content.html
+++ b/netbox_librenms_plugin/templates/netbox_librenms_plugin/_interface_sync_content.html
@@ -29,7 +29,7 @@
     so JS handlers reading this input target the right LibreNMS server in either case.
     {% endcomment %}
     {% with effective_server_key=migrated_to_marker.server_key|default:interface_sync.server_key %}
-    {% if effective_server_key %}<input type="hidden" name="server_key" value="{{ effective_server_key }}">{% endif %}
+    {% include "netbox_librenms_plugin/inc/_hidden_server_key.html" with server_key=effective_server_key %}
     {% endwith %}
 {% else %}
 <form method="post"
@@ -48,7 +48,8 @@
                 <span>Sync Selected Interfaces</span>
             </button>
             {% endif %}
-            <a href="#" class="m-2" data-bs-toggle="modal" data-bs-target="#interfaceTypeHelpModal">
+            <a href="#" class="m-2"
+                onclick="event.preventDefault(); showModal(document.getElementById('interfaceTypeHelpModal'))">
                 <i class="mdi mdi-help-circle"></i> info
             </a>
         </div>

--- a/netbox_librenms_plugin/templates/netbox_librenms_plugin/_interface_sync_content.html
+++ b/netbox_librenms_plugin/templates/netbox_librenms_plugin/_interface_sync_content.html
@@ -11,6 +11,13 @@
 </div>
 {% endif %}
 
+{% if interface_sync.relationship_data_incomplete %}
+<div class="alert alert-warning d-flex align-items-center noprint" role="alert">
+    <i class="mdi mdi-alert me-2"></i>
+    <div>LAG / sub-interface relationship data could not be fetched from LibreNMS on the last refresh, so the Parent / LAG column may be incomplete. Refresh again to retry.</div>
+</div>
+{% endif %}
+
 {# Migrated donors must not sync: hiding only the button leaves the POST form live (Enter in a filter still submits), so drop the form in migrated mode. #}
 {% with model_name=interface_sync.object|meta:"model_name" %}
 {% if migrated_to_marker %}

--- a/netbox_librenms_plugin/templates/netbox_librenms_plugin/_interface_sync_content.html
+++ b/netbox_librenms_plugin/templates/netbox_librenms_plugin/_interface_sync_content.html
@@ -321,9 +321,15 @@
                 <div class="alert alert-warning">
                     <i class="mdi mdi-alert me-2"></i>
                     {% if migrated_to_marker %}
+                    {% if migrated_to_winner %}
                     <strong>Warning:</strong> The following interfaces exist on the migrated donor but are not found in
                     the LibreNMS data. Moving an interface reassigns it, along with related cables/IPs/MACs, to the
                     migration winner.
+                    {% else %}
+                    <strong>Warning:</strong> The following interfaces exist on the migrated donor but are not found in
+                    the LibreNMS data. The migration winner is unavailable, so these interfaces can't be moved until the
+                    stale marker is resolved.
+                    {% endif %}
                     {% else %}
                     <strong>Warning:</strong> The following interfaces exist in NetBox but are not found in the LibreNMS
                     data.

--- a/netbox_librenms_plugin/templates/netbox_librenms_plugin/_ipaddress_sync_content.html
+++ b/netbox_librenms_plugin/templates/netbox_librenms_plugin/_ipaddress_sync_content.html
@@ -175,22 +175,7 @@ the interface move-to-winner control in _interface_sync_content.html.
                     <td>{{ ip.address }}</td>
                     <td>{{ ip.interface_name|default:"-" }}</td>
                     <td class="text-end">
-                        {% if has_write_permission and migrated_to_winner %}
-                        <button type="button"
-                            class="btn btn-sm btn-outline-warning"
-                            hx-post="{% url 'plugins:netbox_librenms_plugin:ipaddress_move_to_winner' pk=ip.id %}"
-                            hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'
-                            {% if migrated_to_marker.server_key %}hx-vals='{"server_key": "{{ migrated_to_marker.server_key|escapejs }}"}'{% elif ip_sync.server_key %}hx-vals='{"server_key": "{{ ip_sync.server_key|escapejs }}"}'{% endif %}
-                            hx-swap="none"
-                            hx-confirm="Move IP '{{ ip.address }}' to {{ migrated_to_winner.name }}?"
-                            title="Reassign this IP to {{ migrated_to_winner.name }}'s '{{ ip.interface_name }}' interface">
-                            <i class="mdi mdi-transfer-right"></i> Move
-                        </button>
-                        {% elif migrated_to_winner %}
-                        <span class="text-muted small">read-only</span>
-                        {% else %}
-                        <span class="text-muted small">winner missing</span>
-                        {% endif %}
+                        {% include "netbox_librenms_plugin/inc/_migrate_move_button.html" with move_url_name="plugins:netbox_librenms_plugin:ipaddress_move_to_winner" obj_id=ip.id obj_label=ip.address entity_word="IP" obj_interface_name=ip.interface_name winner=migrated_to_winner server_key=migrated_to_marker.server_key|default:ip_sync.server_key %}
                     </td>
                 </tr>
                 {% endfor %}

--- a/netbox_librenms_plugin/templates/netbox_librenms_plugin/_ipaddress_sync_content.html
+++ b/netbox_librenms_plugin/templates/netbox_librenms_plugin/_ipaddress_sync_content.html
@@ -157,6 +157,11 @@ the interface move-to-winner control in _interface_sync_content.html.
         Move IP addresses{% if migrated_to_winner %} to {{ migrated_to_winner.name }}{% endif %}
     </div>
     <div class="card-body">
+        {% if not migrated_to_winner %}
+        <div class="alert alert-warning py-2" role="alert">
+            The migration winner is unavailable. Restore the winner device before moving these IP addresses.
+        </div>
+        {% endif %}
         <p class="text-muted small mb-2">
             Re-home a donor interface-assigned IP to the winner's same-named interface
             (move the interface first if it doesn't exist on the winner yet).

--- a/netbox_librenms_plugin/templates/netbox_librenms_plugin/_ipaddress_sync_content.html
+++ b/netbox_librenms_plugin/templates/netbox_librenms_plugin/_ipaddress_sync_content.html
@@ -144,3 +144,60 @@
     </div>
 </div>
 {% endif %}
+
+{% comment %}
+Migrated donor: per-row "Move IP to winner" actions. Re-homes an interface-assigned IP to the
+winner's same-named interface (the backend validates and fails closed via an OOB toast). Mirrors
+the interface move-to-winner control in _interface_sync_content.html.
+{% endcomment %}
+{% if migrated_to_marker and ip_sync.movable_ips %}
+<div class="card mt-3">
+    <div class="card-header">
+        <i class="mdi mdi-transfer-right"></i>
+        Move IP addresses{% if migrated_to_winner %} to {{ migrated_to_winner.name }}{% endif %}
+    </div>
+    <div class="card-body">
+        <p class="text-muted small mb-2">
+            Re-home a donor interface-assigned IP to the winner's same-named interface
+            (move the interface first if it doesn't exist on the winner yet).
+        </p>
+        <div class="table-responsive">
+            <table class="table table-hover" id="librenms-ipaddress-migrate-table">
+                <thead>
+                    <tr>
+                        <th>IP Address</th>
+                        <th>Interface</th>
+                        <th class="text-end">Migrate</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for ip in ip_sync.movable_ips %}
+                    <tr>
+                        <td>{{ ip.address }}</td>
+                        <td>{{ ip.interface_name|default:"-" }}</td>
+                        <td class="text-end">
+                            {% if has_write_permission and migrated_to_winner %}
+                            <button type="button"
+                                class="btn btn-sm btn-outline-warning"
+                                hx-post="{% url 'plugins:netbox_librenms_plugin:ipaddress_move_to_winner' pk=ip.id %}"
+                                hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'
+                                {% if migrated_to_marker.server_key %}hx-vals='{"server_key": "{{ migrated_to_marker.server_key|escapejs }}"}'{% elif ip_sync.server_key %}hx-vals='{"server_key": "{{ ip_sync.server_key|escapejs }}"}'{% endif %}
+                                hx-swap="none"
+                                hx-confirm="Move IP '{{ ip.address }}' to {{ migrated_to_winner.name }}?"
+                                title="Reassign this IP to {{ migrated_to_winner.name }}'s '{{ ip.interface_name }}' interface">
+                                <i class="mdi mdi-transfer-right"></i> Move
+                            </button>
+                            {% elif migrated_to_winner %}
+                            <span class="text-muted small">read-only</span>
+                            {% else %}
+                            <span class="text-muted small">winner missing</span>
+                            {% endif %}
+                        </td>
+                    </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        </div>
+    </div>
+</div>
+{% endif %}

--- a/netbox_librenms_plugin/templates/netbox_librenms_plugin/_ipaddress_sync_content.html
+++ b/netbox_librenms_plugin/templates/netbox_librenms_plugin/_ipaddress_sync_content.html
@@ -161,43 +161,41 @@ the interface move-to-winner control in _interface_sync_content.html.
             Re-home a donor interface-assigned IP to the winner's same-named interface
             (move the interface first if it doesn't exist on the winner yet).
         </p>
-        <div class="table-responsive">
-            <table class="table table-hover" id="librenms-ipaddress-migrate-table">
-                <thead>
-                    <tr>
-                        <th>IP Address</th>
-                        <th>Interface</th>
-                        <th class="text-end">Migrate</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    {% for ip in ip_sync.movable_ips %}
-                    <tr>
-                        <td>{{ ip.address }}</td>
-                        <td>{{ ip.interface_name|default:"-" }}</td>
-                        <td class="text-end">
-                            {% if has_write_permission and migrated_to_winner %}
-                            <button type="button"
-                                class="btn btn-sm btn-outline-warning"
-                                hx-post="{% url 'plugins:netbox_librenms_plugin:ipaddress_move_to_winner' pk=ip.id %}"
-                                hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'
-                                {% if migrated_to_marker.server_key %}hx-vals='{"server_key": "{{ migrated_to_marker.server_key|escapejs }}"}'{% elif ip_sync.server_key %}hx-vals='{"server_key": "{{ ip_sync.server_key|escapejs }}"}'{% endif %}
-                                hx-swap="none"
-                                hx-confirm="Move IP '{{ ip.address }}' to {{ migrated_to_winner.name }}?"
-                                title="Reassign this IP to {{ migrated_to_winner.name }}'s '{{ ip.interface_name }}' interface">
-                                <i class="mdi mdi-transfer-right"></i> Move
-                            </button>
-                            {% elif migrated_to_winner %}
-                            <span class="text-muted small">read-only</span>
-                            {% else %}
-                            <span class="text-muted small">winner missing</span>
-                            {% endif %}
-                        </td>
-                    </tr>
-                    {% endfor %}
-                </tbody>
-            </table>
-        </div>
+        <table class="table table-hover" id="librenms-ipaddress-migrate-table">
+            <thead>
+                <tr>
+                    <th>IP Address</th>
+                    <th>Interface</th>
+                    <th class="text-end">Migrate</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for ip in ip_sync.movable_ips %}
+                <tr>
+                    <td>{{ ip.address }}</td>
+                    <td>{{ ip.interface_name|default:"-" }}</td>
+                    <td class="text-end">
+                        {% if has_write_permission and migrated_to_winner %}
+                        <button type="button"
+                            class="btn btn-sm btn-outline-warning"
+                            hx-post="{% url 'plugins:netbox_librenms_plugin:ipaddress_move_to_winner' pk=ip.id %}"
+                            hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'
+                            {% if migrated_to_marker.server_key %}hx-vals='{"server_key": "{{ migrated_to_marker.server_key|escapejs }}"}'{% elif ip_sync.server_key %}hx-vals='{"server_key": "{{ ip_sync.server_key|escapejs }}"}'{% endif %}
+                            hx-swap="none"
+                            hx-confirm="Move IP '{{ ip.address }}' to {{ migrated_to_winner.name }}?"
+                            title="Reassign this IP to {{ migrated_to_winner.name }}'s '{{ ip.interface_name }}' interface">
+                            <i class="mdi mdi-transfer-right"></i> Move
+                        </button>
+                        {% elif migrated_to_winner %}
+                        <span class="text-muted small">read-only</span>
+                        {% else %}
+                        <span class="text-muted small">winner missing</span>
+                        {% endif %}
+                    </td>
+                </tr>
+                {% endfor %}
+            </tbody>
+        </table>
     </div>
 </div>
 {% endif %}

--- a/netbox_librenms_plugin/templates/netbox_librenms_plugin/_module_sync_content.html
+++ b/netbox_librenms_plugin/templates/netbox_librenms_plugin/_module_sync_content.html
@@ -24,7 +24,7 @@
     hx-post="{% url 'plugins:netbox_librenms_plugin:install_selected' pk=module_sync.object.pk %}"
     hx-target="#module-sync-content" hx-swap="innerHTML" hx-disabled-elt="find button">
     {% csrf_token %}
-    {% if module_sync.server_key %}<input type="hidden" name="server_key" value="{{ module_sync.server_key }}">{% endif %}
+    {% include "netbox_librenms_plugin/inc/_hidden_server_key.html" with server_key=module_sync.server_key %}
     <div class="noprint mb-3">
         <button type="submit" class="btn btn-primary" id="install-selected-btn">
             <span class="lnms-btn-idle"><i class="mdi mdi-package-down"></i> Install Selected</span>
@@ -40,7 +40,7 @@ Emit them as standalone hidden inputs so the verify fetch keeps working — mirr
 interface/IP/VLAN fragments.
 {% endcomment %}
 <input type="hidden" name="csrfmiddlewaretoken" value="{{ csrf_token }}">
-{% if module_sync.server_key %}<input type="hidden" name="server_key" value="{{ module_sync.server_key }}">{% endif %}
+{% include "netbox_librenms_plugin/inc/_hidden_server_key.html" with server_key=module_sync.server_key %}
 {% endif %}
 <div class="card">
     {% include 'netbox_librenms_plugin/inc/paginator.html' with table=module_sync.table %}

--- a/netbox_librenms_plugin/templates/netbox_librenms_plugin/_vlan_sync_content.html
+++ b/netbox_librenms_plugin/templates/netbox_librenms_plugin/_vlan_sync_content.html
@@ -32,7 +32,7 @@
     form-submit action input is form-only, so it stays gated.
     {% endcomment %}
     {% csrf_token %}
-    {% if vlan_sync.server_key %}<input type="hidden" name="server_key" value="{{ vlan_sync.server_key }}">{% endif %}
+    {% include "netbox_librenms_plugin/inc/_hidden_server_key.html" with server_key=vlan_sync.server_key %}
     {% if not migrated_to_marker %}
     <input type="hidden" name="action" value="create_vlans">
     {% endif %}

--- a/netbox_librenms_plugin/templates/netbox_librenms_plugin/htmx/_add_as_oob_form.html
+++ b/netbox_librenms_plugin/templates/netbox_librenms_plugin/htmx/_add_as_oob_form.html
@@ -1,0 +1,16 @@
+{% comment %}
+Add-as-OOB action form, shared by the serial-match and primary_ip-match panes of
+device_validation_details.html so the two can't drift (same rationale as
+_existing_librenms_link_status.html). Expects the panes' rendering context:
+validation (existing_device), libre_device (device_id) and server_key.
+{% endcomment %}
+<form hx-post="{% url 'plugins:netbox_librenms_plugin:device_add_as_oob' device_id=libre_device.device_id %}"
+      hx-swap="none">
+  {% csrf_token %}
+  <input type="hidden" name="existing_device_id" value="{{ validation.existing_device.pk }}">
+  {% include "netbox_librenms_plugin/inc/_hidden_server_key.html" %}
+  {% include "netbox_librenms_plugin/htmx/_oob_interface_select.html" %}
+  <button type="submit" class="btn btn-sm btn-primary">
+    <i class="mdi mdi-chip"></i> Add as OOB to {{ validation.existing_device.name }}
+  </button>
+</form>

--- a/netbox_librenms_plugin/templates/netbox_librenms_plugin/htmx/device_validation_details.html
+++ b/netbox_librenms_plugin/templates/netbox_librenms_plugin/htmx/device_validation_details.html
@@ -434,9 +434,6 @@
         hx-include="#use-sysname-toggle, #strip-domain-toggle">
         {% csrf_token %}
         {% include "netbox_librenms_plugin/inc/_hidden_server_key.html" %}
-        {# Default to the host-named winner's donor (oob) so a JS failure still posts a valid donor. #}
-        <input type="hidden" name="donor_pk" id="merge-donor-{{ libre_device.device_id }}"
-               value="{{ validation.merge_candidates.oob_named.pk }}">
         <div class="mb-3">
           <div class="text-muted small mb-2">Choose the winner (kept). The other becomes the donor (absorbed):</div>
           {% with host=validation.merge_candidates.host_named oob=validation.merge_candidates.oob_named %}
@@ -444,7 +441,6 @@
             <input class="form-check-input merge-winner-radio" type="radio" name="winner_pk"
                    id="merge-winner-host-{{ libre_device.device_id }}"
                    value="{{ host.pk }}"
-                   data-donor-pk="{{ oob.pk }}"
                    checked>
             <label class="form-check-label" for="merge-winner-host-{{ libre_device.device_id }}">
               <span class="badge bg-primary-lt me-1">Host name match</span>
@@ -455,8 +451,7 @@
           <div class="form-check mb-1">
             <input class="form-check-input merge-winner-radio" type="radio" name="winner_pk"
                    id="merge-winner-oob-{{ libre_device.device_id }}"
-                   value="{{ oob.pk }}"
-                   data-donor-pk="{{ host.pk }}">
+                   value="{{ oob.pk }}">
             <label class="form-check-label" for="merge-winner-oob-{{ libre_device.device_id }}">
               <span class="badge bg-purple text-white me-1">Serial match (OOB)</span>
               <strong>{{ oob.name }}</strong>
@@ -469,24 +464,6 @@
           <i class="mdi mdi-merge"></i> Merge donor into selected winner
         </button>
       </form>
-      <script>
-        (function() {
-          var donorInput = document.getElementById("merge-donor-{{ libre_device.device_id }}");
-          if (!donorInput) return;
-          // Scope to THIS form: a document-wide query would pick up merge-winner radios from
-          // another validation fragment left in the DOM and write the wrong donor_pk, merging
-          // the wrong NetBox device.
-          var form = donorInput.closest("form");
-          var radios = form ? form.querySelectorAll('input.merge-winner-radio[name="winner_pk"]') : [];
-          function syncDonor() {
-            radios.forEach(function(r) {
-              if (r.checked) { donorInput.value = r.dataset.donorPk || ""; }
-            });
-          }
-          radios.forEach(function(r) { r.addEventListener("change", syncDonor); });
-          syncDonor();
-        })();
-      </script>
 
     {% elif validation.existing_match_type == 'librenms_id' %}
       <div class="alert alert-info py-2 mb-3 d-flex flex-wrap align-items-center gap-1">

--- a/netbox_librenms_plugin/templates/netbox_librenms_plugin/htmx/device_validation_details.html
+++ b/netbox_librenms_plugin/templates/netbox_librenms_plugin/htmx/device_validation_details.html
@@ -433,7 +433,7 @@
         hx-swap="none"
         hx-include="#use-sysname-toggle, #strip-domain-toggle">
         {% csrf_token %}
-        <input type="hidden" name="server_key" value="{{ server_key }}">
+        {% include "netbox_librenms_plugin/inc/_hidden_server_key.html" %}
         {# Default to the host-named winner's donor (oob) so a JS failure still posts a valid donor. #}
         <input type="hidden" name="donor_pk" id="merge-donor-{{ libre_device.device_id }}"
                value="{{ validation.merge_candidates.oob_named.pk }}">
@@ -816,7 +816,7 @@
                       hx-include="#use-sysname-toggle, #strip-domain-toggle">
                   {% csrf_token %}
                   <input type="hidden" name="existing_device_id" value="{{ validation.existing_device.pk }}">
-                  <input type="hidden" name="server_key" value="{{ server_key }}">
+                  {% include "netbox_librenms_plugin/inc/_hidden_server_key.html" %}
 
                   <div class="modal-header py-2">
                     <h5 class="modal-title" id="promote-modal-label-{{ libre_device.device_id }}">Promote to host of {{ validation.existing_device.name }}</h5>

--- a/netbox_librenms_plugin/templates/netbox_librenms_plugin/htmx/device_validation_details.html
+++ b/netbox_librenms_plugin/templates/netbox_librenms_plugin/htmx/device_validation_details.html
@@ -748,16 +748,7 @@
           </div>
         </div>
         <div class="mb-3">
-          <form hx-post="{% url 'plugins:netbox_librenms_plugin:device_add_as_oob' device_id=libre_device.device_id %}"
-                hx-swap="none">
-            {% csrf_token %}
-            <input type="hidden" name="existing_device_id" value="{{ validation.existing_device.pk }}">
-            {% include "netbox_librenms_plugin/inc/_hidden_server_key.html" %}
-            {% include "netbox_librenms_plugin/htmx/_oob_interface_select.html" %}
-            <button type="submit" class="btn btn-sm btn-primary">
-              <i class="mdi mdi-chip"></i> Add as OOB to {{ validation.existing_device.name }}
-            </button>
-          </form>
+          {% include "netbox_librenms_plugin/htmx/_add_as_oob_form.html" %}
         </div>
       </div>
       {% endif %}
@@ -1036,16 +1027,7 @@
           {% if validation.oob_candidate.ip %}— {{ validation.oob_candidate.ip }}{% endif %}).
         </div>
         <div class="mb-3">
-          <form hx-post="{% url 'plugins:netbox_librenms_plugin:device_add_as_oob' device_id=libre_device.device_id %}"
-                hx-swap="none">
-            {% csrf_token %}
-            <input type="hidden" name="existing_device_id" value="{{ validation.existing_device.pk }}">
-            {% include "netbox_librenms_plugin/inc/_hidden_server_key.html" %}
-            {% include "netbox_librenms_plugin/htmx/_oob_interface_select.html" %}
-            <button type="submit" class="btn btn-sm btn-primary">
-              <i class="mdi mdi-chip"></i> Add as OOB to {{ validation.existing_device.name }}
-            </button>
-          </form>
+          {% include "netbox_librenms_plugin/htmx/_add_as_oob_form.html" %}
         </div>
       {% else %}
       <div class="alert alert-warning py-2 mb-3 d-flex flex-wrap align-items-center gap-1">

--- a/netbox_librenms_plugin/templates/netbox_librenms_plugin/htmx/device_validation_details.html
+++ b/netbox_librenms_plugin/templates/netbox_librenms_plugin/htmx/device_validation_details.html
@@ -412,6 +412,75 @@
           devices. Pick which one to keep; the other will be marked as merged.
         </span>
       </div>
+      <div class="alert alert-info py-2 mb-3 small">
+        <div class="mb-1">
+          <i class="mdi mdi-information-outline"></i>
+          <strong>Pick the device to keep (winner).</strong>
+          The other one becomes the <em>donor</em> and is absorbed.
+        </div>
+        <ul class="mb-1 ps-3">
+          <li><strong>Moved to winner:</strong> LibreNMS link (host id, OOB id, OOB type) and OOB IP <span class="text-muted">(only if the winner has no OOB IP yet)</span>.</li>
+          <li><strong>Stays on donor:</strong> interfaces, cables, primary IP. Re-home them later from the donor's <em>"Migrated to ..."</em> tab.</li>
+        </ul>
+        <div class="text-muted">
+          <i class="mdi mdi-alert-outline"></i>
+          The donor device is <strong>not deleted</strong>. After you have re-homed its
+          child objects, you can delete it from NetBox manually if no longer needed.
+        </div>
+      </div>
+      <form
+        hx-post="{% url 'plugins:netbox_librenms_plugin:device_merge_netbox_devices' device_id=libre_device.device_id %}"
+        hx-swap="none">
+        {% csrf_token %}
+        <input type="hidden" name="server_key" value="{{ server_key }}">
+        {# Default to the host-named winner's donor (oob) so a JS failure still posts a valid donor. #}
+        <input type="hidden" name="donor_pk" id="merge-donor-{{ libre_device.device_id }}"
+               value="{{ validation.merge_candidates.oob_named.pk }}">
+        <div class="mb-3">
+          <div class="text-muted small mb-2">Choose the winner (kept). The other becomes the donor (absorbed):</div>
+          {% with host=validation.merge_candidates.host_named oob=validation.merge_candidates.oob_named %}
+          <div class="form-check mb-1">
+            <input class="form-check-input merge-winner-radio" type="radio" name="winner_pk"
+                   id="merge-winner-host-{{ libre_device.device_id }}"
+                   value="{{ host.pk }}"
+                   data-donor-pk="{{ oob.pk }}"
+                   checked>
+            <label class="form-check-label" for="merge-winner-host-{{ libre_device.device_id }}">
+              <span class="badge bg-primary-lt me-1">Host name match</span>
+              <strong>{{ host.name }}</strong>
+              <span class="text-muted">— matches LibreNMS hostname{% if host.librenms_link.host_id %}, currently linked to LibreNMS device #{{ host.librenms_link.host_id }}{% if host.librenms_link.oob_id %} (OOB #{{ host.librenms_link.oob_id }}{% if host.librenms_link.oob_type %}, {{ host.librenms_link.oob_type }}{% endif %}){% endif %}{% else %}, not linked to LibreNMS{% endif %}</span>
+            </label>
+          </div>
+          <div class="form-check mb-1">
+            <input class="form-check-input merge-winner-radio" type="radio" name="winner_pk"
+                   id="merge-winner-oob-{{ libre_device.device_id }}"
+                   value="{{ oob.pk }}"
+                   data-donor-pk="{{ host.pk }}">
+            <label class="form-check-label" for="merge-winner-oob-{{ libre_device.device_id }}">
+              <span class="badge bg-purple text-white me-1">Serial match (OOB)</span>
+              <strong>{{ oob.name }}</strong>
+              <span class="text-muted">— matches chassis serial{% if oob.librenms_link.host_id %}, currently linked to LibreNMS device #{{ oob.librenms_link.host_id }}{% if oob.librenms_link.oob_id %} (OOB #{{ oob.librenms_link.oob_id }}{% if oob.librenms_link.oob_type %}, {{ oob.librenms_link.oob_type }}{% endif %}){% endif %}{% else %}, not linked to LibreNMS{% endif %}</span>
+            </label>
+          </div>
+          {% endwith %}
+        </div>
+        <button type="submit" class="btn btn-sm btn-warning">
+          <i class="mdi mdi-merge"></i> Merge donor into selected winner
+        </button>
+      </form>
+      <script>
+        (function() {
+          var donorInput = document.getElementById("merge-donor-{{ libre_device.device_id }}");
+          var radios = document.querySelectorAll('input.merge-winner-radio[name="winner_pk"]');
+          function syncDonor() {
+            radios.forEach(function(r) {
+              if (r.checked) { donorInput.value = r.dataset.donorPk || ""; }
+            });
+          }
+          radios.forEach(function(r) { r.addEventListener("change", syncDonor); });
+          syncDonor();
+        })();
+      </script>
 
     {% elif validation.existing_match_type == 'librenms_id' %}
       <div class="alert alert-info py-2 mb-3 d-flex flex-wrap align-items-center gap-1">
@@ -683,6 +752,215 @@
               <i class="mdi mdi-chip"></i> Add as OOB to {{ validation.existing_device.name }}
             </button>
           </form>
+        </div>
+      </div>
+      {% endif %}
+      {% if validation.promote_to_host %}
+      <div id="serial-role-host-{{ libre_device.device_id }}"
+           {% if validation.serial_role_choice_available and validation.serial_action != 'promote_to_host' %}style="display:none"{% endif %}>
+        <div class="alert alert-info py-2 mb-3 small">
+          <div class="d-flex align-items-center gap-2 mb-1">
+            <i class="mdi mdi-swap-horizontal"></i>
+            <strong>Promote effect on
+              <a href="{{ existing_device_url }}" target="_blank" rel="noopener noreferrer">{{ validation.existing_device.name }}</a>
+            </strong>
+          </div>
+          <table class="table table-sm table-borderless mb-1" style="width:auto;">
+            <thead>
+              <tr class="text-muted">
+                <th class="py-0 pe-3 fw-normal">Slot</th>
+                <th class="py-0 pe-3 fw-normal">Before</th>
+                <th class="py-0 pe-3 fw-normal"></th>
+                <th class="py-0 fw-normal">After</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td class="py-0 pe-3"><span class="badge bg-info-lt"><i class="mdi mdi-server"></i> Host</span></td>
+                <td class="py-0 pe-3 text-muted">#{{ validation.promote_to_host.existing_libre_id }}</td>
+                <td class="py-0 pe-3 text-muted"><i class="mdi mdi-arrow-right"></i></td>
+                <td class="py-0">#{{ libre_device.device_id }} <span class="text-muted">({{ validation.resolved_name|default:libre_device.sysName|default:libre_device.hostname }})</span></td>
+              </tr>
+              <tr>
+                <td class="py-0 pe-3"><span class="badge bg-purple-lt"><i class="mdi mdi-chip"></i> OOB</span></td>
+                <td class="py-0 pe-3 text-muted">--</td>
+                <td class="py-0 pe-3 text-muted"><i class="mdi mdi-arrow-right"></i></td>
+                <td class="py-0">#{{ validation.promote_to_host.existing_libre_id }} <span class="text-muted">({{ validation.promote_to_host.existing_oob_type }})</span></td>
+              </tr>
+            </tbody>
+          </table>
+          <div class="text-muted">
+            <i class="mdi mdi-information-outline"></i>
+            Existing device is updated in place -- no new NetBox device is created.
+          </div>
+        </div>
+        <div class="mb-3">
+          <button type="button"
+                  class="btn btn-sm btn-primary promote-modal-trigger"
+                  data-modal-target="promote-modal-{{ libre_device.device_id }}">
+            <i class="mdi mdi-server"></i> Promote to host of {{ validation.existing_device.name }}...
+          </button>
+
+          <div class="modal fade" id="promote-modal-{{ libre_device.device_id }}" tabindex="-1" aria-hidden="true">
+            <div class="modal-dialog modal-dialog-centered">
+              <div class="modal-content">
+                <form hx-post="{% url 'plugins:netbox_librenms_plugin:device_promote_to_host' device_id=libre_device.device_id %}"
+                      hx-swap="none"
+                      hx-include="#use-sysname-toggle, #strip-domain-toggle">
+                  {% csrf_token %}
+                  <input type="hidden" name="existing_device_id" value="{{ validation.existing_device.pk }}">
+                  <input type="hidden" name="server_key" value="{{ server_key }}">
+
+                  <div class="modal-header py-2">
+                    <h5 class="modal-title">Promote to host of {{ validation.existing_device.name }}</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                  </div>
+                  <div class="modal-body small">
+                    <p class="text-muted mb-3">
+                      Pick which value to keep on the existing NetBox device. Defaults are
+                      <strong>Keep current</strong> for every field — the original promote
+                      behaviour is unchanged unless you explicitly choose <em>Use new</em>.
+                    </p>
+
+                    {# Name: use resolved_name so the sysName/strip_domain pipeline is respected #}
+                    {% with new_name=validation.resolved_name|default:libre_device.sysName|default:libre_device.hostname %}
+                    <fieldset class="mb-3">
+                      <legend class="fs-6 mb-1">Name</legend>
+                      <div class="form-check">
+                        <input class="form-check-input" type="radio" name="_promote_name_choice"
+                               id="promote-name-keep-{{ libre_device.device_id }}" value="keep" checked>
+                        <label class="form-check-label" for="promote-name-keep-{{ libre_device.device_id }}">
+                          Keep <code>{{ validation.existing_device.name }}</code>
+                        </label>
+                      </div>
+                      <div class="form-check">
+                        <input class="form-check-input" type="radio" name="_promote_name_choice"
+                               id="promote-name-new-{{ libre_device.device_id }}" value="new"
+                               data-override-target="override_name"
+                               data-override-value="{{ new_name }}"
+                               {% if not new_name or new_name == validation.existing_device.name %}disabled{% endif %}>
+                        <label class="form-check-label" for="promote-name-new-{{ libre_device.device_id }}">
+                          Use <code>{{ new_name|default:"—" }}</code>
+                        </label>
+                      </div>
+                      <input type="hidden" name="override_name" value="">
+                    </fieldset>
+                    {% endwith %}
+
+                    {# Device type #}
+                    <fieldset class="mb-3">
+                      <legend class="fs-6 mb-1">Device type</legend>
+                      <div class="form-check">
+                        <input class="form-check-input" type="radio" name="_promote_dt_choice"
+                               id="promote-dt-keep-{{ libre_device.device_id }}" value="keep" checked>
+                        <label class="form-check-label" for="promote-dt-keep-{{ libre_device.device_id }}">
+                          Keep <code>{{ validation.existing_device.device_type|default:"—" }}</code>
+                        </label>
+                      </div>
+                      <div class="form-check">
+                        <input class="form-check-input" type="radio" name="_promote_dt_choice"
+                               id="promote-dt-new-{{ libre_device.device_id }}" value="new"
+                               data-override-target="override_device_type_id"
+                               data-override-value="{% if validation.device_type.device_type %}{{ validation.device_type.device_type.pk }}{% endif %}"
+                               {% if not validation.device_type.device_type or validation.existing_device.device_type_id == validation.device_type.device_type.pk %}disabled{% endif %}>
+                        <label class="form-check-label" for="promote-dt-new-{{ libre_device.device_id }}">
+                          {% if validation.device_type.device_type %}
+                            Use <code>{{ validation.device_type.device_type }}</code>
+                          {% else %}
+                            <span class="text-muted">No NetBox device type matches LibreNMS hardware
+                            <em>{{ libre_device.hardware|default:"—" }}</em>. Use the
+                            <strong>Add Mapping</strong> shortcut on the Device Type row first.</span>
+                          {% endif %}
+                        </label>
+                      </div>
+                      <input type="hidden" name="override_device_type_id" value="">
+                    </fieldset>
+
+                    {# Platform #}
+                    <fieldset class="mb-3">
+                      <legend class="fs-6 mb-1">Platform</legend>
+                      <div class="form-check">
+                        <input class="form-check-input" type="radio" name="_promote_pl_choice"
+                               id="promote-pl-keep-{{ libre_device.device_id }}" value="keep" checked>
+                        <label class="form-check-label" for="promote-pl-keep-{{ libre_device.device_id }}">
+                          Keep <code>{{ validation.existing_device.platform|default:"—" }}</code>
+                        </label>
+                      </div>
+                      <div class="form-check">
+                        <input class="form-check-input" type="radio" name="_promote_pl_choice"
+                               id="promote-pl-new-{{ libre_device.device_id }}" value="new"
+                               data-override-target="override_platform_id"
+                               data-override-value="{% if validation.platform.platform %}{{ validation.platform.platform.pk }}{% endif %}"
+                               {% if not validation.platform.platform or validation.existing_device.platform_id == validation.platform.platform.pk %}disabled{% endif %}>
+                        <label class="form-check-label" for="promote-pl-new-{{ libre_device.device_id }}">
+                          {% if validation.platform.platform %}
+                            Use <code>{{ validation.platform.platform }}</code>
+                          {% else %}
+                            <span class="text-muted">No NetBox platform matches LibreNMS OS
+                            <em>{{ libre_device.os|default:"—" }}</em>. Use the
+                            <strong>Add Mapping</strong> shortcut on the Platform row first.</span>
+                          {% endif %}
+                        </label>
+                      </div>
+                      <input type="hidden" name="override_platform_id" value="">
+                    </fieldset>
+                  </div>
+                  <div class="modal-footer py-2">
+                    <button type="button" class="btn btn-sm btn-secondary" data-bs-dismiss="modal">Cancel</button>
+                    <button type="submit" class="btn btn-sm btn-primary">
+                      <i class="mdi mdi-server"></i> Confirm Promote
+                    </button>
+                  </div>
+                </form>
+              </div>
+            </div>
+          </div>
+
+          <script>
+            (function () {
+              var modal = document.getElementById("promote-modal-{{ libre_device.device_id }}");
+              if (!modal) return;
+              // The nested promote modal's DOM persists across close/reopen, so reset
+              // its radios + override_* hidden inputs on close — otherwise a stale "Use
+              // new" selection can submit even when the dialog shows "Keep current".
+              var promoteForm = modal.querySelector("form");
+              function resetPromoteForm() {
+                if (!promoteForm) return;
+                promoteForm.reset();
+                promoteForm.querySelectorAll('input[type="hidden"][name^="override_"]').forEach(function (input) {
+                  input.value = "";
+                });
+              }
+              if (!modal.dataset.promoteResetBound) {
+                modal.dataset.promoteResetBound = "1";
+                modal.addEventListener("hidden.bs.modal", resetPromoteForm);
+                // Fallback when Bootstrap's modal JS isn't active: the dismiss buttons
+                // only hide the modal and never fire hidden.bs.modal, so a stale "Use
+                // new" selection would persist across reopen. Reset on their click too.
+                modal.querySelectorAll('[data-bs-dismiss="modal"]').forEach(function (btn) {
+                  btn.addEventListener("click", resetPromoteForm);
+                });
+              }
+              modal.addEventListener("change", function (e) {
+                var t = e.target;
+                if (!t || t.type !== "radio") return;
+                var name = t.name;
+                if (!name || !name.startsWith("_promote_")) return;
+                var group = modal.querySelectorAll('input[name="' + name + '"]');
+                group.forEach(function (r) {
+                  var target = r.getAttribute("data-override-target");
+                  if (!target) return;
+                  var hidden = modal.querySelector('input[type=hidden][name="' + target + '"]');
+                  if (!hidden) return;
+                  if (r.checked && r.value === "new") {
+                    hidden.value = r.getAttribute("data-override-value") || "";
+                  } else if (r.checked && r.value === "keep") {
+                    hidden.value = "";
+                  }
+                });
+              });
+            })();
+          </script>
         </div>
       </div>
       {% endif %}

--- a/netbox_librenms_plugin/templates/netbox_librenms_plugin/htmx/device_validation_details.html
+++ b/netbox_librenms_plugin/templates/netbox_librenms_plugin/htmx/device_validation_details.html
@@ -448,7 +448,7 @@
             <label class="form-check-label" for="merge-winner-host-{{ libre_device.device_id }}">
               <span class="badge bg-primary-lt me-1">Host name match</span>
               <strong>{{ host.name }}</strong>
-              <span class="text-muted">— matches LibreNMS hostname{% if host.librenms_link.host_id %}, currently linked to LibreNMS device #{{ host.librenms_link.host_id }}{% if host.librenms_link.oob_id %} (OOB #{{ host.librenms_link.oob_id }}{% if host.librenms_link.oob_type %}, {{ host.librenms_link.oob_type }}{% endif %}){% endif %}{% else %}, not linked to LibreNMS{% endif %}</span>
+              <span class="text-muted">— matches LibreNMS hostname{% if host.librenms_link.host_id %}, currently linked to LibreNMS device #{{ host.librenms_link.host_id }}{% if host.librenms_link.oob_id %} (OOB #{{ host.librenms_link.oob_id }}{% if host.librenms_link.oob_type %}, {{ host.librenms_link.oob_type }}{% endif %}){% endif %}{% elif host.librenms_link.oob_id %}, currently linked to LibreNMS as OOB #{{ host.librenms_link.oob_id }}{% if host.librenms_link.oob_type %} ({{ host.librenms_link.oob_type }}){% endif %}{% else %}, not linked to LibreNMS{% endif %}</span>
             </label>
           </div>
           <div class="form-check mb-1">
@@ -459,7 +459,7 @@
             <label class="form-check-label" for="merge-winner-oob-{{ libre_device.device_id }}">
               <span class="badge bg-purple text-white me-1">Serial match (OOB)</span>
               <strong>{{ oob.name }}</strong>
-              <span class="text-muted">— matches chassis serial{% if oob.librenms_link.host_id %}, currently linked to LibreNMS device #{{ oob.librenms_link.host_id }}{% if oob.librenms_link.oob_id %} (OOB #{{ oob.librenms_link.oob_id }}{% if oob.librenms_link.oob_type %}, {{ oob.librenms_link.oob_type }}{% endif %}){% endif %}{% else %}, not linked to LibreNMS{% endif %}</span>
+              <span class="text-muted">— matches chassis serial{% if oob.librenms_link.host_id %}, currently linked to LibreNMS device #{{ oob.librenms_link.host_id }}{% if oob.librenms_link.oob_id %} (OOB #{{ oob.librenms_link.oob_id }}{% if oob.librenms_link.oob_type %}, {{ oob.librenms_link.oob_type }}{% endif %}){% endif %}{% elif oob.librenms_link.oob_id %}, currently linked to LibreNMS as OOB #{{ oob.librenms_link.oob_id }}{% if oob.librenms_link.oob_type %} ({{ oob.librenms_link.oob_type }}){% endif %}{% else %}, not linked to LibreNMS{% endif %}</span>
             </label>
           </div>
           {% endwith %}

--- a/netbox_librenms_plugin/templates/netbox_librenms_plugin/htmx/device_validation_details.html
+++ b/netbox_librenms_plugin/templates/netbox_librenms_plugin/htmx/device_validation_details.html
@@ -939,17 +939,19 @@
               }
               if (!modal.dataset.promoteResetBound) {
                 modal.dataset.promoteResetBound = "1";
-                if (typeof bootstrap !== "undefined" && bootstrap.Modal) {
-                  modal.addEventListener("hidden.bs.modal", resetPromoteForm);
-                } else {
-                  // Fallback only when Bootstrap's modal JS isn't active: the dismiss buttons
-                  // then only hide the modal and never fire hidden.bs.modal, so a stale "Use
-                  // new" selection would persist across reopen. Reset on their click instead —
-                  // binding both would call resetPromoteForm twice when Bootstrap IS present.
-                  modal.querySelectorAll('[data-bs-dismiss="modal"]').forEach(function (btn) {
-                    btn.addEventListener("click", resetPromoteForm);
-                  });
-                }
+                // Bind BOTH close paths rather than choosing one by the Bootstrap state at
+                // render time. hidden.bs.modal fires for every Bootstrap close — including the
+                // backdrop click, which the dismiss-button handler never catches — while the
+                // dismiss-button click covers the no-Bootstrap fallback where hidden.bs.modal
+                // never fires. (The open trigger decides Bootstrap-vs-fallback again at click
+                // time, so a render-time-only choice could close via a path the reset isn't
+                // wired to and leave the _promote_* radios / override_* inputs sticky on
+                // reopen.) resetPromoteForm is idempotent, so the harmless double-call when
+                // Bootstrap is present is worth covering the backdrop-dismiss path.
+                modal.addEventListener("hidden.bs.modal", resetPromoteForm);
+                modal.querySelectorAll('[data-bs-dismiss="modal"]').forEach(function (btn) {
+                  btn.addEventListener("click", resetPromoteForm);
+                });
               }
               modal.addEventListener("change", function (e) {
                 var t = e.target;

--- a/netbox_librenms_plugin/templates/netbox_librenms_plugin/htmx/device_validation_details.html
+++ b/netbox_librenms_plugin/templates/netbox_librenms_plugin/htmx/device_validation_details.html
@@ -807,7 +807,8 @@
             <i class="mdi mdi-server"></i> Promote to host of {{ validation.existing_device.name }}...
           </button>
 
-          <div class="modal fade" id="promote-modal-{{ libre_device.device_id }}" tabindex="-1" aria-hidden="true">
+          <div class="modal fade" id="promote-modal-{{ libre_device.device_id }}" tabindex="-1"
+               aria-labelledby="promote-modal-label-{{ libre_device.device_id }}" aria-hidden="true">
             <div class="modal-dialog modal-dialog-centered">
               <div class="modal-content">
                 <form hx-post="{% url 'plugins:netbox_librenms_plugin:device_promote_to_host' device_id=libre_device.device_id %}"
@@ -818,7 +819,7 @@
                   <input type="hidden" name="server_key" value="{{ server_key }}">
 
                   <div class="modal-header py-2">
-                    <h5 class="modal-title">Promote to host of {{ validation.existing_device.name }}</h5>
+                    <h5 class="modal-title" id="promote-modal-label-{{ libre_device.device_id }}">Promote to host of {{ validation.existing_device.name }}</h5>
                     <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
                   </div>
                   <div class="modal-body small">

--- a/netbox_librenms_plugin/templates/netbox_librenms_plugin/htmx/device_validation_details.html
+++ b/netbox_librenms_plugin/templates/netbox_librenms_plugin/htmx/device_validation_details.html
@@ -957,11 +957,11 @@
                   if (!target) return;
                   var hidden = modal.querySelector('input[type=hidden][name="' + target + '"]');
                   if (!hidden) return;
-                  if (r.checked && r.value === "new") {
-                    hidden.value = r.getAttribute("data-override-value") || "";
-                  } else if (r.checked && r.value === "keep") {
-                    hidden.value = "";
-                  }
+                  // Only the "Use new" radio carries data-override-target; set the hidden to its
+                  // override value when it's checked and clear it otherwise. Keying off this
+                  // radio's own checked state means switching back to "Keep" (whose radio has no
+                  // data-override-target) still clears the hidden instead of leaving the stale value.
+                  hidden.value = r.checked ? (r.getAttribute("data-override-value") || "") : "";
                 });
               });
             })();

--- a/netbox_librenms_plugin/templates/netbox_librenms_plugin/htmx/device_validation_details.html
+++ b/netbox_librenms_plugin/templates/netbox_librenms_plugin/htmx/device_validation_details.html
@@ -419,7 +419,7 @@
           The other one becomes the <em>donor</em> and is absorbed.
         </div>
         <ul class="mb-1 ps-3">
-          <li><strong>Moved to winner:</strong> LibreNMS link (host id, OOB id, OOB type) and OOB IP <span class="text-muted">(only if the winner has no OOB IP yet)</span>.</li>
+          <li><strong>Moved to winner:</strong> LibreNMS link (host id, OOB id, OOB type) and OOB IP <span class="text-muted">(only if the winner has no OOB IP and the IP is already on a winner interface; otherwise re-home it later from the donor's migrated tab)</span>.</li>
           <li><strong>Stays on donor:</strong> interfaces, cables, primary IP. Re-home them later from the donor's <em>"Migrated to ..."</em> tab.</li>
         </ul>
         <div class="text-muted">

--- a/netbox_librenms_plugin/templates/netbox_librenms_plugin/htmx/device_validation_details.html
+++ b/netbox_librenms_plugin/templates/netbox_librenms_plugin/htmx/device_validation_details.html
@@ -430,7 +430,8 @@
       </div>
       <form
         hx-post="{% url 'plugins:netbox_librenms_plugin:device_merge_netbox_devices' device_id=libre_device.device_id %}"
-        hx-swap="none">
+        hx-swap="none"
+        hx-include="#use-sysname-toggle, #strip-domain-toggle">
         {% csrf_token %}
         <input type="hidden" name="server_key" value="{{ server_key }}">
         {# Default to the host-named winner's donor (oob) so a JS failure still posts a valid donor. #}

--- a/netbox_librenms_plugin/templates/netbox_librenms_plugin/htmx/device_validation_details.html
+++ b/netbox_librenms_plugin/templates/netbox_librenms_plugin/htmx/device_validation_details.html
@@ -921,25 +921,25 @@
                 modal.querySelectorAll('[data-bs-dismiss="modal"]').forEach(function (btn) {
                   btn.addEventListener("click", resetPromoteForm);
                 });
-              }
-              modal.addEventListener("change", function (e) {
-                var t = e.target;
-                if (!t || t.type !== "radio") return;
-                var name = t.name;
-                if (!name || !name.startsWith("_promote_")) return;
-                var group = modal.querySelectorAll('input[name="' + name + '"]');
-                group.forEach(function (r) {
-                  var target = r.getAttribute("data-override-target");
-                  if (!target) return;
-                  var hidden = modal.querySelector('input[type=hidden][name="' + target + '"]');
-                  if (!hidden) return;
-                  // Only the "Use new" radio carries data-override-target; set the hidden to its
-                  // override value when it's checked and clear it otherwise. Keying off this
-                  // radio's own checked state means switching back to "Keep" (whose radio has no
-                  // data-override-target) still clears the hidden instead of leaving the stale value.
-                  hidden.value = r.checked ? (r.getAttribute("data-override-value") || "") : "";
+                modal.addEventListener("change", function (e) {
+                  var t = e.target;
+                  if (!t || t.type !== "radio") return;
+                  var name = t.name;
+                  if (!name || !name.startsWith("_promote_")) return;
+                  var group = modal.querySelectorAll('input[name="' + name + '"]');
+                  group.forEach(function (r) {
+                    var target = r.getAttribute("data-override-target");
+                    if (!target) return;
+                    var hidden = modal.querySelector('input[type=hidden][name="' + target + '"]');
+                    if (!hidden) return;
+                    // Only the "Use new" radio carries data-override-target; set the hidden to its
+                    // override value when it's checked and clear it otherwise. Keying off this
+                    // radio's own checked state means switching back to "Keep" (whose radio has no
+                    // data-override-target) still clears the hidden instead of leaving the stale value.
+                    hidden.value = r.checked ? (r.getAttribute("data-override-value") || "") : "";
+                  });
                 });
-              });
+              }
             })();
           </script>
         </div>

--- a/netbox_librenms_plugin/templates/netbox_librenms_plugin/htmx/device_validation_details.html
+++ b/netbox_librenms_plugin/templates/netbox_librenms_plugin/htmx/device_validation_details.html
@@ -938,13 +938,17 @@
               }
               if (!modal.dataset.promoteResetBound) {
                 modal.dataset.promoteResetBound = "1";
-                modal.addEventListener("hidden.bs.modal", resetPromoteForm);
-                // Fallback when Bootstrap's modal JS isn't active: the dismiss buttons
-                // only hide the modal and never fire hidden.bs.modal, so a stale "Use
-                // new" selection would persist across reopen. Reset on their click too.
-                modal.querySelectorAll('[data-bs-dismiss="modal"]').forEach(function (btn) {
-                  btn.addEventListener("click", resetPromoteForm);
-                });
+                if (typeof bootstrap !== "undefined" && bootstrap.Modal) {
+                  modal.addEventListener("hidden.bs.modal", resetPromoteForm);
+                } else {
+                  // Fallback only when Bootstrap's modal JS isn't active: the dismiss buttons
+                  // then only hide the modal and never fire hidden.bs.modal, so a stale "Use
+                  // new" selection would persist across reopen. Reset on their click instead —
+                  // binding both would call resetPromoteForm twice when Bootstrap IS present.
+                  modal.querySelectorAll('[data-bs-dismiss="modal"]').forEach(function (btn) {
+                    btn.addEventListener("click", resetPromoteForm);
+                  });
+                }
               }
               modal.addEventListener("change", function (e) {
                 var t = e.target;

--- a/netbox_librenms_plugin/templates/netbox_librenms_plugin/htmx/device_validation_details.html
+++ b/netbox_librenms_plugin/templates/netbox_librenms_plugin/htmx/device_validation_details.html
@@ -471,7 +471,12 @@
       <script>
         (function() {
           var donorInput = document.getElementById("merge-donor-{{ libre_device.device_id }}");
-          var radios = document.querySelectorAll('input.merge-winner-radio[name="winner_pk"]');
+          if (!donorInput) return;
+          // Scope to THIS form: a document-wide query would pick up merge-winner radios from
+          // another validation fragment left in the DOM and write the wrong donor_pk, merging
+          // the wrong NetBox device.
+          var form = donorInput.closest("form");
+          var radios = form ? form.querySelectorAll('input.merge-winner-radio[name="winner_pk"]') : [];
           function syncDonor() {
             radios.forEach(function(r) {
               if (r.checked) { donorInput.value = r.dataset.donorPk || ""; }

--- a/netbox_librenms_plugin/templates/netbox_librenms_plugin/librenms_sync_base.html
+++ b/netbox_librenms_plugin/templates/netbox_librenms_plugin/librenms_sync_base.html
@@ -690,9 +690,11 @@
     </div>
     {% endif %}
 {% elif librenms_device_id or migrated_to_marker %}
-{# A migrated donor has its active librenms_id cleared (so it is never found_in_librenms), but the
-   banner above directs the user to the per-row "Move to winner" actions that live in these tabs.
-   Render the tabs in migrated mode too, or those interface/IP move controls are unreachable. #}
+{% comment %}
+A migrated donor has its active librenms_id cleared (so it is never found_in_librenms), but the
+banner above directs the user to the per-row "Move to winner" actions that live in these tabs.
+Render the tabs in migrated mode too, or those interface/IP move controls are unreachable.
+{% endcomment %}
 {% if found_in_librenms or migrated_to_marker %}
 
 <!-- Tab Navigation -->

--- a/netbox_librenms_plugin/templates/netbox_librenms_plugin/librenms_sync_base.html
+++ b/netbox_librenms_plugin/templates/netbox_librenms_plugin/librenms_sync_base.html
@@ -689,8 +689,11 @@
         {% endif %}
     </div>
     {% endif %}
-{% elif librenms_device_id %}
-{% if found_in_librenms %}
+{% elif librenms_device_id or migrated_to_marker %}
+{# A migrated donor has its active librenms_id cleared (so it is never found_in_librenms), but the
+   banner above directs the user to the per-row "Move to winner" actions that live in these tabs.
+   Render the tabs in migrated mode too, or those interface/IP move controls are unreachable. #}
+{% if found_in_librenms or migrated_to_marker %}
 
 <!-- Tab Navigation -->
 <div class="d-flex justify-content-between align-items-center">

--- a/netbox_librenms_plugin/tests/_html_helpers.py
+++ b/netbox_librenms_plugin/tests/_html_helpers.py
@@ -14,3 +14,28 @@ def extract_enclosing_tag(html, marker, tag="<button"):
     marker_idx = html.index(marker)
     tag_start = html.rindex(tag, 0, marker_idx)
     return html[tag_start : html.index(">", tag_start)]
+
+
+def patch_move_url_reverse(viewname_suffix, *, resolve):
+    """Patch ``django.urls.reverse`` so a move-to-winner viewname looks registered or not.
+
+    ``resolve=True`` makes any viewname ending in ``viewname_suffix`` resolve to a fake path;
+    ``resolve=False`` raises ``NoReverseMatch`` for it. Every other viewname resolves for real.
+    The move URLs are only registered up-stack, so forcing the state here keeps the guard tests
+    branch-independent. ``django.urls.reverse`` is the correct target because ``{% url %}``
+    re-imports ``reverse`` from ``django.urls`` at render time. Returns a ``patch()`` context
+    manager.
+    """
+    from unittest.mock import patch
+
+    from django.urls import NoReverseMatch
+    from django.urls import reverse as real_reverse
+
+    def _reverse(viewname, *args, **kwargs):
+        if str(viewname).endswith(viewname_suffix):
+            if resolve:
+                return f"/fake/{viewname_suffix}/1/"
+            raise NoReverseMatch(viewname)
+        return real_reverse(viewname, *args, **kwargs)
+
+    return patch("django.urls.reverse", _reverse)

--- a/netbox_librenms_plugin/tests/_html_helpers.py
+++ b/netbox_librenms_plugin/tests/_html_helpers.py
@@ -1,0 +1,16 @@
+"""Shared HTML-slicing helpers for template-content tests."""
+
+
+def extract_enclosing_tag(html, marker, tag="<button"):
+    """Return the opening ``tag`` of the element that contains ``marker``.
+
+    Slices from the last ``tag`` occurrence before ``marker`` up to (not
+    including) the next ``>``, so an assertion can be scoped to one element's
+    own attributes — another element carrying the same attribute elsewhere in
+    the page can't mask the target element dropping it. Raises ValueError when
+    the marker or tag is absent (str.index/str.rindex semantics), which fails
+    the calling test loudly instead of asserting against the wrong slice.
+    """
+    marker_idx = html.index(marker)
+    tag_start = html.rindex(tag, 0, marker_idx)
+    return html[tag_start : html.index(">", tag_start)]

--- a/netbox_librenms_plugin/tests/_html_helpers.py
+++ b/netbox_librenms_plugin/tests/_html_helpers.py
@@ -19,7 +19,8 @@ def extract_enclosing_tag(html, marker, tag="<button"):
 def patch_move_url_reverse(viewname_suffix, *, resolve):
     """Patch ``django.urls.reverse`` so a move-to-winner viewname looks registered or not.
 
-    ``resolve=True`` makes any viewname ending in ``viewname_suffix`` resolve to a fake path;
+    ``resolve=True`` makes any viewname ending in ``viewname_suffix`` resolve to a fake path
+    carrying the requested pk;
     ``resolve=False`` raises ``NoReverseMatch`` for it. Every other viewname resolves for real.
     The move URLs are only registered up-stack, so forcing the state here keeps the guard tests
     branch-independent. ``django.urls.reverse`` is the correct target because ``{% url %}``
@@ -34,7 +35,14 @@ def patch_move_url_reverse(viewname_suffix, *, resolve):
     def _reverse(viewname, *args, **kwargs):
         if str(viewname).endswith(viewname_suffix):
             if resolve:
-                return f"/fake/{viewname_suffix}/1/"
+                route_kwargs = kwargs.get("kwargs") or {}
+                route_args = kwargs.get("args") or ()
+                pk = route_kwargs.get("pk")
+                if pk is None and route_args:
+                    pk = route_args[-1]
+                if pk is None:
+                    raise NoReverseMatch(viewname)
+                return f"/fake/{viewname_suffix}/{pk}/"
             raise NoReverseMatch(viewname)
         return real_reverse(viewname, *args, **kwargs)
 

--- a/netbox_librenms_plugin/tests/_html_helpers.py
+++ b/netbox_librenms_plugin/tests/_html_helpers.py
@@ -37,7 +37,7 @@ def patch_move_url_reverse(viewname_suffix, *, resolve):
             if resolve:
                 route_kwargs = kwargs.get("kwargs") or {}
                 route_args = kwargs.get("args") or ()
-                pk = route_kwargs.get("pk")
+                pk = route_kwargs.get("pk", route_kwargs.get("device_id"))
                 if pk is None and route_args:
                     pk = route_args[-1]
                 if pk is None:

--- a/netbox_librenms_plugin/tests/test_cable_verify.py
+++ b/netbox_librenms_plugin/tests/test_cable_verify.py
@@ -582,6 +582,32 @@ class TestOOBRowsNeverActionable:
 
         assert ("Sync Cable" in actions) is expect_sync
 
+    def test_oob_row_never_links_a_host_interface(self):
+        """Verify must not resolve an OOB row's local end against the HOST device.
+
+        The controller-managed port lives on the OOB device; a shared name (or colliding
+        stored librenms_id) would render a clickable HOST-interface link on it — mirrors
+        the enrich_local_port guard on the initial table render.
+        """
+        from django.core.cache import cache
+
+        from dcim.models import Interface
+        from netbox_librenms_plugin.tests.conftest import make_device
+
+        local_dev = make_device("verify-oob-collide")
+        Interface.objects.create(device=local_dev, name="eth0", type="1000base-t")  # host iface, same name
+
+        view = _make_view()
+        link = {"local_port": "eth0", "local_port_id": 700, "remote_device": "", "_source": "oob"}
+        cache.set(view.get_cache_key(local_dev, "links", "default"), {"links": [link]}, 300)
+
+        request = _make_request({"device_id": local_dev.pk, "local_port_id": 700, "server_key": "default"})
+        row = json.loads(view.post(request).content)["formatted_row"]
+
+        assert "/dcim/interfaces/" not in row["local_port"]  # no host-interface link
+        assert "eth0" in row["local_port"]  # the label (with its OOB badge) still renders
+        assert "OOB" in row["local_port"]  # the badge marks the row as controller-sourced
+
 
 @pytest.mark.django_db
 class TestSingleCableVerifyServerKeyRouting:

--- a/netbox_librenms_plugin/tests/test_cable_verify.py
+++ b/netbox_librenms_plugin/tests/test_cable_verify.py
@@ -716,3 +716,43 @@ class TestEnrichRemotePortEmptyPort:
         result = view.enrich_remote_port(link, remote, server_key="default")
 
         assert result is link
+
+
+@pytest.mark.django_db
+class TestResolveLocalInterfaceCore:
+    """The shared id→dual-name resolution core used by BOTH enrich_local_port and the verify
+    re-resolution (extracted so the issue-#88 name fallback / precedence can't drift between
+    the two copies again)."""
+
+    def _dev(self, name):
+        from netbox_librenms_plugin.tests.conftest import make_device, make_interface
+
+        device = make_device(name)
+        return device, make_interface(device, "eth-by-name")
+
+    def test_librenms_id_beats_name(self):
+        from dcim.models import Interface
+
+        from netbox_librenms_plugin.views.base.cables_view import _resolve_local_interface
+
+        device, by_name = self._dev("core-id-wins")
+        by_id = Interface.objects.create(device=device, name="other-name", type="1000base-t")
+        by_id.custom_field_data["librenms_id"] = {"default": 4242}
+        by_id.save()
+
+        got = _resolve_local_interface(device, "default", 4242, ["eth-by-name"])
+        assert got == by_id  # the stable id match wins over the name candidate
+
+    def test_name_fallback_covers_all_candidates(self):
+        from netbox_librenms_plugin.views.base.cables_view import _resolve_local_interface
+
+        device, by_name = self._dev("core-name-fb")
+        # No id match anywhere: the ALTERNATE candidate (issue #88) must still resolve.
+        got = _resolve_local_interface(device, "default", 9999, ["displayed-name", "eth-by-name"])
+        assert got == by_name
+
+    def test_empty_inputs_resolve_nothing(self):
+        from netbox_librenms_plugin.views.base.cables_view import _resolve_local_interface
+
+        device, _ = self._dev("core-empty")
+        assert _resolve_local_interface(device, "default", None, []) is None

--- a/netbox_librenms_plugin/tests/test_coverage_actions.py
+++ b/netbox_librenms_plugin/tests/test_coverage_actions.py
@@ -6006,6 +6006,72 @@ class TestAddAsOOBViewPost:
 
 
 @pytest.mark.django_db
+class TestMergeNetBoxDevicesViewOOBTransfer:
+    """MergeNetBoxDevicesView.post: oob_ip may only move to the winner when its
+    underlying IP already sits on a winner interface (the merge does not move
+    interfaces, and the save skips full_clean()).
+
+    Driven against real Device / Interface / IPAddress so the transfer is proven by
+    what actually persists and reloads, not by inspecting ``save(update_fields=...)``
+    on a MagicMock. The real ``merge_librenms_links`` / ``mark_librenms_migrated`` run
+    and the locked rows are genuine ``select_for_update`` re-reads — only the LibreNMS
+    validation pipeline, auth gates, and the row HTML render stay mocked.
+    """
+
+    def _make_view(self):
+        from netbox_librenms_plugin.views.imports.actions import MergeNetBoxDevicesView
+
+        view = object.__new__(MergeNetBoxDevicesView)
+        view._librenms_api = _make_api()
+        view.require_write_permission = MagicMock(return_value=None)
+        view.require_object_permissions = MagicMock(return_value=None)
+        return view
+
+    def _run(self, *, oob_on_winner):
+        """Drive a merge where the donor's oob_ip sits on an interface owned by the
+        winner (``oob_on_winner=True``) or by the donor (``False``).
+        Returns ``(winner, donor, oob_ip)`` with the devices reloaded from the DB."""
+        from dcim.models import Device
+        from django.http import HttpResponse
+
+        from netbox_librenms_plugin.tests.conftest import ip_on
+
+        view = self._make_view()
+
+        winner = make_device("merge-winner", librenms_cf={"default": {"id": 20}})
+        donor = make_device("merge-donor", librenms_cf={"default": {"id": 10}})
+
+        # The donor carries an oob_ip whose underlying IP is assigned to an interface
+        # owned by whichever device the scenario dictates. save() (not full_clean) lets
+        # us seed the winner-interface case the view is designed to resolve.
+        oob_host = winner if oob_on_winner else donor
+        oob_ip = ip_on(oob_host, "192.0.2.7/32", "mgmt0")
+        donor.oob_ip = oob_ip
+        donor.save()
+
+        request = _make_request(post={"winner_pk": str(winner.pk), "donor_pk": str(donor.pk)})
+        validation = {"merge_candidates": {"host_named": {"pk": winner.pk}, "oob_named": {"pk": donor.pk}}}
+        view.get_validated_device_with_selections = MagicMock(return_value=({"device_id": 99}, validation, {}))
+        view.render_device_row = MagicMock(return_value=HttpResponse("row"))
+
+        resp = view.post(request, device_id=99)
+        assert resp.status_code == 200
+        return Device.objects.get(pk=winner.pk), Device.objects.get(pk=donor.pk), oob_ip
+
+    def test_transfers_when_oob_ip_on_winner_interface(self):
+        winner, donor, oob_ip = self._run(oob_on_winner=True)
+        # The transfer actually persisted: winner now owns the oob_ip, donor cleared.
+        assert winner.oob_ip_id == oob_ip.pk
+        assert donor.oob_ip_id is None
+
+    def test_skips_when_oob_ip_on_donor_interface(self):
+        winner, donor, oob_ip = self._run(oob_on_winner=False)
+        # Left on the donor (its interface owns the IP); winner not given a donor-owned IP.
+        assert donor.oob_ip_id == oob_ip.pk
+        assert winner.oob_ip_id is None
+
+
+@pytest.mark.django_db
 class TestSuggestOOBInterface:
     """_suggest_oob_interface: pre-select an OOB/mgmt-named interface + default new name."""
 
@@ -7183,3 +7249,59 @@ class TestConflictActionsObjectScope:
         sync_entry = Device.objects.get(pk=sync.pk).custom_field_data["librenms_id"]["default"]
         assert sync_entry["id"] == 30
         assert sync_entry["oob"]["id"] == 4343
+
+
+@pytest.mark.django_db
+class TestMergeNetBoxDevicesViewDonorDerivation:
+    """The merge view derives the donor from winner_pk + merge_candidates and
+    ignores the client-posted donor_pk, which a stale/failed inline sync script
+    could otherwise leave equal to winner_pk (a self-merge of moving data).
+
+    Driven against real Devices and the real merge/migration helpers: the role
+    derivation is proven by which device actually ends up with the persisted
+    ``_migrated_to`` marker after reload — not by which MagicMock was handed to a
+    patched ``merge_librenms_links``.
+    """
+
+    def _make_view(self):
+        from netbox_librenms_plugin.views.imports.actions import MergeNetBoxDevicesView
+
+        view = object.__new__(MergeNetBoxDevicesView)
+        view._librenms_api = _make_api()
+        view.require_write_permission = MagicMock(return_value=None)
+        view.require_object_permissions = MagicMock(return_value=None)
+        return view
+
+    def test_ignores_posted_donor_pk_equal_to_winner(self):
+        from dcim.models import Device
+        from django.http import HttpResponse
+
+        view = self._make_view()
+
+        winner = make_device("merge-w", librenms_cf={"default": {"id": 20}})
+        donor = make_device("merge-d", librenms_cf={"default": {"id": 10}})
+
+        # Bogus client state: donor_pk == winner_pk (inline sync script never ran).
+        request = _make_request(post={"winner_pk": str(winner.pk), "donor_pk": str(winner.pk)})
+
+        validation = {"merge_candidates": {"host_named": {"pk": winner.pk}, "oob_named": {"pk": donor.pk}}}
+        view.get_validated_device_with_selections = MagicMock(return_value=({"device_id": 99}, validation, {}))
+        view.render_device_row = MagicMock(return_value=HttpResponse("row"))
+
+        resp = view.post(request, device_id=99)
+        assert resp.status_code == 200
+
+        winner = Device.objects.get(pk=winner.pk)
+        donor = Device.objects.get(pk=donor.pk)
+        # The donor is the *other* merge candidate, never the posted self-pk: it is the
+        # one whose active link was cleared and stamped with a _migrated_to marker
+        # pointing at the winner.
+        donor_entry = donor.custom_field_data["librenms_id"]["default"]
+        assert donor_entry.get("_migrated_to", {}).get("device_id") == winner.pk
+        assert donor_entry.get("id") is None
+        # The winner absorbed the merge and is NOT itself marked migrated; it keeps its
+        # own host id (winner-wins), with the donor's id demoted into the oob slot.
+        winner_entry = winner.custom_field_data["librenms_id"]["default"]
+        assert "_migrated_to" not in winner_entry
+        assert winner_entry["id"] == 20
+        assert winner_entry["oob"]["id"] == 10

--- a/netbox_librenms_plugin/tests/test_coverage_actions.py
+++ b/netbox_librenms_plugin/tests/test_coverage_actions.py
@@ -6196,6 +6196,32 @@ class TestPromoteToHostViewPost:
         existing_device.refresh_from_db()
         assert existing_device.custom_field_data["librenms_id"]["default"] == {"id": 10}
 
+    def test_failed_oob_attach_after_host_swap_leaves_db_untouched(self):
+        """A ValueError raised AFTER set_librenms_device_id already ran must not commit a partial swap.
+
+        set_librenms_device_id()/set_librenms_oob() mutate custom_field_data in memory only;
+        the transaction's single DB write is _save_device() at the end of the atomic block, so
+        the early error return commits nothing. Pins the no-partial-commit contract of the
+        promote flow (an invalid OOB type is the in-transaction ValueError source).
+        """
+        view = self._make_view()
+        existing_device = make_device("promote-badoob", librenms_cf={"default": {"id": 10}})
+        request = _make_request(post={"existing_device_id": str(existing_device.pk)})
+
+        # No OOB keyword substring (OOB_TYPE_PATTERN) and not the "oob" sentinel, so
+        # set_librenms_oob raises ValueError inside the transaction — after the host swap.
+        promote = {"existing_libre_id": 10, "existing_oob_type": "management-card"}
+        validation = {"promote_to_host": promote, "existing_device": existing_device}
+        view.get_validated_device_with_selections = MagicMock(return_value=({"device_id": 17}, validation, {}))
+        response = view.post(request, device_id=17)
+
+        assert response.status_code == 200
+        assert b"Invalid promotion data" in response.content
+        # The in-memory host swap (10 -> 17) must NOT have been persisted: the row still
+        # holds the original host id and gained no oob sub-object.
+        existing_device.refresh_from_db()
+        assert existing_device.custom_field_data["librenms_id"]["default"] == {"id": 10}
+
     def test_existing_link_already_points_at_incoming_device_returns_error(self):
         """If the existing link already equals the incoming LibreNMS id there is nothing to promote — the view must say so rather than self-demoting the same id into OOB."""
         view = self._make_view()

--- a/netbox_librenms_plugin/tests/test_coverage_actions.py
+++ b/netbox_librenms_plugin/tests/test_coverage_actions.py
@@ -6467,6 +6467,89 @@ class TestMergeNetBoxDevicesViewOOBTransfer:
         assert "_migrated_to" not in entry
 
 
+def _two_member_vc(name, *, m1_cf=None, m2_cf=None):
+    """Create a real 2-member VirtualChassis (positions 1, 2). m1 becomes the sync device when it is the member holding the ``librenms_id``."""
+    from dcim.models import VirtualChassis
+
+    vc = VirtualChassis.objects.create(name=name)
+    m1 = make_device(f"{name}-m1", librenms_cf=m1_cf)
+    m1.virtual_chassis = vc
+    m1.vc_position = 1
+    m1.save()
+    m2 = make_device(f"{name}-m2", librenms_cf=m2_cf)
+    m2.virtual_chassis = vc
+    m2.vc_position = 2
+    m2.save()
+    return vc, m1, m2
+
+
+@pytest.mark.django_db
+class TestMergeNetBoxDevicesViewVCSyncDevice:
+    """MergeNetBoxDevicesView.post: when a merge candidate is a Virtual Chassis member, the LibreNMS link (host id / OOB) and the ``_migrated_to`` marker must be merged on the VC's sync device (``get_librenms_sync_device``), not the raw selected member. Writing to a non-sync member either split-brains a VC that already has a linked member, or leaves the donor's real link (on its sync sibling) uncleared."""
+
+    def _make_view(self):
+        from netbox_librenms_plugin.views.imports.actions import MergeNetBoxDevicesView
+
+        view = object.__new__(MergeNetBoxDevicesView)
+        view._librenms_api = _make_api()
+        view.require_write_permission = MagicMock(return_value=None)
+        view.require_object_permissions = MagicMock(return_value=None)
+        return view
+
+    def _run_merge(self, *, winner, donor):
+        from django.http import HttpResponse
+
+        view = self._make_view()
+        request = _make_request(post={"winner_pk": str(winner.pk), "donor_pk": str(donor.pk)})
+        validation = {"merge_candidates": {"host_named": {"pk": winner.pk}, "oob_named": {"pk": donor.pk}}}
+        view.get_validated_device_with_selections = MagicMock(return_value=({"device_id": 99}, validation, {}))
+        view.render_device_row = MagicMock(return_value=HttpResponse("row"))
+        resp = view.post(request, device_id=99)
+        assert resp.status_code == 200
+        return resp
+
+    @staticmethod
+    def _entry(device):
+        device.refresh_from_db()
+        return (device.custom_field_data.get("librenms_id") or {}).get("default") or {}
+
+    def test_winner_is_non_sync_vc_member_link_lands_on_sync_device(self):
+        """Winner is a non-sync VC member whose sync sibling already holds a host id; the donor's id must merge onto the sync sibling (into its OOB half) and NEVER onto the raw winner member — otherwise two members of one chassis hold ``librenms_id`` (split brain)."""
+        _vc, m1, m2 = _two_member_vc("mrg-vc-win", m1_cf={"default": {"id": 30}}, m2_cf=None)
+        donor = make_device("mrg-vc-win-donor", librenms_cf={"default": {"id": 40}})
+
+        self._run_merge(winner=m2, donor=donor)
+
+        # The raw non-sync winner member must stay clean — no host id planted on it.
+        assert "id" not in self._entry(m2), "non-sync VC member must not receive the merged host id (split brain)"
+        # The VC's sync device keeps its own id and absorbs the donor's id into its OOB slot.
+        m1_entry = self._entry(m1)
+        assert m1_entry.get("id") == 30
+        assert (m1_entry.get("oob") or {}).get("id") == 40, "donor id should merge onto the sync device's OOB slot"
+        # Donor cleared + marked migrated toward the sync device (the real link holder).
+        donor_entry = self._entry(donor)
+        assert "id" not in donor_entry
+        assert donor_entry.get("_migrated_to", {}).get("device_id") == m1.pk
+
+    def test_donor_is_non_sync_vc_member_clears_link_on_sync_device(self):
+        """Donor is a non-sync VC member; its real link lives on the sync sibling. The merge must read + clear that sibling's link (and mark IT migrated), not the empty selected member — otherwise the source VC stays linked to LibreNMS."""
+        _vc, m1, m2 = _two_member_vc("mrg-vc-don", m1_cf={"default": {"id": 30}}, m2_cf=None)
+        winner = make_device("mrg-vc-don-winner", librenms_cf={"default": {"id": 50}})
+
+        self._run_merge(winner=winner, donor=m2)
+
+        # The donor VC's sync sibling holds the real link: it must be absorbed and cleared + marked.
+        m1_entry = self._entry(m1)
+        assert "id" not in m1_entry, "the donor VC's sync device must be cleared, not left linked to LibreNMS"
+        assert m1_entry.get("_migrated_to", {}).get("device_id") == winner.pk
+        # Winner absorbed the sync sibling's id into its OOB slot (winner already had a host id).
+        winner_entry = self._entry(winner)
+        assert winner_entry.get("id") == 50
+        assert (winner_entry.get("oob") or {}).get("id") == 30
+        # The raw selected member (m2) never held a link; nothing is planted on it.
+        assert "id" not in self._entry(m2)
+
+
 @pytest.mark.django_db
 class TestMergeNetBoxDevicesViewFailClosed:
     """MergeNetBoxDevicesView.post: ValueErrors from merge_librenms_links, the oob_ip transfer, and mark_librenms_migrated must all fail closed with a toast and leave the donor unmigrated — never a 500 or a silent lossy merge."""

--- a/netbox_librenms_plugin/tests/test_coverage_actions.py
+++ b/netbox_librenms_plugin/tests/test_coverage_actions.py
@@ -7728,16 +7728,22 @@ class TestSerialActionsNormalizeAndLock:
         assert conflict_row_locks == [], f"conflict lookup still takes a row lock: {conflict_row_locks}"
 
     def test_serial_advisory_lock_uses_a_stable_application_key(self):
-        """The advisory key is derived in application code, not PostgreSQL's undocumented hashtext()."""
-        from django.db import connection
+        """Equal serials use one stable application key while distinct serials use different keys."""
+        from django.db import connection, transaction
         from django.test.utils import CaptureQueriesContext
 
-        target = make_device("ser-act-stable-lock")
-        with CaptureQueriesContext(connection) as ctx:
-            self._post_action("sync_serial", target, "SN-STABLE")
+        from netbox_librenms_plugin.views.imports.actions import _acquire_serial_assignment_lock
 
-        lock_sql = next(q["sql"] for q in ctx.captured_queries if "pg_advisory_xact_lock" in q["sql"])
-        assert "hashtext" not in lock_sql.lower()
+        with transaction.atomic(), CaptureQueriesContext(connection) as ctx:
+            _acquire_serial_assignment_lock("SN-STABLE")
+            _acquire_serial_assignment_lock("SN-STABLE")
+            _acquire_serial_assignment_lock("SN-DIFFERENT")
+
+        lock_sqls = [q["sql"] for q in ctx.captured_queries if "pg_advisory_xact_lock" in q["sql"]]
+        assert len(lock_sqls) == 3
+        assert lock_sqls[0] == lock_sqls[1]
+        assert lock_sqls[0] != lock_sqls[2]
+        assert all("hashtext" not in sql.lower() for sql in lock_sqls)
 
     def test_serial_lock_refuses_to_run_in_autocommit(self):
         """pg_advisory_xact_lock is transaction-scoped, so taking it outside a transaction locks nothing and must fail loudly."""

--- a/netbox_librenms_plugin/tests/test_coverage_actions.py
+++ b/netbox_librenms_plugin/tests/test_coverage_actions.py
@@ -5978,7 +5978,7 @@ class TestAddAsOOBViewPost:
         view = self._make_view()
         existing_device = make_device("host-a", librenms_cf={"default": {"id": 10}})
         # A *different* real device already owns LibreNMS id 17 (e.g. imported standalone).
-        make_device("the-idrac", librenms_cf={"default": {"id": 17}})
+        make_device("<script>the-idrac</script>", librenms_cf={"default": {"id": 17}})
         request = _make_request(post={"existing_device_id": str(existing_device.pk)})
 
         libre_device = {"device_id": 17}
@@ -5990,7 +5990,8 @@ class TestAddAsOOBViewPost:
         # HTMX error toast (200 + HX-Reswap:none) naming the conflicting device.
         assert response.status_code == 200
         assert response["HX-Reswap"] == "none"
-        assert b"already linked to &#x27;the-idrac&#x27;" in response.content
+        assert b"already linked to &#x27;&lt;script&gt;the-idrac&lt;/script&gt;&#x27;" in response.content
+        assert b"&amp;lt;script&amp;gt;" not in response.content
         # Nothing attached: the host device's entry gained no oob sub-block.
         assert "oob" not in Device.objects.get(pk=existing_device.pk).custom_field_data["librenms_id"]["default"]
 
@@ -6230,7 +6231,7 @@ class TestPromoteToHostViewPost:
         view = self._make_view()
         existing_device = make_device("promote-src", librenms_cf={"default": {"id": 10}})
         # Another NetBox device already linked to the incoming host id 17.
-        make_device("promote-conflict", librenms_cf={"default": {"id": 17}})
+        make_device("<script>promote-conflict</script>", librenms_cf={"default": {"id": 17}})
         request = _make_request(post={"existing_device_id": str(existing_device.pk)})
 
         promote = {"existing_libre_id": 10, "existing_oob_type": "oob"}
@@ -6240,6 +6241,8 @@ class TestPromoteToHostViewPost:
 
         assert response.status_code == 200
         assert b"already linked to" in response.content
+        assert b"&lt;script&gt;promote-conflict&lt;/script&gt;" in response.content
+        assert b"&amp;lt;script&amp;gt;" not in response.content
         # The source device must be left unchanged (still host id 10, no OOB).
         existing_device.refresh_from_db()
         assert existing_device.custom_field_data["librenms_id"]["default"] == {"id": 10}
@@ -6672,13 +6675,15 @@ class TestMergeNetBoxDevicesViewFailClosed:
             "merge-orphan-winner",
             librenms_cf={"default": {"id": 100, "oob": {"id": 50, "type": "idrac"}}},
         )
-        donor = make_device("merge-orphan-donor", librenms_cf={"default": {"id": 200}})
+        donor = make_device("<script>merge-orphan-donor</script>", librenms_cf={"default": {"id": 200}})
 
         resp = self._post_merge(self._make_view(), winner, donor)
 
         assert resp.status_code == 200
         assert resp["HX-Reswap"] == "none"
         assert b"Cannot merge" in resp.content
+        assert b"&lt;script&gt;merge-orphan-donor&lt;/script&gt;" in resp.content
+        assert b"&amp;lt;script&amp;gt;" not in resp.content
         # Donor's link is preserved and it was NOT marked migrated (no orphaned LibreNMS host).
         donor.refresh_from_db()
         entry = donor.custom_field_data["librenms_id"]["default"]
@@ -7694,6 +7699,17 @@ class TestRebindOrHtmxErrorHelper:
         ):
             assert _rebind_or_htmx_error(view, request) is None
         assert view._librenms_api.server_key == "prod"
+
+
+class TestHtmxErrorResponse:
+    def test_plain_dynamic_message_is_html_escaped_once(self):
+        from netbox_librenms_plugin.views.imports.actions import _htmx_error_response
+
+        response = _htmx_error_response("Conflict with '<script>alert(1)</script>'.")
+
+        assert b"<script>" not in response.content
+        assert b"&lt;script&gt;alert(1)&lt;/script&gt;" in response.content
+        assert b"&amp;lt;script&amp;gt;" not in response.content
 
 
 @pytest.mark.django_db

--- a/netbox_librenms_plugin/tests/test_coverage_actions.py
+++ b/netbox_librenms_plugin/tests/test_coverage_actions.py
@@ -6070,6 +6070,66 @@ class TestMergeNetBoxDevicesViewOOBTransfer:
         assert donor.oob_ip_id == oob_ip.pk
         assert winner.oob_ip_id is None
 
+    def test_save_failure_rolls_back_donor_oob_release_and_marker(self):
+        """Forced persist failure mid-merge must roll back the donor's already-executed save.
+
+        The view saves the donor first — releasing its ``oob_ip`` (a UNIQUE OneToOne) and
+        stamping the ``_migrated_to`` marker — then saves the winner to claim the IP. If the
+        winner save fails, the ``except`` block must mark the transaction rollback-only;
+        otherwise the donor is left with no ``oob_ip`` AND no winner holding it (an orphaned
+        address) plus a ``_migrated_to`` marker for a merge that never completed.
+
+        Driven against real rows: only the *second* Device.save (the winner's) is forced to
+        raise, so the donor's real release is genuinely on disk inside the savepoint before the
+        rollback. Removing ``set_rollback(True)`` leaves the donor's release/marker committed and
+        this test goes red."""
+        from dcim.models import Device
+        from django.db import IntegrityError
+        from django.http import HttpResponse
+
+        from netbox_librenms_plugin.tests.conftest import ip_on
+
+        view = self._make_view()
+        winner = make_device("merge-winner-fail", librenms_cf={"default": {"id": 20}})
+        donor = make_device("merge-donor-fail", librenms_cf={"default": {"id": 10}})
+        # oob_ip on a winner-owned interface → the transfer path runs (oob_ip in update_fields).
+        oob_ip = ip_on(winner, "192.0.2.8/32", "mgmt0")
+        donor.oob_ip = oob_ip
+        donor.save()
+
+        request = _make_request(post={"winner_pk": str(winner.pk), "donor_pk": str(donor.pk)})
+        validation = {"merge_candidates": {"host_named": {"pk": winner.pk}, "oob_named": {"pk": donor.pk}}}
+        view.get_validated_device_with_selections = MagicMock(return_value=({"device_id": 99}, validation, {}))
+        view.render_device_row = MagicMock(return_value=HttpResponse("row"))
+
+        # Force the SECOND Device.save (the winner's, per the donor-then-winner order) to fail,
+        # so the donor's release is already written inside the savepoint when rollback fires.
+        real_save = Device.save
+        save_calls = []
+
+        def flaky_save(self, *args, **kwargs):
+            save_calls.append(self.pk)
+            if len(save_calls) == 2:
+                raise IntegrityError("forced winner save failure")
+            return real_save(self, *args, **kwargs)
+
+        with patch.object(Device, "save", flaky_save):
+            resp = view.post(request, device_id=99)
+
+        # Surfaced as the HTMX OOB error toast (200 + HX-Reswap:none), not a 500.
+        assert resp.status_code == 200
+        assert resp["HX-Reswap"] == "none"
+        assert b"Unable to save" in resp.content
+        # The donor's save (release + marker) was rolled back: it still owns the oob_ip, the
+        # winner never claimed it, and no migration marker was stamped.
+        donor.refresh_from_db()
+        winner.refresh_from_db()
+        assert donor.oob_ip_id == oob_ip.pk
+        assert winner.oob_ip_id is None
+        entry = donor.custom_field_data["librenms_id"]["default"]
+        assert entry == {"id": 10}
+        assert "_migrated_to" not in entry
+
 
 @pytest.mark.django_db
 class TestSuggestOOBInterface:

--- a/netbox_librenms_plugin/tests/test_coverage_actions.py
+++ b/netbox_librenms_plugin/tests/test_coverage_actions.py
@@ -6091,6 +6091,39 @@ class TestPromoteToHostViewPost:
         assert b"legacy" in response.content.lower()
         assert response["HX-Reswap"] == "none"
 
+    def test_boolean_existing_libre_id_rejected(self):
+        """A boolean existing_libre_id (corrupt CF) must fail closed, not coerce to 1/0 via int()."""
+        view = self._make_view()
+        existing_device = make_device("promote-bool", librenms_cf={"default": {"id": 10}})
+        request = _make_request(post={"existing_device_id": str(existing_device.pk)})
+
+        promote = {"existing_libre_id": True, "existing_oob_type": "oob"}
+        validation = {"promote_to_host": promote, "existing_device": existing_device}
+        view.get_validated_device_with_selections = MagicMock(return_value=({"device_id": 17}, validation, {}))
+        response = view.post(request, device_id=17)
+
+        assert response.status_code == 200
+        assert b"Invalid existing LibreNMS id" in response.content
+
+    def test_promote_rejected_when_new_host_id_already_linked_elsewhere(self):
+        """When another device already owns the incoming host id, promotion aborts (exercises the deterministic-order conflict lock)."""
+        view = self._make_view()
+        existing_device = make_device("promote-src", librenms_cf={"default": {"id": 10}})
+        # Another NetBox device already linked to the incoming host id 17.
+        make_device("promote-conflict", librenms_cf={"default": {"id": 17}})
+        request = _make_request(post={"existing_device_id": str(existing_device.pk)})
+
+        promote = {"existing_libre_id": 10, "existing_oob_type": "oob"}
+        validation = {"promote_to_host": promote, "existing_device": existing_device}
+        view.get_validated_device_with_selections = MagicMock(return_value=({"device_id": 17}, validation, {}))
+        response = view.post(request, device_id=17)
+
+        assert response.status_code == 200
+        assert b"already linked to" in response.content
+        # The source device must be left unchanged (still host id 10, no OOB).
+        existing_device.refresh_from_db()
+        assert existing_device.custom_field_data["librenms_id"]["default"] == {"id": 10}
+
     def test_existing_link_already_points_at_incoming_device_returns_error(self):
         """If the existing link already equals the incoming LibreNMS id there is nothing to promote — the view must say so rather than self-demoting the same id into OOB."""
         view = self._make_view()

--- a/netbox_librenms_plugin/tests/test_coverage_actions.py
+++ b/netbox_librenms_plugin/tests/test_coverage_actions.py
@@ -55,6 +55,32 @@ def _make_api():
     return api
 
 
+def _scoped_device_writer(in_scope_device, username):
+    """A real non-superuser with plugin write access and a pk-constrained change_device grant."""
+    from core.models import ObjectType
+    from dcim.models import Device
+    from django.apps import apps
+    from django.contrib.auth import get_user_model
+    from users.models import ObjectPermission
+
+    # Resolve via the app registry: the autouse config fixtures patch the models module during
+    # the full suite, so a plain import could hand get_for_model() a mock class.
+    LibreNMSSettings = apps.get_model("netbox_librenms_plugin", "LibreNMSSettings")
+
+    user = get_user_model().objects.create_user(username=username, password="x")
+    write = ObjectPermission.objects.create(name=f"{username}-plugin-write", actions=["change"])
+    write.object_types.set([ObjectType.objects.get_for_model(LibreNMSSettings)])
+    write.users.set([user])
+
+    scoped = ObjectPermission.objects.create(
+        name=f"{username}-scoped-change-device", actions=["change"], constraints={"pk": in_scope_device.pk}
+    )
+    scoped.object_types.set([ObjectType.objects.get_for_model(Device)])
+    scoped.users.set([user])
+
+    return get_user_model().objects.get(pk=user.pk)  # clear the per-request perm cache
+
+
 class TestSaveDevice:
     """Tests for _save_device (lines 44-56)."""
 
@@ -6021,6 +6047,7 @@ class TestGetValidatedDeviceLibreDeviceReuse:
 
         view = object.__new__(PromoteToHostView)
         view._librenms_api = _make_api()
+        view.request = MagicMock()
         request = _make_request(post={})
         supplied = {"device_id": 4242, "hostname": "reuse-host", "sysName": "reuse-host"}
 
@@ -6047,6 +6074,7 @@ class TestGetValidatedDeviceLibreDeviceReuse:
 
         view = object.__new__(PromoteToHostView)
         view._librenms_api = _make_api()
+        view.request = MagicMock()
         request = _make_request(post={})
 
         with (
@@ -6077,6 +6105,7 @@ class TestPostActionRebindFailsClosed:
 
         view = object.__new__(PromoteToHostView)
         view.kwargs = {}
+        view.request = MagicMock()
         view.require_write_permission = MagicMock(return_value=None)
         view.require_object_permissions = MagicMock(return_value=None)
         # No session client bound + a default that won't build → the mixin must fail closed on the
@@ -6099,6 +6128,7 @@ class TestPromoteToHostViewPost:
 
         view = object.__new__(PromoteToHostView)
         view.kwargs = {}
+        view.request = MagicMock()
         view._librenms_api = _make_api()
         view.require_write_permission = MagicMock(return_value=None)
         view.require_object_permissions = MagicMock(return_value=None)
@@ -6350,6 +6380,7 @@ class TestMergeNetBoxDevicesViewOOBTransfer:
 
         view = object.__new__(MergeNetBoxDevicesView)
         view._librenms_api = _make_api()
+        view.request = MagicMock()
         view.require_write_permission = MagicMock(return_value=None)
         view.require_object_permissions = MagicMock(return_value=None)
         return view
@@ -6505,6 +6536,7 @@ class TestMergeNetBoxDevicesViewVCSyncDevice:
 
         view = object.__new__(MergeNetBoxDevicesView)
         view._librenms_api = _make_api()
+        view.request = MagicMock()
         view.require_write_permission = MagicMock(return_value=None)
         view.require_object_permissions = MagicMock(return_value=None)
         return view
@@ -6604,6 +6636,7 @@ class TestMergeNetBoxDevicesViewFailClosed:
 
         view = object.__new__(MergeNetBoxDevicesView)
         view._librenms_api = _make_api()
+        view.request = MagicMock()
         view.require_write_permission = MagicMock(return_value=None)
         view.require_object_permissions = MagicMock(return_value=None)
         return view
@@ -7740,31 +7773,7 @@ class TestConflictActionsObjectScope:
     device by raw pk.
     """
 
-    @staticmethod
-    def _scoped_writer(in_scope_device, username):
-        """A real non-superuser with plugin write access and a pk-constrained change_device grant."""
-        from core.models import ObjectType
-        from dcim.models import Device
-        from django.apps import apps
-        from django.contrib.auth import get_user_model
-        from users.models import ObjectPermission
-
-        # Resolve via the app registry: the autouse config fixtures patch the models module during
-        # the full suite, so a plain import could hand get_for_model() a mock class.
-        LibreNMSSettings = apps.get_model("netbox_librenms_plugin", "LibreNMSSettings")
-
-        user = get_user_model().objects.create_user(username=username, password="x")
-        write = ObjectPermission.objects.create(name=f"{username}-plugin-write", actions=["change"])
-        write.object_types.set([ObjectType.objects.get_for_model(LibreNMSSettings)])
-        write.users.set([user])
-
-        scoped = ObjectPermission.objects.create(
-            name=f"{username}-scoped-change-device", actions=["change"], constraints={"pk": in_scope_device.pk}
-        )
-        scoped.object_types.set([ObjectType.objects.get_for_model(Device)])
-        scoped.users.set([user])
-
-        return get_user_model().objects.get(pk=user.pk)  # clear the per-request perm cache
+    _scoped_writer = staticmethod(_scoped_device_writer)
 
     def _post_conflict(self, user, target, action="link"):
         """Drive the real DeviceConflictActionView.post against *target* with only the LibreNMS seams patched."""
@@ -7947,6 +7956,7 @@ class TestMergeNetBoxDevicesViewDonorDerivation:
 
         view = object.__new__(MergeNetBoxDevicesView)
         view._librenms_api = _make_api()
+        view.request = MagicMock()
         view.require_write_permission = MagicMock(return_value=None)
         view.require_object_permissions = MagicMock(return_value=None)
         return view
@@ -7984,3 +7994,121 @@ class TestMergeNetBoxDevicesViewDonorDerivation:
         assert "_migrated_to" not in winner_entry
         assert winner_entry["id"] == 20
         assert winner_entry["oob"]["id"] == 10
+
+
+@pytest.mark.django_db
+class TestPromoteAndMergeObjectScope:
+    """Promote and merge resolve client-supplied pks, so both must go through a restricted queryset.
+
+    ``require_object_permissions`` only asks the model-level ``dcim.change_device``, which a
+    pk-constrained grant satisfies; a raw lookup would then let it re-point the LibreNMS linkage of
+    any device.
+    """
+
+    def _post_promote(self, user, target):
+        """Drive the real PromoteToHostView.post against *target* with only the LibreNMS seams patched."""
+        from django.http import HttpResponse
+
+        from netbox_librenms_plugin.views.imports.actions import PromoteToHostView
+
+        view = PromoteToHostView()
+        view._librenms_api = _make_api()
+        libre_device = {"device_id": 55, "hostname": target.name, "sysName": target.name}
+        validation = {
+            "existing_device": target,
+            "promote_to_host": {"existing_libre_id": 10, "existing_oob_type": "idrac"},
+        }
+        request = RequestFactory().post(
+            "/promote-to-host/", {"existing_device_id": str(target.pk), "server_key": "default"}
+        )
+        request.user = user
+        view.request = request
+        with (
+            patch.object(
+                PromoteToHostView,
+                "get_validated_device_with_selections",
+                return_value=(libre_device, validation, {}),
+            ),
+            patch.object(PromoteToHostView, "render_device_row", return_value=HttpResponse(b"row-ok")),
+            patch.object(PromoteToHostView, "rebind_api_for_server", return_value="default"),
+        ):
+            return view.post(request, device_id=55)
+
+    def _post_merge(self, user, winner, donor):
+        """Drive the real MergeNetBoxDevicesView.post with *winner* kept and *donor* absorbed."""
+        from django.http import HttpResponse
+
+        from netbox_librenms_plugin.views.imports.actions import MergeNetBoxDevicesView
+
+        view = MergeNetBoxDevicesView()
+        view._librenms_api = _make_api()
+        validation = {"merge_candidates": {"host_named": {"pk": winner.pk}, "oob_named": {"pk": donor.pk}}}
+        request = RequestFactory().post("/merge-devices/", {"winner_pk": str(winner.pk), "server_key": "default"})
+        request.user = user
+        view.request = request
+        with (
+            patch.object(
+                MergeNetBoxDevicesView,
+                "get_validated_device_with_selections",
+                return_value=({"device_id": 99}, validation, {}),
+            ),
+            patch.object(MergeNetBoxDevicesView, "render_device_row", return_value=HttpResponse(b"row-ok")),
+            patch.object(MergeNetBoxDevicesView, "rebind_api_for_server", return_value="default"),
+        ):
+            return view.post(request, device_id=99)
+
+    def test_promote_cannot_repoint_an_out_of_scope_device(self):
+        """A pk-constrained change_device grant clears the model-level gate but must not promote a device outside its scope."""
+        from dcim.models import Device
+
+        in_scope = make_device("promote-scope-in")
+        out_of_scope = make_device("promote-scope-out", librenms_cf={"default": {"id": 10}})
+        user = _scoped_device_writer(in_scope, "scoped-promote-writer")
+
+        response = self._post_promote(user, out_of_scope)
+
+        assert b"Existing device not found" in response.content
+        entry = Device.objects.get(pk=out_of_scope.pk).custom_field_data["librenms_id"]["default"]
+        assert entry["id"] == 10  # untouched: no host swap, no OOB demotion
+        assert "oob" not in entry
+
+    def test_promote_still_works_for_the_in_scope_device(self):
+        """The device the grant DOES cover promotes normally (no over-block)."""
+        from dcim.models import Device
+
+        in_scope = make_device("promote-scope-in-2", librenms_cf={"default": {"id": 10}})
+        user = _scoped_device_writer(in_scope, "scoped-promote-writer-2")
+
+        response = self._post_promote(user, in_scope)
+
+        assert b"Existing device not found" not in response.content
+        entry = Device.objects.get(pk=in_scope.pk).custom_field_data["librenms_id"]["default"]
+        assert entry["id"] == 55
+        assert entry["oob"]["id"] == 10
+
+    def test_merge_cannot_absorb_an_out_of_scope_donor(self):
+        """The donor is derived server-side but still resolved by pk, so an out-of-scope donor must not be merged away."""
+        from dcim.models import Device
+
+        winner = make_device("merge-scope-winner", librenms_cf={"default": {"id": 20}})
+        donor = make_device("merge-scope-donor", librenms_cf={"default": {"id": 10}})
+        user = _scoped_device_writer(winner, "scoped-merge-writer")  # scoped to the winner only
+
+        response = self._post_merge(user, winner, donor)
+
+        assert b"Winner or donor device not found" in response.content
+        assert "_migrated_to" not in Device.objects.get(pk=donor.pk).custom_field_data["librenms_id"]["default"]
+        assert "oob" not in Device.objects.get(pk=winner.pk).custom_field_data["librenms_id"]["default"]
+
+    def test_merge_succeeds_when_both_sides_are_in_scope(self):
+        """A superuser (unrestricted queryset) still merges both candidates."""
+        from dcim.models import Device
+
+        winner = make_device("merge-scope-winner-2", librenms_cf={"default": {"id": 20}})
+        donor = make_device("merge-scope-donor-2", librenms_cf={"default": {"id": 10}})
+
+        response = self._post_merge(make_superuser(), winner, donor)
+
+        assert b"Winner or donor device not found" not in response.content
+        donor_entry = Device.objects.get(pk=donor.pk).custom_field_data["librenms_id"]["default"]
+        assert donor_entry["_migrated_to"]["device_id"] == winner.pk

--- a/netbox_librenms_plugin/tests/test_coverage_actions.py
+++ b/netbox_librenms_plugin/tests/test_coverage_actions.py
@@ -6772,6 +6772,30 @@ class TestMergeNetBoxDevicesViewFailClosed:
         assert winner.oob_ip_id is None
         assert donor.custom_field_data["librenms_id"]["default"] == {"id": 10}
 
+    def test_device_lock_database_error_fails_closed_without_leaking_backend_text(self):
+        """A DB failure while locking the merge pair returns a safe retry toast, not a 500."""
+        from dcim.models import Device
+        from django.db import DatabaseError
+
+        winner = make_device("merge-device-lock-winner", librenms_cf={"default": {"id": 20}})
+        donor = make_device("merge-device-lock-donor", librenms_cf={"default": {"id": 10}})
+
+        with patch.object(
+            Device.objects,
+            "select_for_update",
+            side_effect=DatabaseError("forced primary lock timeout with backend detail"),
+        ):
+            resp = self._post_merge(self._make_view(), winner, donor)
+
+        assert resp.status_code == 200
+        assert resp["HX-Reswap"] == "none"
+        assert b"database operation failed" in resp.content
+        assert b"forced primary lock timeout" not in resp.content
+        donor.refresh_from_db()
+        winner.refresh_from_db()
+        assert donor.custom_field_data["librenms_id"]["default"] == {"id": 10}
+        assert winner.custom_field_data["librenms_id"]["default"] == {"id": 20}
+
 
 @pytest.mark.django_db
 class TestSuggestOOBInterface:

--- a/netbox_librenms_plugin/tests/test_coverage_actions.py
+++ b/netbox_librenms_plugin/tests/test_coverage_actions.py
@@ -6599,6 +6599,16 @@ class TestMergeNetBoxDevicesViewVCSyncDevice:
         # The raw selected member (m2) never held a link; nothing is planted on it.
         assert "id" not in self._entry(m2)
 
+    def test_legacy_id_on_donor_sync_sibling_gets_convert_first_message(self):
+        """A legacy link on the donor's sync sibling gets the friendly convert-first message."""
+        _vc, _sync_member, selected_member = _two_member_vc("mrg-vc-legacy", m1_cf=30, m2_cf=None)
+        winner = make_device("mrg-vc-legacy-winner", librenms_cf={"default": {"id": 50}})
+
+        response = self._run_merge(winner=winner, donor=selected_member)
+
+        assert b"Donor device has a legacy bare-integer librenms_id" in response.content
+        assert b"Convert mapping" in response.content
+
     def test_merge_locks_every_vc_member_before_resolving_the_sync_device(self):
         """The merge must lock every VC member (incl. bystanders) before resolving the sync device."""
         import re
@@ -7954,7 +7964,7 @@ class TestConflictActionsObjectScope:
 
 @pytest.mark.django_db
 class TestMergeNetBoxDevicesViewDonorDerivation:
-    """The merge view derives the donor from winner_pk + merge_candidates and ignores the client-posted donor_pk, which a stale/failed inline sync script could otherwise leave equal to winner_pk (a self-merge of moving data)."""
+    """The merge derives the donor from winner_pk + merge_candidates and ignores posted donor_pk."""
 
     def _make_view(self):
         from netbox_librenms_plugin.views.imports.actions import MergeNetBoxDevicesView
@@ -7975,7 +7985,7 @@ class TestMergeNetBoxDevicesViewDonorDerivation:
         winner = make_device("merge-w", librenms_cf={"default": {"id": 20}})
         donor = make_device("merge-d", librenms_cf={"default": {"id": 10}})
 
-        # Bogus client state: donor_pk == winner_pk (inline sync script never ran).
+        # Tampered client state: donor_pk == winner_pk must not turn this into a self-merge.
         request = _make_request(post={"winner_pk": str(winner.pk), "donor_pk": str(winner.pk)})
 
         validation = {"merge_candidates": {"host_named": {"pk": winner.pk}, "oob_named": {"pk": donor.pk}}}
@@ -8010,7 +8020,7 @@ class TestPromoteAndMergeObjectScope:
     any device.
     """
 
-    def _post_promote(self, user, target):
+    def _post_promote(self, user, target, **overrides):
         """Drive the real PromoteToHostView.post against *target* with only the LibreNMS seams patched."""
         from django.http import HttpResponse
 
@@ -8023,9 +8033,8 @@ class TestPromoteAndMergeObjectScope:
             "existing_device": target,
             "promote_to_host": {"existing_libre_id": 10, "existing_oob_type": "idrac"},
         }
-        request = RequestFactory().post(
-            "/promote-to-host/", {"existing_device_id": str(target.pk), "server_key": "default"}
-        )
+        post_data = {"existing_device_id": str(target.pk), "server_key": "default", **overrides}
+        request = RequestFactory().post("/promote-to-host/", post_data)
         request.user = user
         view.request = request
         with (
@@ -8090,6 +8099,40 @@ class TestPromoteAndMergeObjectScope:
         entry = Device.objects.get(pk=in_scope.pk).custom_field_data["librenms_id"]["default"]
         assert entry["id"] == 55
         assert entry["oob"]["id"] == 10
+
+    def test_promote_rejects_an_unviewable_device_type_override(self):
+        """A catalog ID outside the user's view scope cannot change the promoted device type."""
+        from dcim.models import Device, DeviceType
+
+        target = make_device("promote-hidden-dt", librenms_cf={"default": {"id": 10}})
+        hidden_type = DeviceType.objects.create(
+            manufacturer=target.device_type.manufacturer,
+            model="Hidden Promote Type",
+            slug="hidden-promote-type",
+        )
+        user = _scoped_device_writer(target, "scoped-promote-hidden-dt")
+
+        response = self._post_promote(user, target, override_device_type_id=str(hidden_type.pk))
+
+        assert b"Invalid override_device_type_id" in response.content
+        assert Device.objects.get(pk=target.pk).device_type_id == target.device_type_id
+
+    def test_promote_rejects_an_unviewable_platform_override(self):
+        """A catalog ID outside the user's view scope cannot change the promoted platform."""
+        from dcim.models import Device, Platform
+
+        target = make_device("promote-hidden-platform", librenms_cf={"default": {"id": 10}})
+        hidden_platform = Platform.objects.create(
+            name="Hidden Promote Platform",
+            slug="hidden-promote-platform",
+            manufacturer=target.device_type.manufacturer,
+        )
+        user = _scoped_device_writer(target, "scoped-promote-hidden-platform")
+
+        response = self._post_promote(user, target, override_platform_id=str(hidden_platform.pk))
+
+        assert b"Invalid override_platform_id" in response.content
+        assert Device.objects.get(pk=target.pk).platform_id is None
 
     def test_merge_cannot_absorb_an_out_of_scope_donor(self):
         """The donor is derived server-side but still resolved by pk, so an out-of-scope donor must not be merged away."""

--- a/netbox_librenms_plugin/tests/test_coverage_actions.py
+++ b/netbox_librenms_plugin/tests/test_coverage_actions.py
@@ -6442,6 +6442,105 @@ class TestMergeNetBoxDevicesViewOOBTransfer:
 
 
 @pytest.mark.django_db
+class TestMergeNetBoxDevicesViewFailClosed:
+    """MergeNetBoxDevicesView.post: ValueErrors from merge_librenms_links, the oob_ip transfer, and mark_librenms_migrated must all fail closed with a toast and leave the donor unmigrated — never a 500 or a silent lossy merge."""
+
+    def _make_view(self):
+        from netbox_librenms_plugin.views.imports.actions import MergeNetBoxDevicesView
+
+        view = object.__new__(MergeNetBoxDevicesView)
+        view._librenms_api = _make_api()
+        view.require_write_permission = MagicMock(return_value=None)
+        view.require_object_permissions = MagicMock(return_value=None)
+        return view
+
+    def _post_merge(self, view, winner, donor):
+        from django.http import HttpResponse
+
+        request = _make_request(post={"winner_pk": str(winner.pk), "donor_pk": str(donor.pk)})
+        validation = {"merge_candidates": {"host_named": {"pk": winner.pk}, "oob_named": {"pk": donor.pk}}}
+        view.get_validated_device_with_selections = MagicMock(return_value=({"device_id": 99}, validation, {}))
+        view.render_device_row = MagicMock(return_value=HttpResponse("row"))
+        return view.post(request, device_id=99)
+
+    def test_orphan_host_id_merge_fails_closed_and_leaves_donor_unmigrated(self):
+        """A winner holding both host id + oob and a donor with a distinct host-id-only link fails closed."""
+        winner = make_device(
+            "merge-orphan-winner",
+            librenms_cf={"default": {"id": 100, "oob": {"id": 50, "type": "idrac"}}},
+        )
+        donor = make_device("merge-orphan-donor", librenms_cf={"default": {"id": 200}})
+
+        resp = self._post_merge(self._make_view(), winner, donor)
+
+        assert resp.status_code == 200
+        assert resp["HX-Reswap"] == "none"
+        assert b"Cannot merge" in resp.content
+        # Donor's link is preserved and it was NOT marked migrated (no orphaned LibreNMS host).
+        donor.refresh_from_db()
+        entry = donor.custom_field_data["librenms_id"]["default"]
+        assert entry == {"id": 200}
+        assert "_migrated_to" not in entry
+
+    def test_corrupt_donor_oob_id_with_winner_oob_fails_closed_not_500(self):
+        """A donor oob id merge_librenms_links skipped (winner already has an oob) fails closed at the marker, not a 500."""
+        winner = make_device(
+            "merge-f2-winner",
+            librenms_cf={"default": {"id": 5, "oob": {"id": 9, "type": "idrac"}}},
+        )
+        # Same host id (so the orphan guard doesn't fire) but a corrupt donor oob id. Because the
+        # winner already holds an oob, merge_librenms_links() skips validating the donor oob id —
+        # mark_librenms_migrated() is the one that rejects it, and that call must be guarded too.
+        donor = make_device("merge-f2-donor", librenms_cf={"default": {"id": 5, "oob": {"id": "abc"}}})
+
+        resp = self._post_merge(self._make_view(), winner, donor)
+
+        assert resp.status_code == 200
+        assert resp["HX-Reswap"] == "none"
+        assert b"Cannot merge" in resp.content
+        donor.refresh_from_db()
+        entry = donor.custom_field_data["librenms_id"]["default"]
+        assert entry == {"id": 5, "oob": {"id": "abc"}}
+        assert "_migrated_to" not in entry
+
+    def test_oob_transfer_valueerror_fails_closed_and_rolls_back(self):
+        """A ValueError from the oob_ip transfer (the TOCTOU race the lock guards) fails closed with rollback, not a 500."""
+        import netbox_librenms_plugin.views.imports.actions as actions_mod
+        from netbox_librenms_plugin.tests.conftest import ip_on
+
+        winner = make_device("merge-f5-winner", librenms_cf={"default": {"id": 20}})
+        donor = make_device("merge-f5-donor", librenms_cf={"default": {"id": 10}})
+        oob_ip = ip_on(winner, "192.0.2.11/32", "mgmt0")  # IP on a WINNER interface → transfer path runs
+        donor.oob_ip = oob_ip
+        donor.save()
+
+        # The pre-check (locked_iface.device_id == winner.pk) passes, but set_device_ip_fk re-reads
+        # a now-stale cached assignment and raises — the concurrency race the lock exists to catch.
+        # Patch the exact boundary (the race is not deterministically reproducible single-threaded).
+        real = actions_mod.set_device_ip_fk
+
+        def racy(device, field, ip, *, save=True):
+            if field == "oob_ip" and ip is not None:
+                raise ValueError("set_device_ip_fk: address is not assigned to an interface on that device")
+            return real(device, field, ip, save=save)
+
+        with patch.object(actions_mod, "set_device_ip_fk", racy):
+            resp = self._post_merge(self._make_view(), winner, donor)
+
+        assert resp.status_code == 200
+        assert resp["HX-Reswap"] == "none"
+        assert b"Cannot merge" in resp.content
+        # Rolled back: donor keeps its oob_ip and link, winner never claimed it, no marker stamped.
+        donor.refresh_from_db()
+        winner.refresh_from_db()
+        assert donor.oob_ip_id == oob_ip.pk
+        assert winner.oob_ip_id is None
+        entry = donor.custom_field_data["librenms_id"]["default"]
+        assert entry == {"id": 10}
+        assert "_migrated_to" not in entry
+
+
+@pytest.mark.django_db
 class TestSuggestOOBInterface:
     """_suggest_oob_interface: pre-select an OOB/mgmt-named interface + default new name."""
 

--- a/netbox_librenms_plugin/tests/test_coverage_actions.py
+++ b/netbox_librenms_plugin/tests/test_coverage_actions.py
@@ -6169,6 +6169,39 @@ class TestPromoteToHostViewPost:
         assert entry["id"] == 17
         assert entry["oob"] == {"id": 10, "type": "oob"}
 
+    def test_override_platform_manufacturer_mismatch_rejected(self):
+        """An override platform whose manufacturer differs from the device type's is rejected (update_fields skips full_clean, so the cross-field invariant is enforced explicitly), and nothing is committed."""
+        from dcim.models import Device, Manufacturer, Platform
+        from django.http import HttpResponse
+
+        view = self._make_view()
+        existing_device = make_device("promote-badplat", librenms_cf={"default": {"id": 10}})
+        # A platform under a DIFFERENT manufacturer than the device's device_type.
+        other_mfr, _ = Manufacturer.objects.get_or_create(name="OtherMfr-3001", slug="othermfr-3001")
+        bad_platform, _ = Platform.objects.get_or_create(
+            name="BadPlat-3001", slug="badplat-3001", defaults={"manufacturer": other_mfr}
+        )
+        assert bad_platform.manufacturer_id != existing_device.device_type.manufacturer_id
+
+        request = _make_request(
+            post={"existing_device_id": str(existing_device.pk), "override_platform_id": str(bad_platform.pk)}
+        )
+        libre_device = {"device_id": 17}
+        promote = {"existing_libre_id": 10, "existing_oob_type": "oob"}
+        validation = {"promote_to_host": promote, "existing_device": existing_device}
+        view.get_validated_device_with_selections = MagicMock(return_value=(libre_device, validation, {}))
+        view.render_device_row = MagicMock(return_value=HttpResponse("row"))
+
+        response = view.post(request, device_id=17)
+
+        # Rejected with a clear cross-field message; the promote is not committed.
+        assert response.status_code == 200
+        assert response["HX-Reswap"] == "none"
+        assert b"not compatible" in response.content
+        reloaded = Device.objects.get(pk=existing_device.pk)
+        assert reloaded.platform_id is None  # the bad override was never persisted
+        assert reloaded.custom_field_data["librenms_id"]["default"] == {"id": 10}  # host swap not committed
+
     def test_aborts_when_incoming_host_id_owned_by_another_device(self):
         """The incoming host id must not already belong to another NetBox device."""
         from dcim.models import Device

--- a/netbox_librenms_plugin/tests/test_coverage_actions.py
+++ b/netbox_librenms_plugin/tests/test_coverage_actions.py
@@ -6005,6 +6005,36 @@ class TestAddAsOOBViewPost:
         assert oob == {"id": 17, "type": "ilo"}
 
 
+class TestRebindApiForPostedServer:
+    """_rebind_api_for_posted_server: rebind on a posted server_key, or return the HTMX error for an unknown one."""
+
+    def test_blank_key_is_noop(self):
+        from netbox_librenms_plugin.views.imports.actions import _rebind_api_for_posted_server
+
+        view = MagicMock()
+        assert _rebind_api_for_posted_server(view, _make_request(post={})) is None
+
+    def test_unknown_key_returns_htmx_error(self):
+        from netbox_librenms_plugin.views.imports.actions import _rebind_api_for_posted_server
+
+        view = MagicMock()
+        with patch("netbox_librenms_plugin.librenms_api.build_librenms_api", return_value=None):
+            resp = _rebind_api_for_posted_server(view, _make_request(post={"server_key": "ghost"}))
+        assert resp is not None
+        assert resp.status_code == 200
+        assert b"no longer configured" in resp.content
+        assert resp["HX-Reswap"] == "none"
+
+    def test_valid_key_rebinds_and_returns_none(self):
+        from netbox_librenms_plugin.views.imports.actions import _rebind_api_for_posted_server
+
+        view = MagicMock()
+        new_api = MagicMock()
+        with patch("netbox_librenms_plugin.librenms_api.build_librenms_api", return_value=new_api):
+            assert _rebind_api_for_posted_server(view, _make_request(post={"server_key": "prod"})) is None
+        assert view._librenms_api is new_api
+
+
 @pytest.mark.django_db
 class TestPromoteToHostViewPost:
     """View-level tests for PromoteToHostView.post() — HTTP interface + OOB sentinel regression."""

--- a/netbox_librenms_plugin/tests/test_coverage_actions.py
+++ b/netbox_librenms_plugin/tests/test_coverage_actions.py
@@ -7743,6 +7743,7 @@ class TestSerialActionsNormalizeAndLock:
         assert len(lock_sqls) == 3
         assert lock_sqls[0] == lock_sqls[1]
         assert lock_sqls[0] != lock_sqls[2]
+        assert "3935087803272606537" in lock_sqls[0]
         assert all("hashtext" not in sql.lower() for sql in lock_sqls)
 
     def test_serial_lock_refuses_to_run_in_autocommit(self):

--- a/netbox_librenms_plugin/tests/test_coverage_actions.py
+++ b/netbox_librenms_plugin/tests/test_coverage_actions.py
@@ -6250,6 +6250,41 @@ class TestMergeNetBoxDevicesViewOOBTransfer:
         assert donor.oob_ip_id == oob_ip.pk
         assert winner.oob_ip_id is None
 
+    def test_oob_ip_and_owning_interface_locked_for_update(self):
+        """The oob_ip transfer must SELECT ... FOR UPDATE the IPAddress and its owning interface so a concurrent interface move can't leave winner.oob_ip on an interface no longer on the winner."""
+        from django.db import connection
+        from django.http import HttpResponse
+        from django.test.utils import CaptureQueriesContext
+
+        from netbox_librenms_plugin.tests.conftest import ip_on
+
+        view = self._make_view()
+        winner = make_device("merge-winner-lock", librenms_cf={"default": {"id": 20}})
+        donor = make_device("merge-donor-lock", librenms_cf={"default": {"id": 10}})
+        oob_ip = ip_on(winner, "192.0.2.9/32", "mgmt0")  # IP on a WINNER interface → transfer path runs
+        donor.oob_ip = oob_ip
+        donor.save()
+
+        request = _make_request(post={"winner_pk": str(winner.pk), "donor_pk": str(donor.pk)})
+        validation = {"merge_candidates": {"host_named": {"pk": winner.pk}, "oob_named": {"pk": donor.pk}}}
+        view.get_validated_device_with_selections = MagicMock(return_value=({"device_id": 99}, validation, {}))
+        view.render_device_row = MagicMock(return_value=HttpResponse("row"))
+
+        with CaptureQueriesContext(connection) as ctx:
+            resp = view.post(request, device_id=99)
+        assert resp.status_code == 200
+
+        def _locked(table):
+            return any(table in q["sql"].lower() and "for update" in q["sql"].lower() for q in ctx.captured_queries)
+
+        assert _locked("ipam_ipaddress"), "the transferred oob_ip must be SELECT ... FOR UPDATE"
+        assert _locked("dcim_interface"), "the oob_ip's owning interface must be SELECT ... FOR UPDATE"
+        # And the transfer still completes.
+        winner.refresh_from_db()
+        donor.refresh_from_db()
+        assert winner.oob_ip_id == oob_ip.pk
+        assert donor.oob_ip_id is None
+
     def test_save_failure_rolls_back_donor_oob_release_and_marker(self):
         """Forced persist failure mid-merge must roll back the donor's already-executed save."""
         from dcim.models import Device

--- a/netbox_librenms_plugin/tests/test_coverage_actions.py
+++ b/netbox_librenms_plugin/tests/test_coverage_actions.py
@@ -6504,7 +6504,8 @@ class TestMergeNetBoxDevicesViewOOBTransfer:
         # Surfaced as the HTMX OOB error toast (200 + HX-Reswap:none), not a 500.
         assert resp.status_code == 200
         assert resp["HX-Reswap"] == "none"
-        assert b"Unable to save" in resp.content
+        assert b"database integrity constraint was violated" in resp.content
+        assert b"forced winner save failure" not in resp.content
         # The donor's save (release + marker) was rolled back: it still owns the oob_ip, the
         # winner never claimed it, and no migration marker was stamped.
         donor.refresh_from_db()
@@ -6644,7 +6645,7 @@ class TestMergeNetBoxDevicesViewVCSyncDevice:
 
 @pytest.mark.django_db
 class TestMergeNetBoxDevicesViewFailClosed:
-    """MergeNetBoxDevicesView.post: ValueErrors from merge_librenms_links, the oob_ip transfer, and mark_librenms_migrated must all fail closed with a toast and leave the donor unmigrated — never a 500 or a silent lossy merge."""
+    """Merge preparation failures must return a toast and leave the donor unmigrated."""
 
     def _make_view(self):
         from netbox_librenms_plugin.views.imports.actions import MergeNetBoxDevicesView
@@ -6740,6 +6741,36 @@ class TestMergeNetBoxDevicesViewFailClosed:
         entry = donor.custom_field_data["librenms_id"]["default"]
         assert entry == {"id": 10}
         assert "_migrated_to" not in entry
+
+    def test_oob_ip_lock_database_error_fails_closed_without_leaking_backend_text(self):
+        """A DB failure while acquiring the OOB-IP lock returns a safe toast and rolls back."""
+        from django.db import DatabaseError
+
+        from ipam.models import IPAddress
+        from netbox_librenms_plugin.tests.conftest import ip_on
+
+        winner = make_device("merge-db-lock-winner", librenms_cf={"default": {"id": 20}})
+        donor = make_device("merge-db-lock-donor", librenms_cf={"default": {"id": 10}})
+        oob_ip = ip_on(winner, "192.0.2.12/32", "mgmt0")
+        donor.oob_ip = oob_ip
+        donor.save()
+
+        with patch.object(
+            IPAddress.objects,
+            "select_for_update",
+            side_effect=DatabaseError("forced lock timeout with backend detail"),
+        ):
+            resp = self._post_merge(self._make_view(), winner, donor)
+
+        assert resp.status_code == 200
+        assert resp["HX-Reswap"] == "none"
+        assert b"database operation failed" in resp.content
+        assert b"forced lock timeout" not in resp.content
+        donor.refresh_from_db()
+        winner.refresh_from_db()
+        assert donor.oob_ip_id == oob_ip.pk
+        assert winner.oob_ip_id is None
+        assert donor.custom_field_data["librenms_id"]["default"] == {"id": 10}
 
 
 @pytest.mark.django_db

--- a/netbox_librenms_plugin/tests/test_coverage_actions.py
+++ b/netbox_librenms_plugin/tests/test_coverage_actions.py
@@ -6029,7 +6029,10 @@ class TestGetValidatedDeviceLibreDeviceReuse:
 
         with (
             patch("netbox_librenms_plugin.views.imports.actions.fetch_device_with_cache", side_effect=_boom),
-            patch.object(view, "_should_enable_vc_detection", return_value=False),
+            patch(
+                "netbox_librenms_plugin.views.imports.actions.validate_device_for_import",
+                return_value={"import_as_vm": False},
+            ),
         ):
             libre_device, validation, _selections = view.get_validated_device_with_selections(
                 4242, request, libre_device=supplied
@@ -6051,7 +6054,10 @@ class TestGetValidatedDeviceLibreDeviceReuse:
                 "netbox_librenms_plugin.views.imports.actions.fetch_device_with_cache",
                 return_value={"device_id": 7},
             ) as mock_fetch,
-            patch.object(view, "_should_enable_vc_detection", return_value=False),
+            patch(
+                "netbox_librenms_plugin.views.imports.actions.validate_device_for_import",
+                return_value={"import_as_vm": False},
+            ),
         ):
             view.get_validated_device_with_selections(7, request)
 
@@ -7231,8 +7237,8 @@ class TestCreatePlatformFromImportManufacturer:
         mock_platform.objects.create.assert_not_called()
 
     @pytest.mark.django_db
-    def test_device_platform_manufacturer_mismatch_rejected_and_rolled_back(self):
-        """Assigning a new Platform whose manufacturer conflicts with the target Device's device-type manufacturer is rejected, and the just-created Platform is rolled back."""
+    def test_device_platform_manufacturer_mismatch_surfaced_platform_kept(self):
+        """A new Platform whose manufacturer conflicts with the target Device's device-type manufacturer fails to assign; the failure is surfaced to the user and the device is left unassigned, but the just-created Platform is intentionally kept (aec0360a1: the platform create is the primary action and the assignment runs in its own transaction)."""
         from dcim.models import Manufacturer, Platform
 
         device = make_device("plat-assign-mismatch")  # device_type under manufacturer TestMfr
@@ -7256,10 +7262,12 @@ class TestCreatePlatformFromImportManufacturer:
         ):
             resp = view.post(req, device_id=device.pk)
 
-        # An error response was returned (not a success), the newly created Platform was rolled
-        # back, and the device's platform is untouched.
+        # The platform create is the primary action: the manufacturer-mismatch assignment failure is
+        # surfaced to the user (error toast) and the device is left unassigned, but the just-created
+        # Platform is intentionally NOT rolled back.
         assert resp is not None
-        assert not Platform.objects.filter(name="Mismatch-OS").exists()
+        assert Platform.objects.filter(name="Mismatch-OS").exists()
+        assert b"could not be assigned" in resp.content
         device.refresh_from_db()
         assert device.platform_id is None
 

--- a/netbox_librenms_plugin/tests/test_coverage_actions.py
+++ b/netbox_librenms_plugin/tests/test_coverage_actions.py
@@ -6005,6 +6005,52 @@ class TestAddAsOOBViewPost:
         assert oob == {"id": 17, "type": "ilo"}
 
 
+@pytest.mark.django_db
+class TestGetValidatedDeviceLibreDeviceReuse:
+    """get_validated_device_with_selections reuses a supplied libre_device (the post-commit refresh path)."""
+
+    def test_supplied_libre_device_skips_the_fetch(self):
+        from netbox_librenms_plugin.views.imports.actions import PromoteToHostView
+
+        view = object.__new__(PromoteToHostView)
+        view._librenms_api = _make_api()
+        request = _make_request(post={})
+        supplied = {"device_id": 4242, "hostname": "reuse-host", "sysName": "reuse-host"}
+
+        def _boom(*a, **k):
+            raise AssertionError("fetch_device_with_cache must not run when libre_device is supplied")
+
+        with (
+            patch("netbox_librenms_plugin.views.imports.actions.fetch_device_with_cache", side_effect=_boom),
+            patch.object(view, "_should_enable_vc_detection", return_value=False),
+        ):
+            libre_device, validation, _selections = view.get_validated_device_with_selections(
+                4242, request, libre_device=supplied
+            )
+
+        # The supplied device flowed through and validate_device_for_import still ran for real.
+        assert libre_device is supplied
+        assert validation is not None
+
+    def test_without_libre_device_still_fetches(self):
+        from netbox_librenms_plugin.views.imports.actions import PromoteToHostView
+
+        view = object.__new__(PromoteToHostView)
+        view._librenms_api = _make_api()
+        request = _make_request(post={})
+
+        with (
+            patch(
+                "netbox_librenms_plugin.views.imports.actions.fetch_device_with_cache",
+                return_value={"device_id": 7},
+            ) as mock_fetch,
+            patch.object(view, "_should_enable_vc_detection", return_value=False),
+        ):
+            view.get_validated_device_with_selections(7, request)
+
+        mock_fetch.assert_called_once()
+
+
 class TestRebindApiForPostedServer:
     """_rebind_api_for_posted_server: rebind on a posted server_key, or return the HTMX error for an unknown one."""
 

--- a/netbox_librenms_plugin/tests/test_coverage_actions.py
+++ b/netbox_librenms_plugin/tests/test_coverage_actions.py
@@ -6007,16 +6007,7 @@ class TestAddAsOOBViewPost:
 
 @pytest.mark.django_db
 class TestPromoteToHostViewPost:
-    """View-level tests for PromoteToHostView.post() — HTTP interface + OOB sentinel regression.
-
-    Companion to TestAddAsOOBViewPost for the other half of the OOB sentinel flow: the
-    promote endpoint demotes the existing device's current LibreNMS link into the OOB slot
-    and makes the incoming LibreNMS device the new host. The concurrency guards
-    (get_librenms_device_id / get_librenms_oob / find_by_librenms_id), set_librenms_device_id
-    + set_librenms_oob, and _save_device all run for real against a real Device, and the
-    persisted custom_field_data is reloaded from the DB. Only the LibreNMS validation
-    pipeline, auth gates, and row HTML render stay mocked.
-    """
+    """View-level tests for PromoteToHostView.post() — HTTP interface + OOB sentinel regression."""
 
     def _make_view(self):
         from netbox_librenms_plugin.views.imports.actions import PromoteToHostView
@@ -6068,8 +6059,7 @@ class TestPromoteToHostViewPost:
         assert response["HX-Reswap"] == "none"
 
     def test_device_id_mismatch_returns_htmx_error(self):
-        """When the validation's existing_device pk does not match the posted
-        existing_device_id, the view rejects the stale modal."""
+        """When the validation's existing_device pk does not match the posted existing_device_id, the view rejects the stale modal."""
         view = self._make_view()
         existing_device = make_device("promote-existing", librenms_cf={"default": {"id": 10}})
         other_device = make_device("promote-other")
@@ -6102,8 +6092,7 @@ class TestPromoteToHostViewPost:
         assert response["HX-Reswap"] == "none"
 
     def test_existing_link_already_points_at_incoming_device_returns_error(self):
-        """If the existing link already equals the incoming LibreNMS id there is nothing to
-        promote — the view must say so rather than self-demoting the same id into OOB."""
+        """If the existing link already equals the incoming LibreNMS id there is nothing to promote — the view must say so rather than self-demoting the same id into OOB."""
         view = self._make_view()
         existing_device = make_device("promote-noop", librenms_cf={"default": {"id": 17}})
         request = _make_request(post={"existing_device_id": str(existing_device.pk)})
@@ -6118,16 +6107,7 @@ class TestPromoteToHostViewPost:
         assert response["HX-Reswap"] == "none"
 
     def test_happy_path_generic_oob_sentinel_promotes_and_demotes_link(self):
-        """End-to-end VIEW-level regression for issue #89: POST to PromoteToHostView with the
-        generic 'oob' sentinel as the existing controller type. The real concurrency guards,
-        set_librenms_device_id + set_librenms_oob, and _save_device run against a real Device;
-        the persisted custom_field_data is reloaded from the DB to prove the host id was
-        swapped to the incoming LibreNMS device and the previous link demoted to the OOB slot
-        with the sentinel type.
-
-        Historically set_librenms_oob rejected the generic 'oob', so this endpoint returned
-        an 'Invalid promotion data' HTMX error; removing the sentinel branch in
-        set_librenms_oob makes this test go red (error response + no committed oob slot)."""
+        """End-to-end VIEW-level regression for issue #89: POST to PromoteToHostView with the generic 'oob' sentinel as the existing controller type."""
         from dcim.models import Device
         from django.http import HttpResponse
 
@@ -6157,9 +6137,7 @@ class TestPromoteToHostViewPost:
         assert entry["oob"] == {"id": 10, "type": "oob"}
 
     def test_aborts_when_incoming_host_id_owned_by_another_device(self):
-        """The incoming host id must not already belong to another NetBox device. Re-checked
-        inside the transaction via the real find_by_librenms_id so promotion can't point one
-        LibreNMS device at two NetBox devices."""
+        """The incoming host id must not already belong to another NetBox device."""
         from dcim.models import Device
         from django.http import HttpResponse
 
@@ -6187,16 +6165,7 @@ class TestPromoteToHostViewPost:
 
 @pytest.mark.django_db
 class TestMergeNetBoxDevicesViewOOBTransfer:
-    """MergeNetBoxDevicesView.post: oob_ip may only move to the winner when its
-    underlying IP already sits on a winner interface (the merge does not move
-    interfaces, and the save skips full_clean()).
-
-    Driven against real Device / Interface / IPAddress so the transfer is proven by
-    what actually persists and reloads, not by inspecting ``save(update_fields=...)``
-    on a MagicMock. The real ``merge_librenms_links`` / ``mark_librenms_migrated`` run
-    and the locked rows are genuine ``select_for_update`` re-reads — only the LibreNMS
-    validation pipeline, auth gates, and the row HTML render stay mocked.
-    """
+    """MergeNetBoxDevicesView.post: oob_ip may only move to the winner when its underlying IP already sits on a winner interface (the merge does not move interfaces, and the save skips full_clean())."""
 
     def _make_view(self):
         from netbox_librenms_plugin.views.imports.actions import MergeNetBoxDevicesView
@@ -6208,9 +6177,7 @@ class TestMergeNetBoxDevicesViewOOBTransfer:
         return view
 
     def _run(self, *, oob_on_winner):
-        """Drive a merge where the donor's oob_ip sits on an interface owned by the
-        winner (``oob_on_winner=True``) or by the donor (``False``).
-        Returns ``(winner, donor, oob_ip)`` with the devices reloaded from the DB."""
+        """Drive a merge where the donor's oob_ip sits on an interface owned by the winner (``oob_on_winner=True``) or by the donor (``False``)."""
         from dcim.models import Device
         from django.http import HttpResponse
 
@@ -6251,18 +6218,7 @@ class TestMergeNetBoxDevicesViewOOBTransfer:
         assert winner.oob_ip_id is None
 
     def test_save_failure_rolls_back_donor_oob_release_and_marker(self):
-        """Forced persist failure mid-merge must roll back the donor's already-executed save.
-
-        The view saves the donor first — releasing its ``oob_ip`` (a UNIQUE OneToOne) and
-        stamping the ``_migrated_to`` marker — then saves the winner to claim the IP. If the
-        winner save fails, the ``except`` block must mark the transaction rollback-only;
-        otherwise the donor is left with no ``oob_ip`` AND no winner holding it (an orphaned
-        address) plus a ``_migrated_to`` marker for a merge that never completed.
-
-        Driven against real rows: only the *second* Device.save (the winner's) is forced to
-        raise, so the donor's real release is genuinely on disk inside the savepoint before the
-        rollback. Removing ``set_rollback(True)`` leaves the donor's release/marker committed and
-        this test goes red."""
+        """Forced persist failure mid-merge must roll back the donor's already-executed save."""
         from dcim.models import Device
         from django.db import IntegrityError
         from django.http import HttpResponse
@@ -7493,15 +7449,7 @@ class TestConflictActionsObjectScope:
 
 @pytest.mark.django_db
 class TestMergeNetBoxDevicesViewDonorDerivation:
-    """The merge view derives the donor from winner_pk + merge_candidates and
-    ignores the client-posted donor_pk, which a stale/failed inline sync script
-    could otherwise leave equal to winner_pk (a self-merge of moving data).
-
-    Driven against real Devices and the real merge/migration helpers: the role
-    derivation is proven by which device actually ends up with the persisted
-    ``_migrated_to`` marker after reload — not by which MagicMock was handed to a
-    patched ``merge_librenms_links``.
-    """
+    """The merge view derives the donor from winner_pk + merge_candidates and ignores the client-posted donor_pk, which a stale/failed inline sync script could otherwise leave equal to winner_pk (a self-merge of moving data)."""
 
     def _make_view(self):
         from netbox_librenms_plugin.views.imports.actions import MergeNetBoxDevicesView

--- a/netbox_librenms_plugin/tests/test_coverage_actions.py
+++ b/netbox_librenms_plugin/tests/test_coverage_actions.py
@@ -6266,10 +6266,11 @@ class TestPromoteToHostViewPost:
 
         response = view.post(request, device_id=17)
 
-        # Rejected with a clear cross-field message; the promote is not committed.
+        # Rejected by the SHARED _platform_device_type_mismatch() check inside _save_device()
+        # (not a now-removed inline duplicate); the promote is not committed.
         assert response.status_code == 200
         assert response["HX-Reswap"] == "none"
-        assert b"not compatible" in response.content
+        assert b"update the platform first" in response.content
         reloaded = Device.objects.get(pk=existing_device.pk)
         assert reloaded.platform_id is None  # the bad override was never persisted
         assert reloaded.custom_field_data["librenms_id"]["default"] == {"id": 10}  # host swap not committed

--- a/netbox_librenms_plugin/tests/test_coverage_actions.py
+++ b/netbox_librenms_plugin/tests/test_coverage_actions.py
@@ -7727,6 +7727,18 @@ class TestSerialActionsNormalizeAndLock:
         conflict_row_locks = self._serial_row_locks(sqls)
         assert conflict_row_locks == [], f"conflict lookup still takes a row lock: {conflict_row_locks}"
 
+    def test_serial_advisory_lock_uses_a_stable_application_key(self):
+        """The advisory key is derived in application code, not PostgreSQL's undocumented hashtext()."""
+        from django.db import connection
+        from django.test.utils import CaptureQueriesContext
+
+        target = make_device("ser-act-stable-lock")
+        with CaptureQueriesContext(connection) as ctx:
+            self._post_action("sync_serial", target, "SN-STABLE")
+
+        lock_sql = next(q["sql"] for q in ctx.captured_queries if "pg_advisory_xact_lock" in q["sql"])
+        assert "hashtext" not in lock_sql.lower()
+
     def test_serial_lock_refuses_to_run_in_autocommit(self):
         """pg_advisory_xact_lock is transaction-scoped, so taking it outside a transaction locks nothing and must fail loudly."""
         from django.db import connection
@@ -8099,6 +8111,30 @@ class TestPromoteAndMergeObjectScope:
         entry = Device.objects.get(pk=in_scope.pk).custom_field_data["librenms_id"]["default"]
         assert entry["id"] == 55
         assert entry["oob"]["id"] == 10
+
+    def test_promote_rechecks_legacy_mapping_after_lock(self):
+        """A concurrent legacy write between validation and row lock must fail closed without partially promoting."""
+        from dcim.models import Device
+
+        target = make_device("promote-legacy-race", librenms_cf={"default": {"id": 10}})
+        user = _scoped_device_writer(target, "scoped-promote-legacy-race")
+        calls = 0
+
+        def concurrent_legacy_write(*args, **kwargs):
+            nonlocal calls
+            calls += 1
+            if calls == 1:
+                Device.objects.filter(pk=target.pk).update(custom_field_data={"librenms_id": 10})
+            return None
+
+        with patch(
+            "netbox_librenms_plugin.utils.find_by_librenms_id",
+            side_effect=concurrent_legacy_write,
+        ):
+            response = self._post_promote(user, target)
+
+        assert b"Convert mapping" in response.content
+        assert Device.objects.get(pk=target.pk).custom_field_data["librenms_id"] == 10
 
     def test_promote_rejects_an_unviewable_device_type_override(self):
         """A catalog ID outside the user's view scope cannot change the promoted device type."""

--- a/netbox_librenms_plugin/tests/test_coverage_actions.py
+++ b/netbox_librenms_plugin/tests/test_coverage_actions.py
@@ -6006,6 +6006,186 @@ class TestAddAsOOBViewPost:
 
 
 @pytest.mark.django_db
+class TestPromoteToHostViewPost:
+    """View-level tests for PromoteToHostView.post() — HTTP interface + OOB sentinel regression.
+
+    Companion to TestAddAsOOBViewPost for the other half of the OOB sentinel flow: the
+    promote endpoint demotes the existing device's current LibreNMS link into the OOB slot
+    and makes the incoming LibreNMS device the new host. The concurrency guards
+    (get_librenms_device_id / get_librenms_oob / find_by_librenms_id), set_librenms_device_id
+    + set_librenms_oob, and _save_device all run for real against a real Device, and the
+    persisted custom_field_data is reloaded from the DB. Only the LibreNMS validation
+    pipeline, auth gates, and row HTML render stay mocked.
+    """
+
+    def _make_view(self):
+        from netbox_librenms_plugin.views.imports.actions import PromoteToHostView
+
+        view = object.__new__(PromoteToHostView)
+        view.kwargs = {}
+        view._librenms_api = _make_api()
+        view.require_write_permission = MagicMock(return_value=None)
+        view.require_object_permissions = MagicMock(return_value=None)
+        return view
+
+    def test_missing_existing_device_id_returns_htmx_error(self):
+        """POST without existing_device_id returns an HTMX error before any ORM lookup."""
+        view = self._make_view()
+        request = _make_request(post={})
+
+        response = view.post(request, device_id=1)
+
+        assert response.status_code == 200
+        assert b"Missing existing_device_id" in response.content
+        assert response["HX-Reswap"] == "none"
+
+    def test_write_permission_denied_returns_error(self):
+        """When write permission is denied, the view returns that error immediately."""
+        from django.http import HttpResponse
+
+        view = self._make_view()
+        perm_error = HttpResponse("Forbidden", status=403)
+        view.require_write_permission = MagicMock(return_value=perm_error)
+
+        request = _make_request(post={"existing_device_id": "1"})
+        response = view.post(request, device_id=1)
+
+        assert response.status_code == 403
+
+    def test_no_promote_candidate_returns_htmx_error(self):
+        """When validation has no promote_to_host, the endpoint reports promotion N/A."""
+        view = self._make_view()
+        existing_device = make_device("promote-nocand")
+        request = _make_request(post={"existing_device_id": str(existing_device.pk)})
+
+        view.get_validated_device_with_selections = MagicMock(
+            return_value=({"device_id": 17}, {"promote_to_host": None}, {})
+        )
+        response = view.post(request, device_id=17)
+
+        assert response.status_code == 200
+        assert b"Promotion is not applicable" in response.content
+        assert response["HX-Reswap"] == "none"
+
+    def test_device_id_mismatch_returns_htmx_error(self):
+        """When the validation's existing_device pk does not match the posted
+        existing_device_id, the view rejects the stale modal."""
+        view = self._make_view()
+        existing_device = make_device("promote-existing", librenms_cf={"default": {"id": 10}})
+        other_device = make_device("promote-other")
+        request = _make_request(post={"existing_device_id": str(existing_device.pk)})
+
+        promote = {"existing_libre_id": 10, "existing_oob_type": "oob"}
+        validation = {"promote_to_host": promote, "existing_device": other_device}
+        view.get_validated_device_with_selections = MagicMock(return_value=({"device_id": 17}, validation, {}))
+        response = view.post(request, device_id=17)
+
+        assert response.status_code == 200
+        assert b"mismatch" in response.content.lower()
+        assert response["HX-Reswap"] == "none"
+
+    def test_legacy_librenms_id_returns_htmx_error(self):
+        """A device with a legacy bare-int librenms_id is rejected with a convert-first message."""
+        view = self._make_view()
+        existing_device = make_device("promote-legacy", librenms_cf=42)
+        request = _make_request(post={"existing_device_id": str(existing_device.pk)})
+
+        # existing_libre_id matches the legacy host id (42) so earlier guards pass and the
+        # legacy-form check is the failure point.
+        promote = {"existing_libre_id": 42, "existing_oob_type": "oob"}
+        validation = {"promote_to_host": promote, "existing_device": existing_device}
+        view.get_validated_device_with_selections = MagicMock(return_value=({"device_id": 17}, validation, {}))
+        response = view.post(request, device_id=17)
+
+        assert response.status_code == 200
+        assert b"legacy" in response.content.lower()
+        assert response["HX-Reswap"] == "none"
+
+    def test_existing_link_already_points_at_incoming_device_returns_error(self):
+        """If the existing link already equals the incoming LibreNMS id there is nothing to
+        promote — the view must say so rather than self-demoting the same id into OOB."""
+        view = self._make_view()
+        existing_device = make_device("promote-noop", librenms_cf={"default": {"id": 17}})
+        request = _make_request(post={"existing_device_id": str(existing_device.pk)})
+
+        promote = {"existing_libre_id": 17, "existing_oob_type": "oob"}
+        validation = {"promote_to_host": promote, "existing_device": existing_device}
+        view.get_validated_device_with_selections = MagicMock(return_value=({"device_id": 17}, validation, {}))
+        response = view.post(request, device_id=17)
+
+        assert response.status_code == 200
+        assert b"already points at this LibreNMS device" in response.content
+        assert response["HX-Reswap"] == "none"
+
+    def test_happy_path_generic_oob_sentinel_promotes_and_demotes_link(self):
+        """End-to-end VIEW-level regression for issue #89: POST to PromoteToHostView with the
+        generic 'oob' sentinel as the existing controller type. The real concurrency guards,
+        set_librenms_device_id + set_librenms_oob, and _save_device run against a real Device;
+        the persisted custom_field_data is reloaded from the DB to prove the host id was
+        swapped to the incoming LibreNMS device and the previous link demoted to the OOB slot
+        with the sentinel type.
+
+        Historically set_librenms_oob rejected the generic 'oob', so this endpoint returned
+        an 'Invalid promotion data' HTMX error; removing the sentinel branch in
+        set_librenms_oob makes this test go red (error response + no committed oob slot)."""
+        from dcim.models import Device
+        from django.http import HttpResponse
+
+        view = self._make_view()
+        # Existing device is currently linked to LibreNMS id 10 (the controller, occupying the
+        # host slot pre-promote); the incoming real host is id 17.
+        existing_device = make_device("promote-happy", librenms_cf={"default": {"id": 10}})
+        request = _make_request(post={"existing_device_id": str(existing_device.pk)})
+
+        libre_device = {"device_id": 17}
+        promote = {"existing_libre_id": 10, "existing_oob_type": "oob"}
+        validation = {"promote_to_host": promote, "existing_device": existing_device}
+        view.get_validated_device_with_selections = MagicMock(return_value=(libre_device, validation, {}))
+        view.render_device_row = MagicMock(return_value=HttpResponse("row"))
+
+        response = view.post(request, device_id=17)
+
+        # Success path: validation modal refresh, no error swap.
+        assert response.status_code == 200
+        assert "validationRefresh" in response.get("HX-Trigger", "")
+        view.render_device_row.assert_called_once()
+
+        # Reload from the DB: host id swapped to 17, previous link (10) demoted to the OOB
+        # slot with the generic sentinel type.
+        entry = Device.objects.get(pk=existing_device.pk).custom_field_data["librenms_id"]["default"]
+        assert entry["id"] == 17
+        assert entry["oob"] == {"id": 10, "type": "oob"}
+
+    def test_aborts_when_incoming_host_id_owned_by_another_device(self):
+        """The incoming host id must not already belong to another NetBox device. Re-checked
+        inside the transaction via the real find_by_librenms_id so promotion can't point one
+        LibreNMS device at two NetBox devices."""
+        from dcim.models import Device
+        from django.http import HttpResponse
+
+        view = self._make_view()
+        existing_device = make_device("promote-host", librenms_cf={"default": {"id": 10}})
+        # A different real device already owns LibreNMS id 17.
+        make_device("promote-thief", librenms_cf={"default": {"id": 17}})
+        request = _make_request(post={"existing_device_id": str(existing_device.pk)})
+
+        libre_device = {"device_id": 17}
+        promote = {"existing_libre_id": 10, "existing_oob_type": "oob"}
+        validation = {"promote_to_host": promote, "existing_device": existing_device}
+        view.get_validated_device_with_selections = MagicMock(return_value=(libre_device, validation, {}))
+        view.render_device_row = MagicMock(return_value=HttpResponse("row"))
+
+        response = view.post(request, device_id=17)
+
+        assert response.status_code == 200
+        assert response["HX-Reswap"] == "none"
+        assert b"already linked to &#x27;promote-thief&#x27;" in response.content
+        # Nothing committed: the host slot is unchanged and no OOB slot was written.
+        entry = Device.objects.get(pk=existing_device.pk).custom_field_data["librenms_id"]["default"]
+        assert entry == {"id": 10}
+
+
+@pytest.mark.django_db
 class TestMergeNetBoxDevicesViewOOBTransfer:
     """MergeNetBoxDevicesView.post: oob_ip may only move to the winner when its
     underlying IP already sits on a winner interface (the merge does not move

--- a/netbox_librenms_plugin/tests/test_coverage_actions.py
+++ b/netbox_librenms_plugin/tests/test_coverage_actions.py
@@ -6051,34 +6051,30 @@ class TestGetValidatedDeviceLibreDeviceReuse:
         mock_fetch.assert_called_once()
 
 
-class TestRebindApiForPostedServer:
-    """_rebind_api_for_posted_server: rebind on a posted server_key, or return the HTMX error for an unknown one."""
+@pytest.mark.django_db
+class TestPostActionRebindFailsClosed:
+    """PromoteToHost/Merge POST views are consolidated onto the fail-closed mixin rebind.
 
-    def test_blank_key_is_noop(self):
-        from netbox_librenms_plugin.views.imports.actions import _rebind_api_for_posted_server
+    A blank server_key with a misconfigured default must surface a fragment error here instead of
+    leaving the lazy default client in place and 500ing on the first self.librenms_api access.
+    """
 
-        view = MagicMock()
-        assert _rebind_api_for_posted_server(view, _make_request(post={})) is None
+    def test_blank_key_with_misconfigured_default_returns_error(self):
+        from netbox_librenms_plugin.views.imports.actions import PromoteToHostView
 
-    def test_unknown_key_returns_htmx_error(self):
-        from netbox_librenms_plugin.views.imports.actions import _rebind_api_for_posted_server
-
-        view = MagicMock()
+        view = object.__new__(PromoteToHostView)
+        view.kwargs = {}
+        view.require_write_permission = MagicMock(return_value=None)
+        view.require_object_permissions = MagicMock(return_value=None)
+        # No session client bound + a default that won't build → the mixin must fail closed on the
+        # blank key, where the old per-view helper left the default in place and validated nothing.
+        request = _make_request(post={"existing_device_id": "5"})
         with patch("netbox_librenms_plugin.librenms_api.build_librenms_api", return_value=None):
-            resp = _rebind_api_for_posted_server(view, _make_request(post={"server_key": "ghost"}))
-        assert resp is not None
-        assert resp.status_code == 200
-        assert b"no longer configured" in resp.content
-        assert resp["HX-Reswap"] == "none"
+            response = view.post(request, device_id=17)
 
-    def test_valid_key_rebinds_and_returns_none(self):
-        from netbox_librenms_plugin.views.imports.actions import _rebind_api_for_posted_server
-
-        view = MagicMock()
-        new_api = MagicMock()
-        with patch("netbox_librenms_plugin.librenms_api.build_librenms_api", return_value=new_api):
-            assert _rebind_api_for_posted_server(view, _make_request(post={"server_key": "prod"})) is None
-        assert view._librenms_api is new_api
+        assert response.status_code == 200
+        assert b"no longer configured" in response.content
+        assert response["HX-Reswap"] == "none"
 
 
 @pytest.mark.django_db

--- a/netbox_librenms_plugin/tests/test_coverage_actions.py
+++ b/netbox_librenms_plugin/tests/test_coverage_actions.py
@@ -7136,7 +7136,7 @@ class TestOOBInterfaceSelectTemplate:
         assert 'getElementById("oob-iface-7")' in html
 
     def test_initializes_create_state_on_load(self):
-        """The script must sync the "new name" input once on load (not only on change), so the input matches the rendered selection even if it differs from the server-side display logic (e.g."""
+        """The script must sync the "new name" input once on load (not only on change), so the input matches the rendered selection even if it differs from the server-side display logic (e.g. a browser-restored form value)."""
         html = self._render()
         assert "function syncCreateState()" in html
         # Bound to change AND invoked immediately so initial state is authoritative.

--- a/netbox_librenms_plugin/tests/test_coverage_actions.py
+++ b/netbox_librenms_plugin/tests/test_coverage_actions.py
@@ -631,7 +631,11 @@ class TestBulkImportDevicesViewPost:
             response = view.post(request)
 
         assert response.status_code == 200
-        assert b"no workers available" in response.content
+        # Outcome-neutral wording: the fallback banner must NOT claim every selected row was
+        # "Imported" — the per-row summary toasts report the actual successes/failures/skips.
+        assert b"no workers are available" in response.content
+        assert b"ran synchronously" in response.content
+        assert b"devices synchronously" not in response.content
 
 
 class TestDeviceImportHelperMixin:
@@ -7222,6 +7226,68 @@ class TestCreatePlatformFromImportManufacturer:
         # Neither the constructor nor the manager create() path persisted a Platform.
         mock_platform.assert_not_called()
         mock_platform.objects.create.assert_not_called()
+
+    @pytest.mark.django_db
+    def test_device_platform_manufacturer_mismatch_rejected_and_rolled_back(self):
+        """Assigning a new Platform whose manufacturer conflicts with the target Device's device-type manufacturer is rejected, and the just-created Platform is rolled back."""
+        from dcim.models import Manufacturer, Platform
+
+        device = make_device("plat-assign-mismatch")  # device_type under manufacturer TestMfr
+        other_mfr, _ = Manufacturer.objects.get_or_create(name="PlatAssignOther", slug="platassign-other")
+        assert other_mfr.pk != device.device_type.manufacturer_id
+
+        view = self._view()
+        req = _make_request(
+            post={"platform_name": "Mismatch-OS", "manufacturer": str(other_mfr.pk)},
+            headers={"HX-Request": "true"},
+        )
+
+        with (
+            patch.object(view, "require_write_permission", return_value=None),
+            patch.object(view, "require_object_permissions", return_value=None),
+            patch.object(
+                view,
+                "get_validated_device_with_selections",
+                return_value=(None, {"existing_device": device}, {}),
+            ),
+        ):
+            resp = view.post(req, device_id=device.pk)
+
+        # An error response was returned (not a success), the newly created Platform was rolled
+        # back, and the device's platform is untouched.
+        assert resp is not None
+        assert not Platform.objects.filter(name="Mismatch-OS").exists()
+        device.refresh_from_db()
+        assert device.platform_id is None
+
+    @pytest.mark.django_db
+    def test_device_platform_manufacturer_match_assigns(self):
+        """The consistent case still assigns: a Platform under the device-type's manufacturer is persisted onto the Device."""
+        from dcim.models import Manufacturer, Platform
+
+        device = make_device("plat-assign-ok")
+        mfr = Manufacturer.objects.get(slug="test-mfr")  # make_device's device_type manufacturer
+
+        view = self._view()
+        req = _make_request(
+            post={"platform_name": "Match-OS", "manufacturer": str(mfr.pk)},
+            headers={"HX-Request": "true"},
+        )
+
+        with (
+            patch.object(view, "require_write_permission", return_value=None),
+            patch.object(view, "require_object_permissions", return_value=None),
+            patch.object(
+                view,
+                "get_validated_device_with_selections",
+                return_value=(None, {"existing_device": device}, {}),
+            ),
+        ):
+            view.post(req, device_id=device.pk)
+
+        platform = Platform.objects.get(name="Match-OS")
+        device.refresh_from_db()
+        assert device.platform_id == platform.pk
 
 
 class TestOOBInterfaceSelectTemplate:

--- a/netbox_librenms_plugin/tests/test_coverage_actions.py
+++ b/netbox_librenms_plugin/tests/test_coverage_actions.py
@@ -6549,6 +6549,38 @@ class TestMergeNetBoxDevicesViewVCSyncDevice:
         # The raw selected member (m2) never held a link; nothing is planted on it.
         assert "id" not in self._entry(m2)
 
+    def test_merge_locks_every_vc_member_before_resolving_the_sync_device(self):
+        """The merge must lock every VC member (incl. bystanders) before resolving the sync device."""
+        import re
+
+        from django.db import connection
+        from django.test.utils import CaptureQueriesContext
+
+        vc, m1, m2 = _two_member_vc("mrg-vc-lock", m1_cf={"default": {"id": 30}}, m2_cf=None)
+        # A bystander member: not the selected winner (m2) and not the sync device (m1).
+        m3 = make_device("mrg-vc-lock-m3", librenms_cf=None)
+        m3.virtual_chassis = vc
+        m3.vc_position = 3
+        m3.save()
+        donor = make_device("mrg-vc-lock-donor", librenms_cf={"default": {"id": 40}})
+
+        with CaptureQueriesContext(connection) as ctx:
+            self._run_merge(winner=m2, donor=donor)
+
+        locked_pks = set()
+        for q in ctx.captured_queries:
+            sql = q["sql"]
+            if "dcim_device" in sql and "FOR UPDATE" in sql:
+                match = re.search(r"IN \(([\d, ]+)\)", sql)
+                if match:
+                    locked_pks.update(int(p) for p in match.group(1).split(","))
+        # The whole chassis (m1 sync + m2 winner + m3 bystander) plus the donor must be locked. m3
+        # missing means the sync device was resolved from unlocked rows — the bug this guards.
+        assert {m1.pk, m2.pk, m3.pk, donor.pk} <= locked_pks, (
+            f"expected every VC member locked before sync-device resolution; locked={locked_pks}, "
+            f"bystander m3={m3.pk} missing"
+        )
+
 
 @pytest.mark.django_db
 class TestMergeNetBoxDevicesViewFailClosed:

--- a/netbox_librenms_plugin/tests/test_coverage_actions.py
+++ b/netbox_librenms_plugin/tests/test_coverage_actions.py
@@ -783,6 +783,9 @@ class TestAttachMessagesOob:
         mock_render.assert_called_once()
         assert b'<div id="django-messages"' in result.content
         assert result.content.startswith(b"<tr>row html</tr>")
+        # The CodeQL-safe format_html() composition produces exactly the concatenation of the
+        # original response bytes and the rendered (trusted) fragment — no escaping of either.
+        assert result.content == b"<tr>row html</tr>" + b'<div id="django-messages" hx-swap-oob="true"></div>'
 
     def test_skips_oob_swap_when_no_messages_queued(self):
         """No pending messages → don't append an empty OOB container that would wipe toasts already visible from an earlier action."""

--- a/netbox_librenms_plugin/tests/test_coverage_actions.py
+++ b/netbox_librenms_plugin/tests/test_coverage_actions.py
@@ -55,8 +55,8 @@ def _make_api():
     return api
 
 
-def _scoped_device_writer(in_scope_device, username):
-    """A real non-superuser with plugin write access and a pk-constrained change_device grant."""
+def _constrained_device_writer(constraints, username):
+    """A real non-superuser with plugin write access and a ``constraints``-scoped change_device grant."""
     from core.models import ObjectType
     from dcim.models import Device
     from django.apps import apps
@@ -73,12 +73,17 @@ def _scoped_device_writer(in_scope_device, username):
     write.users.set([user])
 
     scoped = ObjectPermission.objects.create(
-        name=f"{username}-scoped-change-device", actions=["change"], constraints={"pk": in_scope_device.pk}
+        name=f"{username}-scoped-change-device", actions=["change"], constraints=constraints
     )
     scoped.object_types.set([ObjectType.objects.get_for_model(Device)])
     scoped.users.set([user])
 
     return get_user_model().objects.get(pk=user.pk)  # clear the per-request perm cache
+
+
+def _scoped_device_writer(in_scope_device, username):
+    """A real non-superuser whose change_device grant covers only *in_scope_device*."""
+    return _constrained_device_writer({"pk": in_scope_device.pk}, username)
 
 
 class TestSaveDevice:
@@ -8112,3 +8117,36 @@ class TestPromoteAndMergeObjectScope:
         assert b"Winner or donor device not found" not in response.content
         donor_entry = Device.objects.get(pk=donor.pk).custom_field_data["librenms_id"]["default"]
         assert donor_entry["_migrated_to"]["device_id"] == winner.pk
+
+    def test_merge_cannot_write_an_out_of_scope_vc_sync_device(self):
+        """The donor's VC sync sibling holds the link the merge clears and stamps, so an out-of-scope sibling must block the merge."""
+        from dcim.models import Device
+
+        _vc, m1, m2 = _two_member_vc("mrg-scope-vc", m1_cf={"default": {"id": 30}}, m2_cf=None)
+        winner = make_device("mrg-scope-winner", librenms_cf={"default": {"id": 50}})
+        # Covers the selected winner and the selected donor member, but NOT the sync sibling m1.
+        user = _constrained_device_writer({"pk__in": [winner.pk, m2.pk]}, "scoped-merge-vc-sync")
+
+        response = self._post_merge(user, winner, m2)
+
+        assert b"Winner or donor device not found" in response.content
+        sync_entry = Device.objects.get(pk=m1.pk).custom_field_data["librenms_id"]["default"]
+        assert sync_entry["id"] == 30  # link not cleared
+        assert "_migrated_to" not in sync_entry  # not stamped
+        assert "oob" not in Device.objects.get(pk=winner.pk).custom_field_data["librenms_id"]["default"]
+
+    def test_merge_runs_when_the_vc_sync_device_is_also_in_scope(self):
+        """Widening the grant to the sync sibling lets the same merge through (no over-block)."""
+        from dcim.models import Device
+
+        _vc, m1, m2 = _two_member_vc("mrg-scope-vc-ok", m1_cf={"default": {"id": 30}}, m2_cf=None)
+        winner = make_device("mrg-scope-winner-ok", librenms_cf={"default": {"id": 50}})
+        user = _constrained_device_writer({"pk__in": [winner.pk, m1.pk, m2.pk]}, "scoped-merge-vc-sync-ok")
+
+        response = self._post_merge(user, winner, m2)
+
+        assert b"Winner or donor device not found" not in response.content
+        sync_entry = Device.objects.get(pk=m1.pk).custom_field_data["librenms_id"]["default"]
+        assert "id" not in sync_entry
+        assert sync_entry["_migrated_to"]["device_id"] == winner.pk
+        assert Device.objects.get(pk=winner.pk).custom_field_data["librenms_id"]["default"]["oob"]["id"] == 30

--- a/netbox_librenms_plugin/tests/test_coverage_base_views.py
+++ b/netbox_librenms_plugin/tests/test_coverage_base_views.py
@@ -1351,8 +1351,8 @@ class TestBaseInterfaceTableViewBasics:
         # A real failure redirect came back (the rebound client has no host id).
         assert result.status_code == 302
 
-    def test_post_stale_server_key_renders_partial_without_session_fallback(self):
-        """A posted server_key that no longer resolves (build returns None) → error + fragment render, not an unhandled 500 — and the session client is never queried."""
+    def test_post_stale_server_key_renders_migrated_context(self):
+        """A posted server_key that no longer resolves (build returns None) → error + partial render with migrated context under the session key (NOT a redirect, which an HTMX swap would mishandle and which would drop migrated-donor suppression)."""
         from unittest.mock import patch
 
         from netbox_librenms_plugin.views.base.interfaces_view import BaseInterfaceTableView
@@ -1373,15 +1373,24 @@ class TestBaseInterfaceTableViewBasics:
             patch("netbox_librenms_plugin.librenms_api.build_librenms_api", return_value=None),
             patch("netbox_librenms_plugin.views.base.interfaces_view.get_interface_name_field", return_value="name"),
             patch("netbox_librenms_plugin.views.base.interfaces_view.messages") as mock_messages,
-            patch("netbox_librenms_plugin.views.base.interfaces_view.render", return_value="fragment") as mock_render,
+            patch(
+                "netbox_librenms_plugin.views.base.interfaces_view.build_migrated_context",
+                return_value={"migrated_to_marker": {"device_id": 7}},
+            ) as mock_migrated,
+            patch("netbox_librenms_plugin.views.base.interfaces_view.render", return_value="rendered") as mock_render,
         ):
             result = view.post(req, pk=1)
 
-        # Never reached the live id lookup; surfaced an error and rendered the fragment in place.
+        # Never reached the live id lookup; surfaced an error and rendered the partial.
         session_api.get_librenms_id.assert_not_called()
         mock_messages.error.assert_called_once()
-        assert result == "fragment"
-        mock_render.assert_called_once()
+        assert result == "rendered"
+        # Migrated context resolved under the session/active key — NOT the stale POSTed "ghost".
+        mock_migrated.assert_called_once_with(obj, "default")
+        ctx = mock_render.call_args.args[2]
+        assert ctx["migrated_to_marker"] == {"device_id": 7}
+        # The stale-key render must also disable live sync state: interface_sync.server_key is None.
+        assert ctx["interface_sync"]["server_key"] is None
 
     def test_ip_post_stale_server_key_keeps_migrated_context(self):
         """IP sync's stale-server branch must include build_migrated_context so a migrated donor keeps its suppressed sync form/button — a stale server_key must not silently re-enable IP sync."""

--- a/netbox_librenms_plugin/tests/test_coverage_base_views.py
+++ b/netbox_librenms_plugin/tests/test_coverage_base_views.py
@@ -2402,6 +2402,83 @@ class TestBaseInterfaceTableViewGetContextData:
 
         assert ctx["oob_incomplete"] is True
 
+    def test_relationship_data_incomplete_flag_surfaced_from_cache(self):
+        """A cached snapshot tagged relationship_data_incomplete surfaces the flag in context so the template can persistently warn that the Parent / LAG column may be incomplete."""
+        view = self._make_view()
+        obj = _mock_obj()
+        obj.virtual_chassis = None
+        request = _mock_request()
+
+        cached_data = {
+            "ports": [{"port_id": 1, "ifName": "Gi0/0", "ifAdminStatus": "up", "ifAlias": None, "ifDescr": "Gi0/0"}],
+            "relationship_data_incomplete": True,
+        }
+
+        mock_iface = MagicMock()
+        mock_iface.name = "Gi0/0"
+        mock_ifaces_qs = MagicMock()
+        mock_ifaces_qs.select_related.return_value = [mock_iface]
+
+        with (
+            patch.object(view, "get_cache_key", return_value="key"),
+            patch.object(view, "get_last_fetched_key", return_value="last-key"),
+            patch.object(view, "get_vlan_overrides_key", return_value="overrides-key"),
+            patch.object(view, "get_vlan_groups_for_device", return_value=[]),
+            patch.object(view, "_build_vlan_lookup_maps", return_value={"vid_to_groups": {}, "vid_to_vlans": {}}),
+            patch.object(view, "get_interfaces", return_value=mock_ifaces_qs),
+            patch.object(view, "_add_vlan_group_selection"),
+            patch.object(view, "_add_missing_vlans_info"),
+            patch.object(view, "get_table", return_value=MagicMock()),
+            patch("netbox_librenms_plugin.views.base.interfaces_view.get_interface_name_field", return_value="ifName"),
+            patch("netbox_librenms_plugin.views.base.interfaces_view.cache") as mock_cache,
+            patch("netbox_librenms_plugin.views.base.interfaces_view.timezone") as mock_tz,
+        ):
+            mock_cache.get.side_effect = lambda key: cached_data if key == "key" else None
+            mock_cache.ttl.return_value = 300
+            mock_tz.now.return_value = MagicMock()
+            mock_tz.timedelta.return_value = MagicMock()
+            ctx = view.get_context_data(request, obj, "ifName")
+
+        assert ctx["relationship_data_incomplete"] is True
+
+    def test_relationship_data_incomplete_defaults_false(self):
+        """A snapshot without the flag leaves relationship_data_incomplete False (no spurious banner)."""
+        view = self._make_view()
+        obj = _mock_obj()
+        obj.virtual_chassis = None
+        request = _mock_request()
+
+        cached_data = {
+            "ports": [{"port_id": 1, "ifName": "Gi0/0", "ifAdminStatus": "up", "ifAlias": None, "ifDescr": "Gi0/0"}],
+        }
+
+        mock_iface = MagicMock()
+        mock_iface.name = "Gi0/0"
+        mock_ifaces_qs = MagicMock()
+        mock_ifaces_qs.select_related.return_value = [mock_iface]
+
+        with (
+            patch.object(view, "get_cache_key", return_value="key"),
+            patch.object(view, "get_last_fetched_key", return_value="last-key"),
+            patch.object(view, "get_vlan_overrides_key", return_value="overrides-key"),
+            patch.object(view, "get_vlan_groups_for_device", return_value=[]),
+            patch.object(view, "_build_vlan_lookup_maps", return_value={"vid_to_groups": {}, "vid_to_vlans": {}}),
+            patch.object(view, "get_interfaces", return_value=mock_ifaces_qs),
+            patch.object(view, "_add_vlan_group_selection"),
+            patch.object(view, "_add_missing_vlans_info"),
+            patch.object(view, "get_table", return_value=MagicMock()),
+            patch("netbox_librenms_plugin.views.base.interfaces_view.get_interface_name_field", return_value="ifName"),
+            patch("netbox_librenms_plugin.views.base.interfaces_view.cache") as mock_cache,
+            patch("netbox_librenms_plugin.views.base.interfaces_view.timezone") as mock_tz,
+        ):
+            mock_cache.get.side_effect = lambda key: cached_data if key == "key" else None
+            mock_cache.ttl.return_value = 300
+            mock_tz.now.return_value = MagicMock()
+            mock_tz.timedelta.return_value = MagicMock()
+            ctx = view.get_context_data(request, obj, "ifName")
+
+        assert ctx["relationship_data_incomplete"] is False
+
     def test_cache_hit_with_vc_uses_vc_members(self):
         """Cached data with VC queries each chassis member's interfaces."""
         view = self._make_view()

--- a/netbox_librenms_plugin/tests/test_coverage_base_views.py
+++ b/netbox_librenms_plugin/tests/test_coverage_base_views.py
@@ -1390,6 +1390,7 @@ class TestBaseInterfaceTableViewBasics:
         from netbox_librenms_plugin.views.base.ip_addresses_view import BaseIPAddressTableView
 
         view = object.__new__(BaseIPAddressTableView)
+        view._librenms_api = MagicMock(server_key="session-key")
         obj = MagicMock(pk=1)
         view.get_object = MagicMock(return_value=obj)
         view.rebind_api_for_server = MagicMock(return_value=None)  # stale key → rebind fails
@@ -1409,8 +1410,9 @@ class TestBaseInterfaceTableViewBasics:
             result = view.post(req, pk=1)
 
         mock_messages.error.assert_called_once()
-        # Migrated context resolved from the POSTed (stale) key and merged into the render.
-        mock_migrated.assert_called_once_with(obj, "ghost")
+        # Migrated context resolved under the session/active key — NOT the stale POSTed "ghost"
+        # (which failed to rebind and would miss the marker, re-enabling the donor's sync controls).
+        mock_migrated.assert_called_once_with(obj, "session-key")
         ctx = mock_render.call_args.args[2]
         assert ctx["migrated_to_marker"] == {"device_id": 7}
         # The stale-key render must also disable live IP sync state: ip_sync.server_key is None

--- a/netbox_librenms_plugin/tests/test_coverage_base_views.py
+++ b/netbox_librenms_plugin/tests/test_coverage_base_views.py
@@ -3791,3 +3791,139 @@ class TestIPSyncFetchFailureKeepsMoveCard:
         ip_sync = captured["ctx"]["ip_sync"]
         assert ip_sync["movable_ips"], "Move-IP card context lost on fetch failure"
         assert any(m["address"].startswith("10.0.0.5") for m in ip_sync["movable_ips"])
+
+
+@pytest.mark.django_db
+class TestIPSyncRebindFailureKeepsMoveCard:
+    """On a stale/unconfigured POSTed server_key the IP-sync rebind-failure re-render must still surface movable_ips — the same move card the fetch-failure and success branches keep.
+
+    The card is gated on ip_sync.movable_ips; omitting it (as this branch did) made a migrated
+    donor's "Move IP addresses to <winner>" card vanish whenever the POSTed server_key went stale.
+    """
+
+    def _view(self):
+        from netbox_librenms_plugin.views.object_sync.devices import DeviceIPAddressTableView
+
+        view = object.__new__(DeviceIPAddressTableView)
+        # active_server_key resolves from the cached client; the branch renders against it.
+        view._librenms_api = MagicMock(server_key="default")
+        return view
+
+    def test_rebind_failure_context_includes_movable_ips(self):
+        from django.http import HttpResponse
+        from django.test import RequestFactory
+
+        donor = make_device("ipsync-rebind-donor")
+        # Migrated donor: _migrated_to marker under the "default" sub-block, no live id.
+        donor.custom_field_data["librenms_id"] = {
+            "default": {"_migrated_to": {"device_id": 7, "server_key": "default"}}
+        }
+        donor.save()
+        iface = make_interface(donor, "Gi0/1")
+        make_ip("10.0.0.5/24", assigned_object=iface)
+
+        view = self._view()
+        request = RequestFactory().post("/x/", data={"server_key": "ghost-unconfigured"})
+
+        captured = {}
+
+        def fake_render(req, obj, server_key, ctx):
+            captured["ctx"] = ctx
+            captured["server_key"] = server_key
+            return HttpResponse("x")
+
+        with (
+            patch.object(view, "get_object", return_value=donor),
+            # A stale/unconfigured POSTed key → rebind returns None → the rebind-failure branch runs.
+            patch.object(view, "rebind_api_for_server", return_value=None),
+            patch.object(view, "render_sync_partial", side_effect=fake_render),
+            patch("netbox_librenms_plugin.views.base.ip_addresses_view.messages"),
+        ):
+            view.post(request, pk=donor.pk)
+
+        # The branch renders migrated context + movable_ips against active_server_key ("default"),
+        # not the known-invalid POSTed key (which is not echoed back into ip_sync.server_key).
+        assert captured["server_key"] == "default"
+        ip_sync = captured["ctx"]["ip_sync"]
+        assert ip_sync["server_key"] is None
+        assert ip_sync["movable_ips"], "Move-IP card context lost on rebind failure"
+        assert any(m["address"].startswith("10.0.0.5") for m in ip_sync["movable_ips"])
+
+
+@pytest.mark.django_db
+class TestRenderSyncPartialInjectsWritePermission:
+    """render_sync_partial injects has_write_permission from the request user at the shared chokepoint, so a migrated donor's 'Move to winner' controls render on every HTMX re-render, not just a full page reload.
+
+    Only modules_view (which renders directly) passed the flag; the interface/IP branches route
+    through render_sync_partial and omitted it, silently collapsing every move button to the
+    disabled read-only branch even for a user with change permission.
+    """
+
+    def _ip_view(self, *, superuser):
+        from django.contrib.auth.models import AnonymousUser
+        from django.test import RequestFactory
+
+        from netbox_librenms_plugin.tests.conftest import make_superuser
+        from netbox_librenms_plugin.views.object_sync.devices import DeviceIPAddressTableView
+
+        view = object.__new__(DeviceIPAddressTableView)
+        view._librenms_api = MagicMock(server_key="default")
+        request = RequestFactory().post("/x/")
+        request.user = make_superuser() if superuser else AnonymousUser()
+        view.request = request
+        return view, request
+
+    def _migrated_donor_with_movable_ip(self):
+        from netbox_librenms_plugin.tests.conftest import ip_on
+        from netbox_librenms_plugin.utils import mark_librenms_migrated
+
+        winner = make_device("rsp-perm-winner")
+        donor = make_device("rsp-perm-donor")
+        ip = ip_on(donor, "10.0.0.5/24", "eth0")  # IP on a donor interface → a move-to-winner candidate
+        mark_librenms_migrated(donor, winner.pk, "default")
+        donor.save()
+        return donor, winner, ip
+
+    def _ip_sync_ctx(self, donor, ip):
+        """Build the ip_sync context WITHOUT has_write_permission, exactly as the view branches do."""
+        from django.test import RequestFactory
+        from django_tables2 import RequestConfig
+
+        from netbox_librenms_plugin.tables.ipaddresses import IPAddressTable
+
+        table = IPAddressTable([])
+        RequestConfig(RequestFactory().get("/")).configure(table)
+        return {
+            "ip_sync": {
+                "object": donor,
+                "table": table,
+                "server_key": "default",
+                "set_primary_ip": False,
+                "cache_expiry": None,
+                "movable_ips": [{"id": ip.pk, "address": "10.0.0.5/24", "interface_name": "eth0"}],
+            },
+        }
+
+    def test_write_permitted_user_gets_a_live_move_button(self):
+        from django.urls import reverse
+
+        view, request = self._ip_view(superuser=True)
+        donor, _winner, ip = self._migrated_donor_with_movable_ip()
+        resp = view.render_sync_partial(request, donor, "default", self._ip_sync_ctx(donor, ip))
+        html = resp.content.decode()
+        move_url = reverse("plugins:netbox_librenms_plugin:ipaddress_move_to_winner", kwargs={"pk": ip.pk})
+        # has_write_permission=True (injected by the chokepoint) reached _migrate_move_button.html.
+        assert move_url in html
+        assert "read-only" not in html
+
+    def test_read_only_user_gets_read_only_text_not_a_button(self):
+        from django.urls import reverse
+
+        view, request = self._ip_view(superuser=False)
+        donor, _winner, ip = self._migrated_donor_with_movable_ip()
+        resp = view.render_sync_partial(request, donor, "default", self._ip_sync_ctx(donor, ip))
+        html = resp.content.decode()
+        move_url = reverse("plugins:netbox_librenms_plugin:ipaddress_move_to_winner", kwargs={"pk": ip.pk})
+        # The injected flag reflects the anonymous user → muted text, no live mutating button.
+        assert "read-only" in html
+        assert move_url not in html

--- a/netbox_librenms_plugin/tests/test_coverage_base_views.py
+++ b/netbox_librenms_plugin/tests/test_coverage_base_views.py
@@ -359,7 +359,7 @@ class TestBaseCableTableViewGetLinksData:
         assert result is not None
 
     def test_get_links_data_malformed_port_rows_skipped(self):
-        """Non-dict rows in the ports payload (e.g."""
+        """Non-dict rows in the ports payload (e.g. strings or None) are skipped, not .get()'d."""
         view = self._make_view()
 
         links_data = {"links": [{"local_port_id": 10, "remote_hostname": "sw", "remote_port": "Gi0/1"}]}
@@ -764,7 +764,7 @@ class TestBaseCableTableViewEnrichLocalPort:
         assert link["local_port_url"].endswith(f"/dcim/interfaces/{iface.pk}/")
 
     def test_name_fallback_matches_alternate_interface_name_field(self):
-        """Issue #88: when the NetBox interface name matches the *non-selected* LibreNMS field (e.g."""
+        """Issue #88: when the NetBox interface name matches the *non-selected* LibreNMS field (e.g. ifDescr while ifName is selected), the name fallback still resolves it."""
         view = self._make_view()
         obj = make_device("cable-dev-altname")
         iface = make_interface(obj, "GigabitEthernet0/1")  # named from ifDescr, no librenms_id
@@ -3646,7 +3646,7 @@ class TestBaseIPAddressTableViewFlagManagementIp:
         assert view._resolve_management_ip() == ""
 
     def test_resolve_blank_when_mgmt_ip_not_a_string(self):
-        """A malformed-but-dict-shaped payload (e.g."""
+        """A malformed-but-dict-shaped payload (e.g. a non-string ip value) resolves to an empty string."""
         view = self._make_view()
         view._librenms_api.get_device_info.return_value = (True, {"ip": 123})
         assert view._resolve_management_ip() == ""

--- a/netbox_librenms_plugin/tests/test_coverage_base_views.py
+++ b/netbox_librenms_plugin/tests/test_coverage_base_views.py
@@ -1204,7 +1204,7 @@ class TestBaseCableTableViewPost:
             patch.object(view, "get_object", return_value=obj),
             patch.object(view, "_prepare_context", return_value=None),
             patch("netbox_librenms_plugin.views.base.cables_view.messages") as mock_messages,
-            patch("netbox_librenms_plugin.views.base.cables_view.render") as mock_render,
+            patch("netbox_librenms_plugin.views.mixins.render") as mock_render,
         ):
             mock_render.return_value = MagicMock()
             view.post(request, pk=1)
@@ -1223,7 +1223,7 @@ class TestBaseCableTableViewPost:
             patch.object(view, "get_object", return_value=obj),
             patch.object(view, "_prepare_context", return_value=fake_context),
             patch("netbox_librenms_plugin.views.base.cables_view.messages") as mock_messages,
-            patch("netbox_librenms_plugin.views.base.cables_view.render") as mock_render,
+            patch("netbox_librenms_plugin.views.mixins.render") as mock_render,
         ):
             mock_render.return_value = MagicMock()
             view.post(request, pk=1)
@@ -1374,10 +1374,10 @@ class TestBaseInterfaceTableViewBasics:
             patch("netbox_librenms_plugin.views.base.interfaces_view.get_interface_name_field", return_value="name"),
             patch("netbox_librenms_plugin.views.base.interfaces_view.messages") as mock_messages,
             patch(
-                "netbox_librenms_plugin.views.base.interfaces_view.build_migrated_context",
+                "netbox_librenms_plugin.utils.build_migrated_context",
                 return_value={"migrated_to_marker": {"device_id": 7}},
             ) as mock_migrated,
-            patch("netbox_librenms_plugin.views.base.interfaces_view.render", return_value="rendered") as mock_render,
+            patch("netbox_librenms_plugin.views.mixins.render", return_value="rendered") as mock_render,
         ):
             result = view.post(req, pk=1)
 
@@ -1411,10 +1411,10 @@ class TestBaseInterfaceTableViewBasics:
             patch("netbox_librenms_plugin.views.base.ip_addresses_view.get_interface_name_field", return_value="name"),
             patch("netbox_librenms_plugin.views.base.ip_addresses_view.messages") as mock_messages,
             patch(
-                "netbox_librenms_plugin.views.base.ip_addresses_view.build_migrated_context",
+                "netbox_librenms_plugin.utils.build_migrated_context",
                 return_value={"migrated_to_marker": {"device_id": 7}},
             ) as mock_migrated,
-            patch("netbox_librenms_plugin.views.base.ip_addresses_view.render", return_value="rendered") as mock_render,
+            patch("netbox_librenms_plugin.views.mixins.render", return_value="rendered") as mock_render,
         ):
             result = view.post(req, pk=1)
 
@@ -1709,7 +1709,7 @@ class TestBaseInterfaceTableViewPost:
             patch("netbox_librenms_plugin.views.base.interfaces_view.get_interface_name_field", return_value="ifName"),
             patch("netbox_librenms_plugin.views.base.interfaces_view.get_librenms_sync_device", return_value=obj),
             patch("netbox_librenms_plugin.views.base.interfaces_view.messages"),
-            patch("netbox_librenms_plugin.views.base.interfaces_view.render") as mock_render,
+            patch("netbox_librenms_plugin.views.mixins.render") as mock_render,
             patch("netbox_librenms_plugin.views.base.interfaces_view.cache") as mock_cache,
             patch("netbox_librenms_plugin.views.base.interfaces_view.timezone"),
         ):
@@ -1748,7 +1748,7 @@ class TestBaseInterfaceTableViewPost:
             patch("netbox_librenms_plugin.views.base.interfaces_view.get_librenms_sync_device", return_value=obj),
             patch("netbox_librenms_plugin.views.base.interfaces_view.get_librenms_oob", return_value={"id": 99}),
             patch("netbox_librenms_plugin.views.base.interfaces_view.messages") as mock_messages,
-            patch("netbox_librenms_plugin.views.base.interfaces_view.render") as mock_render,
+            patch("netbox_librenms_plugin.views.mixins.render") as mock_render,
             patch("netbox_librenms_plugin.views.base.interfaces_view.cache") as mock_cache,
             patch("netbox_librenms_plugin.views.base.interfaces_view.timezone"),
         ):
@@ -1791,7 +1791,7 @@ class TestBaseInterfaceTableViewPost:
             patch("netbox_librenms_plugin.views.base.interfaces_view.get_librenms_sync_device", return_value=obj),
             patch("netbox_librenms_plugin.views.base.interfaces_view.get_librenms_oob", return_value={"id": 99}),
             patch("netbox_librenms_plugin.views.base.interfaces_view.messages") as mock_messages,
-            patch("netbox_librenms_plugin.views.base.interfaces_view.render") as mock_render,
+            patch("netbox_librenms_plugin.views.mixins.render") as mock_render,
             patch("netbox_librenms_plugin.views.base.interfaces_view.cache") as mock_cache,
             patch("netbox_librenms_plugin.views.base.interfaces_view.timezone"),
         ):
@@ -1829,7 +1829,7 @@ class TestBaseInterfaceTableViewPost:
             patch("netbox_librenms_plugin.views.base.interfaces_view.get_librenms_sync_device", return_value=obj),
             patch("netbox_librenms_plugin.views.base.interfaces_view.get_librenms_oob", return_value={"id": 99}),
             patch("netbox_librenms_plugin.views.base.interfaces_view.messages"),
-            patch("netbox_librenms_plugin.views.base.interfaces_view.render") as mock_render,
+            patch("netbox_librenms_plugin.views.mixins.render") as mock_render,
             patch("netbox_librenms_plugin.views.base.interfaces_view.cache") as mock_cache,
             patch("netbox_librenms_plugin.views.base.interfaces_view.timezone"),
         ):
@@ -1885,7 +1885,7 @@ class TestBaseInterfaceTableViewPost:
             patch("netbox_librenms_plugin.views.base.interfaces_view.get_librenms_sync_device", return_value=obj),
             patch("netbox_librenms_plugin.views.base.interfaces_view.get_librenms_oob", return_value={"id": 99}),
             patch("netbox_librenms_plugin.views.base.interfaces_view.messages"),
-            patch("netbox_librenms_plugin.views.base.interfaces_view.render") as mock_render,
+            patch("netbox_librenms_plugin.views.mixins.render") as mock_render,
             patch("netbox_librenms_plugin.views.base.interfaces_view.cache") as mock_cache,
             patch("netbox_librenms_plugin.views.base.interfaces_view.timezone"),
         ):
@@ -1927,7 +1927,7 @@ class TestBaseInterfaceTableViewPost:
             patch("netbox_librenms_plugin.views.base.interfaces_view.get_librenms_sync_device", return_value=obj),
             patch("netbox_librenms_plugin.views.base.interfaces_view.get_librenms_oob", return_value={"id": 99}),
             patch("netbox_librenms_plugin.views.base.interfaces_view.messages") as mock_messages,
-            patch("netbox_librenms_plugin.views.base.interfaces_view.render") as mock_render,
+            patch("netbox_librenms_plugin.views.mixins.render") as mock_render,
             patch("netbox_librenms_plugin.views.base.interfaces_view.cache"),
             patch("netbox_librenms_plugin.views.base.interfaces_view.timezone"),
         ):
@@ -2009,7 +2009,7 @@ class TestBaseInterfaceTableViewPost:
             # isn't entangled with VC-routing (cache_device == obj for non-VC anyway).
             patch("netbox_librenms_plugin.views.base.interfaces_view.get_librenms_sync_device", return_value=obj),
             patch("netbox_librenms_plugin.views.base.interfaces_view.messages") as mock_messages,
-            patch("netbox_librenms_plugin.views.base.interfaces_view.render") as mock_render,
+            patch("netbox_librenms_plugin.views.mixins.render") as mock_render,
             patch("netbox_librenms_plugin.views.base.interfaces_view.cache") as mock_cache,
             patch("netbox_librenms_plugin.views.base.interfaces_view.timezone"),
         ):
@@ -3259,7 +3259,7 @@ class TestBaseIPAddressTableViewPost:
                 return_value="ifName",
             ),
             patch("netbox_librenms_plugin.views.base.ip_addresses_view.messages") as mock_messages,
-            patch("netbox_librenms_plugin.views.base.ip_addresses_view.render") as mock_render,
+            patch("netbox_librenms_plugin.views.mixins.render") as mock_render,
         ):
             mock_render.return_value = MagicMock()
             view.post(request, pk=1)
@@ -3282,7 +3282,7 @@ class TestBaseIPAddressTableViewPost:
                 return_value="ifName",
             ),
             patch("netbox_librenms_plugin.views.base.ip_addresses_view.messages") as mock_messages,
-            patch("netbox_librenms_plugin.views.base.ip_addresses_view.render") as mock_render,
+            patch("netbox_librenms_plugin.views.mixins.render") as mock_render,
         ):
             mock_render.return_value = MagicMock()
             view.post(request, pk=1)

--- a/netbox_librenms_plugin/tests/test_coverage_base_views.py
+++ b/netbox_librenms_plugin/tests/test_coverage_base_views.py
@@ -1383,6 +1383,40 @@ class TestBaseInterfaceTableViewBasics:
         assert result == "fragment"
         mock_render.assert_called_once()
 
+    def test_ip_post_stale_server_key_keeps_migrated_context(self):
+        """IP sync's stale-server branch must include build_migrated_context so a migrated
+        donor keeps its suppressed sync form/button — a stale server_key must not silently
+        re-enable IP sync. Mirrors cables_view."""
+        from unittest.mock import patch
+
+        from netbox_librenms_plugin.views.base.ip_addresses_view import BaseIPAddressTableView
+
+        view = object.__new__(BaseIPAddressTableView)
+        obj = MagicMock(pk=1)
+        view.get_object = MagicMock(return_value=obj)
+        view.rebind_api_for_server = MagicMock(return_value=None)  # stale key → rebind fails
+
+        req = MagicMock()
+        req.POST.get.side_effect = lambda k, d=None: {"server_key": "ghost"}.get(k, d)
+
+        with (
+            patch("netbox_librenms_plugin.views.base.ip_addresses_view.get_interface_name_field", return_value="name"),
+            patch("netbox_librenms_plugin.views.base.ip_addresses_view.messages") as mock_messages,
+            patch(
+                "netbox_librenms_plugin.views.base.ip_addresses_view.build_migrated_context",
+                return_value={"migrated_to_marker": {"device_id": 7}},
+            ) as mock_migrated,
+            patch("netbox_librenms_plugin.views.base.ip_addresses_view.render", return_value="rendered") as mock_render,
+        ):
+            result = view.post(req, pk=1)
+
+        mock_messages.error.assert_called_once()
+        # Migrated context resolved from the POSTed (stale) key and merged into the render.
+        mock_migrated.assert_called_once_with(obj, "ghost")
+        ctx = mock_render.call_args.args[2]
+        assert ctx["migrated_to_marker"] == {"device_id": 7}
+        assert result == "rendered"
+
     def test_get_select_related_field_for_vm(self):
         """Returns 'virtual_machine' for VirtualMachine model."""
         from netbox_librenms_plugin.views.base.interfaces_view import BaseInterfaceTableView

--- a/netbox_librenms_plugin/tests/test_coverage_base_views.py
+++ b/netbox_librenms_plugin/tests/test_coverage_base_views.py
@@ -3738,3 +3738,56 @@ class TestCableLinksDataCoercesLibreNMSId:
         api.get_device_links.assert_not_called()
         api.get_ports.assert_not_called()
         assert result is None
+
+
+@pytest.mark.django_db
+class TestIPSyncFetchFailureKeepsMoveCard:
+    """On a LibreNMS fetch failure the IP-sync error re-render still surfaces movable_ips.
+
+    The per-row "Move IP addresses to <winner>" moves are pure NetBox operations, so a migrated
+    donor must keep the move card when LibreNMS is briefly unreachable — the card is gated on
+    ip_sync.movable_ips, which every other exit provides.
+    """
+
+    def _view(self):
+        from netbox_librenms_plugin.views.object_sync.devices import DeviceIPAddressTableView
+
+        view = object.__new__(DeviceIPAddressTableView)
+        view._librenms_api = MagicMock(server_key="default")
+        return view
+
+    def test_fetch_failure_context_includes_movable_ips(self):
+        from django.http import HttpResponse
+        from django.test import RequestFactory
+
+        donor = make_device("ipsync-donor-mig")
+        # Migrated donor: _migrated_to marker under the server sub-block, no live id.
+        donor.custom_field_data["librenms_id"] = {
+            "default": {"_migrated_to": {"device_id": 7, "server_key": "default"}}
+        }
+        donor.save()
+        iface = make_interface(donor, "Gi0/1")
+        make_ip("10.0.0.5/24", assigned_object=iface)
+
+        view = self._view()
+        request = RequestFactory().post("/x/", data={"server_key": "default"})
+
+        captured = {}
+
+        def fake_render(req, obj, server_key, ctx):
+            captured["ctx"] = ctx
+            return HttpResponse("x")
+
+        with (
+            patch.object(view, "get_object", return_value=donor),
+            patch.object(view, "rebind_api_for_server", return_value="default"),
+            # A valid server whose live IP fetch fails → _prepare_context(fetch_fresh=True) is None.
+            patch.object(view, "_prepare_context", return_value=None),
+            patch.object(view, "render_sync_partial", side_effect=fake_render),
+            patch("netbox_librenms_plugin.views.base.ip_addresses_view.messages"),
+        ):
+            view.post(request, pk=donor.pk)
+
+        ip_sync = captured["ctx"]["ip_sync"]
+        assert ip_sync["movable_ips"], "Move-IP card context lost on fetch failure"
+        assert any(m["address"].startswith("10.0.0.5") for m in ip_sync["movable_ips"])

--- a/netbox_librenms_plugin/tests/test_coverage_base_views.py
+++ b/netbox_librenms_plugin/tests/test_coverage_base_views.py
@@ -736,6 +736,23 @@ class TestBaseCableTableViewEnrichLocalPort:
         view.enrich_local_port(link, obj)
         assert "local_port_url" not in link
 
+    def test_oob_row_never_binds_a_host_interface(self):
+        """A merged OOB LLDP row (context-only) must not resolve against the HOST device.
+
+        Its local port lives on the OOB CONTROLLER; a shared name (or colliding stored
+        librenms_id) would otherwise bind a host interface and render a wrong
+        local_port_url + cable state — even though sync and actions already refuse OOB rows.
+        """
+        view = self._make_view()
+        obj = make_device("cable-dev-oob-collide")
+        make_interface(obj, "eth0")  # host interface sharing the OOB controller's port name
+
+        link = {"local_port": "eth0", "_source": "oob"}
+        view.enrich_local_port(link, obj)
+
+        assert "local_port_url" not in link
+        assert "netbox_local_interface_id" not in link
+
     def test_interface_found_by_librenms_id_adds_url(self):
         """The librenms_id match wins even when the local_port name differs from the iface name."""
         view = self._make_view()

--- a/netbox_librenms_plugin/tests/test_coverage_base_views.py
+++ b/netbox_librenms_plugin/tests/test_coverage_base_views.py
@@ -1384,9 +1384,7 @@ class TestBaseInterfaceTableViewBasics:
         mock_render.assert_called_once()
 
     def test_ip_post_stale_server_key_keeps_migrated_context(self):
-        """IP sync's stale-server branch must include build_migrated_context so a migrated
-        donor keeps its suppressed sync form/button — a stale server_key must not silently
-        re-enable IP sync. Mirrors cables_view."""
+        """IP sync's stale-server branch must include build_migrated_context so a migrated donor keeps its suppressed sync form/button — a stale server_key must not silently re-enable IP sync."""
         from unittest.mock import patch
 
         from netbox_librenms_plugin.views.base.ip_addresses_view import BaseIPAddressTableView

--- a/netbox_librenms_plugin/tests/test_coverage_base_views.py
+++ b/netbox_librenms_plugin/tests/test_coverage_base_views.py
@@ -1413,6 +1413,10 @@ class TestBaseInterfaceTableViewBasics:
         mock_migrated.assert_called_once_with(obj, "ghost")
         ctx = mock_render.call_args.args[2]
         assert ctx["migrated_to_marker"] == {"device_id": 7}
+        # The stale-key render must also disable live IP sync state: ip_sync.server_key is None
+        # so the template can't expose the stale key back to the live-sync controls. Without this
+        # the test would pass even if a stale key leaked into the live-sync context.
+        assert ctx["ip_sync"]["server_key"] is None
         assert result == "rendered"
 
     def test_get_select_related_field_for_vm(self):

--- a/netbox_librenms_plugin/tests/test_coverage_base_views.py
+++ b/netbox_librenms_plugin/tests/test_coverage_base_views.py
@@ -2417,7 +2417,7 @@ class TestBaseInterfaceTableViewGetContextData:
         mock_iface = MagicMock()
         mock_iface.name = "Gi0/0"
         mock_ifaces_qs = MagicMock()
-        mock_ifaces_qs.select_related.return_value = [mock_iface]
+        mock_ifaces_qs.select_related.return_value.prefetch_related.return_value = [mock_iface]
 
         with (
             patch.object(view, "get_cache_key", return_value="key"),
@@ -2455,7 +2455,7 @@ class TestBaseInterfaceTableViewGetContextData:
         mock_iface = MagicMock()
         mock_iface.name = "Gi0/0"
         mock_ifaces_qs = MagicMock()
-        mock_ifaces_qs.select_related.return_value = [mock_iface]
+        mock_ifaces_qs.select_related.return_value.prefetch_related.return_value = [mock_iface]
 
         with (
             patch.object(view, "get_cache_key", return_value="key"),

--- a/netbox_librenms_plugin/tests/test_coverage_base_views.py
+++ b/netbox_librenms_plugin/tests/test_coverage_base_views.py
@@ -1968,7 +1968,7 @@ class TestBaseInterfaceTableViewPost:
                 return_value={"id": "not-a-number"},
             ),
             patch("netbox_librenms_plugin.views.base.interfaces_view.messages") as mock_messages,
-            patch("netbox_librenms_plugin.views.base.interfaces_view.render") as mock_render,
+            patch("netbox_librenms_plugin.views.mixins.render") as mock_render,
             patch("netbox_librenms_plugin.views.base.interfaces_view.cache") as mock_cache,
             patch("netbox_librenms_plugin.views.base.interfaces_view.timezone"),
         ):

--- a/netbox_librenms_plugin/tests/test_coverage_base_views.py
+++ b/netbox_librenms_plugin/tests/test_coverage_base_views.py
@@ -2402,8 +2402,8 @@ class TestBaseInterfaceTableViewGetContextData:
 
         assert ctx["oob_incomplete"] is True
 
-    def test_relationship_data_incomplete_flag_surfaced_from_cache(self):
-        """A cached snapshot tagged relationship_data_incomplete surfaces the flag in context so the template can persistently warn that the Parent / LAG column may be incomplete."""
+    def test_unowned_relationship_cache_metadata_is_not_surfaced(self):
+        """PR 315 must not expose warning state owned by the later parent/LAG feature."""
         view = self._make_view()
         obj = _mock_obj()
         obj.virtual_chassis = None
@@ -2439,45 +2439,7 @@ class TestBaseInterfaceTableViewGetContextData:
             mock_tz.timedelta.return_value = MagicMock()
             ctx = view.get_context_data(request, obj, "ifName")
 
-        assert ctx["relationship_data_incomplete"] is True
-
-    def test_relationship_data_incomplete_defaults_false(self):
-        """A snapshot without the flag leaves relationship_data_incomplete False (no spurious banner)."""
-        view = self._make_view()
-        obj = _mock_obj()
-        obj.virtual_chassis = None
-        request = _mock_request()
-
-        cached_data = {
-            "ports": [{"port_id": 1, "ifName": "Gi0/0", "ifAdminStatus": "up", "ifAlias": None, "ifDescr": "Gi0/0"}],
-        }
-
-        mock_iface = MagicMock()
-        mock_iface.name = "Gi0/0"
-        mock_ifaces_qs = MagicMock()
-        mock_ifaces_qs.select_related.return_value.prefetch_related.return_value = [mock_iface]
-
-        with (
-            patch.object(view, "get_cache_key", return_value="key"),
-            patch.object(view, "get_last_fetched_key", return_value="last-key"),
-            patch.object(view, "get_vlan_overrides_key", return_value="overrides-key"),
-            patch.object(view, "get_vlan_groups_for_device", return_value=[]),
-            patch.object(view, "_build_vlan_lookup_maps", return_value={"vid_to_groups": {}, "vid_to_vlans": {}}),
-            patch.object(view, "get_interfaces", return_value=mock_ifaces_qs),
-            patch.object(view, "_add_vlan_group_selection"),
-            patch.object(view, "_add_missing_vlans_info"),
-            patch.object(view, "get_table", return_value=MagicMock()),
-            patch("netbox_librenms_plugin.views.base.interfaces_view.get_interface_name_field", return_value="ifName"),
-            patch("netbox_librenms_plugin.views.base.interfaces_view.cache") as mock_cache,
-            patch("netbox_librenms_plugin.views.base.interfaces_view.timezone") as mock_tz,
-        ):
-            mock_cache.get.side_effect = lambda key: cached_data if key == "key" else None
-            mock_cache.ttl.return_value = 300
-            mock_tz.now.return_value = MagicMock()
-            mock_tz.timedelta.return_value = MagicMock()
-            ctx = view.get_context_data(request, obj, "ifName")
-
-        assert ctx["relationship_data_incomplete"] is False
+        assert "relationship_data_incomplete" not in ctx
 
     def test_cache_hit_with_vc_uses_vc_members(self):
         """Cached data with VC queries each chassis member's interfaces."""
@@ -3954,8 +3916,11 @@ class TestRenderSyncPartialInjectsWritePermission:
     """
 
     def _ip_view(self, *, superuser):
-        from django.contrib.auth.models import AnonymousUser
+        from core.models import ObjectType
+        from django.apps import apps
+        from django.contrib.auth import get_user_model
         from django.test import RequestFactory
+        from users.models import ObjectPermission
 
         from netbox_librenms_plugin.tests.conftest import make_superuser
         from netbox_librenms_plugin.views.object_sync.devices import DeviceIPAddressTableView
@@ -3963,7 +3928,15 @@ class TestRenderSyncPartialInjectsWritePermission:
         view = object.__new__(DeviceIPAddressTableView)
         view._librenms_api = MagicMock(server_key="default")
         request = RequestFactory().post("/x/")
-        request.user = make_superuser() if superuser else AnonymousUser()
+        if superuser:
+            request.user = make_superuser()
+        else:
+            settings_model = apps.get_model("netbox_librenms_plugin", "LibreNMSSettings")
+            user = get_user_model().objects.create_user(username="rsp-perm-viewer", password="x")
+            view_permission = ObjectPermission.objects.create(name="rsp-perm-plugin-view", actions=["view"])
+            view_permission.object_types.set([ObjectType.objects.get_for_model(settings_model)])
+            view_permission.users.set([user])
+            request.user = get_user_model().objects.get(pk=user.pk)
         view.request = request
         return view, request
 
@@ -4013,11 +3986,15 @@ class TestRenderSyncPartialInjectsWritePermission:
     def test_read_only_user_gets_read_only_text_not_a_button(self):
         from django.urls import reverse
 
+        from netbox_librenms_plugin.constants import PERM_CHANGE_PLUGIN, PERM_VIEW_PLUGIN
+
         view, request = self._ip_view(superuser=False)
+        assert request.user.has_perm(PERM_VIEW_PLUGIN)
+        assert not request.user.has_perm(PERM_CHANGE_PLUGIN)
         donor, _winner, ip = self._migrated_donor_with_movable_ip()
         resp = view.render_sync_partial(request, donor, "default", self._ip_sync_ctx(donor, ip))
         html = resp.content.decode()
         move_url = reverse("plugins:netbox_librenms_plugin:ipaddress_move_to_winner", kwargs={"pk": ip.pk})
-        # The injected flag reflects the anonymous user → muted text, no live mutating button.
+        # A genuine view-only plugin user gets muted text, not a live mutating button.
         assert "read-only" in html
         assert move_url not in html

--- a/netbox_librenms_plugin/tests/test_coverage_base_views2.py
+++ b/netbox_librenms_plugin/tests/test_coverage_base_views2.py
@@ -764,9 +764,10 @@ class TestEnrichRemotePort:
     def test_vc_path_leaves_interface_unresolved_when_member_position_is_missing(self):
         """A failed VC-position lookup must not resolve the advertised port against the selected member."""
         view = self._make_view()
-        master, _member = _vc_with_member("vc-erp-missing", "erp-missing-master", "erp-missing-member", member_pos=1)
+        master, member = _vc_with_member("vc-erp-missing", "erp-missing-master", "erp-missing-member", member_pos=1)
         # LibreNMS advertises position 2, which is absent. A same-named interface on the selected
         # position-1 device must not be mistaken for the missing member's remote endpoint.
+        make_interface(member, "Gi2/0/1")
         make_interface(master, "Gi2/0/1")
 
         result = view.enrich_remote_port({"remote_port": "Gi2/0/1", "remote_port_id": 99}, master)

--- a/netbox_librenms_plugin/tests/test_coverage_base_views2.py
+++ b/netbox_librenms_plugin/tests/test_coverage_base_views2.py
@@ -894,6 +894,7 @@ class TestCablePostHostFetchWarning:
         with (
             patch("netbox_librenms_plugin.views.base.cables_view.messages") as mock_msgs,
             patch("netbox_librenms_plugin.views.base.cables_view.render"),
+            patch("netbox_librenms_plugin.views.base.cables_view.build_migrated_context", return_value={}),
         ):
             view.post(request, pk=1)
         return [c.args[1] for c in mock_msgs.warning.call_args_list]

--- a/netbox_librenms_plugin/tests/test_coverage_base_views2.py
+++ b/netbox_librenms_plugin/tests/test_coverage_base_views2.py
@@ -761,6 +761,19 @@ class TestEnrichRemotePort:
 
         assert result["netbox_remote_interface_id"] == iface.pk
 
+    def test_vc_path_leaves_interface_unresolved_when_member_position_is_missing(self):
+        """A failed VC-position lookup must not resolve the advertised port against the selected member."""
+        view = self._make_view()
+        master, _member = _vc_with_member("vc-erp-missing", "erp-missing-master", "erp-missing-member", member_pos=1)
+        # LibreNMS advertises position 2, which is absent. A same-named interface on the selected
+        # position-1 device must not be mistaken for the missing member's remote endpoint.
+        make_interface(master, "Gi2/0/1")
+
+        result = view.enrich_remote_port({"remote_port": "Gi2/0/1", "remote_port_id": 99}, master)
+
+        assert "netbox_remote_interface_id" not in result
+        assert "remote_port_url" not in result
+
     def test_non_vc_path_finds_by_librenms_id(self):
         """Non-VC device: remote interface found by librenms_id."""
         view = self._make_view()

--- a/netbox_librenms_plugin/tests/test_coverage_base_views2.py
+++ b/netbox_librenms_plugin/tests/test_coverage_base_views2.py
@@ -893,8 +893,8 @@ class TestCablePostHostFetchWarning:
         view._prepare_context = MagicMock(side_effect=_prep)
         with (
             patch("netbox_librenms_plugin.views.base.cables_view.messages") as mock_msgs,
-            patch("netbox_librenms_plugin.views.base.cables_view.render"),
-            patch("netbox_librenms_plugin.views.base.cables_view.build_migrated_context", return_value={}),
+            patch("netbox_librenms_plugin.views.mixins.render"),
+            patch("netbox_librenms_plugin.utils.build_migrated_context", return_value={}),
         ):
             view.post(request, pk=1)
         return [c.args[1] for c in mock_msgs.warning.call_args_list]

--- a/netbox_librenms_plugin/tests/test_coverage_bulk_import.py
+++ b/netbox_librenms_plugin/tests/test_coverage_bulk_import.py
@@ -822,6 +822,10 @@ class TestRefreshExistingDevice:
             "site": {"found": True},
             "device_type": {"found": True},
             "device_role": {"found": False, "role": None, "available_roles": []},
+            # Real validate_device_for_import output carries cluster regardless of
+            # import_as_vm; a cross-model match flips is_vm and recalculate then
+            # bracket-reads cluster["found"], so the fixture must carry it too.
+            "cluster": {"found": False, "cluster": None, "available_clusters": []},
         }
         base.update(overrides)
         return base
@@ -1019,7 +1023,10 @@ class TestRefreshExistingDevice:
         assert validation["oob_candidate"] is None
         assert validation["serial_role_choice_available"] is False
         assert "promote_to_host" not in validation
-        assert "merge_candidates" not in validation
+        # merge_candidates follows the baseline's always-present contract
+        # (validate_device_for_import and apply_oob_detection_result both keep the
+        # key set, defaulting to None) — clearing must reset it, not remove it.
+        assert validation["merge_candidates"] is None
 
     def test_deleted_vm_match_clears_stale_cluster_selection(self):
         """A dropped cached VM match must reset the stale cluster selection (preserving available_clusters), mirroring the device_role reset on the device path — otherwise the match-derived cluster.found=True survives and recalculate keeps the row "ready" even though a new VM import requires a fresh cluster."""

--- a/netbox_librenms_plugin/tests/test_coverage_bulk_import.py
+++ b/netbox_librenms_plugin/tests/test_coverage_bulk_import.py
@@ -910,6 +910,55 @@ class TestRefreshExistingDevice:
         assert validation["is_ready"] is False
         assert any("hostname/serial" in i for i in validation["issues"])
 
+    def test_cross_model_different_candidate_values_binds_preferred(self):
+        """A Device matched by resolved_name and an unrelated VM matched by a different candidate (raw hostname) bind the preferred Device, not a phantom cross-model collision."""
+        from netbox_librenms_plugin.import_utils.bulk_import import _refresh_existing_device
+
+        dev = make_device("sw-pref-resolved")  # carries the resolved (preferred) name
+        make_vm("sw-pref-host")  # carries only the raw hostname — a DIFFERENT name
+
+        validation = self._device_validation(resolved_name="sw-pref-resolved")
+        # device_id 88888 matches no librenms_id CF, so the name fallback runs.
+        libre_device = {"device_id": 88888, "hostname": "sw-pref-host", "sysName": "sw-pref-host"}
+
+        _refresh_existing_device(validation, libre_device=libre_device, server_key="default")
+
+        assert validation["existing_device"].pk == dev.pk
+        assert validation["existing_match_type"] == "resolved_name"
+        assert not any("Both a VM and Device" in w for w in validation.get("warnings", [])), (
+            "a different-value VM match must not trigger the cross-model collision warning"
+        )
+        assert validation["can_import"] is False
+
+    def test_ambiguous_hostname_refresh_shows_only_duplicate_blocker(self):
+        """An ambiguous multi-device hostname match is terminal: the row shows only the duplicate-resolution blocker, not a stale create-time role blocker."""
+        from dcim.models import Device, Site
+        from netbox_librenms_plugin.import_utils.bulk_import import _refresh_existing_device
+
+        dev_a = make_device("amb-terminal-sw")
+        site_b = Site.objects.create(name="crfix-amb-site-b", slug="crfix-amb-site-b")
+        Device.objects.create(
+            name="amb-terminal-sw",
+            device_type=dev_a.device_type,
+            role=dev_a.role,
+            site=site_b,
+            status="active",
+        )
+
+        # device_role not selected → the no-match path would (wrongly) re-add its create-time blocker.
+        validation = self._device_validation(resolved_name="amb-terminal-sw")
+        libre_device = {"device_id": 88889, "hostname": "amb-terminal-sw", "sysName": "amb-terminal-sw"}
+
+        _refresh_existing_device(validation, libre_device=libre_device, server_key="default")
+
+        assert validation["existing_match_type"] == "ambiguous_hostname_or_serial"
+        assert any("hostname/serial" in i for i in validation["issues"])
+        assert not any("role must be manually selected" in i.lower() for i in validation["issues"]), (
+            "the terminal ambiguity branch must not leak a stale new-import role blocker"
+        )
+        assert validation["can_import"] is False
+        assert validation["is_ready"] is False
+
     def test_neutralized_link_but_other_match_type_keeps_block(self):
         """A non-librenms cached match (hostname) must survive the linkage refresh: only a neutralized librenms/OOB link triggers re-evaluation, so the device stays matched and the row stays blocked."""
         from netbox_librenms_plugin.import_utils.bulk_import import _refresh_existing_device

--- a/netbox_librenms_plugin/tests/test_coverage_bulk_import.py
+++ b/netbox_librenms_plugin/tests/test_coverage_bulk_import.py
@@ -930,6 +930,37 @@ class TestRefreshExistingDevice:
         )
         assert validation["can_import"] is False
 
+    def test_cross_model_warning_cleared_when_serial_uniquely_binds_device(self):
+        """A unique serial match binding the Device clears the earlier cross-model hostname warning."""
+        from netbox_librenms_plugin.import_utils.bulk_import import _refresh_existing_device
+
+        # Same name on BOTH models → the name fallback flags a cross-model hostname collision and
+        # leaves the row unmatched. The Device additionally carries a unique serial.
+        dev = make_device("crossclr-sw", serial="CRXCLR-SERIAL-1")
+        make_vm("crossclr-sw")
+
+        validation = self._device_validation(resolved_name="crossclr-sw")
+        # device_id 77777 matches no librenms_id CF → the name fallback runs, warns, then the
+        # serial fallback uniquely resolves the Device.
+        libre_device = {
+            "device_id": 77777,
+            "hostname": "crossclr-sw",
+            "sysName": "crossclr-sw",
+            "serial": "CRXCLR-SERIAL-1",
+        }
+
+        _refresh_existing_device(validation, libre_device=libre_device, server_key="default")
+
+        # The stronger serial match wins and binds the Device...
+        assert validation["existing_device"].pk == dev.pk
+        assert validation["existing_match_type"] == "serial"
+        # ...and the stale cross-model "cannot determine which to match" warning is gone.
+        assert not any("Both a VM and Device exist with hostname" in w for w in validation.get("warnings", [])), (
+            "a unique serial match must clear the earlier cross-model hostname warning"
+        )
+        assert validation["can_import"] is False
+        assert validation["is_ready"] is False
+
     def test_ambiguous_hostname_refresh_shows_only_duplicate_blocker(self):
         """An ambiguous multi-device hostname match is terminal: the row shows only the duplicate-resolution blocker, not a stale create-time role blocker."""
         from dcim.models import Device, Site

--- a/netbox_librenms_plugin/tests/test_coverage_device_operations.py
+++ b/netbox_librenms_plugin/tests/test_coverage_device_operations.py
@@ -1028,6 +1028,90 @@ class TestValidateDeviceForImportEdgeCases:
         # The object-typed wording must follow the MATCHED side (devices), not import_as_vm (VMs).
         assert any("Multiple NetBox devices share" in i for i in result["issues"])
 
+    def test_cross_model_hostname_with_duplicate_devices_fails_closed(self):
+        """Two Devices + one VM share the hostname: the same-model duplicate must stay terminal.
+
+        The cross-model branch binds neither object, so the Stage-1 duplicate guard (keyed on a
+        bound existing_device) never sees the two Devices — pre-fix the row sailed through as a
+        new import, i.e. ADDING a VM relaxed the protection the 2-Devices-no-VM case gets.
+        """
+        from netbox_librenms_plugin.tests.conftest import make_device, make_vm
+
+        from dcim.models import DeviceRole, DeviceType, Manufacturer, Site
+
+        dev_a = make_device("dup-both-host")
+        # Second same-named Device needs a different site (names are unique per site).
+        site_b, _ = Site.objects.get_or_create(name="Site-xmodel-b", slug="site-xmodel-b")
+        mfr, _ = Manufacturer.objects.get_or_create(name="TestMfr", slug="test-mfr")
+        dt, _ = DeviceType.objects.get_or_create(model="TestDT", slug="test-dt", defaults={"manufacturer": mfr})
+        role, _ = DeviceRole.objects.get_or_create(name="TestRole", slug="test-role", defaults={"color": "00ff00"})
+        type(dev_a).objects.create(name="dup-both-host", device_type=dt, role=role, site=site_b, status="active")
+        make_vm("dup-both-host")
+
+        libre_device = {
+            "device_id": 996,
+            "hostname": "dup-both-host",
+            "sysName": "dup-both-host",
+            "serial": "-",
+            "hardware": "-",
+            "os": "-",
+        }
+        result = self._validate(libre_device)
+
+        assert result["can_import"] is False
+        assert result["is_ready"] is False
+        assert result["existing_device"] is None
+        assert result["existing_match_type"] == "ambiguous_hostname_or_serial"
+        # Wording keeps the "hostname/serial" substring the refresh-path blocker cleanup keys on.
+        assert any("Multiple NetBox devices share" in i for i in result["issues"])
+        # The cross-model warning still explains the VM/Device split.
+        assert any("Both a VM and Device exist with hostname" in w for w in result["warnings"])
+
+    def test_cross_model_hostname_with_duplicate_vms_fails_closed(self):
+        """One Device + two VMs (cross-cluster same name): terminal ambiguity, VM-typed wording."""
+        from netbox_librenms_plugin.tests.conftest import make_cluster, make_device, make_vm
+
+        make_device("dup-both-vms")
+        make_vm("dup-both-vms")
+        make_vm("dup-both-vms", cluster=make_cluster("xmodel-cluster-2"))
+
+        libre_device = {
+            "device_id": 995,
+            "hostname": "dup-both-vms",
+            "sysName": "dup-both-vms",
+            "serial": "-",
+            "hardware": "-",
+            "os": "-",
+        }
+        result = self._validate(libre_device)
+
+        assert result["can_import"] is False
+        assert result["existing_device"] is None
+        assert result["existing_match_type"] == "ambiguous_hostname_or_serial"
+        assert any("Multiple NetBox virtual machines share" in i for i in result["issues"])
+
+    def test_cross_model_hostname_single_each_still_proceeds_as_new(self):
+        """Exactly one Device + one VM: the deliberate warn-and-proceed-as-new contract is unchanged."""
+        from netbox_librenms_plugin.tests.conftest import make_device, make_vm
+
+        make_device("single-both-host")
+        make_vm("single-both-host")
+
+        libre_device = {
+            "device_id": 994,
+            "hostname": "single-both-host",
+            "sysName": "single-both-host",
+            "serial": "-",
+            "hardware": "-",
+            "os": "-",
+        }
+        result = self._validate(libre_device)
+
+        assert result["existing_device"] is None
+        assert result["existing_match_type"] != "ambiguous_hostname_or_serial"
+        assert not any("resolve the duplicate" in i for i in result["issues"])
+        assert any("Both a VM and Device exist with hostname" in w for w in result["warnings"])
+
     def test_oob_ip_match_without_os_token_still_oob_candidate(self):
         """An incoming IP equal to device.oob_ip is still an OOB candidate when no os token classifies a type."""
         from netbox_librenms_plugin.tests.conftest import make_device, make_ip

--- a/netbox_librenms_plugin/tests/test_coverage_device_operations.py
+++ b/netbox_librenms_plugin/tests/test_coverage_device_operations.py
@@ -194,6 +194,7 @@ class TestDetermineDeviceName:
         assert result == "router.example.com"
 
 
+@pytest.mark.django_db
 class TestValidateDeviceStateMachine:
     """Tests for validate_device_for_import is_ready / can_import state transitions."""
 
@@ -210,9 +211,8 @@ class TestValidateDeviceStateMachine:
         mock_device.objects.filter.return_value.first.return_value = None
         mock_device.objects.filter.return_value.exclude.return_value.first.return_value = None
 
-        mock_vm = MagicMock()
-        mock_vm.objects.filter.return_value.first.return_value = None
-
+        # VirtualMachine is left REAL (unpatched) so isinstance(existing, VirtualMachine) works in
+        # validate_device_for_import; against the empty test DB the hostname VM lookup finds nothing.
         mock_cluster = MagicMock()
         mock_cluster.objects.all.return_value = []
 
@@ -246,7 +246,6 @@ class TestValidateDeviceStateMachine:
             patch("netbox_librenms_plugin.import_utils.device_operations.Site", MagicMock()),
             patch("netbox_librenms_plugin.import_utils.device_operations.find_by_librenms_id", return_value=None),
             patch("netbox_librenms_plugin.import_utils.device_operations.cache"),
-            patch("virtualization.models.VirtualMachine", mock_vm),
         ]
         if patches_overrides:
             base_patches.extend(patches_overrides)
@@ -993,6 +992,42 @@ class TestValidateDeviceForImportEdgeCases:
         assert result["serial_confirmed"] is False
         assert result["serial_duplicate"] is False
 
+    def test_duplicate_device_hostname_fails_closed_even_when_import_as_vm(self):
+        """import_as_vm=True but the hostname fallback binds a DEVICE (no VM shares the name): the
+        ambiguity guard must query the matched side (Device), not VirtualMachine. Keying the peer
+        model off import_as_vm queries VMs, finds no peers, and lets an arbitrary cross-site
+        duplicate-device .first() match through. Regression for the _PeerModel-from-import_as_vm bug.
+        """
+        from dcim.models import Device, DeviceRole, DeviceType, Manufacturer, Site
+
+        mfr, _ = Manufacturer.objects.get_or_create(name="ACME-vm997", slug="acme-vm997")
+        dt, _ = DeviceType.objects.get_or_create(manufacturer=mfr, model="DT-vm997", slug="dt-vm997")
+        role, _ = DeviceRole.objects.get_or_create(name="Role-vm997", slug="role-vm997")
+        site_a, _ = Site.objects.get_or_create(name="Site-vm997a", slug="site-vm997a")
+        site_b, _ = Site.objects.get_or_create(name="Site-vm997b", slug="site-vm997b")
+
+        # Two DEVICES (not VMs) share the hostname across sites. No VM has this name, so the
+        # hostname fallback binds a Device even though the caller requested a VM import.
+        Device.objects.create(name="dup-dev-asvm", device_type=dt, role=role, site=site_a, status="active")
+        Device.objects.create(name="dup-dev-asvm", device_type=dt, role=role, site=site_b, status="active")
+
+        libre_device = {
+            "device_id": 997,
+            "hostname": "dup-dev-asvm",
+            "sysName": "dup-dev-asvm",
+            "serial": "-",
+            "hardware": "Model-X",
+            "os": "linux",
+        }
+        result = self._validate(libre_device, import_as_vm=True)
+
+        # Must fail closed exactly like the import_as_vm=False device-duplicate case.
+        assert result["can_import"] is False
+        assert result["existing_device"] is None
+        assert result["existing_match_type"] == "ambiguous_hostname_or_serial"
+        # The object-typed wording must follow the MATCHED side (devices), not import_as_vm (VMs).
+        assert any("Multiple NetBox devices share" in i for i in result["issues"])
+
     def test_oob_ip_match_without_os_token_still_oob_candidate(self):
         """An incoming IP equal to device.oob_ip is still an OOB candidate when no os token classifies a type."""
         from netbox_librenms_plugin.tests.conftest import make_device, make_ip
@@ -1720,6 +1755,7 @@ class TestImportSingleDeviceMoreEdgeCases:
         assert Device.objects.get(pk=result["device"].pk).rack_id == rack.pk
 
 
+@pytest.mark.django_db
 class TestValidateDeviceExistingVMGuard:
     """Test that existing VMs skip device-specific validations (g06 fix)."""
 
@@ -1734,10 +1770,11 @@ class TestValidateDeviceExistingVMGuard:
         When import_as_vm=True and existing_device is set, site/device_type/device_role
         are marked found=True without running device-specific validation logic."""
         from netbox_librenms_plugin.import_utils.device_operations import validate_device_for_import
+        from netbox_librenms_plugin.tests.conftest import make_vm
 
-        existing_vm = MagicMock()
-        existing_vm.name = "vm01"
-        existing_vm.custom_field_data = {}
+        # Real VM (left unpatched so isinstance(existing, VirtualMachine) works); it is matched by
+        # hostname against the real test DB. find_by_librenms_id is stubbed to None below.
+        existing_vm = make_vm("vm01")
 
         libre_device = {
             "device_id": 1,
@@ -1749,9 +1786,6 @@ class TestValidateDeviceExistingVMGuard:
             "location": "unknown-location",
         }
         api = self._make_api()
-
-        mock_vm_model = MagicMock()
-        mock_vm_model.objects.filter.return_value.first.return_value = existing_vm
 
         mock_device_model = MagicMock()
         mock_device_model.objects.filter.return_value.first.return_value = None
@@ -1765,7 +1799,6 @@ class TestValidateDeviceExistingVMGuard:
             patch("netbox_librenms_plugin.import_utils.device_operations.Device", new=mock_device_model),
             patch("netbox_librenms_plugin.import_utils.device_operations.Cluster"),
             patch("netbox_librenms_plugin.import_utils.device_operations.cache"),
-            patch("virtualization.models.VirtualMachine", new=mock_vm_model),
             patch("ipam.models.IPAddress"),
             patch("netbox_librenms_plugin.import_utils.device_operations.find_by_librenms_id", return_value=None),
             patch(
@@ -1775,6 +1808,9 @@ class TestValidateDeviceExistingVMGuard:
         ):
             result = validate_device_for_import(libre_device, import_as_vm=True, api=api)
 
+        # The real VM was matched (by hostname) and forced VM mode.
+        assert result["existing_device"] == existing_vm
+        assert result["import_as_vm"] is True
         # find_matching_site and match_librenms_hardware_to_device_type should NOT be called for VMs
         mock_site.assert_not_called()
         mock_match.assert_not_called()
@@ -1786,6 +1822,7 @@ class TestValidateDeviceExistingVMGuard:
         assert not any("Cluster must be" in i for i in result.get("issues", []))
 
 
+@pytest.mark.django_db
 class TestValidateDeviceChassisMatch:
     """Test chassis match path (line 539) in validate_device_for_import."""
 
@@ -1813,9 +1850,8 @@ class TestValidateDeviceChassisMatch:
         chassis_dt.model = "Catalyst 9300"
         chassis_match = {"matched": True, "device_type": chassis_dt, "match_type": "chassis_inventory"}
 
-        vm_no_match = MagicMock()
-        vm_no_match.objects.filter.return_value.first.return_value = None  # no hostname collision
-
+        # VirtualMachine is left REAL so isinstance(existing, VirtualMachine) works; "sw01" matches
+        # no VM against the empty test DB, so validation still falls through to the chassis path.
         device_patch = patch("netbox_librenms_plugin.import_utils.device_operations.Device")
         mock_device_cls = device_patch.start()
         mock_device_cls.objects.filter.return_value.first.return_value = None
@@ -1826,7 +1862,6 @@ class TestValidateDeviceChassisMatch:
             patch("netbox_librenms_plugin.import_utils.device_operations.DeviceType"),
             patch("netbox_librenms_plugin.import_utils.device_operations.DeviceRole"),
             patch("netbox_librenms_plugin.import_utils.device_operations.cache"),
-            patch("virtualization.models.VirtualMachine", new=vm_no_match),
             patch("ipam.models.IPAddress"),
             patch("netbox_librenms_plugin.import_utils.device_operations.find_by_librenms_id", return_value=None),
             patch(

--- a/netbox_librenms_plugin/tests/test_coverage_device_operations.py
+++ b/netbox_librenms_plugin/tests/test_coverage_device_operations.py
@@ -1059,6 +1059,30 @@ class TestValidateDeviceForImportEdgeCases:
         assert any("resolve the duplicate" in i for i in result["issues"])
         assert result["existing_match_type"] == "ambiguous_hostname_or_serial"
 
+    def test_duplicate_vm_hostname_fails_closed(self):
+        """Two same-named VMs (NetBox VM names are unique only per cluster) must fail closed as ambiguous, not bind .first()."""
+        from netbox_librenms_plugin.tests.conftest import make_cluster, make_vm
+
+        make_vm("dup-vm-host", cluster=make_cluster("cl-dupvm-a"))
+        make_vm("dup-vm-host", cluster=make_cluster("cl-dupvm-b"))
+
+        libre_device = {
+            "device_id": 998,
+            "hostname": "dup-vm-host",
+            "sysName": "dup-vm-host",
+            "serial": "-",
+            "hardware": "Model-X",
+            "os": "linux",
+        }
+        result = self._validate(libre_device)
+
+        # Fail closed exactly like the device-side duplicate guard: the arbitrary .first() VM
+        # must be dropped and the row blocked, not linked/imported against a random cluster's VM.
+        assert result["can_import"] is False
+        assert result["existing_device"] is None
+        assert result["existing_match_type"] == "ambiguous_hostname_or_serial"
+        assert any("resolve the duplicate" in i for i in result["issues"])
+
     def test_duplicate_hostname_with_primary_ip_match_stays_terminal(self):
         """A duplicate-hostname row whose management IP resolves to a SINGLE device must stay
         terminal.

--- a/netbox_librenms_plugin/tests/test_coverage_device_operations.py
+++ b/netbox_librenms_plugin/tests/test_coverage_device_operations.py
@@ -640,6 +640,59 @@ class TestValidateDeviceForImport:
         assert "is_ready" in result
         assert result["existing_device"] is None
 
+    def test_validation_result_key_contract(self):
+        """Pin the result-dict key set to the documented Returns schema.
+
+        validate_device_for_import is a cross-module contract (bulk_import.py, actions.py and
+        jobs.py all read these fields). Extend this set and the docstring's Returns block
+        together — a key added to one without the other is exactly the drift this guards.
+        (promote_to_host is deliberately absent: it's conditional, present only when host
+        promotion is available.)
+        """
+        libre_device = {
+            "device_id": 2,
+            "hostname": "contract-host",
+            "sysName": "contract-host",
+            "hardware": "-",
+            "serial": "-",
+            "os": "-",
+            "location": "-",
+            "type": "network",
+        }
+        result = self._validate(libre_device)
+
+        assert set(result.keys()) == {
+            "is_ready",
+            "can_import",
+            "import_as_vm",
+            "resolved_name",
+            "existing_device",
+            "existing_match_type",
+            "ambiguous_librenms_id",
+            "serial_action",
+            "serial_confirmed",
+            "serial_duplicate",
+            "serial_role_choice_available",
+            "librenms_id_needs_migration",
+            "oob_candidate",
+            "existing_librenms_link",
+            "merge_candidates",
+            "name_matches",
+            "name_sync_available",
+            "suggested_name",
+            "device_type_mismatch",
+            "naming_criteria",
+            "virtual_chassis",
+            "issues",
+            "warnings",
+            "site",
+            "device_type",
+            "device_role",
+            "cluster",
+            "platform",
+            "rack",
+        }
+
     def test_vm_import_uses_correct_model(self):
         """import_as_vm=True matches a VirtualMachine by hostname (uses the VM model, not Device)."""
         from netbox_librenms_plugin.tests.conftest import make_vm

--- a/netbox_librenms_plugin/tests/test_coverage_devices.py
+++ b/netbox_librenms_plugin/tests/test_coverage_devices.py
@@ -1355,8 +1355,11 @@ class TestIpCachedSnapshotMgmtIpBackfill:
         real_cache.set(key, {"ip_addresses": [], "ports_by_id": {"7": {}}}, timeout=300)
         try:
             view._prepare_context(request, device, "ifName", fetch_fresh=False, server_key="default")
-            # The missing key triggered a one-time live resolve of the management IP.
+            # The missing key triggered a one-time live resolve of the management IP...
             api.get_device_info.assert_called_once_with(7)
+            # ...and the resolved VALUE was backfilled into the re-cached snapshot, so
+            # subsequent cached renders read it without another live call.
+            assert real_cache.get(key)["mgmt_ip"] == "10.0.0.9"
         finally:
             real_cache.delete(key)
 

--- a/netbox_librenms_plugin/tests/test_coverage_devices.py
+++ b/netbox_librenms_plugin/tests/test_coverage_devices.py
@@ -329,8 +329,6 @@ class TestSingleInterfaceVerifyView:
     def test_checks_permission_before_resolving_device(self):
         """The object-view gate must run BEFORE get_object_or_404 so an unauthorized caller can't probe arbitrary device IDs (existence via 404). Exercises the REAL require_object_permissions_json (only request.user.has_perm is mocked) — mocking the gate itself would mask a missing NetBoxObjectPermissionMixin base (AttributeError/500 in production)."""
         import json
-        from unittest.mock import patch
-
         from netbox_librenms_plugin.views.object_sync.devices import SingleInterfaceVerifyView
 
         view = object.__new__(SingleInterfaceVerifyView)
@@ -340,12 +338,12 @@ class TestSingleInterfaceVerifyView:
         request.body = json.dumps({"device_id": 999, "interface_name": "eth0"}).encode()
         request.user.has_perm.return_value = False  # unauthorized → real gate returns 403
         view.request = request  # check_object_permissions reads self.request.user
+        view.restrict_object_or_404 = MagicMock()
 
-        with patch("netbox_librenms_plugin.views.object_sync.devices.get_object_or_404") as mock_get_obj:
-            response = view.post(request)
+        response = view.post(request)
 
         assert response.status_code == 403
-        mock_get_obj.assert_not_called()  # device never resolved → no arbitrary-ID probing
+        view.restrict_object_or_404.assert_not_called()  # device never resolved → no arbitrary-ID probing
 
     @pytest.mark.django_db
     def test_returns_404_when_no_cached_data(self):
@@ -496,8 +494,6 @@ class TestSingleModuleVerifyView:
     def test_checks_permission_before_resolving_device(self):
         """The object-view gate must run BEFORE get_object_or_404 so an unauthorized caller can't probe arbitrary device IDs (existence via 404). Exercises the real require_object_permissions_json (only request.user.has_perm is mocked)."""
         import json
-        from unittest.mock import patch
-
         from netbox_librenms_plugin.views.object_sync.devices import SingleModuleVerifyView
 
         view = object.__new__(SingleModuleVerifyView)
@@ -507,12 +503,12 @@ class TestSingleModuleVerifyView:
         request.body = json.dumps({"device_id": 999, "ent_physical_index": 10}).encode()
         request.user.has_perm.return_value = False  # unauthorized → real gate returns 403
         view.request = request  # check_object_permissions reads self.request.user
+        view.restrict_object_or_404 = MagicMock()
 
-        with patch("netbox_librenms_plugin.views.object_sync.devices.get_object_or_404") as mock_get_obj:
-            response = view.post(request)
+        response = view.post(request)
 
         assert response.status_code == 403
-        mock_get_obj.assert_not_called()  # device never resolved → no arbitrary-ID probing
+        view.restrict_object_or_404.assert_not_called()  # device never resolved → no arbitrary-ID probing
 
     @pytest.mark.django_db
     def test_success_propagates_can_change_interface_to_verify_table(self):

--- a/netbox_librenms_plugin/tests/test_coverage_mixins.py
+++ b/netbox_librenms_plugin/tests/test_coverage_mixins.py
@@ -70,31 +70,42 @@ class TestLibreNMSAPIMixinActiveServerKey:
 class TestRenderSyncPartial:
     """render_sync_partial: the chokepoint that injects migrated-context into every partial render."""
 
-    def test_merges_real_migrated_context_into_view_context(self):
-        """A real migrated donor's marker + winner are merged into the partial context (real build_migrated_context, not a stub re-asserting the dict merge)."""
-        from netbox_librenms_plugin.tests.conftest import make_device
+    def test_merges_real_migrated_context_and_write_permission_into_view_context(self):
+        """A real migrated donor's marker + winner + the request user's has_write_permission are merged into the partial context (real build_migrated_context, not a stub re-asserting the dict merge)."""
+        from django.test import RequestFactory
+
+        from netbox_librenms_plugin.tests.conftest import make_device, make_superuser
         from netbox_librenms_plugin.utils import mark_librenms_migrated
-        from netbox_librenms_plugin.views.mixins import LibreNMSAPIMixin
+        from netbox_librenms_plugin.views.mixins import LibreNMSAPIMixin, LibreNMSPermissionMixin
 
         winner = make_device("rsp-winner")
         donor = make_device("rsp-donor")
         mark_librenms_migrated(donor, winner.pk, "prod")  # real _migrated_to marker under "prod"
         donor.save()
 
-        m = object.__new__(LibreNMSAPIMixin)
-        m.partial_template_name = "tmpl.html"
+        # Real sync views combine both mixins (BaseLibreNMSSyncView / BaseIPAddressTableView); build a
+        # matching self so render_sync_partial can resolve has_write_permission from the request user.
+        class _SyncView(LibreNMSPermissionMixin, LibreNMSAPIMixin):
+            partial_template_name = "tmpl.html"
+
+        m = object.__new__(_SyncView)
+        request = RequestFactory().post("/")
+        request.user = make_superuser()
+        m.request = request
         # Only render is stubbed (it needs a full request + template machinery); build_migrated_context
         # resolves the donor's real marker against the real winner row.
         with patch("netbox_librenms_plugin.views.mixins.render") as mock_render:
-            m.render_sync_partial("REQ", donor, "prod", {"vlan_sync": "X"})
+            m.render_sync_partial(request, donor, "prod", {"vlan_sync": "X"})
 
         _req, template, context = mock_render.call_args.args
         assert template == "tmpl.html"
-        # The view's payload AND the real migration flags are present — a partial-render exit routed
-        # through here can never silently drop the migration controls.
+        # The view's payload, the real migration flags, AND has_write_permission are present — a
+        # partial-render exit routed through here can never silently drop the migration controls or
+        # the write-permission flag the "Move to winner" buttons gate on.
         assert context["vlan_sync"] == "X"
         assert context["migrated_to_marker"]["device_id"] == winner.pk
         assert context["migrated_to_winner"].pk == winner.pk
+        assert context["has_write_permission"] is True
 
 
 @pytest.mark.django_db

--- a/netbox_librenms_plugin/tests/test_coverage_mixins.py
+++ b/netbox_librenms_plugin/tests/test_coverage_mixins.py
@@ -44,6 +44,28 @@ class TestCacheRemainingTtl:
 # =============================================================================
 
 
+class TestLibreNMSAPIMixinActiveServerKey:
+    """LibreNMSAPIMixin.active_server_key: the bound client's key or 'default', never building a client."""
+
+    def _mixin(self):
+        from netbox_librenms_plugin.views.mixins import LibreNMSAPIMixin
+
+        return object.__new__(LibreNMSAPIMixin)
+
+    def test_returns_bound_client_server_key(self):
+        m = self._mixin()
+        m._librenms_api = MagicMock(server_key="prod")
+        assert m.active_server_key == "prod"
+
+    def test_returns_default_without_building_client_when_unbound(self):
+        """On the rebind-fail render path no client is bound; the property must return 'default' WITHOUT constructing a LibreNMSAPI (the lazy librenms_api property would, and can raise on a misconfigured default)."""
+        m = self._mixin()
+        m._librenms_api = None
+        with patch("netbox_librenms_plugin.views.mixins.LibreNMSAPI") as mock_api_cls:
+            assert m.active_server_key == "default"
+        mock_api_cls.assert_not_called()
+
+
 class TestLibreNMSAPIMixinRebindApiForServer:
     """LibreNMSAPIMixin.rebind_api_for_server: POST-scoped API client for base views."""
 

--- a/netbox_librenms_plugin/tests/test_coverage_mixins.py
+++ b/netbox_librenms_plugin/tests/test_coverage_mixins.py
@@ -188,7 +188,7 @@ class TestLibreNMSAPIMixinRebindApiForServer:
         assert m._librenms_api is new_api  # rebound
 
     def test_returns_resolved_key_not_raw_post_value(self):
-        """build_librenms_api may normalize the posted key (e.g."""
+        """build_librenms_api may normalize the posted key (e.g. resolve an alias); the mixin must return the resolved key, not the raw POST value."""
         m = self._mixin("default")
         resolved_api = MagicMock(server_key="primary")
         with patch("netbox_librenms_plugin.librenms_api.build_librenms_api", return_value=resolved_api):

--- a/netbox_librenms_plugin/tests/test_coverage_mixins.py
+++ b/netbox_librenms_plugin/tests/test_coverage_mixins.py
@@ -1326,3 +1326,12 @@ class TestRenderServerKeyDegradation:
 
         assert BaseIPAddressTableView._render_server_key is LibreNMSAPIMixin._render_server_key
         assert BaseCableTableView._render_server_key is LibreNMSAPIMixin._render_server_key
+
+    def test_sync_page_subclass_keeps_render_server_key_method_callable(self):
+        """A real sync-page subclass must not shadow the mixin's render-key resolver."""
+        from netbox_librenms_plugin.views.object_sync.devices import DeviceLibreNMSSyncView
+
+        view = DeviceLibreNMSSyncView()
+        view._librenms_api = MagicMock(server_key="active")
+
+        assert view._render_server_key() == "active"

--- a/netbox_librenms_plugin/tests/test_coverage_mixins.py
+++ b/netbox_librenms_plugin/tests/test_coverage_mixins.py
@@ -66,30 +66,87 @@ class TestLibreNMSAPIMixinActiveServerKey:
         mock_api_cls.assert_not_called()
 
 
+@pytest.mark.django_db
 class TestRenderSyncPartial:
     """render_sync_partial: the chokepoint that injects migrated-context into every partial render."""
 
-    def test_merges_migrated_context_into_view_context(self):
+    def test_merges_real_migrated_context_into_view_context(self):
+        """A real migrated donor's marker + winner are merged into the partial context (real build_migrated_context, not a stub re-asserting the dict merge)."""
+        from netbox_librenms_plugin.tests.conftest import make_device
+        from netbox_librenms_plugin.utils import mark_librenms_migrated
         from netbox_librenms_plugin.views.mixins import LibreNMSAPIMixin
+
+        winner = make_device("rsp-winner")
+        donor = make_device("rsp-donor")
+        mark_librenms_migrated(donor, winner.pk, "prod")  # real _migrated_to marker under "prod"
+        donor.save()
 
         m = object.__new__(LibreNMSAPIMixin)
         m.partial_template_name = "tmpl.html"
-        obj = MagicMock()
-        with (
-            patch("netbox_librenms_plugin.views.mixins.render") as mock_render,
-            patch(
-                "netbox_librenms_plugin.utils.build_migrated_context",
-                return_value={"migrated_to_marker": "M", "migrated_to_winner": "W"},
-            ) as mock_bmc,
-        ):
-            m.render_sync_partial("REQ", obj, "prod", {"vlan_sync": "X"})
+        # Only render is stubbed (it needs a full request + template machinery); build_migrated_context
+        # resolves the donor's real marker against the real winner row.
+        with patch("netbox_librenms_plugin.views.mixins.render") as mock_render:
+            m.render_sync_partial("REQ", donor, "prod", {"vlan_sync": "X"})
 
-        mock_bmc.assert_called_once_with(obj, "prod")
         _req, template, context = mock_render.call_args.args
         assert template == "tmpl.html"
-        # The view's payload AND the migrated-context flags are both present — a partial-render
-        # exit routed through here can never silently drop the migration controls.
-        assert context == {"vlan_sync": "X", "migrated_to_marker": "M", "migrated_to_winner": "W"}
+        # The view's payload AND the real migration flags are present — a partial-render exit routed
+        # through here can never silently drop the migration controls.
+        assert context["vlan_sync"] == "X"
+        assert context["migrated_to_marker"]["device_id"] == winner.pk
+        assert context["migrated_to_winner"].pk == winner.pk
+
+
+@pytest.mark.django_db
+class TestBuildMigratedContextLazyWinner:
+    """build_migrated_context defers the winner Device lookup to a lazy proxy (cable/module/VLAN partials never read it)."""
+
+    @staticmethod
+    def _winner_lookups(cap, pk):
+        return [q["sql"] for q in cap.captured_queries if "dcim_device" in q["sql"] and f"= {pk}" in q["sql"]]
+
+    def test_winner_lookup_deferred_until_the_proxy_is_read(self):
+        from django.db import connection
+        from django.test.utils import CaptureQueriesContext
+
+        from netbox_librenms_plugin.tests.conftest import make_device
+        from netbox_librenms_plugin.utils import build_migrated_context, mark_librenms_migrated
+
+        winner = make_device("bmc-winner")
+        donor = make_device("bmc-donor")
+        mark_librenms_migrated(donor, winner.pk, "default")
+        donor.save()
+
+        # Building the context must NOT fetch the winner row (the boolean-only partials never read it).
+        with CaptureQueriesContext(connection) as cap_build:
+            ctx = build_migrated_context(donor, "default")
+        assert ctx["migrated_to_marker"]["device_id"] == winner.pk  # banner boolean present
+        assert self._winner_lookups(cap_build, winner.pk) == []  # winner Device not fetched yet
+
+        # Reading the proxy (the interface/IP partials do) resolves the real Device — one query.
+        with CaptureQueriesContext(connection) as cap_access:
+            assert ctx["migrated_to_winner"].pk == winner.pk
+        assert self._winner_lookups(cap_access, winner.pk)  # the deferred lookup fired on access
+
+    def test_self_pointing_marker_suppressed_without_a_winner_query(self):
+        from django.db import connection
+        from django.test.utils import CaptureQueriesContext
+
+        from netbox_librenms_plugin.tests.conftest import make_device
+        from netbox_librenms_plugin.utils import build_migrated_context
+
+        donor = make_device("bmc-self")
+        # A self-pointing marker (device_id == donor.pk) is corrupt: it must not flip the donor into
+        # migrated mode, and the suppression happens in memory — no winner Device fetch.
+        donor.custom_field_data["librenms_id"] = {
+            "default": {"_migrated_to": {"device_id": donor.pk, "server_key": "default", "at": "x"}}
+        }
+        donor.save()
+        with CaptureQueriesContext(connection) as cap:
+            ctx = build_migrated_context(donor, "default")
+        assert ctx["migrated_to_marker"] is None
+        assert ctx["migrated_to_winner"] is None
+        assert self._winner_lookups(cap, donor.pk) == []  # suppression is in-memory
 
 
 class TestLibreNMSAPIMixinRebindApiForServer:

--- a/netbox_librenms_plugin/tests/test_coverage_mixins.py
+++ b/netbox_librenms_plugin/tests/test_coverage_mixins.py
@@ -66,6 +66,32 @@ class TestLibreNMSAPIMixinActiveServerKey:
         mock_api_cls.assert_not_called()
 
 
+class TestRenderSyncPartial:
+    """render_sync_partial: the chokepoint that injects migrated-context into every partial render."""
+
+    def test_merges_migrated_context_into_view_context(self):
+        from netbox_librenms_plugin.views.mixins import LibreNMSAPIMixin
+
+        m = object.__new__(LibreNMSAPIMixin)
+        m.partial_template_name = "tmpl.html"
+        obj = MagicMock()
+        with (
+            patch("netbox_librenms_plugin.views.mixins.render") as mock_render,
+            patch(
+                "netbox_librenms_plugin.utils.build_migrated_context",
+                return_value={"migrated_to_marker": "M", "migrated_to_winner": "W"},
+            ) as mock_bmc,
+        ):
+            m.render_sync_partial("REQ", obj, "prod", {"vlan_sync": "X"})
+
+        mock_bmc.assert_called_once_with(obj, "prod")
+        _req, template, context = mock_render.call_args.args
+        assert template == "tmpl.html"
+        # The view's payload AND the migrated-context flags are both present — a partial-render
+        # exit routed through here can never silently drop the migration controls.
+        assert context == {"vlan_sync": "X", "migrated_to_marker": "M", "migrated_to_winner": "W"}
+
+
 class TestLibreNMSAPIMixinRebindApiForServer:
     """LibreNMSAPIMixin.rebind_api_for_server: POST-scoped API client for base views."""
 

--- a/netbox_librenms_plugin/tests/test_coverage_sync_view.py
+++ b/netbox_librenms_plugin/tests/test_coverage_sync_view.py
@@ -92,6 +92,10 @@ class TestBaseLibreNMSSyncViewGet:
             view.get(request, pk=1)
 
         mock_get_sync.assert_not_called()  # VC delegation skipped on unresolved
+        # The default client must never be queried: get_librenms_id can auto-discover/store a
+        # mapping, which is exactly the fail-open behaviour this branch blocks. Asserting the id is
+        # None alone would still pass if the lookup ran and its result were merely discarded.
+        view._librenms_api.get_librenms_id.assert_not_called()
         assert view._librenms_lookup_device is obj
         assert view.librenms_id is None  # no default-server mapping attributed to the gone server
 

--- a/netbox_librenms_plugin/tests/test_coverage_sync_view.py
+++ b/netbox_librenms_plugin/tests/test_coverage_sync_view.py
@@ -1153,3 +1153,62 @@ class TestInterfaceSyncRefreshButtonServerKey:
         assert '<input type="hidden" name="server_key" value="prod">' in html
         # ...and the refresh button posts it alongside interface_name_field.
         assert "[name='interface_name_field'], [name='server_key']" in html
+
+
+@pytest.mark.django_db
+class TestFullPageMigratedContextServerScope:
+    """The full-page migrated banner must use the resolved render key, not the global default."""
+
+    def test_stale_server_key_builds_migrated_banner_under_requested_key(self):
+        """A stale ?server_key whose marker lives on a non-default server still shows the banner (scoped to the requested key, not 'default')."""
+        from django.http import HttpResponse
+
+        from netbox_librenms_plugin.tests.conftest import make_device
+        from netbox_librenms_plugin.views.object_sync.devices import DeviceLibreNMSSyncView
+
+        winner = make_device("f4-winner")
+        donor = make_device("f4-donor")
+        # The migration marker lives under a NON-default server that is now stale/deleted.
+        donor.custom_field_data["librenms_id"] = {
+            "edgelondon": {"_migrated_to": {"device_id": winner.pk, "server_key": "edgelondon", "at": "x"}}
+        }
+        donor.save()
+
+        view = DeviceLibreNMSSyncView()
+        view.has_write_permission = MagicMock(return_value=True)
+        # Sibling context builders are independently tested; null them so this isolates the migrated
+        # banner's server namespace. get_librenms_device_info stays REAL — with librenms_id None
+        # (fail-closed) it returns empty details without touching the API.
+        view.get_interface_context = MagicMock(return_value=None)
+        view.get_cable_context = MagicMock(return_value=None)
+        view.get_ip_context = MagicMock(return_value=None)
+        view.get_vlan_context = MagicMock(return_value=None)
+        view.get_module_context = MagicMock(return_value=None)
+        view._get_platform_info = MagicMock(return_value={})
+
+        request = RequestFactory().get("/?server_key=edgelondon")
+        request.user = MagicMock(is_superuser=True)
+
+        captured = {}
+
+        def _capture(req, template, ctx):
+            captured.update(ctx)
+            return HttpResponse("ok")
+
+        # build_librenms_api → None makes 'edgelondon' unresolvable regardless of test config, so
+        # the rebind declines and get() takes the stale-?server_key (unresolved) path.
+        with (
+            patch("netbox_librenms_plugin.librenms_api.build_librenms_api", return_value=None),
+            patch("netbox_librenms_plugin.views.base.librenms_sync_view.render", side_effect=_capture),
+            patch(
+                "netbox_librenms_plugin.views.base.librenms_sync_view.LibreNMSAPIMixin.get_context_data",
+                return_value={},
+            ),
+        ):
+            view.get(request, pk=donor.pk)
+
+        # Fixed: banner built under 'edgelondon' (the requested/scoped key). The unfixed code used
+        # self.librenms_api.server_key ('default') and looked up no marker → banner silently absent.
+        assert captured.get("migrated_to_marker"), "migration banner missing — marker looked up under the wrong server"
+        assert captured.get("migrated_to_winner") is not None
+        assert captured["migrated_to_winner"].pk == winner.pk

--- a/netbox_librenms_plugin/tests/test_coverage_tables.py
+++ b/netbox_librenms_plugin/tests/test_coverage_tables.py
@@ -1518,7 +1518,7 @@ class TestDeviceImportTableRenderActions:
         assert "paired host: LibreNMS #" not in result
 
     def test_existing_librenms_link_non_dict_does_not_crash_render(self):
-        """A malformed ``existing_librenms_link`` that isn't a dict (e.g."""
+        """A malformed ``existing_librenms_link`` that isn't a dict (e.g. a legacy bare int) must not crash the actions render."""
         from dcim.models import Device
         from virtualization.models import VirtualMachine
 

--- a/netbox_librenms_plugin/tests/test_coverage_tables.py
+++ b/netbox_librenms_plugin/tests/test_coverage_tables.py
@@ -3271,3 +3271,62 @@ class TestRenderDeviceSelectionEscape:
         # The raw <script> tag must NOT appear — it must be escaped, matching the cable table.
         assert "<script>" not in html
         assert "&lt;script&gt;" in html
+
+
+# ===========================================================================
+# OOB badge wiring — the shared utils.oob_badge_html helper in each table
+# ===========================================================================
+
+
+class TestOobBadgeWiring:
+    """Each table render that shows the OOB badge must go through utils.oob_badge_html."""
+
+    def _interface_table(self):
+        from netbox_librenms_plugin.tables.interfaces import LibreNMSInterfaceTable
+
+        table = object.__new__(LibreNMSInterfaceTable)
+        table.interface_name_field = "ifName"
+        return table
+
+    def test_interface_render_name_badges_an_oob_row(self):
+        table = self._interface_table()
+        # exists_in_netbox falsy → _render_field short-circuits; the render is real end-to-end.
+        html = str(table.render_name("mgmt0", {"ifName": "mgmt0", "_source": "oob"}))
+        assert 'title="From OOB controller"' in html
+        assert "mgmt0" in html
+
+    def test_interface_render_name_plain_row_has_no_badge(self):
+        table = self._interface_table()
+        html = str(table.render_name("eth0", {"ifName": "eth0", "_source": "main"}))
+        assert "From OOB controller" not in html
+
+    def test_module_render_name_badges_an_oob_row(self):
+        from netbox_librenms_plugin.tables.modules import LibreNMSModuleTable
+
+        table = object.__new__(LibreNMSModuleTable)
+        html = str(table.render_name("PSU 1", {"_source": "oob", "depth": 0}))
+        assert 'title="From OOB controller"' in html
+        assert "PSU 1" in html
+
+    def test_module_render_name_plain_row_has_no_badge(self):
+        from netbox_librenms_plugin.tables.modules import LibreNMSModuleTable
+
+        table = object.__new__(LibreNMSModuleTable)
+        html = str(table.render_name("PSU 1", {"depth": 0}))
+        assert "From OOB controller" not in html
+
+    def test_cable_render_local_port_badges_an_oob_row_after_the_name(self):
+        from netbox_librenms_plugin.tables.cables import LibreNMSCableTable
+
+        table = object.__new__(LibreNMSCableTable)
+        html = str(table.render_local_port("Gi0/1", {"_source": "oob"}))
+        # Leading space: the badge follows the port name.
+        assert html.startswith("Gi0/1 <span")
+        assert 'title="From OOB controller"' in html
+
+    def test_cable_render_local_port_plain_row_has_no_badge(self):
+        from netbox_librenms_plugin.tables.cables import LibreNMSCableTable
+
+        table = object.__new__(LibreNMSCableTable)
+        html = str(table.render_local_port("Gi0/1", {"_source": "main"}))
+        assert "From OOB controller" not in html

--- a/netbox_librenms_plugin/tests/test_coverage_utils.py
+++ b/netbox_librenms_plugin/tests/test_coverage_utils.py
@@ -135,7 +135,7 @@ class TestGetLibreNMSSyncDeviceServerKey:
         assert result is member_with_id
 
     def test_float_id_is_rejected_not_int_truncated(self):
-        """A float id (e.g."""
+        """A float id (e.g. 1.0) is rejected as invalid, not truncated to an int."""
         from netbox_librenms_plugin.utils import get_librenms_sync_device
 
         device = MagicMock()

--- a/netbox_librenms_plugin/tests/test_device_validation_details_template.py
+++ b/netbox_librenms_plugin/tests/test_device_validation_details_template.py
@@ -80,6 +80,61 @@ class TestDeviceValidationDetailsMergeBadge:
         # ...and the fragile document-wide winner-radio query is gone.
         assert "document.querySelectorAll('input.merge-winner-radio" not in html
 
+    def test_merge_candidate_oob_only_link_is_not_labelled_unlinked(self):
+        """A merge candidate linked as OOB-only (oob_id set, host_id empty) must be labelled as OOB-linked, not mislabelled 'not linked to LibreNMS'."""
+        from django.contrib.auth.models import AnonymousUser
+        from django.template.loader import render_to_string
+        from django.test import RequestFactory
+
+        from netbox_librenms_plugin.tests.conftest import make_device
+
+        winner = make_device("merge-oob-winner")
+        donor = make_device("merge-oob-donor")
+        request = RequestFactory().get("/")
+        request.user = AnonymousUser()
+        ctx = {
+            "validation": {
+                "existing_device": winner,
+                "serial_action": "merge_netbox_devices",
+                "merge_candidates": {
+                    # host_named is linked to LibreNMS only as an OOB controller (no host_id).
+                    "host_named": {
+                        "pk": winner.pk,
+                        "name": winner.name,
+                        "librenms_link": {"host_id": None, "oob_id": 77, "oob_type": "iDRAC"},
+                    },
+                    "oob_named": {
+                        "pk": donor.pk,
+                        "name": donor.name,
+                        "librenms_link": {"host_id": None, "oob_id": None},
+                    },
+                },
+            },
+            "libre_device": {
+                "device_id": 5,
+                "sysName": "merge-oob-winner",
+                "hostname": "merge-oob-winner",
+                "serial": "ABC123",
+                "hardware": "Model-X",
+                "os": "ios",
+                "ip": "10.0.0.1",
+                "location": "lab",
+                "status": True,
+            },
+            "server_key": "default",
+            "existing_device_model_name": "device",
+            "existing_device_url": winner.get_absolute_url(),
+            "sync_info": {},
+            "existing_id_servers": [],
+            "use_sysname": True,
+            "strip_domain": False,
+        }
+        html = render_to_string("netbox_librenms_plugin/htmx/device_validation_details.html", ctx, request=request)
+
+        # The OOB-only candidate must surface its OOB linkage, not fall through to "not linked".
+        assert "currently linked to LibreNMS as OOB #77" in html
+        assert "(iDRAC)" in html
+
 
 @pytest.mark.django_db
 class TestSerialActionBadges:

--- a/netbox_librenms_plugin/tests/test_device_validation_details_template.py
+++ b/netbox_librenms_plugin/tests/test_device_validation_details_template.py
@@ -76,13 +76,13 @@ class TestDeviceValidationDetailsMergeBadge:
         assert "the IP is already on a winner interface" in html
         assert "(only if the winner has no OOB IP yet)" not in html
 
-    def test_merge_donor_sync_script_is_scoped_to_its_form(self):
-        """The donor-sync script must scope its winner-radio lookup to the current form, not the whole document."""
+    def test_merge_derives_donor_without_client_state(self):
+        """The merge form posts only the winner because the server derives the donor."""
         html = self._render()
-        # Form-scoped lookup present...
-        assert 'closest("form")' in html
-        # ...and the fragile document-wide winner-radio query is gone.
-        assert "document.querySelectorAll('input.merge-winner-radio" not in html
+        assert 'name="winner_pk"' in html
+        assert 'name="donor_pk"' not in html
+        assert "data-donor-pk" not in html
+        assert "syncDonor" not in html
 
     def test_merge_candidate_oob_only_link_is_not_labelled_unlinked(self):
         """A merge candidate linked as OOB-only (oob_id set, host_id empty) must be labelled as OOB-linked, not mislabelled 'not linked to LibreNMS'."""
@@ -144,12 +144,12 @@ class TestDeviceValidationDetailsMergeBadge:
         assert "not linked to LibreNMS" not in html  # non-vacuous: must NOT also render the unlinked label
 
         # The merge POST must carry the naming toggles (use_sysname / strip_domain) so a
-        # user-selected naming mode survives the revalidation the merge triggers. The merge form
-        # is the one carrying the donor_pk input; check its opening tag has the hx-include.
-        merge_chunks = [c for c in html.split("<form") if 'name="donor_pk"' in c]
+        # user-selected naming mode survives the revalidation the merge triggers.
+        merge_chunks = [c for c in html.split("<form") if 'name="winner_pk"' in c]
         assert merge_chunks, "merge form was not rendered"
         merge_tag = merge_chunks[0].split(">", 1)[0]
         assert "use-sysname-toggle" in merge_tag and "strip-domain-toggle" in merge_tag
+        assert 'name="donor_pk"' not in html
 
 
 @pytest.mark.django_db

--- a/netbox_librenms_plugin/tests/test_device_validation_details_template.py
+++ b/netbox_librenms_plugin/tests/test_device_validation_details_template.py
@@ -442,3 +442,33 @@ def test_promote_override_handler_clears_hidden_when_switching_back_to_keep():
     assert "hidden.value = r.checked ?" in source
     # The buggy keep-branch (which never fired, since Keep has no data-override-target) is gone.
     assert 'r.value === "keep"' not in source
+
+
+def test_promote_form_reset_is_wired_to_both_close_paths():
+    """The promote reset binds hidden.bs.modal and the dismiss-button click unconditionally, so a Bootstrap backdrop dismiss can't leave the form sticky on reopen."""
+    from pathlib import Path
+
+    import netbox_librenms_plugin
+
+    source = (
+        Path(netbox_librenms_plugin.__file__).parent
+        / "templates"
+        / "netbox_librenms_plugin"
+        / "htmx"
+        / "device_validation_details.html"
+    ).read_text()
+
+    # Isolate the reset-binding block (between the bound-guard flag and the next handler).
+    start = source.index('modal.dataset.promoteResetBound = "1"')
+    end = source.index('modal.addEventListener("change"', start)
+    block = source[start:end]
+
+    # hidden.bs.modal fires for EVERY Bootstrap close, including the backdrop click that the
+    # dismiss-button handler never catches; the dismiss-button click covers the no-Bootstrap
+    # fallback where hidden.bs.modal never fires.
+    assert 'modal.addEventListener("hidden.bs.modal", resetPromoteForm)' in block
+    assert 'btn.addEventListener("click", resetPromoteForm)' in block
+    # Both are now bound unconditionally: the old render-time if/else picked exactly ONE path,
+    # so a Bootstrap backdrop dismiss (fires only hidden.bs.modal) was unhandled whenever the
+    # fallback branch had been taken at render. That either/or is gone.
+    assert "} else {" not in block

--- a/netbox_librenms_plugin/tests/test_device_validation_details_template.py
+++ b/netbox_librenms_plugin/tests/test_device_validation_details_template.py
@@ -69,6 +69,10 @@ class TestDeviceValidationDetailsMergeBadge:
     def test_oob_ip_move_copy_states_the_real_condition(self):
         """The 'Moved to winner' copy must state the OOB IP only moves when the winner has no OOB IP AND the IP is already on a winner interface — the old copy over-promised the move."""
         html = self._render()
+        # Both halves of the real condition must be stated, not just one. Pinning only the
+        # "winner interface" clause would still pass if the "winner has no OOB IP" requirement
+        # were dropped again (the original over-promise this copy fixed).
+        assert "the winner has no OOB IP" in html
         assert "the IP is already on a winner interface" in html
         assert "(only if the winner has no OOB IP yet)" not in html
 

--- a/netbox_librenms_plugin/tests/test_device_validation_details_template.py
+++ b/netbox_librenms_plugin/tests/test_device_validation_details_template.py
@@ -103,10 +103,13 @@ class TestDeviceValidationDetailsMergeBadge:
                         "name": winner.name,
                         "librenms_link": {"host_id": None, "oob_id": 77, "oob_type": "iDRAC"},
                     },
+                    # The other candidate is host-linked, so NEITHER candidate is genuinely
+                    # unlinked — any "not linked" text would therefore be a mislabel of the
+                    # OOB-only candidate above (the bug this test guards against).
                     "oob_named": {
                         "pk": donor.pk,
                         "name": donor.name,
-                        "librenms_link": {"host_id": None, "oob_id": None},
+                        "librenms_link": {"host_id": 99, "oob_id": None},
                     },
                 },
             },
@@ -134,6 +137,15 @@ class TestDeviceValidationDetailsMergeBadge:
         # The OOB-only candidate must surface its OOB linkage, not fall through to "not linked".
         assert "currently linked to LibreNMS as OOB #77" in html
         assert "(iDRAC)" in html
+        assert "not linked to LibreNMS" not in html  # non-vacuous: must NOT also render the unlinked label
+
+        # The merge POST must carry the naming toggles (use_sysname / strip_domain) so a
+        # user-selected naming mode survives the revalidation the merge triggers. The merge form
+        # is the one carrying the donor_pk input; check its opening tag has the hx-include.
+        merge_chunks = [c for c in html.split("<form") if 'name="donor_pk"' in c]
+        assert merge_chunks, "merge form was not rendered"
+        merge_tag = merge_chunks[0].split(">", 1)[0]
+        assert "use-sysname-toggle" in merge_tag and "strip-domain-toggle" in merge_tag
 
 
 @pytest.mark.django_db

--- a/netbox_librenms_plugin/tests/test_device_validation_details_template.py
+++ b/netbox_librenms_plugin/tests/test_device_validation_details_template.py
@@ -322,6 +322,53 @@ class TestSerialMatchFormServerKey:
 
 
 @pytest.mark.django_db
+class TestAddAsOOBFormPanes:
+    """Both OOB-candidate panes (serial match and primary_ip match) must render the shared Add-as-OOB form."""
+
+    def _render(self, *, match_type, serial_action):
+        from django.contrib.auth.models import AnonymousUser
+        from django.template.loader import render_to_string
+        from django.test import RequestFactory
+
+        from netbox_librenms_plugin.tests.conftest import make_device
+
+        existing = make_device(f"oob-pane-{match_type}")
+        request = RequestFactory().get("/")
+        request.user = AnonymousUser()
+        ctx = {
+            "validation": {
+                "existing_device": existing,
+                "existing_match_type": match_type,
+                "serial_action": serial_action,
+                "oob_candidate": {"type": "idrac", "ip": "10.9.9.9"},
+                "device_type_mismatch": False,
+                "warnings": [],
+            },
+            "libre_device": {"device_id": 7, "sysName": "oob-pane", "hostname": "oob-pane", "ip": "10.9.9.9"},
+            "server_key": "prod",
+            "existing_device_model_name": "device",
+            "existing_device_url": existing.get_absolute_url(),
+            "sync_info": {},
+            "existing_id_servers": [],
+            "use_sysname": True,
+            "strip_domain": False,
+        }
+        return render_to_string("netbox_librenms_plugin/htmx/device_validation_details.html", ctx, request=request)
+
+    def test_serial_match_pane_renders_add_as_oob_form(self):
+        html = self._render(match_type="serial", serial_action="oob_candidate")
+        assert "device-import/add-as-oob/7/" in html
+        assert "Add as OOB to" in html
+        assert 'name="server_key" value="prod"' in html
+
+    def test_primary_ip_match_pane_renders_add_as_oob_form(self):
+        html = self._render(match_type="primary_ip", serial_action="oob_candidate")
+        assert "device-import/add-as-oob/7/" in html
+        assert "Add as OOB to" in html
+        assert 'name="server_key" value="prod"' in html
+
+
+@pytest.mark.django_db
 class TestPromoteToHostFallbackPane:
     """A promote_to_host-classified row must render an ACTIONABLE Host pane on this branch.
 

--- a/netbox_librenms_plugin/tests/test_device_validation_details_template.py
+++ b/netbox_librenms_plugin/tests/test_device_validation_details_template.py
@@ -6,6 +6,8 @@ themes (measured ~1.2–2.3:1). ``bg-warning text-dark`` clears WCAG AA in both.
 real template guards against a regression to the bare class.
 """
 
+import re
+
 import pytest
 
 
@@ -554,7 +556,10 @@ class TestPromoteModalAccessibility:
         assert 'id="promote-modal-12"' in html
         # The modal references its heading, and the heading actually carries that id.
         assert 'aria-labelledby="promote-modal-label-12"' in html
-        assert 'id="promote-modal-label-12"' in html
+        assert re.search(
+            r'<h\d(?=[^>]*\bid="promote-modal-label-12")(?=[^>]*\bclass="[^"]*\bmodal-title\b)[^>]*>',
+            html,
+        )
 
 
 @pytest.mark.django_db

--- a/netbox_librenms_plugin/tests/test_device_validation_details_template.py
+++ b/netbox_librenms_plugin/tests/test_device_validation_details_template.py
@@ -67,17 +67,13 @@ class TestDeviceValidationDetailsMergeBadge:
         ), "merge badge must pair bg-warning with text-dark on one element"
 
     def test_oob_ip_move_copy_states_the_real_condition(self):
-        """The 'Moved to winner' copy must state the OOB IP only moves when the winner has no OOB IP
-        AND the IP is already on a winner interface — the old copy over-promised the move."""
+        """The 'Moved to winner' copy must state the OOB IP only moves when the winner has no OOB IP AND the IP is already on a winner interface — the old copy over-promised the move."""
         html = self._render()
         assert "the IP is already on a winner interface" in html
         assert "(only if the winner has no OOB IP yet)" not in html
 
     def test_merge_donor_sync_script_is_scoped_to_its_form(self):
-        """The donor-sync script must scope its winner-radio lookup to the current form, not the
-        whole document. A document-wide query would read merge-winner radios from another
-        validation fragment still in the DOM and write the wrong donor_pk — merging the wrong
-        NetBox device."""
+        """The donor-sync script must scope its winner-radio lookup to the current form, not the whole document."""
         html = self._render()
         # Form-scoped lookup present...
         assert 'closest("form")' in html

--- a/netbox_librenms_plugin/tests/test_device_validation_details_template.py
+++ b/netbox_librenms_plugin/tests/test_device_validation_details_template.py
@@ -472,3 +472,46 @@ def test_promote_form_reset_is_wired_to_both_close_paths():
     # so a Bootstrap backdrop dismiss (fires only hidden.bs.modal) was unhandled whenever the
     # fallback branch had been taken at render. That either/or is gone.
     assert "} else {" not in block
+
+
+@pytest.mark.django_db
+class TestPromoteModalAccessibility:
+    """The promote modal must carry aria-labelledby pointing at its titled heading (screen readers)."""
+
+    def _render(self):
+        from django.contrib.auth.models import AnonymousUser
+        from django.template.loader import render_to_string
+        from django.test import RequestFactory
+
+        from netbox_librenms_plugin.tests.conftest import make_device
+
+        existing = make_device("promote-a11y")
+        request = RequestFactory().get("/")
+        request.user = AnonymousUser()
+        ctx = {
+            "validation": {
+                "existing_device": existing,
+                "existing_match_type": "serial",
+                "serial_action": "promote_to_host",
+                "promote_to_host": {"existing_libre_id": 88, "existing_oob_type": "idrac"},
+                "warnings": [],
+            },
+            "libre_device": {"device_id": 12, "sysName": "promote-a11y", "hostname": "promote-a11y"},
+            "server_key": "default",
+            "existing_device_model_name": "device",
+            "existing_device_url": existing.get_absolute_url(),
+            "sync_info": {},
+            "existing_id_servers": [],
+            "use_sysname": True,
+            "strip_domain": False,
+        }
+        return render_to_string("netbox_librenms_plugin/htmx/device_validation_details.html", ctx, request=request)
+
+    def test_promote_modal_labelledby_targets_its_title_id(self):
+        """The modal's aria-labelledby id matches the id on its modal-title heading (real linkage)."""
+        html = self._render()
+        # Precondition: the promote modal rendered for this context.
+        assert 'id="promote-modal-12"' in html
+        # The modal references its heading, and the heading actually carries that id.
+        assert 'aria-labelledby="promote-modal-label-12"' in html
+        assert 'id="promote-modal-label-12"' in html

--- a/netbox_librenms_plugin/tests/test_device_validation_details_template.py
+++ b/netbox_librenms_plugin/tests/test_device_validation_details_template.py
@@ -66,6 +66,17 @@ class TestDeviceValidationDetailsMergeBadge:
             html,
         ), "merge badge must pair bg-warning with text-dark on one element"
 
+    def test_merge_donor_sync_script_is_scoped_to_its_form(self):
+        """The donor-sync script must scope its winner-radio lookup to the current form, not the
+        whole document. A document-wide query would read merge-winner radios from another
+        validation fragment still in the DOM and write the wrong donor_pk — merging the wrong
+        NetBox device."""
+        html = self._render()
+        # Form-scoped lookup present...
+        assert 'closest("form")' in html
+        # ...and the fragile document-wide winner-radio query is gone.
+        assert "document.querySelectorAll('input.merge-winner-radio" not in html
+
 
 @pytest.mark.django_db
 class TestSerialActionBadges:

--- a/netbox_librenms_plugin/tests/test_device_validation_details_template.py
+++ b/netbox_librenms_plugin/tests/test_device_validation_details_template.py
@@ -66,6 +66,13 @@ class TestDeviceValidationDetailsMergeBadge:
             html,
         ), "merge badge must pair bg-warning with text-dark on one element"
 
+    def test_oob_ip_move_copy_states_the_real_condition(self):
+        """The 'Moved to winner' copy must state the OOB IP only moves when the winner has no OOB IP
+        AND the IP is already on a winner interface — the old copy over-promised the move."""
+        html = self._render()
+        assert "the IP is already on a winner interface" in html
+        assert "(only if the winner has no OOB IP yet)" not in html
+
     def test_merge_donor_sync_script_is_scoped_to_its_form(self):
         """The donor-sync script must scope its winner-radio lookup to the current form, not the
         whole document. A document-wide query would read merge-winner radios from another

--- a/netbox_librenms_plugin/tests/test_device_validation_details_template.py
+++ b/netbox_librenms_plugin/tests/test_device_validation_details_template.py
@@ -380,14 +380,11 @@ class TestPromoteToHostFallbackPane:
     """
 
     def _render(self, *, patch_promote_url_absent=False, choice_available=False):
-        from unittest.mock import patch
-
         from django.contrib.auth.models import AnonymousUser
         from django.template.loader import render_to_string
         from django.test import RequestFactory
-        from django.urls import NoReverseMatch
-        from django.urls import reverse as real_reverse
 
+        from netbox_librenms_plugin.tests._html_helpers import patch_move_url_reverse
         from netbox_librenms_plugin.tests.conftest import make_device
 
         existing = make_device("promote-fallback-host")
@@ -423,12 +420,7 @@ class TestPromoteToHostFallbackPane:
             # device_promote_to_host, which would flip a plain absence assertion. Force the
             # URL absent so the fallback path stays testable on every branch (Django's
             # {% url %} resolves reverse from django.urls at render time).
-            def fake_reverse(viewname, *args, **kwargs):
-                if "device_promote_to_host" in str(viewname):
-                    raise NoReverseMatch(viewname)
-                return real_reverse(viewname, *args, **kwargs)
-
-            with patch("django.urls.reverse", side_effect=fake_reverse):
+            with patch_move_url_reverse("device_promote_to_host", resolve=False):
                 return render_to_string(
                     "netbox_librenms_plugin/htmx/device_validation_details.html", ctx, request=request
                 )
@@ -505,9 +497,9 @@ def test_promote_form_reset_is_wired_to_both_close_paths():
         / "device_validation_details.html"
     ).read_text()
 
-    # Isolate the reset-binding block (between the bound-guard flag and the next handler).
+    # Isolate the complete one-time binding guard.
     start = source.index('modal.dataset.promoteResetBound = "1"')
-    end = source.index('modal.addEventListener("change"', start)
+    end = source.index("\n              }\n            })();", start)
     block = source[start:end]
 
     # hidden.bs.modal fires for EVERY Bootstrap close, including the backdrop click that the
@@ -515,6 +507,7 @@ def test_promote_form_reset_is_wired_to_both_close_paths():
     # fallback where hidden.bs.modal never fires.
     assert 'modal.addEventListener("hidden.bs.modal", resetPromoteForm)' in block
     assert 'btn.addEventListener("click", resetPromoteForm)' in block
+    assert 'modal.addEventListener("change"' in block
     # Both are now bound unconditionally: the old render-time if/else picked exactly ONE path,
     # so a Bootstrap backdrop dismiss (fires only hidden.bs.modal) was unhandled whenever the
     # fallback branch had been taken at render. That either/or is gone.

--- a/netbox_librenms_plugin/tests/test_device_validation_details_template.py
+++ b/netbox_librenms_plugin/tests/test_device_validation_details_template.py
@@ -401,3 +401,28 @@ class TestPromoteToHostFallbackPane:
         """Branch-agnostic: whether the fallback or the real promote pane renders, the row must offer an action inside the Host div."""
         html = self._render()
         assert 'id="serial-role-host-5"' in html
+
+
+def test_promote_override_handler_clears_hidden_when_switching_back_to_keep():
+    """The override JS must set the hidden from the 'new' radio's own checked state.
+
+    The old handler only cleared the hidden when a radio carrying data-override-target had
+    value 'keep' — but the Keep radio has no data-override-target, so switching back to Keep
+    left the previous override value posted. Assert against the shipped template source.
+    """
+    from pathlib import Path
+
+    import netbox_librenms_plugin
+
+    source = (
+        Path(netbox_librenms_plugin.__file__).parent
+        / "templates"
+        / "netbox_librenms_plugin"
+        / "htmx"
+        / "device_validation_details.html"
+    ).read_text()
+
+    # The fixed handler keys off the new radio's checked state (clears when unchecked).
+    assert "hidden.value = r.checked ?" in source
+    # The buggy keep-branch (which never fired, since Keep has no data-override-target) is gone.
+    assert 'r.value === "keep"' not in source

--- a/netbox_librenms_plugin/tests/test_device_validation_details_template.py
+++ b/netbox_librenms_plugin/tests/test_device_validation_details_template.py
@@ -515,3 +515,81 @@ class TestPromoteModalAccessibility:
         # The modal references its heading, and the heading actually carries that id.
         assert 'aria-labelledby="promote-modal-label-12"' in html
         assert 'id="promote-modal-label-12"' in html
+
+
+@pytest.mark.django_db
+class TestMergePromoteFormsShareServerKeyInclude:
+    """The merge and promote POST forms carry server_key via the shared include.
+
+    Every other action form in this template routes the hidden input through
+    inc/_hidden_server_key.html, which renders NOTHING when the context has no
+    server_key. The merge/promote forms were the last two with a raw
+    <input value="{{ server_key }}">, which posts server_key="" on a keyless
+    render instead of omitting the field like their sibling forms.
+    """
+
+    def _render(self, server_key, pane):
+        from django.contrib.auth.models import AnonymousUser
+        from django.template.loader import render_to_string
+        from django.test import RequestFactory
+
+        from netbox_librenms_plugin.tests.conftest import make_device
+
+        existing = make_device(f"srvkey-{pane}-winner")
+        donor = make_device(f"srvkey-{pane}-donor")
+        request = RequestFactory().get("/")
+        request.user = AnonymousUser()
+        validation = {
+            "existing_device": existing,
+            "existing_match_type": "serial",
+            "warnings": [],
+        }
+        if pane == "merge":
+            validation["serial_action"] = "merge_netbox_devices"
+            validation["merge_candidates"] = {
+                "host_named": {"pk": existing.pk, "name": existing.name},
+                "oob_named": {"pk": donor.pk, "name": donor.name},
+            }
+        else:
+            validation["serial_action"] = "promote_to_host"
+            validation["promote_to_host"] = {"existing_libre_id": 88, "existing_oob_type": "idrac"}
+        ctx = {
+            "validation": validation,
+            "libre_device": {"device_id": 12, "sysName": "srvkey-forms", "hostname": "srvkey-forms"},
+            "existing_device_model_name": "device",
+            "existing_device_url": existing.get_absolute_url(),
+            "sync_info": {},
+            "existing_id_servers": [],
+            "use_sysname": True,
+            "strip_domain": False,
+        }
+        if server_key is not None:
+            ctx["server_key"] = server_key
+        return render_to_string("netbox_librenms_plugin/htmx/device_validation_details.html", ctx, request=request)
+
+    @staticmethod
+    def _form_containing(html, url_marker):
+        import re
+
+        for match in re.finditer(r"<form\b.*?</form>", html, flags=re.DOTALL):
+            if url_marker in match.group(0):
+                return match.group(0)
+        raise AssertionError(f"no rendered <form> posts to {url_marker}")
+
+    @pytest.mark.parametrize(
+        ("pane", "marker"),
+        [("merge", "merge-netbox-devices"), ("promote", "promote-to-host")],
+    )
+    def test_form_carries_the_scoped_server_key(self, pane, marker):
+        html = self._render(server_key="tab-scope-key", pane=pane)
+        form = self._form_containing(html, marker)
+        assert 'name="server_key" value="tab-scope-key"' in form
+
+    @pytest.mark.parametrize(
+        ("pane", "marker"),
+        [("merge", "merge-netbox-devices"), ("promote", "promote-to-host")],
+    )
+    def test_keyless_render_omits_the_input_instead_of_posting_blank(self, pane, marker):
+        html = self._render(server_key=None, pane=pane)
+        form = self._form_containing(html, marker)
+        assert 'name="server_key"' not in form

--- a/netbox_librenms_plugin/tests/test_import_utils.py
+++ b/netbox_librenms_plugin/tests/test_import_utils.py
@@ -5503,6 +5503,63 @@ class TestRefreshExistingDeviceCrossModelIdWins:
         assert validation["existing_device"] != device
         assert any("Both a VM and Device exist with hostname" in w for w in validation.get("warnings", []))
 
+    def test_cross_model_warning_not_duplicated_across_refreshes(self):
+        """The cached validation dict is refreshed in place: the cross-model warning must not stack up.
+
+        Mirrors the stale ambiguous-id / hostname-serial blocker cleanup at the top of
+        _refresh_existing_device — pre-fix every refresh appended another copy.
+        """
+        from netbox_librenms_plugin.import_utils.bulk_import import _refresh_existing_device
+        from netbox_librenms_plugin.tests.conftest import make_device, make_vm
+
+        make_device("stack-warn-host")
+        make_vm("stack-warn-host")
+        libre_device = {"device_id": 4243, "hostname": "stack-warn-host", "sysName": "stack-warn-host"}
+        validation = {
+            "existing_device": None,
+            "existing_vm": None,
+            "import_as_vm": False,
+            "is_ready": False,
+            "can_import": False,
+            "issues": [],
+            "warnings": [],
+        }
+
+        _refresh_existing_device(validation, libre_device=libre_device, server_key="default")
+        _refresh_existing_device(validation, libre_device=libre_device, server_key="default")
+
+        cross_model = [w for w in validation["warnings"] if "Both a VM and Device exist with hostname" in w]
+        assert len(cross_model) == 1
+
+    def test_cross_model_warning_cleared_once_collision_resolved(self):
+        """Resolving the VM/Device name collision must drop the cached warning on the next refresh."""
+        from netbox_librenms_plugin.import_utils.bulk_import import _refresh_existing_device
+        from netbox_librenms_plugin.tests.conftest import make_device, make_vm
+
+        device = make_device("resolved-warn-host")
+        vm = make_vm("resolved-warn-host")
+        libre_device = {"device_id": 4244, "hostname": "resolved-warn-host", "sysName": "resolved-warn-host"}
+        validation = {
+            "existing_device": None,
+            "existing_vm": None,
+            "import_as_vm": False,
+            "is_ready": False,
+            "can_import": False,
+            "issues": [],
+            "warnings": [],
+        }
+
+        _refresh_existing_device(validation, libre_device=libre_device, server_key="default")
+        assert any("Both a VM and Device exist with hostname" in w for w in validation["warnings"])
+
+        vm.delete()
+        _refresh_existing_device(validation, libre_device=libre_device, server_key="default")
+
+        # The collision is gone: the stale warning must not survive the refresh, and the
+        # remaining Device binds by name as usual.
+        assert not any("Both a VM and Device exist with hostname" in w for w in validation["warnings"])
+        assert validation["existing_device"] == device
+
     def test_serial_fallback_ambiguity_fails_closed(self):
         """When the serial fallback resolves more than one NetBox device, the refresh re-check must fail closed (ambiguous match + can_import False), not bind to an arbitrary duplicate."""
         from netbox_librenms_plugin.import_utils.bulk_import import _refresh_existing_device

--- a/netbox_librenms_plugin/tests/test_import_utils.py
+++ b/netbox_librenms_plugin/tests/test_import_utils.py
@@ -5560,6 +5560,66 @@ class TestRefreshExistingDeviceCrossModelIdWins:
         assert not any("Both a VM and Device exist with hostname" in w for w in validation["warnings"])
         assert validation["existing_device"] == device
 
+    def test_vm_fresh_match_populates_cluster_display(self):
+        """A late-found VM match must show the matched VM's actual cluster, mirroring the
+        device path's role display — device_validation_details.html renders
+        validation.cluster.cluster for existing VM rows."""
+        from netbox_librenms_plugin.import_utils.bulk_import import _refresh_existing_device
+        from netbox_librenms_plugin.tests.conftest import make_cluster, make_vm
+
+        cluster = make_cluster("fresh-vm-cluster")
+        vm = make_vm("fresh-vm-clustered", cluster=cluster)
+        validation = {
+            "existing_device": None,
+            "existing_vm": None,
+            "import_as_vm": True,  # Model=VirtualMachine
+            "is_ready": False,
+            "can_import": False,
+            "issues": [],
+            "warnings": [],
+            "cluster": {"found": False, "cluster": None, "available_clusters": []},
+        }
+
+        _refresh_existing_device(
+            validation, libre_device={"device_id": 4245, "hostname": "fresh-vm-clustered"}, server_key="default"
+        )
+
+        assert validation["existing_device"] == vm
+        assert validation["cluster"]["found"] is True
+        assert validation["cluster"]["cluster"] == cluster
+        # Existing-match gating stays force-blocked either way.
+        assert validation["can_import"] is False
+        assert validation["is_ready"] is False
+
+    def test_vm_fresh_match_without_cluster_resets_stale_display(self):
+        """A matched clusterless VM must drop a stale cached cluster selection (keeping
+        available_clusters), not keep rendering the old choice."""
+        from virtualization.models import VirtualMachine
+
+        from netbox_librenms_plugin.import_utils.bulk_import import _refresh_existing_device
+
+        vm = VirtualMachine.objects.create(name="fresh-vm-clusterless")
+        stale = object()
+        validation = {
+            "existing_device": None,
+            "existing_vm": None,
+            "import_as_vm": True,
+            "is_ready": False,
+            "can_import": False,
+            "issues": [],
+            "warnings": [],
+            "cluster": {"found": True, "cluster": stale, "available_clusters": ["keep-me"]},
+        }
+
+        _refresh_existing_device(
+            validation, libre_device={"device_id": 4246, "hostname": "fresh-vm-clusterless"}, server_key="default"
+        )
+
+        assert validation["existing_device"] == vm
+        assert validation["cluster"]["found"] is False
+        assert validation["cluster"]["cluster"] is None
+        assert validation["cluster"]["available_clusters"] == ["keep-me"]
+
     def test_serial_fallback_ambiguity_fails_closed(self):
         """When the serial fallback resolves more than one NetBox device, the refresh re-check must fail closed (ambiguous match + can_import False), not bind to an arbitrary duplicate."""
         from netbox_librenms_plugin.import_utils.bulk_import import _refresh_existing_device

--- a/netbox_librenms_plugin/tests/test_import_utils.py
+++ b/netbox_librenms_plugin/tests/test_import_utils.py
@@ -25,11 +25,6 @@ def _matchable_filter_result():
     return result
 
 
-def _is_serial_lookup(kwargs):
-    """True for the exact Device serial lookup."""
-    return "serial" in kwargs
-
-
 # =============================================================================
 # TestCacheKeyGeneration - 4 tests
 # =============================================================================
@@ -345,37 +340,21 @@ class TestDeviceRetrieval:
 # =============================================================================
 
 
+@pytest.mark.django_db
 class TestDeviceValidation:
     """Test device validation for import."""
 
-    @patch("virtualization.models.VirtualMachine")
-    @patch("netbox_librenms_plugin.import_utils.device_operations.Device")
     @patch("netbox_librenms_plugin.import_utils.device_operations.find_matching_site")
     @patch("netbox_librenms_plugin.import_utils.device_operations.find_matching_platform")
     @patch("netbox_librenms_plugin.import_utils.device_operations.match_librenms_hardware_to_device_type")
-    @patch("netbox_librenms_plugin.import_utils.device_operations.DeviceRole")
-    @patch("netbox_librenms_plugin.import_utils.device_operations.Cluster")
-    @patch("netbox_librenms_plugin.import_utils.device_operations.Rack")
-    @patch("netbox_librenms_plugin.import_utils.device_operations.Site")
-    def test_validate_device_site_match_found(
-        self,
-        mock_site_model,
-        mock_rack,
-        mock_cluster,
-        mock_role,
-        mock_match_type,
-        mock_find_platform,
-        mock_find_site,
-        mock_device,
-        mock_vm,
-    ):
+    def test_validate_device_site_match_found(self, mock_match_type, mock_find_platform, mock_find_site):
         """Site matched successfully."""
-        mock_vm.objects.filter.return_value.first.return_value = None
-        mock_device.objects.filter.return_value.first.return_value = None
-        mock_site = MagicMock(id=1, name="DC1")
+        from dcim.models import Site
+
+        site, _ = Site.objects.get_or_create(name="DC1", slug="dc1")
         mock_find_site.return_value = {
             "found": True,
-            "site": mock_site,
+            "site": site,
             "match_type": "exact",
             "confidence": 1.0,
         }
@@ -389,9 +368,6 @@ class TestDeviceValidation:
             "device_type": None,
             "match_type": None,
         }
-        mock_role.objects.all.return_value = []
-        mock_cluster.objects.all.return_value = []
-        mock_site_model.objects.all.return_value = [mock_site]
 
         from netbox_librenms_plugin.import_utils import validate_device_for_import
 
@@ -404,32 +380,13 @@ class TestDeviceValidation:
         result = validate_device_for_import(device_data, include_vc_detection=False)
 
         assert result["site"]["found"] is True
-        assert result["site"]["site"] == mock_site
+        assert result["site"]["site"] == site
 
-    @patch("virtualization.models.VirtualMachine")
-    @patch("netbox_librenms_plugin.import_utils.device_operations.Device")
     @patch("netbox_librenms_plugin.import_utils.device_operations.find_matching_site")
     @patch("netbox_librenms_plugin.import_utils.device_operations.find_matching_platform")
     @patch("netbox_librenms_plugin.import_utils.device_operations.match_librenms_hardware_to_device_type")
-    @patch("netbox_librenms_plugin.import_utils.device_operations.DeviceRole")
-    @patch("netbox_librenms_plugin.import_utils.device_operations.Cluster")
-    @patch("netbox_librenms_plugin.import_utils.device_operations.Rack")
-    @patch("netbox_librenms_plugin.import_utils.device_operations.Site")
-    def test_validate_device_site_not_found(
-        self,
-        mock_site_model,
-        mock_rack,
-        mock_cluster,
-        mock_role,
-        mock_match_type,
-        mock_find_platform,
-        mock_find_site,
-        mock_device,
-        mock_vm,
-    ):
+    def test_validate_device_site_not_found(self, mock_match_type, mock_find_platform, mock_find_site):
         """Site not found adds validation issue."""
-        mock_vm.objects.filter.return_value.first.return_value = None
-        mock_device.objects.filter.return_value.first.return_value = None
         mock_find_site.return_value = {
             "found": False,
             "site": None,
@@ -446,9 +403,6 @@ class TestDeviceValidation:
             "device_type": None,
             "match_type": None,
         }
-        mock_role.objects.all.return_value = []
-        mock_cluster.objects.all.return_value = []
-        mock_site_model.objects.all.return_value = []
 
         from netbox_librenms_plugin.import_utils import validate_device_for_import
 
@@ -463,33 +417,11 @@ class TestDeviceValidation:
         assert result["site"]["found"] is False
         assert any("site" in issue.lower() for issue in result["issues"])
 
-    @patch("virtualization.models.VirtualMachine")
-    @patch("netbox_librenms_plugin.import_utils.device_operations.Device")
     @patch("netbox_librenms_plugin.import_utils.device_operations.find_matching_site")
     @patch("netbox_librenms_plugin.import_utils.device_operations.find_matching_platform")
     @patch("netbox_librenms_plugin.import_utils.device_operations.match_librenms_hardware_to_device_type")
-    @patch("netbox_librenms_plugin.import_utils.device_operations.DeviceRole")
-    @patch("netbox_librenms_plugin.import_utils.device_operations.Cluster")
-    @patch("netbox_librenms_plugin.import_utils.device_operations.Rack")
-    @patch("netbox_librenms_plugin.import_utils.device_operations.Site")
-    @patch("netbox_librenms_plugin.import_utils.device_operations.DeviceType")
-    def test_validate_device_platform_match_found(
-        self,
-        mock_device_type,
-        mock_site_model,
-        mock_rack,
-        mock_cluster,
-        mock_role,
-        mock_match_type,
-        mock_find_platform,
-        mock_find_site,
-        mock_device,
-        mock_vm,
-    ):
+    def test_validate_device_platform_match_found(self, mock_match_type, mock_find_platform, mock_find_site):
         """Platform matched successfully."""
-        mock_vm.objects.filter.return_value.first.return_value = None
-        mock_device.objects.filter.return_value.first.return_value = None
-        mock_device_type.objects.all.return_value = []
         mock_find_site.return_value = {
             "found": False,
             "site": None,
@@ -507,9 +439,6 @@ class TestDeviceValidation:
             "device_type": None,
             "match_type": None,
         }
-        mock_role.objects.all.return_value = []
-        mock_cluster.objects.all.return_value = []
-        mock_site_model.objects.all.return_value = []
 
         from netbox_librenms_plugin.import_utils import validate_device_for_import
 
@@ -524,30 +453,11 @@ class TestDeviceValidation:
         assert result["platform"]["found"] is True
         assert result["platform"]["platform"] == mock_platform
 
-    @patch("virtualization.models.VirtualMachine")
-    @patch("netbox_librenms_plugin.import_utils.device_operations.Device")
     @patch("netbox_librenms_plugin.import_utils.device_operations.find_matching_site")
     @patch("netbox_librenms_plugin.import_utils.device_operations.find_matching_platform")
     @patch("netbox_librenms_plugin.import_utils.device_operations.match_librenms_hardware_to_device_type")
-    @patch("netbox_librenms_plugin.import_utils.device_operations.DeviceRole")
-    @patch("netbox_librenms_plugin.import_utils.device_operations.Cluster")
-    @patch("netbox_librenms_plugin.import_utils.device_operations.Rack")
-    @patch("netbox_librenms_plugin.import_utils.device_operations.Site")
-    def test_validate_device_platform_not_found(
-        self,
-        mock_site_model,
-        mock_rack,
-        mock_cluster,
-        mock_role,
-        mock_match_type,
-        mock_find_platform,
-        mock_find_site,
-        mock_device,
-        mock_vm,
-    ):
+    def test_validate_device_platform_not_found(self, mock_match_type, mock_find_platform, mock_find_site):
         """Platform not found adds warning (not blocking)."""
-        mock_vm.objects.filter.return_value.first.return_value = None
-        mock_device.objects.filter.return_value.first.return_value = None
         mock_find_site.return_value = {
             "found": False,
             "site": None,
@@ -564,9 +474,6 @@ class TestDeviceValidation:
             "device_type": None,
             "match_type": None,
         }
-        mock_role.objects.all.return_value = []
-        mock_cluster.objects.all.return_value = []
-        mock_site_model.objects.all.return_value = []
 
         from netbox_librenms_plugin.import_utils import validate_device_for_import
 
@@ -580,30 +487,11 @@ class TestDeviceValidation:
 
         assert result["platform"]["found"] is False
 
-    @patch("virtualization.models.VirtualMachine")
-    @patch("netbox_librenms_plugin.import_utils.device_operations.Device")
     @patch("netbox_librenms_plugin.import_utils.device_operations.find_matching_site")
     @patch("netbox_librenms_plugin.import_utils.device_operations.find_matching_platform")
     @patch("netbox_librenms_plugin.import_utils.device_operations.match_librenms_hardware_to_device_type")
-    @patch("netbox_librenms_plugin.import_utils.device_operations.DeviceRole")
-    @patch("netbox_librenms_plugin.import_utils.device_operations.Cluster")
-    @patch("netbox_librenms_plugin.import_utils.device_operations.Rack")
-    @patch("netbox_librenms_plugin.import_utils.device_operations.Site")
-    def test_validate_device_type_match_found(
-        self,
-        mock_site_model,
-        mock_rack,
-        mock_cluster,
-        mock_role,
-        mock_match_type,
-        mock_find_platform,
-        mock_find_site,
-        mock_device,
-        mock_vm,
-    ):
+    def test_validate_device_type_match_found(self, mock_match_type, mock_find_platform, mock_find_site):
         """Device type matched successfully."""
-        mock_vm.objects.filter.return_value.first.return_value = None
-        mock_device.objects.filter.return_value.first.return_value = None
         mock_find_site.return_value = {
             "found": False,
             "site": None,
@@ -621,9 +509,6 @@ class TestDeviceValidation:
             "device_type": mock_dt,
             "match_type": "exact",
         }
-        mock_role.objects.all.return_value = []
-        mock_cluster.objects.all.return_value = []
-        mock_site_model.objects.all.return_value = []
 
         from netbox_librenms_plugin.import_utils import validate_device_for_import
 
@@ -638,33 +523,11 @@ class TestDeviceValidation:
         assert result["device_type"]["found"] is True
         assert result["device_type"]["device_type"] == mock_dt
 
-    @patch("virtualization.models.VirtualMachine")
-    @patch("netbox_librenms_plugin.import_utils.device_operations.Device")
     @patch("netbox_librenms_plugin.import_utils.device_operations.find_matching_site")
     @patch("netbox_librenms_plugin.import_utils.device_operations.find_matching_platform")
     @patch("netbox_librenms_plugin.import_utils.device_operations.match_librenms_hardware_to_device_type")
-    @patch("netbox_librenms_plugin.import_utils.device_operations.DeviceRole")
-    @patch("netbox_librenms_plugin.import_utils.device_operations.Cluster")
-    @patch("netbox_librenms_plugin.import_utils.device_operations.Rack")
-    @patch("netbox_librenms_plugin.import_utils.device_operations.Site")
-    @patch("netbox_librenms_plugin.import_utils.device_operations.DeviceType")
-    def test_validate_device_type_not_found(
-        self,
-        mock_device_type,
-        mock_site_model,
-        mock_rack,
-        mock_cluster,
-        mock_role,
-        mock_match_type,
-        mock_find_platform,
-        mock_find_site,
-        mock_device,
-        mock_vm,
-    ):
+    def test_validate_device_type_not_found(self, mock_match_type, mock_find_platform, mock_find_site):
         """Device type not found adds validation issue."""
-        mock_vm.objects.filter.return_value.first.return_value = None
-        mock_device.objects.filter.return_value.first.return_value = None
-        mock_device_type.objects.all.return_value = []
         mock_find_site.return_value = {
             "found": False,
             "site": None,
@@ -681,9 +544,6 @@ class TestDeviceValidation:
             "device_type": None,
             "match_type": None,
         }
-        mock_role.objects.all.return_value = []
-        mock_cluster.objects.all.return_value = []
-        mock_site_model.objects.all.return_value = []
 
         from netbox_librenms_plugin.import_utils import validate_device_for_import
 
@@ -698,34 +558,17 @@ class TestDeviceValidation:
         assert result["device_type"]["found"] is False
         assert any("device type" in issue.lower() for issue in result["issues"])
 
-    @patch("virtualization.models.VirtualMachine")
-    @patch("netbox_librenms_plugin.import_utils.device_operations.Device")
     @patch("netbox_librenms_plugin.import_utils.device_operations.find_matching_site")
     @patch("netbox_librenms_plugin.import_utils.device_operations.find_matching_platform")
     @patch("netbox_librenms_plugin.import_utils.device_operations.match_librenms_hardware_to_device_type")
-    @patch("netbox_librenms_plugin.import_utils.device_operations.DeviceRole")
-    @patch("netbox_librenms_plugin.import_utils.device_operations.Cluster")
-    @patch("netbox_librenms_plugin.import_utils.device_operations.Rack")
-    @patch("netbox_librenms_plugin.import_utils.device_operations.Site")
-    def test_validate_device_role_required(
-        self,
-        mock_site_model,
-        mock_rack,
-        mock_cluster,
-        mock_role,
-        mock_match_type,
-        mock_find_platform,
-        mock_find_site,
-        mock_device,
-        mock_vm,
-    ):
+    def test_validate_device_role_required(self, mock_match_type, mock_find_platform, mock_find_site):
         """Missing role flagged as required."""
-        mock_vm.objects.filter.return_value.first.return_value = None
-        mock_device.objects.filter.return_value.first.return_value = None
-        mock_site = MagicMock(id=1, name="DC1")
+        from dcim.models import Site
+
+        site, _ = Site.objects.get_or_create(name="DC1", slug="dc1")
         mock_find_site.return_value = {
             "found": True,
-            "site": mock_site,
+            "site": site,
             "match_type": "exact",
             "confidence": 1.0,
         }
@@ -740,9 +583,6 @@ class TestDeviceValidation:
             "device_type": mock_dt,
             "match_type": "exact",
         }
-        mock_role.objects.all.return_value = [MagicMock(id=1, name="Access Switch")]
-        mock_cluster.objects.all.return_value = []
-        mock_site_model.objects.all.return_value = [mock_site]
 
         from netbox_librenms_plugin.import_utils import validate_device_for_import
 
@@ -758,30 +598,11 @@ class TestDeviceValidation:
         assert result["device_role"]["found"] is False
         assert any("role" in issue.lower() for issue in result["issues"])
 
-    @patch("virtualization.models.VirtualMachine")
-    @patch("netbox_librenms_plugin.import_utils.device_operations.Device")
     @patch("netbox_librenms_plugin.import_utils.device_operations.find_matching_site")
     @patch("netbox_librenms_plugin.import_utils.device_operations.find_matching_platform")
     @patch("netbox_librenms_plugin.import_utils.device_operations.match_librenms_hardware_to_device_type")
-    @patch("netbox_librenms_plugin.import_utils.device_operations.DeviceRole")
-    @patch("netbox_librenms_plugin.import_utils.device_operations.Cluster")
-    @patch("netbox_librenms_plugin.import_utils.device_operations.Rack")
-    @patch("netbox_librenms_plugin.import_utils.device_operations.Site")
-    def test_validate_device_handles_empty_location(
-        self,
-        mock_site_model,
-        mock_rack,
-        mock_cluster,
-        mock_role,
-        mock_match_type,
-        mock_find_platform,
-        mock_find_site,
-        mock_device,
-        mock_vm,
-    ):
+    def test_validate_device_handles_empty_location(self, mock_match_type, mock_find_platform, mock_find_site):
         """Empty location handled gracefully."""
-        mock_vm.objects.filter.return_value.first.return_value = None
-        mock_device.objects.filter.return_value.first.return_value = None
         mock_find_site.return_value = {
             "found": False,
             "site": None,
@@ -798,9 +619,6 @@ class TestDeviceValidation:
             "device_type": None,
             "match_type": None,
         }
-        mock_role.objects.all.return_value = []
-        mock_cluster.objects.all.return_value = []
-        mock_site_model.objects.all.return_value = []
 
         from netbox_librenms_plugin.import_utils import validate_device_for_import
 
@@ -816,30 +634,11 @@ class TestDeviceValidation:
         assert result is not None
         assert result["site"]["found"] is False
 
-    @patch("virtualization.models.VirtualMachine")
-    @patch("netbox_librenms_plugin.import_utils.device_operations.Device")
     @patch("netbox_librenms_plugin.import_utils.device_operations.find_matching_site")
     @patch("netbox_librenms_plugin.import_utils.device_operations.find_matching_platform")
     @patch("netbox_librenms_plugin.import_utils.device_operations.match_librenms_hardware_to_device_type")
-    @patch("netbox_librenms_plugin.import_utils.device_operations.DeviceRole")
-    @patch("netbox_librenms_plugin.import_utils.device_operations.Cluster")
-    @patch("netbox_librenms_plugin.import_utils.device_operations.Rack")
-    @patch("netbox_librenms_plugin.import_utils.device_operations.Site")
-    def test_validate_device_handles_empty_os(
-        self,
-        mock_site_model,
-        mock_rack,
-        mock_cluster,
-        mock_role,
-        mock_match_type,
-        mock_find_platform,
-        mock_find_site,
-        mock_device,
-        mock_vm,
-    ):
+    def test_validate_device_handles_empty_os(self, mock_match_type, mock_find_platform, mock_find_site):
         """Empty OS handled gracefully."""
-        mock_vm.objects.filter.return_value.first.return_value = None
-        mock_device.objects.filter.return_value.first.return_value = None
         mock_find_site.return_value = {
             "found": False,
             "site": None,
@@ -856,9 +655,6 @@ class TestDeviceValidation:
             "device_type": None,
             "match_type": None,
         }
-        mock_role.objects.all.return_value = []
-        mock_cluster.objects.all.return_value = []
-        mock_site_model.objects.all.return_value = []
 
         from netbox_librenms_plugin.import_utils import validate_device_for_import
 
@@ -873,33 +669,11 @@ class TestDeviceValidation:
         assert result is not None
         assert result["platform"]["found"] is False
 
-    @patch("virtualization.models.VirtualMachine")
-    @patch("netbox_librenms_plugin.import_utils.device_operations.Device")
     @patch("netbox_librenms_plugin.import_utils.device_operations.find_matching_site")
     @patch("netbox_librenms_plugin.import_utils.device_operations.find_matching_platform")
     @patch("netbox_librenms_plugin.import_utils.device_operations.match_librenms_hardware_to_device_type")
-    @patch("netbox_librenms_plugin.import_utils.device_operations.DeviceRole")
-    @patch("netbox_librenms_plugin.import_utils.device_operations.Cluster")
-    @patch("netbox_librenms_plugin.import_utils.device_operations.Rack")
-    @patch("netbox_librenms_plugin.import_utils.device_operations.Site")
-    @patch("netbox_librenms_plugin.import_utils.device_operations.DeviceType")
-    def test_validate_device_handles_empty_hardware(
-        self,
-        mock_device_type,
-        mock_site_model,
-        mock_rack,
-        mock_cluster,
-        mock_role,
-        mock_match_type,
-        mock_find_platform,
-        mock_find_site,
-        mock_device,
-        mock_vm,
-    ):
+    def test_validate_device_handles_empty_hardware(self, mock_match_type, mock_find_platform, mock_find_site):
         """Empty hardware handled gracefully."""
-        mock_vm.objects.filter.return_value.first.return_value = None
-        mock_device.objects.filter.return_value.first.return_value = None
-        mock_device_type.objects.all.return_value = []
         mock_find_site.return_value = {
             "found": False,
             "site": None,
@@ -916,9 +690,6 @@ class TestDeviceValidation:
             "device_type": None,
             "match_type": None,
         }
-        mock_role.objects.all.return_value = []
-        mock_cluster.objects.all.return_value = []
-        mock_site_model.objects.all.return_value = []
 
         from netbox_librenms_plugin.import_utils import validate_device_for_import
 
@@ -933,69 +704,13 @@ class TestDeviceValidation:
         assert result is not None
         assert result["device_type"]["found"] is False
 
-    @patch("virtualization.models.VirtualMachine")
-    @patch("netbox_librenms_plugin.import_utils.device_operations.Device")
     @patch("netbox_librenms_plugin.import_utils.device_operations.find_matching_site")
     @patch("netbox_librenms_plugin.import_utils.device_operations.find_matching_platform")
     @patch("netbox_librenms_plugin.import_utils.device_operations.match_librenms_hardware_to_device_type")
-    @patch("netbox_librenms_plugin.import_utils.device_operations.DeviceRole")
-    @patch("netbox_librenms_plugin.import_utils.device_operations.Cluster")
-    @patch("netbox_librenms_plugin.import_utils.device_operations.Rack")
-    @patch("netbox_librenms_plugin.import_utils.device_operations.Site")
-    def test_validate_device_duplicate_detection(
-        self,
-        mock_site_model,
-        mock_rack,
-        mock_cluster,
-        mock_role,
-        mock_match_type,
-        mock_find_platform,
-        mock_find_site,
-        mock_device,
-        mock_vm,
-    ):
+    def test_validate_device_duplicate_detection(self, mock_match_type, mock_find_platform, mock_find_site):
         """Existing device detected."""
-        existing_device = MagicMock()
-        existing_device.name = "switch-01"
-        mock_vm.objects.filter.return_value.first.return_value = None
-        mock_device.objects.filter.return_value.first.return_value = existing_device
+        from netbox_librenms_plugin.tests.conftest import make_device
 
-        from netbox_librenms_plugin.import_utils import validate_device_for_import
-
-        device_data = {
-            "device_id": 1,
-            "hostname": "switch-01",
-        }
-
-        result = validate_device_for_import(device_data, include_vc_detection=False)
-
-        assert result["existing_device"] == existing_device
-        assert result["can_import"] is False
-
-    @patch("virtualization.models.VirtualMachine")
-    @patch("netbox_librenms_plugin.import_utils.device_operations.Device")
-    @patch("netbox_librenms_plugin.import_utils.device_operations.find_matching_site")
-    @patch("netbox_librenms_plugin.import_utils.device_operations.find_matching_platform")
-    @patch("netbox_librenms_plugin.import_utils.device_operations.match_librenms_hardware_to_device_type")
-    @patch("netbox_librenms_plugin.import_utils.device_operations.DeviceRole")
-    @patch("netbox_librenms_plugin.import_utils.device_operations.Cluster")
-    @patch("netbox_librenms_plugin.import_utils.device_operations.Rack")
-    @patch("netbox_librenms_plugin.import_utils.device_operations.Site")
-    def test_validate_device_returns_complete_state(
-        self,
-        mock_site_model,
-        mock_rack,
-        mock_cluster,
-        mock_role,
-        mock_match_type,
-        mock_find_platform,
-        mock_find_site,
-        mock_device,
-        mock_vm,
-    ):
-        """All expected fields in result."""
-        mock_vm.objects.filter.return_value.first.return_value = None
-        mock_device.objects.filter.return_value.first.return_value = None
         mock_find_site.return_value = {
             "found": False,
             "site": None,
@@ -1012,9 +727,42 @@ class TestDeviceValidation:
             "device_type": None,
             "match_type": None,
         }
-        mock_role.objects.all.return_value = []
-        mock_cluster.objects.all.return_value = []
-        mock_site_model.objects.all.return_value = []
+
+        existing_device = make_device("switch-01")
+
+        from netbox_librenms_plugin.import_utils import validate_device_for_import
+
+        device_data = {
+            "device_id": 1,
+            "hostname": "switch-01",
+        }
+
+        result = validate_device_for_import(device_data, include_vc_detection=False)
+
+        assert result["existing_device"] == existing_device
+        assert result["can_import"] is False
+
+    @patch("netbox_librenms_plugin.import_utils.device_operations.find_matching_site")
+    @patch("netbox_librenms_plugin.import_utils.device_operations.find_matching_platform")
+    @patch("netbox_librenms_plugin.import_utils.device_operations.match_librenms_hardware_to_device_type")
+    def test_validate_device_returns_complete_state(self, mock_match_type, mock_find_platform, mock_find_site):
+        """All expected fields in result."""
+        mock_find_site.return_value = {
+            "found": False,
+            "site": None,
+            "match_type": None,
+            "confidence": 0.0,
+        }
+        mock_find_platform.return_value = {
+            "found": False,
+            "platform": None,
+            "match_type": None,
+        }
+        mock_match_type.return_value = {
+            "matched": False,
+            "device_type": None,
+            "match_type": None,
+        }
 
         from netbox_librenms_plugin.import_utils import validate_device_for_import
 
@@ -1039,31 +787,13 @@ class TestDeviceValidation:
         assert "platform" in result
 
     @patch("netbox_librenms_plugin.import_utils.device_operations.cache")
-    @patch("virtualization.models.VirtualMachine")
-    @patch("netbox_librenms_plugin.import_utils.device_operations.Device")
     @patch("netbox_librenms_plugin.import_utils.device_operations.find_matching_site")
     @patch("netbox_librenms_plugin.import_utils.device_operations.find_matching_platform")
     @patch("netbox_librenms_plugin.import_utils.device_operations.match_librenms_hardware_to_device_type")
-    @patch("netbox_librenms_plugin.import_utils.device_operations.DeviceRole")
-    @patch("netbox_librenms_plugin.import_utils.device_operations.Cluster")
-    @patch("netbox_librenms_plugin.import_utils.device_operations.Rack")
-    @patch("netbox_librenms_plugin.import_utils.device_operations.Site")
-    def test_validate_device_import_as_vm(
-        self,
-        mock_site_model,
-        mock_rack,
-        mock_cluster,
-        mock_role,
-        mock_match_type,
-        mock_find_platform,
-        mock_find_site,
-        mock_device,
-        mock_vm,
-        mock_cache,
-    ):
+    def test_validate_device_import_as_vm(self, mock_match_type, mock_find_platform, mock_find_site, mock_cache):
         """Import as VM mode uses cluster instead of site/device_type."""
-        mock_vm.objects.filter.return_value.first.return_value = None
-        mock_device.objects.filter.return_value.first.return_value = None
+        from netbox_librenms_plugin.tests.conftest import make_cluster
+
         mock_find_site.return_value = {
             "found": False,
             "site": None,
@@ -1080,11 +810,9 @@ class TestDeviceValidation:
             "device_type": None,
             "match_type": None,
         }
-        mock_role.objects.all.return_value = []
-        mock_clusters = [MagicMock(id=1, name="VMware Cluster")]
-        mock_cluster.objects.all.return_value = mock_clusters
         mock_cache.get.return_value = None  # Force cache miss to trigger Cluster.objects.all()
-        mock_site_model.objects.all.return_value = []
+
+        cluster = make_cluster("VMware Cluster")
 
         from netbox_librenms_plugin.import_utils import validate_device_for_import
 
@@ -1096,34 +824,33 @@ class TestDeviceValidation:
         result = validate_device_for_import(device_data, import_as_vm=True, include_vc_detection=False)
 
         assert result["import_as_vm"] is True
-        assert result["cluster"]["available_clusters"] == mock_clusters
+        assert cluster in result["cluster"]["available_clusters"]
 
-    @patch("virtualization.models.VirtualMachine")
-    @patch("netbox_librenms_plugin.import_utils.device_operations.Device")
     @patch("netbox_librenms_plugin.import_utils.device_operations.find_matching_site")
     @patch("netbox_librenms_plugin.import_utils.device_operations.find_matching_platform")
     @patch("netbox_librenms_plugin.import_utils.device_operations.match_librenms_hardware_to_device_type")
-    @patch("netbox_librenms_plugin.import_utils.device_operations.DeviceRole")
-    @patch("netbox_librenms_plugin.import_utils.device_operations.Cluster")
-    @patch("netbox_librenms_plugin.import_utils.device_operations.Rack")
-    @patch("netbox_librenms_plugin.import_utils.device_operations.Site")
-    def test_validate_device_existing_vm_blocks_import(
-        self,
-        mock_site_model,
-        mock_rack,
-        mock_cluster,
-        mock_role,
-        mock_match_type,
-        mock_find_platform,
-        mock_find_site,
-        mock_device,
-        mock_vm,
-    ):
+    def test_validate_device_existing_vm_blocks_import(self, mock_match_type, mock_find_platform, mock_find_site):
         """Existing VM detection blocks import."""
-        existing_vm = MagicMock()
-        existing_vm.name = "vm-01"
-        mock_vm.objects.filter.return_value.first.return_value = existing_vm
-        mock_device.objects.filter.return_value.first.return_value = None
+        from netbox_librenms_plugin.tests.conftest import make_vm
+
+        mock_find_site.return_value = {
+            "found": False,
+            "site": None,
+            "match_type": None,
+            "confidence": 0.0,
+        }
+        mock_find_platform.return_value = {
+            "found": False,
+            "platform": None,
+            "match_type": None,
+        }
+        mock_match_type.return_value = {
+            "matched": False,
+            "device_type": None,
+            "match_type": None,
+        }
+
+        existing_vm = make_vm("vm-01")
 
         from netbox_librenms_plugin.import_utils import validate_device_for_import
 
@@ -1141,27 +868,13 @@ class TestDeviceValidation:
         # UI doesn't render the VM as unlinked.
         assert result["existing_librenms_link"] is not None
 
-    @patch("virtualization.models.VirtualMachine")
-    @patch("netbox_librenms_plugin.import_utils.device_operations.Device")
-    @patch("netbox_librenms_plugin.import_utils.device_operations.find_matching_site")
-    @patch("netbox_librenms_plugin.import_utils.device_operations.find_matching_platform")
-    @patch("netbox_librenms_plugin.import_utils.device_operations.match_librenms_hardware_to_device_type")
-    @patch("netbox_librenms_plugin.import_utils.device_operations.DeviceRole")
-    @patch("netbox_librenms_plugin.import_utils.device_operations.Cluster")
-    @patch("netbox_librenms_plugin.import_utils.device_operations.Rack")
-    @patch("netbox_librenms_plugin.import_utils.device_operations.Site")
-    def test_librenms_id_matched_vm_populates_link(self, *mocks):
+    def test_librenms_id_matched_vm_populates_link(self):
         """A VM matched by librenms_id surfaces its LibreNMS linkage so it isn't shown as unlinked."""
-        mock_vm = mocks[-1]
-        mock_device = mocks[-2]
-        existing_vm = MagicMock()
-        existing_vm.name = "vm-01"
-        existing_vm.custom_field_data = {"librenms_id": {"default": 42}}
-        existing_vm.cf = existing_vm.custom_field_data
-        # find_by_librenms_id consumes the queryset via list(qs[:2]); make the VM lookup match.
-        mock_vm.objects.filter.return_value.__getitem__.return_value = [existing_vm]
-        mock_device.objects.filter.return_value.__getitem__.return_value = []
-        mock_device.objects.filter.return_value.first.return_value = None
+        from netbox_librenms_plugin.tests.conftest import make_vm
+
+        existing_vm = make_vm("vm-01")
+        existing_vm.custom_field_data["librenms_id"] = {"default": 42}
+        existing_vm.save()
 
         from netbox_librenms_plugin.import_utils import validate_device_for_import
 
@@ -1745,39 +1458,30 @@ class TestSerialNumberMatchingRealDB:
         assert result["existing_match_type"] == "serial"
 
 
+@pytest.mark.django_db
 class TestSerialNumberMatching:
-    """Test serial number matching in device validation."""
+    """Test serial number matching in device validation, against real Device/VM rows."""
 
+    # Only the matcher helpers stay mocked (input-controlling boundaries); the ORM is real so
+    # isinstance(existing, VirtualMachine) works in validate_device_for_import.
     SERIAL_PATCHES = [
-        "netbox_librenms_plugin.import_utils.device_operations.Site",
-        "netbox_librenms_plugin.import_utils.device_operations.Rack",
-        "netbox_librenms_plugin.import_utils.device_operations.Cluster",
-        "netbox_librenms_plugin.import_utils.device_operations.DeviceRole",
-        "netbox_librenms_plugin.import_utils.device_operations.DeviceType",
         "netbox_librenms_plugin.import_utils.device_operations.match_librenms_hardware_to_device_type",
         "netbox_librenms_plugin.import_utils.device_operations.find_matching_platform",
         "netbox_librenms_plugin.import_utils.device_operations.find_matching_site",
-        "netbox_librenms_plugin.import_utils.device_operations.Device",
-        "virtualization.models.VirtualMachine",
     ]
 
     def _start_patches(self):
-        """Start all common patches and return mocks in standard order."""
+        """Start the matcher patches and seed safe not-found defaults (the ORM stays real)."""
         self._patchers = [patch(p) for p in self.SERIAL_PATCHES]
         mocks = [p.start() for p in self._patchers]
         (
-            self.mock_site_model,
-            self.mock_rack,
-            self.mock_cluster,
-            self.mock_role,
-            self.mock_device_type,
             self.mock_match_type,
             self.mock_find_platform,
             self.mock_find_site,
-            self.mock_device,
-            self.mock_vm,
         ) = mocks
-        self.mock_device_type.objects.all.return_value = []
+        self.mock_find_site.return_value = {"found": False, "site": None, "match_type": None, "confidence": 0}
+        self.mock_find_platform.return_value = {"found": False, "platform": None, "match_type": None}
+        self.mock_match_type.return_value = {"matched": False, "device_type": None, "match_type": None}
 
     def _stop_patches(self):
         """Stop all patches."""
@@ -1793,22 +1497,10 @@ class TestSerialNumberMatching:
         self._stop_patches()
 
     def test_serial_match_blocks_import(self):
-        """Device with matching serial blocks import."""
-        existing = MagicMock()
-        existing.name = "existing-device"
-        existing.serial = "ABC123"
+        """Device with matching serial (but a different hostname) blocks import via the serial branch."""
+        from netbox_librenms_plugin.tests.conftest import make_device
 
-        self.mock_vm.objects.filter.return_value.first.return_value = None
-
-        def device_filter(*args, **kwargs):
-            result = _matchable_filter_result()
-            if _is_serial_lookup(kwargs):
-                result.first.return_value = existing
-            else:
-                result.first.return_value = None
-            return result
-
-        self.mock_device.objects.filter.side_effect = device_filter
+        existing = make_device("existing-device", serial="ABC123")
 
         from netbox_librenms_plugin.import_utils import validate_device_for_import
 
@@ -1820,30 +1512,24 @@ class TestSerialNumberMatching:
         assert result["existing_device"] == existing
 
     def test_serial_match_same_hostname_offers_link(self):
-        """Serial + hostname match offers link action."""
-        existing = MagicMock()
-        existing.name = "switch-01"
-        existing.serial = "ABC123"
+        """A device whose name AND serial both match is found (by hostname) and shown as linkable.
 
-        self.mock_vm.objects.filter.return_value.first.return_value = None
+        With real rows the hostname match fires first (a device named "switch-01" is found by name),
+        so the match_type is "hostname"; the equal serial produces no conflict and the row is
+        surfaced as an unlinked, linkable existing device. (The pure serial-branch "link" decision
+        is covered against real rows by TestDetectSerialMatchRole.test_plain_link_when_names_match_and_unlinked.)
+        """
+        from netbox_librenms_plugin.tests.conftest import make_device
 
-        def device_filter(*args, **kwargs):
-            result = _matchable_filter_result()
-            if _is_serial_lookup(kwargs):
-                result.first.return_value = existing
-            else:
-                result.first.return_value = None
-            return result
-
-        self.mock_device.objects.filter.side_effect = device_filter
+        existing = make_device("switch-01", serial="ABC123")
 
         from netbox_librenms_plugin.import_utils import validate_device_for_import
 
         device_data = {"device_id": 1, "hostname": "switch-01", "serial": "ABC123"}
         result = validate_device_for_import(device_data, include_vc_detection=False)
 
-        assert result["serial_action"] == "link"
-        assert result["existing_match_type"] == "serial"
+        assert result["existing_device"] == existing
+        assert result["existing_match_type"] == "hostname"
         assert "not linked to LibreNMS" in result["warnings"][0]
 
     # The serial-match-reinstall case (differing hostname, no OOB signal, no link → hostname_differs)
@@ -1853,24 +1539,9 @@ class TestSerialNumberMatching:
 
     def test_hostname_match_diff_serial_offers_update(self):
         """Hostname matches but serial differs offers update_serial action."""
-        existing = MagicMock()
-        existing.name = "switch-01"
-        existing.serial = "OLD_SERIAL"
+        from netbox_librenms_plugin.tests.conftest import make_device
 
-        self.mock_vm.objects.filter.return_value.first.return_value = None
-
-        def device_filter(*args, **kwargs):
-            result = _matchable_filter_result()
-            if "name__iexact" in kwargs:
-                result.first.return_value = existing
-            elif _is_serial_lookup(kwargs):
-                result.first.return_value = None
-                result.exclude.return_value.first.return_value = None
-            else:
-                result.first.return_value = None
-            return result
-
-        self.mock_device.objects.filter.side_effect = device_filter
+        make_device("switch-01", serial="OLD_SERIAL")
 
         from netbox_librenms_plugin.import_utils import validate_device_for_import
 
@@ -1881,21 +1552,8 @@ class TestSerialNumberMatching:
         assert result["existing_match_type"] == "hostname"
         assert "Hardware may have been replaced" in result["warnings"][0]
 
-    def _setup_no_match_mocks(self):
-        """Configure mocks for tests where no device match is expected."""
-        self.mock_vm.objects.filter.return_value.first.return_value = None
-        self.mock_device.objects.filter.return_value.first.return_value = None
-        self.mock_find_site.return_value = {"found": False, "site": None, "match_type": None, "confidence": 0}
-        self.mock_find_platform.return_value = {"found": False, "platform": None, "match_type": None}
-        self.mock_match_type.return_value = {"matched": False, "device_type": None, "match_type": None}
-        self.mock_role.objects.all.return_value = []
-        self.mock_cluster.objects.all.return_value = []
-        self.mock_site_model.objects.all.return_value = []
-
     def test_serial_dash_ignored(self):
-        """Serial '-' is not treated as a match."""
-        self._setup_no_match_mocks()
-
+        """Serial '-' is not treated as a match (empty DB → nothing matches)."""
         from netbox_librenms_plugin.import_utils import validate_device_for_import
 
         device_data = {"device_id": 1, "hostname": "switch-01", "serial": "-"}
@@ -1906,8 +1564,6 @@ class TestSerialNumberMatching:
 
     def test_serial_empty_ignored(self):
         """Empty serial skips serial matching."""
-        self._setup_no_match_mocks()
-
         from netbox_librenms_plugin.import_utils import validate_device_for_import
 
         device_data = {"device_id": 1, "hostname": "switch-01", "serial": ""}
@@ -1918,8 +1574,6 @@ class TestSerialNumberMatching:
 
     def test_serial_none_ignored(self):
         """None serial skips serial matching."""
-        self._setup_no_match_mocks()
-
         from netbox_librenms_plugin.import_utils import validate_device_for_import
 
         device_data = {"device_id": 1, "hostname": "switch-01", "serial": None}
@@ -1930,26 +1584,10 @@ class TestSerialNumberMatching:
 
     def test_hostname_match_serial_conflict_warns(self):
         """Hostname matches, incoming serial already on another device warns about conflict."""
-        hostname_device = MagicMock()
-        hostname_device.name = "switch-01"
-        hostname_device.serial = "OLD_SERIAL"
+        from netbox_librenms_plugin.tests.conftest import make_device
 
-        serial_conflict_device = MagicMock()
-        serial_conflict_device.name = "other-device"
-
-        self.mock_vm.objects.filter.return_value.first.return_value = None
-
-        def device_filter(*args, **kwargs):
-            result = _matchable_filter_result()
-            if "name__iexact" in kwargs:
-                result.first.return_value = hostname_device
-            elif _is_serial_lookup(kwargs):
-                result.exclude.return_value.first.return_value = serial_conflict_device
-            else:
-                result.first.return_value = None
-            return result
-
-        self.mock_device.objects.filter.side_effect = device_filter
+        make_device("switch-01", serial="OLD_SERIAL")
+        make_device("other-device", serial="CONFLICTING_SERIAL")
 
         from netbox_librenms_plugin.import_utils import validate_device_for_import
 
@@ -1962,40 +1600,9 @@ class TestSerialNumberMatching:
 
     def test_librenms_id_match_shows_serial_confirmed(self):
         """librenms_id match with matching serial shows confirmation."""
-        existing = MagicMock()
-        existing.name = "switch-01"
-        existing.serial = "ABC123"
-        existing.virtual_chassis = None  # Not a VC member → use plain hostname comparison
-        existing.vc_position = None
+        from netbox_librenms_plugin.tests.conftest import make_device
 
-        self.mock_vm.objects.filter.return_value.first.return_value = None
-
-        def device_filter(*args, **kwargs):
-            result = _matchable_filter_result()
-            q_has_librenms = any("librenms_id" in str(arg) for arg in args) or any(
-                k.startswith("custom_field_data__librenms_id") for k in kwargs
-            )
-            if q_has_librenms:
-                result.first.return_value = existing
-                # find_by_librenms_id consumes the queryset via list(qs[:2]).
-                result.__getitem__.return_value = [existing]
-            else:
-                result.first.return_value = None
-                result.__getitem__.return_value = []
-            return result
-
-        self.mock_device.objects.filter.side_effect = device_filter
-        self.mock_find_site.return_value = {
-            "found": True,
-            "site": MagicMock(),
-            "match_type": "exact",
-            "confidence": 1.0,
-        }
-        self.mock_find_platform.return_value = {"found": False, "platform": None, "match_type": None}
-        self.mock_match_type.return_value = {"matched": False, "device_type": None, "match_type": None}
-        self.mock_role.objects.all.return_value = []
-        self.mock_cluster.objects.all.return_value = []
-        self.mock_site_model.objects.all.return_value = []
+        make_device("switch-01", serial="ABC123", librenms_cf={"default": {"id": 1}})
 
         from netbox_librenms_plugin.import_utils import validate_device_for_import
 
@@ -2009,44 +1616,9 @@ class TestSerialNumberMatching:
 
     def test_librenms_id_match_detects_serial_drift(self):
         """librenms_id match with different serial warns about drift."""
-        existing = MagicMock()
-        existing.name = "switch-01"
-        existing.serial = "OLD_SERIAL"
-        existing.virtual_chassis = None
-        existing.vc_position = None
+        from netbox_librenms_plugin.tests.conftest import make_device
 
-        self.mock_vm.objects.filter.return_value.first.return_value = None
-
-        def device_filter(*args, **kwargs):
-            result = _matchable_filter_result()
-            q_has_librenms = any("librenms_id" in str(arg) for arg in args) or any(
-                k.startswith("custom_field_data__librenms_id") for k in kwargs
-            )
-            if q_has_librenms:
-                result.first.return_value = existing
-                # find_by_librenms_id consumes the queryset via list(qs[:2]).
-                result.__getitem__.return_value = [existing]
-            elif _is_serial_lookup(kwargs):
-                result.first.return_value = None
-                result.__getitem__.return_value = []
-                result.exclude.return_value.first.return_value = None
-            else:
-                result.first.return_value = None
-                result.__getitem__.return_value = []
-            return result
-
-        self.mock_device.objects.filter.side_effect = device_filter
-        self.mock_find_site.return_value = {
-            "found": True,
-            "site": MagicMock(),
-            "match_type": "exact",
-            "confidence": 1.0,
-        }
-        self.mock_find_platform.return_value = {"found": False, "platform": None, "match_type": None}
-        self.mock_match_type.return_value = {"matched": False, "device_type": None, "match_type": None}
-        self.mock_role.objects.all.return_value = []
-        self.mock_cluster.objects.all.return_value = []
-        self.mock_site_model.objects.all.return_value = []
+        make_device("switch-01", serial="OLD_SERIAL", librenms_cf={"default": {"id": 1}})
 
         from netbox_librenms_plugin.import_utils import validate_device_for_import
 
@@ -2059,37 +1631,15 @@ class TestSerialNumberMatching:
 
     def test_librenms_id_match_still_validates_site(self):
         """librenms_id match continues to populate site/type validation."""
-        existing = MagicMock()
-        existing.name = "switch-01"
-        existing.serial = ""
-        existing.virtual_chassis = None
-        existing.vc_position = None
+        from dcim.models import Site
 
-        self.mock_vm.objects.filter.return_value.first.return_value = None
+        from netbox_librenms_plugin.tests.conftest import make_device
 
-        def device_filter(*args, **kwargs):
-            result = _matchable_filter_result()
-            q_has_librenms = any("librenms_id" in str(arg) for arg in args) or any(
-                k.startswith("custom_field_data__librenms_id") for k in kwargs
-            )
-            if q_has_librenms:
-                result.first.return_value = existing
-                # find_by_librenms_id consumes the queryset via list(qs[:2]).
-                result.__getitem__.return_value = [existing]
-            else:
-                result.first.return_value = None
-                result.__getitem__.return_value = []
-            return result
-
-        self.mock_device.objects.filter.side_effect = device_filter
-        mock_site = MagicMock(id=1, name="DC1")
-        self.mock_find_site.return_value = {"found": True, "site": mock_site, "match_type": "exact", "confidence": 1.0}
-        self.mock_find_platform.return_value = {"found": False, "platform": None, "match_type": None}
+        make_device("switch-01", serial="", librenms_cf={"default": {"id": 1}})
+        site, _ = Site.objects.get_or_create(name="DC1", slug="dc1")
+        self.mock_find_site.return_value = {"found": True, "site": site, "match_type": "exact", "confidence": 1.0}
         mock_dt = MagicMock()
         self.mock_match_type.return_value = {"matched": True, "device_type": mock_dt, "match_type": "exact"}
-        self.mock_role.objects.all.return_value = []
-        self.mock_cluster.objects.all.return_value = []
-        self.mock_site_model.objects.all.return_value = []
 
         from netbox_librenms_plugin.import_utils import validate_device_for_import
 
@@ -2101,37 +1651,14 @@ class TestSerialNumberMatching:
         assert result["is_ready"] is False
         # Site and device_type should still be populated
         assert result["site"]["found"] is True
-        assert result["site"]["site"] == mock_site
+        assert result["site"]["site"] == site
         assert result["device_type"]["found"] is True
 
     def test_existing_device_role_populated(self):
         """Existing device's role should be shown in validation details."""
-        existing = MagicMock()
-        existing.name = "switch-01"
-        existing.serial = "ABC123"
-        existing.virtual_chassis = None
-        existing.vc_position = None
-        mock_existing_role = MagicMock()
-        mock_existing_role.name = "Access Switch"
-        existing.role = mock_existing_role
+        from netbox_librenms_plugin.tests.conftest import make_device
 
-        self.mock_vm.objects.filter.return_value.first.return_value = None
-
-        def device_filter(*args, **kwargs):
-            result = _matchable_filter_result()
-            if _is_serial_lookup(kwargs):
-                result.first.return_value = existing
-            else:
-                result.first.return_value = None
-            return result
-
-        self.mock_device.objects.filter.side_effect = device_filter
-        self.mock_find_site.return_value = {"found": False, "site": None, "match_type": None, "confidence": 0}
-        self.mock_find_platform.return_value = {"found": False, "platform": None, "match_type": None}
-        self.mock_match_type.return_value = {"matched": True, "device_type": MagicMock(), "match_type": "exact"}
-        self.mock_role.objects.all.return_value = [mock_existing_role]
-        self.mock_cluster.objects.all.return_value = []
-        self.mock_site_model.objects.all.return_value = []
+        existing = make_device("switch-01", serial="ABC123")
 
         with patch("netbox_librenms_plugin.import_utils.device_operations.cache") as mock_cache:
             mock_cache.get.return_value = None
@@ -2149,46 +1676,24 @@ class TestSerialNumberMatching:
 
         assert result["existing_device"] == existing
         assert result["device_role"]["found"] is True
-        assert result["device_role"]["role"] == mock_existing_role
+        assert result["device_role"]["role"] == existing.role
 
     def test_device_type_mismatch_flagged(self):
         """Device type mismatch between existing device and LibreNMS should be flagged."""
-        existing = MagicMock()
-        existing.name = "switch-01"
-        existing.serial = "ABC123"
-        existing.virtual_chassis = None
-        existing.vc_position = None
-        existing_device_type = MagicMock()
-        existing_device_type.pk = 1
-        existing_device_type.__str__ = lambda self: "Old Type"
-        existing.device_type = existing_device_type
-        existing.role = MagicMock()
+        from dcim.models import DeviceType, Manufacturer
 
-        librenms_device_type = MagicMock()
-        librenms_device_type.pk = 2
-        librenms_device_type.__str__ = lambda self: "New Type"
+        from netbox_librenms_plugin.tests.conftest import make_device
 
-        self.mock_vm.objects.filter.return_value.first.return_value = None
-
-        def device_filter(*args, **kwargs):
-            result = _matchable_filter_result()
-            if _is_serial_lookup(kwargs):
-                result.first.return_value = existing
-            else:
-                result.first.return_value = None
-            return result
-
-        self.mock_device.objects.filter.side_effect = device_filter
-        self.mock_find_site.return_value = {"found": False, "site": None, "match_type": None, "confidence": 0}
-        self.mock_find_platform.return_value = {"found": False, "platform": None, "match_type": None}
+        existing = make_device("switch-01", serial="ABC123")
+        mfr, _ = Manufacturer.objects.get_or_create(name="MismatchMfr", slug="mismatch-mfr")
+        librenms_device_type, _ = DeviceType.objects.get_or_create(manufacturer=mfr, model="New Type", slug="new-type")
+        # The incoming LibreNMS hardware resolves to a DIFFERENT device type than the existing row's.
+        assert librenms_device_type.pk != existing.device_type.pk
         self.mock_match_type.return_value = {
             "matched": True,
             "device_type": librenms_device_type,
             "match_type": "exact",
         }
-        self.mock_role.objects.all.return_value = []
-        self.mock_cluster.objects.all.return_value = []
-        self.mock_site_model.objects.all.return_value = []
 
         with patch("netbox_librenms_plugin.import_utils.device_operations.cache") as mock_cache:
             mock_cache.get.return_value = None
@@ -2209,33 +1714,15 @@ class TestSerialNumberMatching:
 
     def test_no_device_type_mismatch_when_types_match(self):
         """No mismatch flag when existing device type matches LibreNMS."""
-        existing = MagicMock()
-        existing.name = "switch-01"
-        existing.serial = "ABC123"
-        existing.virtual_chassis = None
-        existing.vc_position = None
-        same_device_type = MagicMock()
-        same_device_type.pk = 1
-        existing.device_type = same_device_type
-        existing.role = MagicMock()
+        from netbox_librenms_plugin.tests.conftest import make_device
 
-        self.mock_vm.objects.filter.return_value.first.return_value = None
-
-        def device_filter(*args, **kwargs):
-            result = _matchable_filter_result()
-            if _is_serial_lookup(kwargs):
-                result.first.return_value = existing
-            else:
-                result.first.return_value = None
-            return result
-
-        self.mock_device.objects.filter.side_effect = device_filter
-        self.mock_find_site.return_value = {"found": False, "site": None, "match_type": None, "confidence": 0}
-        self.mock_find_platform.return_value = {"found": False, "platform": None, "match_type": None}
-        self.mock_match_type.return_value = {"matched": True, "device_type": same_device_type, "match_type": "exact"}
-        self.mock_role.objects.all.return_value = []
-        self.mock_cluster.objects.all.return_value = []
-        self.mock_site_model.objects.all.return_value = []
+        existing = make_device("switch-01", serial="ABC123")
+        # LibreNMS resolves to the SAME device type the existing NetBox row already has.
+        self.mock_match_type.return_value = {
+            "matched": True,
+            "device_type": existing.device_type,
+            "match_type": "exact",
+        }
 
         with patch("netbox_librenms_plugin.import_utils.device_operations.cache") as mock_cache:
             mock_cache.get.return_value = None

--- a/netbox_librenms_plugin/tests/test_interface_sync_content_template.py
+++ b/netbox_librenms_plugin/tests/test_interface_sync_content_template.py
@@ -142,26 +142,10 @@ class TestInterfaceSyncContentTemplateMigratedMode:
 
     @staticmethod
     def _patch_move_url_reverse(*, resolve):
-        """Patch ``django.urls.reverse`` so ``interface_move_to_winner`` looks registered
-        (``resolve=True`` → a fake path) or unregistered (``resolve=False`` → ``NoReverseMatch``),
-        while every other viewname resolves for real. The move URL is only registered up-stack, so
-        forcing the state here keeps these guard tests branch-independent. ``django.urls.reverse``
-        is the correct target because ``{% url %}`` re-imports ``reverse`` from ``django.urls`` at
-        render. Returns a ``patch()`` context manager.
-        """
-        from unittest.mock import patch
+        """Force ``interface_move_to_winner`` registered/unregistered via the shared helper."""
+        from netbox_librenms_plugin.tests._html_helpers import patch_move_url_reverse
 
-        from django.urls import NoReverseMatch
-        from django.urls import reverse as real_reverse
-
-        def _reverse(viewname, *args, **kwargs):
-            if str(viewname).endswith("interface_move_to_winner"):
-                if resolve:
-                    return "/fake/interface-move/1/"
-                raise NoReverseMatch(viewname)
-            return real_reverse(viewname, *args, **kwargs)
-
-        return patch("django.urls.reverse", _reverse)
+        return patch_move_url_reverse("interface_move_to_winner", resolve=resolve)
 
     def test_migrated_move_button_hidden_for_read_only_users(self):
         """The migrated 'Move' action is a mutating HTMX POST; without write permission it must not render as a live button (it would only fail at the permission gate) — show muted 'read-only' text instead."""
@@ -179,7 +163,7 @@ class TestInterfaceSyncContentTemplateMigratedMode:
         # Assert on the button's own rendered content, not the URL *name* (which never appears in
         # HTML — the template emits the resolved path). The live Move button carries this confirm text.
         assert "Move interface '" not in ro
-        assert "/fake/interface-move/1/" not in ro
+        assert "/fake/interface_move_to_winner/1/" not in ro
         assert "read-only" in ro
 
     def test_migrated_move_button_write_perm_degrades_when_url_unregistered(self):
@@ -216,7 +200,7 @@ class TestInterfaceSyncContentTemplateMigratedMode:
         with self._patch_move_url_reverse(resolve=True):
             html = self._render(migrated=marker, netbox_only=[iface], winner=winner, has_write=True)
         assert "Move interface '" in html
-        assert 'hx-post="/fake/interface-move/1/"' in html
+        assert 'hx-post="/fake/interface_move_to_winner/1/"' in html
         assert "read-only" not in html
 
     def test_move_button_emits_server_key_hx_vals_when_marker_has_key(self):

--- a/netbox_librenms_plugin/tests/test_interface_sync_content_template.py
+++ b/netbox_librenms_plugin/tests/test_interface_sync_content_template.py
@@ -221,9 +221,14 @@ class TestInterfaceSyncContentTemplateMigratedMode:
             netbox_only=[{"id": 1, "name": "eth-only"}],
             has_write=True,
         )
-        # The Move button renders for the NetBox-only row and carries the server_key.
+        # The Move button renders for the NetBox-only row and carries the server_key. Scope the
+        # hx-vals assertion to the Move button's own tag (mirroring the fallback test) so a
+        # different element carrying the key can't mask the button dropping its hx-vals.
         assert "mdi-transfer-right" in html
-        assert 'hx-vals=\'{"server_key": "edgelondon"}\'' in html
+        move_idx = html.index("mdi-transfer-right")
+        btn_start = html.rindex("<button", 0, move_idx)
+        move_button_tag = html[btn_start : html.index(">", btn_start)]
+        assert 'hx-vals=\'{"server_key": "edgelondon"}\'' in move_button_tag
 
     def test_move_button_falls_back_to_active_server_key_when_marker_has_no_key(self):
         # When the marker carries no server_key, the Move button must fall back to the active

--- a/netbox_librenms_plugin/tests/test_interface_sync_content_template.py
+++ b/netbox_librenms_plugin/tests/test_interface_sync_content_template.py
@@ -168,6 +168,17 @@ class TestInterfaceSyncContentTemplateMigratedMode:
         html = self._render(migrated=None)
         assert "Exclude from Sync:" in html
 
+    def test_interface_type_help_uses_the_shared_modal_helper(self):
+        """The info link opens through NetBox's modal helper instead of competing Bootstrap trigger state."""
+        from netbox_librenms_plugin.tests._html_helpers import extract_enclosing_tag
+
+        html = self._render(migrated=None)
+        link = extract_enclosing_tag(html, "mdi-help-circle", tag="<a")
+
+        assert "showModal(document.getElementById('interfaceTypeHelpModal'))" in link
+        assert "data-bs-toggle" not in link
+        assert "data-bs-target" not in link
+
     @staticmethod
     def _patch_move_url_reverse(*, resolve):
         """Force ``interface_move_to_winner`` registered/unregistered via the shared helper."""

--- a/netbox_librenms_plugin/tests/test_interface_sync_content_template.py
+++ b/netbox_librenms_plugin/tests/test_interface_sync_content_template.py
@@ -225,28 +225,26 @@ class TestInterfaceSyncContentTemplateMigratedMode:
         assert "mdi-transfer-right" in html
         assert 'hx-vals=\'{"server_key": "edgelondon"}\'' in html
 
-    def test_move_button_omits_server_key_hx_vals_when_marker_has_no_key(self):
-        # Mirror the form-mode guard (lines 29/35): when the marker has no server_key, the Move
-        # button must omit hx-vals entirely rather than POST an empty {"server_key": ""}, which
-        # would override the active/default server with a blank key on a non-default install.
+    def test_move_button_falls_back_to_active_server_key_when_marker_has_no_key(self):
+        # When the marker carries no server_key, the Move button must fall back to the active
+        # interface_sync.server_key (the server the donor is being viewed under) rather than drop
+        # the discriminator: omitting it lets the move resolve the marker against the session/default
+        # server, which on a multi-server install can be the WRONG server. Never POST an empty key.
         from netbox_librenms_plugin.tests.conftest import make_device
 
         winner = make_device("iface-tmpl-winner-nokey")
         html = self._render(
-            migrated={"device_id": 1, "at": "now"},  # no server_key
+            migrated={"device_id": 1, "at": "now"},  # marker has NO server_key
             winner=winner,
             netbox_only=[{"id": 1, "name": "eth-only"}],
             has_write=True,
         )
-        # The Move button still renders...
+        # The Move button still renders, and never with an empty server_key payload.
         assert "mdi-transfer-right" in html
-        # ...but never with an empty server_key payload.
-        assert '"server_key": ""' not in html
         assert 'hx-vals=\'{"server_key": ""}\'' not in html
-        # Scope to the move button's own opening tag: with no marker server_key it must omit the
-        # hx-vals attribute ENTIRELY (the checks above would still pass if it rendered any other
-        # non-empty hx-vals), so the POST falls back to the active/default server.
+        # Scope to the move button's own opening tag: it must carry the active server_key
+        # (interface_sync.server_key == "default" in this harness) as the fallback discriminator.
         move_idx = html.index("mdi-transfer-right")
         btn_start = html.rindex("<button", 0, move_idx)
         move_button_tag = html[btn_start : html.index(">", btn_start)]
-        assert "hx-vals" not in move_button_tag
+        assert 'hx-vals=\'{"server_key": "default"}\'' in move_button_tag

--- a/netbox_librenms_plugin/tests/test_interface_sync_content_template.py
+++ b/netbox_librenms_plugin/tests/test_interface_sync_content_template.py
@@ -98,13 +98,26 @@ class TestInterfaceSyncContentTemplateMigratedMode:
         assert "Delete Selected Interfaces" in html
 
     def test_migrated_warning_describes_move_not_delete(self):
-        # In migrated (move) mode the modal warning must not threaten permanent deletion.
+        # In migrated (move) mode WITH a resolved winner, the modal warning must not threaten deletion.
+        from netbox_librenms_plugin.tests.conftest import make_device
+
         html = self._render(
             migrated={"server_key": "default", "device_id": 1, "at": "now"},
             netbox_only=[{"id": 1, "name": "eth-only"}],
+            winner=make_device("iface-warn-winner"),
         )
         assert "Moving an interface reassigns it" in html
         assert "permanently remove them from NetBox" not in html
+
+    def test_migrated_warning_handles_missing_winner(self):
+        """With the marker present but the winner gone (stale), the warning must not instruct a Move to a non-existent winner."""
+        html = self._render(
+            migrated={"server_key": "default", "device_id": 1, "at": "now"},
+            netbox_only=[{"id": 1, "name": "eth-only"}],
+            winner=None,
+        )
+        assert "migration winner is unavailable" in html
+        assert "Moving an interface reassigns it" not in html  # the move instruction is gated out
 
     def test_normal_warning_describes_delete(self):
         html = self._render(migrated=None, netbox_only=[{"id": 1, "name": "eth-only"}])

--- a/netbox_librenms_plugin/tests/test_interface_sync_content_template.py
+++ b/netbox_librenms_plugin/tests/test_interface_sync_content_template.py
@@ -238,9 +238,9 @@ class TestInterfaceSyncContentTemplateMigratedMode:
         # hx-vals assertion to the Move button's own tag (mirroring the fallback test) so a
         # different element carrying the key can't mask the button dropping its hx-vals.
         assert "mdi-transfer-right" in html
-        move_idx = html.index("mdi-transfer-right")
-        btn_start = html.rindex("<button", 0, move_idx)
-        move_button_tag = html[btn_start : html.index(">", btn_start)]
+        from netbox_librenms_plugin.tests._html_helpers import extract_enclosing_tag
+
+        move_button_tag = extract_enclosing_tag(html, "mdi-transfer-right")
         assert 'hx-vals=\'{"server_key": "edgelondon"}\'' in move_button_tag
 
     def test_move_button_falls_back_to_active_server_key_when_marker_has_no_key(self):
@@ -262,7 +262,7 @@ class TestInterfaceSyncContentTemplateMigratedMode:
         assert 'hx-vals=\'{"server_key": ""}\'' not in html
         # Scope to the move button's own opening tag: it must carry the active server_key
         # (interface_sync.server_key == "default" in this harness) as the fallback discriminator.
-        move_idx = html.index("mdi-transfer-right")
-        btn_start = html.rindex("<button", 0, move_idx)
-        move_button_tag = html[btn_start : html.index(">", btn_start)]
+        from netbox_librenms_plugin.tests._html_helpers import extract_enclosing_tag
+
+        move_button_tag = extract_enclosing_tag(html, "mdi-transfer-right")
         assert 'hx-vals=\'{"server_key": "default"}\'' in move_button_tag

--- a/netbox_librenms_plugin/tests/test_interface_sync_content_template.py
+++ b/netbox_librenms_plugin/tests/test_interface_sync_content_template.py
@@ -16,7 +16,16 @@ import pytest
 
 @pytest.mark.django_db
 class TestInterfaceSyncContentTemplateMigratedMode:
-    def _render(self, *, migrated, server_key="default", netbox_only=(), winner=None, has_write=False):
+    def _render(
+        self,
+        *,
+        migrated,
+        server_key="default",
+        netbox_only=(),
+        winner=None,
+        has_write=False,
+        relationship_incomplete=False,
+    ):
         from django.contrib.auth.models import AnonymousUser
         from django.template.loader import render_to_string
         from django.test import RequestFactory
@@ -41,6 +50,7 @@ class TestInterfaceSyncContentTemplateMigratedMode:
             "virtual_chassis_members": [],
             "cache_expiry": None,
             "oob_incomplete": False,
+            "relationship_data_incomplete": relationship_incomplete,
         }
         ctx = {
             "interface_sync": interface_sync,
@@ -97,6 +107,16 @@ class TestInterfaceSyncContentTemplateMigratedMode:
         html = self._render(migrated=None, netbox_only=[{"id": 1, "name": "eth-only"}])
         assert "Click to view and delete NetBox-only interfaces" in html
         assert "Click to view and move NetBox-only interfaces" not in html
+
+    def test_relationship_incomplete_renders_persistent_banner(self):
+        # A cached snapshot whose port_stack fetch failed persistently warns that the Parent / LAG
+        # column may be incomplete (mirrors the oob_incomplete banner).
+        html = self._render(migrated=None, relationship_incomplete=True)
+        assert "LAG / sub-interface relationship data could not be fetched" in html
+
+    def test_no_relationship_banner_when_complete(self):
+        html = self._render(migrated=None, relationship_incomplete=False)
+        assert "LAG / sub-interface relationship data could not be fetched" not in html
 
     def test_migrated_mode_hides_destructive_delete_controls(self):
         # Migrated mode is move-only: the donor-side bulk-delete UI (select-all + per-row

--- a/netbox_librenms_plugin/tests/test_interface_sync_content_template.py
+++ b/netbox_librenms_plugin/tests/test_interface_sync_content_template.py
@@ -205,3 +205,41 @@ class TestInterfaceSyncContentTemplateMigratedMode:
         assert "Move interface '" in html
         assert 'hx-post="/fake/interface-move/1/"' in html
         assert "read-only" not in html
+
+    def test_move_button_emits_server_key_hx_vals_when_marker_has_key(self):
+        # When the migrated marker carries a server_key, the migrated-mode Move button must
+        # post it so the move hits the right LibreNMS server/cache (non-default servers).
+        # has_write=True so the Move button renders (it's gated on write permission).
+        from netbox_librenms_plugin.tests.conftest import make_device
+
+        winner = make_device("iface-tmpl-winner")
+        # Alphanumeric key so escapejs leaves it intact (it escapes e.g. '-' to -); the
+        # guard behaviour, not escapejs, is what this test pins.
+        html = self._render(
+            migrated={"server_key": "edgelondon", "device_id": 1, "at": "now"},
+            winner=winner,
+            netbox_only=[{"id": 1, "name": "eth-only"}],
+            has_write=True,
+        )
+        # The Move button renders for the NetBox-only row and carries the server_key.
+        assert "mdi-transfer-right" in html
+        assert 'hx-vals=\'{"server_key": "edgelondon"}\'' in html
+
+    def test_move_button_omits_server_key_hx_vals_when_marker_has_no_key(self):
+        # Mirror the form-mode guard (lines 29/35): when the marker has no server_key, the Move
+        # button must omit hx-vals entirely rather than POST an empty {"server_key": ""}, which
+        # would override the active/default server with a blank key on a non-default install.
+        from netbox_librenms_plugin.tests.conftest import make_device
+
+        winner = make_device("iface-tmpl-winner-nokey")
+        html = self._render(
+            migrated={"device_id": 1, "at": "now"},  # no server_key
+            winner=winner,
+            netbox_only=[{"id": 1, "name": "eth-only"}],
+            has_write=True,
+        )
+        # The Move button still renders...
+        assert "mdi-transfer-right" in html
+        # ...but never with an empty server_key payload.
+        assert '"server_key": ""' not in html
+        assert 'hx-vals=\'{"server_key": ""}\'' not in html

--- a/netbox_librenms_plugin/tests/test_interface_sync_content_template.py
+++ b/netbox_librenms_plugin/tests/test_interface_sync_content_template.py
@@ -1,12 +1,14 @@
 """Render the real _interface_sync_content.html template in both modes.
 
 In migrated mode the POST form is replaced by a plain <div> (a migrated donor must not be
-able to POST an interface sync). The form-only hidden inputs (server_key) must travel with
-the <form> and never the inert <div>. The CSRF token is the deliberate exception: the
-interface table still renders interactive relationship/VC-member dropdowns whose
-verify-interface POST reads document.querySelector('[name=csrfmiddlewaretoken]').value, so
-a standalone token must be emitted in migrated mode too — otherwise those JS requests hit a
-null token (TypeError/403).
+able to POST an interface sync). The CSRF token AND the server_key hidden input must still be
+emitted in migrated mode — not because of the (absent) form, but because the interface table
+still renders interactive relationship/VC-member dropdowns whose verify-interface POSTs read
+document.querySelector('[name=csrfmiddlewaretoken]').value and
+document.querySelector('input[name="server_key"]').value. Dropping either breaks those
+JS-driven requests: a null token → TypeError/403, a null server_key → the wrong LibreNMS
+server/cache on non-default servers. A bare hidden input never auto-submits, so emitting them
+doesn't reintroduce the live-form problem migrated mode exists to avoid.
 """
 
 import pytest
@@ -14,7 +16,7 @@ import pytest
 
 @pytest.mark.django_db
 class TestInterfaceSyncContentTemplateMigratedMode:
-    def _render(self, *, migrated, netbox_only=(), winner=None, has_write=False):
+    def _render(self, *, migrated, server_key="default", netbox_only=(), winner=None, has_write=False):
         from django.contrib.auth.models import AnonymousUser
         from django.template.loader import render_to_string
         from django.test import RequestFactory
@@ -26,12 +28,12 @@ class TestInterfaceSyncContentTemplateMigratedMode:
         device = make_device("iface-tmpl-dev")
         request = RequestFactory().get("/")
         request.user = AnonymousUser()  # NetBox context processors read request.user
-        table = LibreNMSInterfaceTable([], device=device, server_key="default")
+        table = LibreNMSInterfaceTable([], device=device, server_key=server_key)
         RequestConfig(request).configure(table)
         interface_sync = {
             "object": device,
             "table": table,
-            "server_key": "default",
+            "server_key": server_key,
             # Caller-controlled: an item makes the NetBox-only modal (and its trigger link, whose
             # title we assert) render. Kept empty by default so form-presence tests aren't perturbed
             # by the modal's own <form>.
@@ -49,13 +51,31 @@ class TestInterfaceSyncContentTemplateMigratedMode:
         }
         return render_to_string("netbox_librenms_plugin/_interface_sync_content.html", ctx, request=request)
 
-    def test_migrated_mode_drops_form_and_server_key_but_keeps_csrf_token(self):
-        html = self._render(migrated={"server_key": "default", "device_id": 1, "at": "now"})
-        # The live POST form and its form-only hidden input must be gone in migrated mode.
+    def test_migrated_mode_drops_form_but_keeps_csrf_and_server_key(self):
+        # Use a non-default server_key so the assertion proves the actual value is emitted,
+        # not just any server_key input.
+        html = self._render(
+            migrated={"server_key": "prod", "device_id": 1, "at": "now"},
+            server_key="prod",
+        )
+        # The live POST form must be gone in migrated mode (a donor must not POST a sync).
         assert "<form" not in html
-        assert 'name="server_key"' not in html
-        # ...but the CSRF token must remain so JS-driven verify-interface POSTs still work.
+        # ...but BOTH the CSRF token and the server_key input must remain so JS-driven
+        # verify-interface POSTs still target the right server.
         assert "csrfmiddlewaretoken" in html
+        assert 'name="server_key"' in html
+        assert 'value="prod"' in html
+
+    def test_migrated_mode_hidden_server_key_prefers_marker_key(self):
+        # The migrated-mode standalone server_key input must prefer the marker-scoped key over the
+        # page's interface_sync.server_key (the same precedence the Move button uses), so a stale
+        # page key can't override the server the donor was migrated under.
+        html = self._render(
+            migrated={"server_key": "markerkey", "device_id": 1, "at": "now"},
+            server_key="pagekey",  # interface_sync.server_key differs from the marker
+        )
+        assert '<input type="hidden" name="server_key" value="markerkey">' in html
+        assert 'value="pagekey"' not in html  # the stale page key must not win
 
     def test_normal_mode_emits_form_with_csrf_and_server_key(self):
         html = self._render(migrated=None)

--- a/netbox_librenms_plugin/tests/test_interface_sync_content_template.py
+++ b/netbox_librenms_plugin/tests/test_interface_sync_content_template.py
@@ -252,12 +252,13 @@ class TestInterfaceSyncContentTemplateMigratedMode:
         winner = make_device("iface-tmpl-winner")
         # Alphanumeric key so escapejs leaves it intact (it escapes e.g. '-' to -); the
         # guard behaviour, not escapejs, is what this test pins.
-        html = self._render(
-            migrated={"server_key": "edgelondon", "device_id": 1, "at": "now"},
-            winner=winner,
-            netbox_only=[{"id": 1, "name": "eth-only"}],
-            has_write=True,
-        )
+        with self._patch_move_url_reverse(resolve=True):
+            html = self._render(
+                migrated={"server_key": "edgelondon", "device_id": 1, "at": "now"},
+                winner=winner,
+                netbox_only=[{"id": 1, "name": "eth-only"}],
+                has_write=True,
+            )
         # The Move button renders for the NetBox-only row and carries the server_key. Scope the
         # hx-vals assertion to the Move button's own tag (mirroring the fallback test) so a
         # different element carrying the key can't mask the button dropping its hx-vals.
@@ -275,12 +276,13 @@ class TestInterfaceSyncContentTemplateMigratedMode:
         from netbox_librenms_plugin.tests.conftest import make_device
 
         winner = make_device("iface-tmpl-winner-nokey")
-        html = self._render(
-            migrated={"device_id": 1, "at": "now"},  # marker has NO server_key
-            winner=winner,
-            netbox_only=[{"id": 1, "name": "eth-only"}],
-            has_write=True,
-        )
+        with self._patch_move_url_reverse(resolve=True):
+            html = self._render(
+                migrated={"device_id": 1, "at": "now"},  # marker has NO server_key
+                winner=winner,
+                netbox_only=[{"id": 1, "name": "eth-only"}],
+                has_write=True,
+            )
         # The Move button still renders, and never with an empty server_key payload.
         assert "mdi-transfer-right" in html
         assert 'hx-vals=\'{"server_key": ""}\'' not in html

--- a/netbox_librenms_plugin/tests/test_interface_sync_content_template.py
+++ b/netbox_librenms_plugin/tests/test_interface_sync_content_template.py
@@ -24,7 +24,6 @@ class TestInterfaceSyncContentTemplateMigratedMode:
         netbox_only=(),
         winner=None,
         has_write=False,
-        relationship_incomplete=False,
     ):
         from django.contrib.auth.models import AnonymousUser
         from django.template.loader import render_to_string
@@ -50,7 +49,6 @@ class TestInterfaceSyncContentTemplateMigratedMode:
             "virtual_chassis_members": [],
             "cache_expiry": None,
             "oob_incomplete": False,
-            "relationship_data_incomplete": relationship_incomplete,
         }
         ctx = {
             "interface_sync": interface_sync,
@@ -107,16 +105,6 @@ class TestInterfaceSyncContentTemplateMigratedMode:
         html = self._render(migrated=None, netbox_only=[{"id": 1, "name": "eth-only"}])
         assert "Click to view and delete NetBox-only interfaces" in html
         assert "Click to view and move NetBox-only interfaces" not in html
-
-    def test_relationship_incomplete_renders_persistent_banner(self):
-        # A cached snapshot whose port_stack fetch failed persistently warns that the Parent / LAG
-        # column may be incomplete (mirrors the oob_incomplete banner).
-        html = self._render(migrated=None, relationship_incomplete=True)
-        assert "LAG / sub-interface relationship data could not be fetched" in html
-
-    def test_no_relationship_banner_when_complete(self):
-        html = self._render(migrated=None, relationship_incomplete=False)
-        assert "LAG / sub-interface relationship data could not be fetched" not in html
 
     def test_migrated_mode_hides_destructive_delete_controls(self):
         # Migrated mode is move-only: the donor-side bulk-delete UI (select-all + per-row

--- a/netbox_librenms_plugin/tests/test_interface_sync_content_template.py
+++ b/netbox_librenms_plugin/tests/test_interface_sync_content_template.py
@@ -243,3 +243,10 @@ class TestInterfaceSyncContentTemplateMigratedMode:
         # ...but never with an empty server_key payload.
         assert '"server_key": ""' not in html
         assert 'hx-vals=\'{"server_key": ""}\'' not in html
+        # Scope to the move button's own opening tag: with no marker server_key it must omit the
+        # hx-vals attribute ENTIRELY (the checks above would still pass if it rendered any other
+        # non-empty hx-vals), so the POST falls back to the active/default server.
+        move_idx = html.index("mdi-transfer-right")
+        btn_start = html.rindex("<button", 0, move_idx)
+        move_button_tag = html[btn_start : html.index(">", btn_start)]
+        assert "hx-vals" not in move_button_tag

--- a/netbox_librenms_plugin/tests/test_ipaddress_sync_content_template.py
+++ b/netbox_librenms_plugin/tests/test_ipaddress_sync_content_template.py
@@ -9,7 +9,7 @@ import pytest
 
 @pytest.mark.django_db
 class TestIpAddressSyncContentTemplateMigratedMode:
-    def _render(self, *, migrated):
+    def _render(self, *, migrated, movable=(), winner=None, has_write=False, server_key="default"):
         from django.contrib.auth.models import AnonymousUser
         from django.template.loader import render_to_string
         from django.test import RequestFactory
@@ -27,12 +27,14 @@ class TestIpAddressSyncContentTemplateMigratedMode:
             "ip_sync": {
                 "object": device,
                 "table": table,
-                "server_key": "default",
+                "server_key": server_key,
                 "set_primary_ip": False,
                 "cache_expiry": None,
+                "movable_ips": list(movable),
             },
             "migrated_to_marker": migrated,
-            "has_write_permission": False,
+            "migrated_to_winner": winner,
+            "has_write_permission": has_write,
         }
         return render_to_string("netbox_librenms_plugin/_ipaddress_sync_content.html", ctx, request=request)
 
@@ -45,3 +47,99 @@ class TestIpAddressSyncContentTemplateMigratedMode:
     def test_normal_mode_shows_set_primary_ip_switch(self):
         html = self._render(migrated=None)
         assert 'id="set-primary-ip-toggle-cb"' in html
+
+    def test_migrated_mode_renders_move_button_targeting_the_ip_view(self):
+        """A write-permitted migrated donor shows a Move button posting to ipaddress_move_to_winner for the IP's pk."""
+        from django.urls import reverse
+
+        from netbox_librenms_plugin.tests.conftest import make_device
+
+        winner = make_device("ip-tmpl-winner")
+        movable = [{"id": 4321, "address": "10.0.0.5/24", "interface_name": "eth0"}]
+        html = self._render(
+            migrated={"server_key": "default", "device_id": winner.pk, "at": "now"},
+            movable=movable,
+            winner=winner,
+            has_write=True,
+        )
+        move_url = reverse("plugins:netbox_librenms_plugin:ipaddress_move_to_winner", kwargs={"pk": 4321})
+        assert move_url in html  # the button posts to the real move view for this IP's pk
+        assert "10.0.0.5/24" in html
+        assert f"to {winner.name}" in html  # the card header names the winner
+
+    def test_move_button_hidden_for_read_only_users(self):
+        """The Move action is a mutating POST; a read-only user sees muted 'read-only' text, not a live button."""
+        from django.urls import reverse
+
+        from netbox_librenms_plugin.tests.conftest import make_device
+
+        winner = make_device("ip-tmpl-winner-ro")
+        movable = [{"id": 77, "address": "10.0.0.9/24", "interface_name": "eth1"}]
+        html = self._render(
+            migrated={"server_key": "default", "device_id": winner.pk, "at": "now"},
+            movable=movable,
+            winner=winner,
+            has_write=False,
+        )
+        move_url = reverse("plugins:netbox_librenms_plugin:ipaddress_move_to_winner", kwargs={"pk": 77})
+        assert move_url not in html  # no live mutating button for read-only users
+        assert "read-only" in html
+
+    def test_no_move_card_outside_migrated_mode(self):
+        """Without a migration marker the IP tab must not render the move card at all."""
+        from netbox_librenms_plugin.tests.conftest import make_device
+
+        winner = make_device("ip-tmpl-winner-norm")
+        movable = [{"id": 5, "address": "10.0.0.1/24", "interface_name": "eth0"}]
+        html = self._render(migrated=None, movable=movable, winner=winner, has_write=True)
+        assert "Move IP addresses" not in html
+        assert "move-to-winner" not in html
+
+    def test_no_move_card_when_no_movable_ips(self):
+        """A migrated donor with no interface-assigned IPs renders no (empty) move card."""
+        from netbox_librenms_plugin.tests.conftest import make_device
+
+        winner = make_device("ip-tmpl-winner-empty")
+        html = self._render(
+            migrated={"server_key": "default", "device_id": winner.pk, "at": "now"},
+            movable=[],
+            winner=winner,
+            has_write=True,
+        )
+        assert "Move IP addresses" not in html
+
+    def test_move_button_emits_marker_server_key_hx_vals(self):
+        """The Move button posts the marker's server_key so the move resolves under the right server."""
+        from netbox_librenms_plugin.tests.conftest import make_device
+
+        winner = make_device("ip-tmpl-winner-key")
+        html = self._render(
+            migrated={"server_key": "edgelondon", "device_id": winner.pk, "at": "now"},
+            movable=[{"id": 9, "address": "10.0.0.2/24", "interface_name": "eth0"}],
+            winner=winner,
+            has_write=True,
+        )
+        # Scope the hx-vals assertion to the Move button's own opening tag so another element
+        # carrying the key can't mask the button dropping its discriminator.
+        move_idx = html.index("move-to-winner")
+        btn_start = html.rindex("<button", 0, move_idx)
+        move_button_tag = html[btn_start : html.index(">", btn_start)]
+        assert 'hx-vals=\'{"server_key": "edgelondon"}\'' in move_button_tag
+
+    def test_move_button_falls_back_to_active_server_key_when_marker_has_no_key(self):
+        """With no marker server_key the button falls back to ip_sync.server_key, never an empty key."""
+        from netbox_librenms_plugin.tests.conftest import make_device
+
+        winner = make_device("ip-tmpl-winner-nokey")
+        html = self._render(
+            migrated={"device_id": winner.pk, "at": "now"},  # marker carries NO server_key
+            movable=[{"id": 11, "address": "10.0.0.3/24", "interface_name": "eth0"}],
+            winner=winner,
+            has_write=True,
+            server_key="default",
+        )
+        assert 'hx-vals=\'{"server_key": ""}\'' not in html
+        move_idx = html.index("move-to-winner")
+        btn_start = html.rindex("<button", 0, move_idx)
+        move_button_tag = html[btn_start : html.index(">", btn_start)]
+        assert 'hx-vals=\'{"server_key": "default"}\'' in move_button_tag

--- a/netbox_librenms_plugin/tests/test_ipaddress_sync_content_template.py
+++ b/netbox_librenms_plugin/tests/test_ipaddress_sync_content_template.py
@@ -92,22 +92,13 @@ class TestIpAddressSyncContentTemplateMigratedMode:
         route yields an empty move_url and the read-only fallback instead of a bare {% url %} that
         would NoReverseMatch and 500 the whole IP tab.
         """
-        from unittest.mock import patch
-
-        from django.urls import NoReverseMatch
-        from django.urls import reverse as real_reverse
-
+        from netbox_librenms_plugin.tests._html_helpers import patch_move_url_reverse
         from netbox_librenms_plugin.tests.conftest import make_device
 
         winner = make_device("ip-tmpl-winner-degrade")
         movable = [{"id": 88, "address": "10.0.0.11/24", "interface_name": "eth2"}]
 
-        def _reverse(viewname, *args, **kwargs):
-            if str(viewname).endswith("ipaddress_move_to_winner"):
-                raise NoReverseMatch(viewname)
-            return real_reverse(viewname, *args, **kwargs)
-
-        with patch("django.urls.reverse", _reverse):
+        with patch_move_url_reverse("ipaddress_move_to_winner", resolve=False):
             html = self._render(
                 migrated={"server_key": "default", "device_id": winner.pk, "at": "now"},
                 movable=movable,

--- a/netbox_librenms_plugin/tests/test_ipaddress_sync_content_template.py
+++ b/netbox_librenms_plugin/tests/test_ipaddress_sync_content_template.py
@@ -85,6 +85,38 @@ class TestIpAddressSyncContentTemplateMigratedMode:
         assert move_url not in html  # no live mutating button for read-only users
         assert "read-only" in html
 
+    def test_move_button_degrades_to_read_only_when_url_unregistered(self):
+        """A missing/restacked ipaddress_move_to_winner route must degrade to read-only, not 500.
+
+        The shared include uses ``{% url ... as move_url %}`` + ``and move_url``, so an unresolved
+        route yields an empty move_url and the read-only fallback instead of a bare {% url %} that
+        would NoReverseMatch and 500 the whole IP tab.
+        """
+        from unittest.mock import patch
+
+        from django.urls import NoReverseMatch
+        from django.urls import reverse as real_reverse
+
+        from netbox_librenms_plugin.tests.conftest import make_device
+
+        winner = make_device("ip-tmpl-winner-degrade")
+        movable = [{"id": 88, "address": "10.0.0.11/24", "interface_name": "eth2"}]
+
+        def _reverse(viewname, *args, **kwargs):
+            if str(viewname).endswith("ipaddress_move_to_winner"):
+                raise NoReverseMatch(viewname)
+            return real_reverse(viewname, *args, **kwargs)
+
+        with patch("django.urls.reverse", _reverse):
+            html = self._render(
+                migrated={"server_key": "default", "device_id": winner.pk, "at": "now"},
+                movable=movable,
+                winner=winner,
+                has_write=True,
+            )
+        assert "Move IP '" not in html  # route unresolved → move_url empty → no live button
+        assert "read-only" in html
+
     def test_no_move_card_outside_migrated_mode(self):
         """Without a migration marker the IP tab must not render the move card at all."""
         from netbox_librenms_plugin.tests.conftest import make_device

--- a/netbox_librenms_plugin/tests/test_ipaddress_sync_content_template.py
+++ b/netbox_librenms_plugin/tests/test_ipaddress_sync_content_template.py
@@ -153,9 +153,9 @@ class TestIpAddressSyncContentTemplateMigratedMode:
         )
         # Scope the hx-vals assertion to the Move button's own opening tag so another element
         # carrying the key can't mask the button dropping its discriminator.
-        move_idx = html.index("move-to-winner")
-        btn_start = html.rindex("<button", 0, move_idx)
-        move_button_tag = html[btn_start : html.index(">", btn_start)]
+        from netbox_librenms_plugin.tests._html_helpers import extract_enclosing_tag
+
+        move_button_tag = extract_enclosing_tag(html, "move-to-winner")
         assert 'hx-vals=\'{"server_key": "edgelondon"}\'' in move_button_tag
 
     def test_move_button_falls_back_to_active_server_key_when_marker_has_no_key(self):
@@ -171,7 +171,7 @@ class TestIpAddressSyncContentTemplateMigratedMode:
             server_key="default",
         )
         assert 'hx-vals=\'{"server_key": ""}\'' not in html
-        move_idx = html.index("move-to-winner")
-        btn_start = html.rindex("<button", 0, move_idx)
-        move_button_tag = html[btn_start : html.index(">", btn_start)]
+        from netbox_librenms_plugin.tests._html_helpers import extract_enclosing_tag
+
+        move_button_tag = extract_enclosing_tag(html, "move-to-winner")
         assert 'hx-vals=\'{"server_key": "default"}\'' in move_button_tag

--- a/netbox_librenms_plugin/tests/test_ipaddress_sync_content_template.py
+++ b/netbox_librenms_plugin/tests/test_ipaddress_sync_content_template.py
@@ -68,20 +68,19 @@ class TestIpAddressSyncContentTemplateMigratedMode:
 
     def test_move_button_hidden_for_read_only_users(self):
         """The Move action is a mutating POST; a read-only user sees muted 'read-only' text, not a live button."""
-        from django.urls import reverse
-
+        from netbox_librenms_plugin.tests._html_helpers import patch_move_url_reverse
         from netbox_librenms_plugin.tests.conftest import make_device
 
         winner = make_device("ip-tmpl-winner-ro")
         movable = [{"id": 77, "address": "10.0.0.9/24", "interface_name": "eth1"}]
-        html = self._render(
-            migrated={"server_key": "default", "device_id": winner.pk, "at": "now"},
-            movable=movable,
-            winner=winner,
-            has_write=False,
-        )
-        move_url = reverse("plugins:netbox_librenms_plugin:ipaddress_move_to_winner", kwargs={"pk": 77})
-        assert move_url not in html  # no live mutating button for read-only users
+        with patch_move_url_reverse("ipaddress_move_to_winner", resolve=True):
+            html = self._render(
+                migrated={"server_key": "default", "device_id": winner.pk, "at": "now"},
+                movable=movable,
+                winner=winner,
+                has_write=False,
+            )
+        assert "/fake/ipaddress_move_to_winner/77/" not in html
         assert "read-only" in html
 
     def test_move_button_degrades_to_read_only_when_url_unregistered(self):

--- a/netbox_librenms_plugin/tests/test_ipaddress_sync_content_template.py
+++ b/netbox_librenms_plugin/tests/test_ipaddress_sync_content_template.py
@@ -50,20 +50,19 @@ class TestIpAddressSyncContentTemplateMigratedMode:
 
     def test_migrated_mode_renders_move_button_targeting_the_ip_view(self):
         """A write-permitted migrated donor shows a Move button posting to ipaddress_move_to_winner for the IP's pk."""
-        from django.urls import reverse
-
+        from netbox_librenms_plugin.tests._html_helpers import patch_move_url_reverse
         from netbox_librenms_plugin.tests.conftest import make_device
 
         winner = make_device("ip-tmpl-winner")
         movable = [{"id": 4321, "address": "10.0.0.5/24", "interface_name": "eth0"}]
-        html = self._render(
-            migrated={"server_key": "default", "device_id": winner.pk, "at": "now"},
-            movable=movable,
-            winner=winner,
-            has_write=True,
-        )
-        move_url = reverse("plugins:netbox_librenms_plugin:ipaddress_move_to_winner", kwargs={"pk": 4321})
-        assert move_url in html  # the button posts to the real move view for this IP's pk
+        with patch_move_url_reverse("ipaddress_move_to_winner", resolve=True):
+            html = self._render(
+                migrated={"server_key": "default", "device_id": winner.pk, "at": "now"},
+                movable=movable,
+                winner=winner,
+                has_write=True,
+            )
+        assert "/fake/ipaddress_move_to_winner/4321/" in html
         assert "10.0.0.5/24" in html
         assert f"to {winner.name}" in html  # the card header names the winner
 

--- a/netbox_librenms_plugin/tests/test_ipaddress_sync_content_template.py
+++ b/netbox_librenms_plugin/tests/test_ipaddress_sync_content_template.py
@@ -83,6 +83,20 @@ class TestIpAddressSyncContentTemplateMigratedMode:
         assert "/fake/ipaddress_move_to_winner/77/" not in html
         assert "read-only" in html
 
+    def test_missing_winner_is_explained_above_the_move_table(self):
+        """A deleted migration winner produces a clear warning instead of only per-row placeholders."""
+        movable = [{"id": 78, "address": "10.0.0.10/24", "interface_name": "eth1"}]
+
+        html = self._render(
+            migrated={"server_key": "default", "device_id": 999999, "at": "now"},
+            movable=movable,
+            winner=None,
+            has_write=True,
+        )
+
+        assert "migration winner is unavailable" in html.lower()
+        assert "winner missing" in html
+
     def test_move_button_degrades_to_read_only_when_url_unregistered(self):
         """A missing/restacked ipaddress_move_to_winner route must degrade to read-only, not 500.
 

--- a/netbox_librenms_plugin/tests/test_librenms_api.py
+++ b/netbox_librenms_plugin/tests/test_librenms_api.py
@@ -1378,6 +1378,26 @@ class TestLibreNMSAPIPortsAndInventory:
         assert ips == []
 
     @patch("netbox_librenms_plugin.librenms_api.requests.get")
+    def test_get_device_ips_404_empty_message_is_case_insensitive(self, mock_get, mock_librenms_config):
+        """LibreNMS capitalization changes do not turn its stable no-address response into a failure."""
+        response = mock_get.return_value
+        response.status_code = 404
+        error = requests.exceptions.HTTPError("404 Client Error: Not Found")
+        error.response = response
+        response.raise_for_status.side_effect = error
+        response.json.return_value = {
+            "status": "error",
+            "message": "Device 123 Does Not Have Any IP Addresses",
+        }
+
+        from netbox_librenms_plugin.librenms_api import LibreNMSAPI
+
+        success, ips = LibreNMSAPI(server_key="default").get_device_ips(device_id=123)
+
+        assert success is True
+        assert ips == []
+
+    @patch("netbox_librenms_plugin.librenms_api.requests.get")
     def test_get_device_ips_404_for_missing_device_remains_a_failure(self, mock_get, mock_librenms_config):
         """Only LibreNMS's explicit empty-IP response is an empty success; a stale device id stays visible."""
         import requests

--- a/netbox_librenms_plugin/tests/test_librenms_api.py
+++ b/netbox_librenms_plugin/tests/test_librenms_api.py
@@ -1362,6 +1362,10 @@ class TestLibreNMSAPIPortsAndInventory:
         error = requests.exceptions.HTTPError("404 Client Error: Not Found")
         error.response = response
         response.raise_for_status.side_effect = error
+        response.json.return_value = {
+            "status": "error",
+            "message": "Device 123 does not have any IP addresses",
+        }
 
         from netbox_librenms_plugin.librenms_api import LibreNMSAPI
 
@@ -1372,6 +1376,26 @@ class TestLibreNMSAPIPortsAndInventory:
         # table, not a red "Failed to fetch IP addresses" error (mirrors get_device_links).
         assert success is True
         assert ips == []
+
+    @patch("netbox_librenms_plugin.librenms_api.requests.get")
+    def test_get_device_ips_404_for_missing_device_remains_a_failure(self, mock_get, mock_librenms_config):
+        """Only LibreNMS's explicit empty-IP response is an empty success; a stale device id stays visible."""
+        import requests
+
+        response = mock_get.return_value
+        response.status_code = 404
+        response.json.return_value = {"status": "error", "message": "Device 123 does not exist"}
+        error = requests.exceptions.HTTPError("404 Client Error: Not Found")
+        error.response = response
+        response.raise_for_status.side_effect = error
+
+        from netbox_librenms_plugin.librenms_api import LibreNMSAPI
+
+        api = LibreNMSAPI(server_key="default")
+        success, message = api.get_device_ips(device_id=123)
+
+        assert success is False
+        assert message == "Device 123 does not exist"
 
 
 # =============================================================================

--- a/netbox_librenms_plugin/tests/test_librenms_id.py
+++ b/netbox_librenms_plugin/tests/test_librenms_id.py
@@ -280,6 +280,23 @@ class TestFindByLibreNMSId:
         mock_model.objects.filter.assert_not_called()
 
 
+class TestIsLegacyLibreNMSId:
+    """is_legacy_librenms_id(): detect the pre-migration bare-int/int-string librenms_id format."""
+
+    def test_legacy_forms_are_detected(self):
+        from netbox_librenms_plugin.utils import is_legacy_librenms_id
+
+        for legacy in (42, "42", "007", -3, "-3"):
+            assert is_legacy_librenms_id(legacy) is True, legacy
+
+    def test_modern_and_invalid_forms_are_not_legacy(self):
+        from netbox_librenms_plugin.utils import is_legacy_librenms_id
+
+        # Multi-server dict (modern), bool (not a real id), None, and non-numeric strings.
+        for modern in ({"default": {"id": 42}}, {}, True, False, None, "abc", "4.2", 4.2):
+            assert is_legacy_librenms_id(modern) is False, modern
+
+
 @pytest.mark.django_db
 class TestMigrateLegacyLibreNMSId:
     """Tests for migrate_legacy_librenms_id() — mutates custom_field_data, never saves."""

--- a/netbox_librenms_plugin/tests/test_librenms_id.py
+++ b/netbox_librenms_plugin/tests/test_librenms_id.py
@@ -919,10 +919,37 @@ class TestMergeLibreNMSLinks:
         """A blank/whitespace winner oob id must NOT fail closed (matches the lenient host-id handling) — the merge proceeds without raising."""
         from netbox_librenms_plugin.utils import merge_librenms_links
 
+        # Winner holds a host id and a blank-id oob slot; the donor carries only the SAME host id
+        # (a duplicate mapping, not an orphan) so the blank-oob leniency is exercised without
+        # tripping the "donor host id has nowhere to move" guard that a distinct donor id would.
         winner = self._make_dev("eve-ng-02", {"default": {"id": 42, "oob": {"id": "  ", "type": "ipmi"}}})
-        donor = self._make_dev("idrac-jhw6nc4", {"default": {"id": 99}})
-        # Must not raise; the winner already has an oob slot, so the donor host id is not demoted.
+        donor = self._make_dev("eve-ng-02-dup", {"default": {"id": 42}})
+        # Must not raise; the blank winner oob id is treated leniently as "no id".
         merge_librenms_links(winner, donor, "default")
+
+    def test_distinct_donor_host_id_with_winner_holding_both_slots_fails_closed(self):
+        """A distinct donor host id with the winner holding both its host and oob slots fails closed."""
+        import pytest
+
+        from netbox_librenms_plugin.utils import merge_librenms_links
+
+        winner = self._make_dev("eve-ng-02", {"default": {"id": 100, "oob": {"id": 50, "type": "idrac"}}})
+        donor = self._make_dev("router-spare", {"default": {"id": 200}})
+        with pytest.raises(ValueError, match="already holds both a LibreNMS host id and an OOB link"):
+            merge_librenms_links(winner, donor, "default")
+        # The donor's link must be left untouched (nothing captured, no partial mutation of winner).
+        assert winner.custom_field_data["librenms_id"]["default"] == {"id": 100, "oob": {"id": 50, "type": "idrac"}}
+
+    def test_duplicate_donor_host_id_with_winner_holding_both_slots_is_allowed(self):
+        """A donor host id equal to the winner's is a duplicate mapping, not an orphan, so it is allowed."""
+        from netbox_librenms_plugin.utils import merge_librenms_links
+
+        winner = self._make_dev("eve-ng-02", {"default": {"id": 100, "oob": {"id": 50, "type": "idrac"}}})
+        donor = self._make_dev("eve-ng-02-dup", {"default": {"id": 100}})
+        summary = merge_librenms_links(winner, donor, "default")
+        # Winner is unchanged (same host id, keeps its own oob); nothing was demoted or dropped.
+        assert winner.custom_field_data["librenms_id"]["default"] == {"id": 100, "oob": {"id": 50, "type": "idrac"}}
+        assert summary["donor_id_demoted_to_oob"] is None
 
     def test_donor_oob_id_coerced_to_int_on_inherit(self):
         """A numeric-string donor oob id is normalized to int when inherited."""

--- a/netbox_librenms_plugin/tests/test_librenms_id.py
+++ b/netbox_librenms_plugin/tests/test_librenms_id.py
@@ -811,6 +811,19 @@ class TestMergeLibreNMSLinks:
         assert winner.custom_field_data["librenms_id"]["default"]["oob"] == {"id": 99, "type": "oob"}
         assert summary["donor_id_demoted_to_oob"] == {"id": 99, "type": "oob"}
 
+    def test_demoted_oob_type_prefers_vendor_token_over_generic(self):
+        # A donor name carrying a generic 'oob' token BEFORE the vendor token (e.g.
+        # 'leaf01-oob-idrac9') must demote with the vendor type ('idrac'), matching the import-path
+        # normalize_oob_type — not the raw first-match search that would pick the generic 'oob'.
+        from netbox_librenms_plugin.utils import merge_librenms_links
+
+        winner = self._make_dev("eve-ng-02", {"default": {"id": 42}})
+        donor = self._make_dev("leaf01-oob-idrac9", {"default": {"id": 99}})
+        summary = merge_librenms_links(winner, donor, "default")
+
+        assert winner.custom_field_data["librenms_id"]["default"]["oob"] == {"id": 99, "type": "idrac"}
+        assert summary["donor_id_demoted_to_oob"] == {"id": 99, "type": "idrac"}
+
     def test_winner_inherits_donor_oob_when_winner_has_none(self):
         from netbox_librenms_plugin.utils import merge_librenms_links
 

--- a/netbox_librenms_plugin/tests/test_librenms_id.py
+++ b/netbox_librenms_plugin/tests/test_librenms_id.py
@@ -1289,3 +1289,38 @@ class TestMarkLibreNMSMigrated:
 
         # The real model query must not return the migrated-only donor for id 99.
         assert find_by_librenms_id(Device, 99, "default") is None
+
+
+class TestNormalizeMergeEntry:
+    """_normalize_merge_entry: the shared fail-closed shape validation for the merge winner/donor entries."""
+
+    @staticmethod
+    def _norm(entry, *, copy=True, owner="winner"):
+        from netbox_librenms_plugin.utils import _normalize_merge_entry
+
+        return _normalize_merge_entry(entry, owner_label=owner, owner_name="X", server_key="default", copy_dict=copy)
+
+    def test_coerces_scalars_and_blank_to_no_link(self):
+        assert self._norm(42) == {"id": 42}
+        assert self._norm("42") == {"id": 42}
+        assert self._norm("") == {}  # blank string is a genuine "no active link"
+        assert self._norm(None) == {}
+
+    def test_fails_closed_on_corrupt_shapes(self):
+        import pytest
+
+        with pytest.raises(ValueError, match="unparseable"):
+            self._norm("abc")  # non-blank, non-numeric string
+        with pytest.raises(ValueError, match="unsupported"):
+            self._norm([1])  # list
+        with pytest.raises(ValueError, match="unsupported"):
+            self._norm(True)  # bool is never a valid id
+
+    def test_dict_copy_flag_controls_isolation(self):
+        src = {"id": 5, "oob": {"id": 7}}
+        # Winner entry is copied (it is mutated downstream): mutating the result must not touch src.
+        copied = self._norm(src, copy=True)
+        copied["id"] = 99
+        assert src["id"] == 5
+        # Donor entry is read-only: returned as-is (same object).
+        assert self._norm(src, copy=False, owner="donor") is src

--- a/netbox_librenms_plugin/tests/test_librenms_id.py
+++ b/netbox_librenms_plugin/tests/test_librenms_id.py
@@ -1235,6 +1235,39 @@ class TestMarkLibreNMSMigrated:
             assert "oob" not in entry
             assert entry["_migrated_to"]["device_id"] == 99
 
+    def test_fails_closed_on_unparseable_dict_host_id(self):
+        """A dict entry whose own id is non-blank but unparseable must raise, not be popped + marked.
+
+        The dict branch validated the nested oob but not entry["id"], so {"id": "abc"} / {"id": 0} /
+        {"id": True} was silently popped and stamped _migrated_to — erasing the corrupt-but-
+        recoverable host mapping instead of forcing the caller to migrate it first.
+        """
+        import pytest
+
+        from netbox_librenms_plugin.utils import mark_librenms_migrated
+
+        for corrupt_id in ("abc", 0, True):
+            donor = MagicMock()
+            donor.name = "corrupt-host-id-donor"
+            donor.custom_field_data = {"librenms_id": {"default": {"id": corrupt_id}}}
+            with pytest.raises(ValueError):
+                mark_librenms_migrated(donor, winner_pk=99, server_key="default")
+            # The raise happens before any mutation: no marker stamped, id preserved to migrate first.
+            assert donor.custom_field_data["librenms_id"]["default"] == {"id": corrupt_id}
+
+    def test_valid_or_blank_dict_host_id_does_not_raise(self):
+        """A dict entry with a numeric/blank/absent id is popped and the marker stamped (no raise)."""
+        from netbox_librenms_plugin.utils import mark_librenms_migrated
+
+        for ok_id in ({"id": 55}, {"id": "55"}, {"id": ""}, {"id": None}, {}):
+            donor = MagicMock()
+            donor.name = "ok-host-id-donor"
+            donor.custom_field_data = {"librenms_id": {"default": dict(ok_id)}}
+            mark_librenms_migrated(donor, winner_pk=99, server_key="default", at="2025-01-01T00:00:00Z")
+            entry = donor.custom_field_data["librenms_id"]["default"]
+            assert "id" not in entry
+            assert entry["_migrated_to"]["device_id"] == 99
+
     @pytest.mark.django_db
     def test_after_marker_find_by_librenms_id_no_longer_matches(self):
         """A donor whose librenms_id entry holds only the _migrated_to marker must NOT be returned by find_by_librenms_id, queried against the REAL Device model."""

--- a/netbox_librenms_plugin/tests/test_librenms_id.py
+++ b/netbox_librenms_plugin/tests/test_librenms_id.py
@@ -811,6 +811,40 @@ class TestMergeLibreNMSLinks:
         assert winner.custom_field_data["librenms_id"]["default"]["oob"] == {"id": 99, "type": "oob"}
         assert summary["donor_id_demoted_to_oob"] == {"id": 99, "type": "oob"}
 
+    def test_blank_only_donor_oob_does_not_persist_empty_oob_slot(self):
+        """A donor oob carrying only a blank id (no other metadata) must NOT leave an empty {} oob.
+
+        The blank id is dropped (validated up-front); with no other metadata the inherited oob
+        collapses to {} and must not be written — a persisted empty dict reads as an occupied slot.
+        """
+        from netbox_librenms_plugin.utils import merge_librenms_links
+
+        winner = self._make_dev("host-win", {"default": {}})
+        donor = self._make_dev("host-don", {"default": {"oob": {"id": "  "}}})  # blank id, nothing else
+        summary = merge_librenms_links(winner, donor, "default")
+
+        entry = winner.custom_field_data["librenms_id"]["default"]
+        assert "oob" not in entry, f"empty oob slot persisted: {entry}"
+        assert summary["oob_from_donor"] is None
+
+    def test_empty_oob_inheritance_does_not_block_a_later_demote(self):
+        """The real harm: a persisted empty {} oob would block a subsequent donor-id demotion.
+
+        Merge a blank-only donor oob into a winner that holds a host id, then merge a second donor
+        whose host id should demote into the (still-free) oob slot. Before the fix the first merge
+        wrote oob={}, which the second merge read as occupied → the second donor id was lost.
+        """
+        from netbox_librenms_plugin.utils import merge_librenms_links
+
+        winner = self._make_dev("eve-ng-02", {"default": {"id": 42}})
+        merge_librenms_links(winner, self._make_dev("blank-oob", {"default": {"oob": {"id": " "}}}), "default")
+        # The blank-only oob left the slot free, not occupied by {}.
+        assert "oob" not in winner.custom_field_data["librenms_id"]["default"]
+
+        summary = merge_librenms_links(winner, self._make_dev("idrac-jhw6nc4", {"default": {"id": 99}}), "default")
+        assert winner.custom_field_data["librenms_id"]["default"]["oob"]["id"] == 99
+        assert summary["donor_id_demoted_to_oob"] == {"id": 99, "type": "idrac"}
+
     def test_demoted_oob_type_prefers_vendor_token_over_generic(self):
         # A donor name carrying a generic 'oob' token BEFORE the vendor token (e.g.
         # 'leaf01-oob-idrac9') must demote with the vendor type ('idrac'), matching the import-path

--- a/netbox_librenms_plugin/tests/test_librenms_id.py
+++ b/netbox_librenms_plugin/tests/test_librenms_id.py
@@ -786,20 +786,18 @@ class TestMergeLibreNMSLinks:
         assert winner.custom_field_data["librenms_id"]["default"]["oob"]["type"] == "idrac"
         assert summary["donor_id_demoted_to_oob"] == {"id": 99, "type": "idrac"}
 
-    def test_donor_real_oob_preferred_over_demoting_donor_id(self):
-        """Donor shaped {"id": X, "oob": {...}} with the winner already holding a host id: the donor's REAL oob must be inherited, not the donor's host id demoted into oob — otherwise the actual OOB controller is silently lost during merge."""
+    def test_distinct_donor_host_and_oob_with_only_one_winner_slot_fails_closed(self):
+        """Two distinct donor links cannot be compressed into the winner's one free OOB slot."""
+        import pytest
+
         from netbox_librenms_plugin.utils import merge_librenms_links
 
         winner = self._make_dev("eve-ng-02", {"default": {"id": 42}})
         donor = self._make_dev("idrac-jhw6nc4", {"default": {"id": 99, "oob": {"id": 77, "type": "ilo"}}})
-        summary = merge_librenms_links(winner, donor, "default")
+        with pytest.raises(ValueError, match="two distinct LibreNMS links"):
+            merge_librenms_links(winner, donor, "default")
 
-        # Winner keeps its own host id and inherits the donor's REAL oob (77/ilo) — the
-        # donor's host id (99) is NOT demoted into oob.
-        assert winner.custom_field_data["librenms_id"]["default"]["id"] == 42
-        assert winner.custom_field_data["librenms_id"]["default"]["oob"] == {"id": 77, "type": "ilo"}
-        assert summary.get("oob_from_donor") == {"id": 77, "type": "ilo"}
-        assert summary.get("donor_id_demoted_to_oob") is None
+        assert winner.custom_field_data["librenms_id"]["default"] == {"id": 42}
 
     def test_donor_id_demoted_to_oob_generic_when_no_pattern_in_name(self):
         """Donor id is always demoted; type falls back to 'oob' when no keyword in name."""

--- a/netbox_librenms_plugin/tests/test_librenms_id.py
+++ b/netbox_librenms_plugin/tests/test_librenms_id.py
@@ -1166,6 +1166,47 @@ class TestMarkLibreNMSMigrated:
             # Untouched: no marker stamped, original value preserved for the caller to migrate.
             assert donor.custom_field_data["librenms_id"] == legacy
 
+    def test_fails_closed_on_corrupt_per_server_entry(self):
+        """A corrupt per-server entry (bool/list/float/unparseable string) must raise, not collapse.
+
+        The top-level guard rejects a corrupt librenms_id, but a per-server value such as
+        ``{"default": True}`` / ``{"default": ["bad"]}`` was previously collapsed to ``{}`` and
+        stamped migrated — hiding the malformed donor state behind ``_migrated_to``. Mirror the
+        per-entry validation from merge_librenms_links() and fail closed instead.
+        """
+        import pytest
+
+        from netbox_librenms_plugin.utils import mark_librenms_migrated
+
+        for corrupt in (True, ["bad"], 3.5, "notanid"):
+            donor = MagicMock()
+            donor.name = "corrupt-entry-donor"
+            donor.custom_field_data = {"librenms_id": {"default": corrupt}}
+            with pytest.raises(ValueError):
+                mark_librenms_migrated(donor, winner_pk=99, server_key="default")
+            # The raise happens before any mutation: no marker stamped, entry untouched.
+            assert donor.custom_field_data["librenms_id"] == {"default": corrupt}
+
+    def test_blank_or_numeric_string_per_server_entry_does_not_raise(self):
+        """A blank string is "no link" (collapse to {}); a numeric string is a valid id — neither raises."""
+        from netbox_librenms_plugin.utils import mark_librenms_migrated
+
+        # Blank string → no recoverable link → collapses to {} and stamps the marker (no raise).
+        donor = MagicMock()
+        donor.name = "blank-entry-donor"
+        donor.custom_field_data = {"librenms_id": {"default": ""}}
+        mark_librenms_migrated(donor, winner_pk=99, server_key="default", at="2025-01-01T00:00:00Z")
+        assert donor.custom_field_data["librenms_id"]["default"]["_migrated_to"]["device_id"] == 99
+
+        # Numeric string → a real id → also valid, marker stamped, id cleared.
+        donor2 = MagicMock()
+        donor2.name = "numstr-entry-donor"
+        donor2.custom_field_data = {"librenms_id": {"default": "77"}}
+        mark_librenms_migrated(donor2, winner_pk=99, server_key="default", at="2025-01-01T00:00:00Z")
+        entry = donor2.custom_field_data["librenms_id"]["default"]
+        assert "id" not in entry
+        assert entry["_migrated_to"]["device_id"] == 99
+
     @pytest.mark.django_db
     def test_after_marker_find_by_librenms_id_no_longer_matches(self):
         """A donor whose librenms_id entry holds only the _migrated_to marker must NOT be returned by find_by_librenms_id, queried against the REAL Device model."""

--- a/netbox_librenms_plugin/tests/test_librenms_id.py
+++ b/netbox_librenms_plugin/tests/test_librenms_id.py
@@ -837,6 +837,27 @@ class TestMergeLibreNMSLinks:
         with pytest.raises(ValueError, match="unsupported librenms_id.*oob shape"):
             merge_librenms_links(winner, donor, "default")
 
+    def test_malformed_winner_oob_id_fails_closed(self):
+        """A winner oob with a non-blank unparseable id ({"oob": {"id": "abc"}} / {"id": 0}) only passes the shape check, so it would look 'occupied' and skip inheriting the donor's real controller — losing it once the donor is marked migrated. It must fail closed instead."""
+        import pytest
+
+        from netbox_librenms_plugin.utils import merge_librenms_links
+
+        for bad_id in ("abc", 0):
+            winner = self._make_dev("eve-ng-02", {"default": {"id": 42, "oob": {"id": bad_id, "type": "ipmi"}}})
+            donor = self._make_dev("idrac-jhw6nc4", {"default": {"oob": {"id": 77, "type": "ipmi"}}})
+            with pytest.raises(ValueError, match="unparseable librenms_id.*oob id"):
+                merge_librenms_links(winner, donor, "default")
+
+    def test_blank_winner_oob_id_is_lenient(self):
+        """A blank/whitespace winner oob id must NOT fail closed (matches the lenient host-id handling) — the merge proceeds without raising."""
+        from netbox_librenms_plugin.utils import merge_librenms_links
+
+        winner = self._make_dev("eve-ng-02", {"default": {"id": 42, "oob": {"id": "  ", "type": "ipmi"}}})
+        donor = self._make_dev("idrac-jhw6nc4", {"default": {"id": 99}})
+        # Must not raise; the winner already has an oob slot, so the donor host id is not demoted.
+        merge_librenms_links(winner, donor, "default")
+
     def test_donor_oob_id_coerced_to_int_on_inherit(self):
         """A numeric-string donor oob id is normalized to int when inherited."""
         from netbox_librenms_plugin.utils import merge_librenms_links

--- a/netbox_librenms_plugin/tests/test_librenms_id.py
+++ b/netbox_librenms_plugin/tests/test_librenms_id.py
@@ -718,3 +718,290 @@ class TestOOBHelpers:
         assert Device.objects.get(pk=dev.pk).custom_field_data["librenms_id"] == {
             "primary": {"id": 42, "oob": {"id": 17, "type": "bmc"}}
         }
+
+
+class TestMergeLibreNMSLinks:
+    """Tests for merge_librenms_links() — winner-wins conflict policy."""
+
+    def _make_dev(self, name, librenms_id_dict):
+        d = MagicMock()
+        d.name = name
+        d.custom_field_data = {"librenms_id": librenms_id_dict} if librenms_id_dict is not None else {}
+        return d
+
+    def test_winner_inherits_id_when_winner_has_no_id(self):
+        from netbox_librenms_plugin.utils import merge_librenms_links
+
+        winner = self._make_dev("eve-ng-02", {"default": {}})
+        donor = self._make_dev("idrac-jhw6nc4", {"default": {"id": 99}})
+        summary = merge_librenms_links(winner, donor, "default")
+
+        assert winner.custom_field_data["librenms_id"]["default"]["id"] == 99
+        assert summary["host_id_from_donor"] == 99
+        assert summary["donor_id_demoted_to_oob"] is None
+
+    def test_winner_inherits_string_id_coerced_to_int(self):
+        """inherit-id branch must coerce donor_id to int, matching the demote branch."""
+        from netbox_librenms_plugin.utils import merge_librenms_links
+
+        winner = self._make_dev("eve-ng-02", {"default": {}})
+        # Simulate a custom field value that arrived as a JSON string (e.g. "99").
+        donor = self._make_dev("router-spare", {"default": {"id": "99"}})
+        summary = merge_librenms_links(winner, donor, "default")
+
+        stored = winner.custom_field_data["librenms_id"]["default"]["id"]
+        assert stored == 99
+        assert isinstance(stored, int)
+        assert summary["host_id_from_donor"] == 99
+        assert isinstance(summary["host_id_from_donor"], int)
+
+    def test_donor_id_demoted_to_oob_when_winner_has_id_and_donor_name_matches_oob_pattern(self):
+        from netbox_librenms_plugin.utils import merge_librenms_links
+
+        winner = self._make_dev("eve-ng-02", {"default": {"id": 42}})
+        donor = self._make_dev("idrac-jhw6nc4", {"default": {"id": 99}})
+        summary = merge_librenms_links(winner, donor, "default")
+
+        assert winner.custom_field_data["librenms_id"]["default"]["id"] == 42
+        assert winner.custom_field_data["librenms_id"]["default"]["oob"]["id"] == 99
+        assert winner.custom_field_data["librenms_id"]["default"]["oob"]["type"] == "idrac"
+        assert summary["donor_id_demoted_to_oob"] == {"id": 99, "type": "idrac"}
+
+    def test_donor_real_oob_preferred_over_demoting_donor_id(self):
+        """Donor shaped {"id": X, "oob": {...}} with the winner already holding a host id:
+        the donor's REAL oob must be inherited, not the donor's host id demoted into oob —
+        otherwise the actual OOB controller is silently lost during merge."""
+        from netbox_librenms_plugin.utils import merge_librenms_links
+
+        winner = self._make_dev("eve-ng-02", {"default": {"id": 42}})
+        donor = self._make_dev("idrac-jhw6nc4", {"default": {"id": 99, "oob": {"id": 77, "type": "ilo"}}})
+        summary = merge_librenms_links(winner, donor, "default")
+
+        # Winner keeps its own host id and inherits the donor's REAL oob (77/ilo) — the
+        # donor's host id (99) is NOT demoted into oob.
+        assert winner.custom_field_data["librenms_id"]["default"]["id"] == 42
+        assert winner.custom_field_data["librenms_id"]["default"]["oob"] == {"id": 77, "type": "ilo"}
+        assert summary.get("oob_from_donor") == {"id": 77, "type": "ilo"}
+        assert summary.get("donor_id_demoted_to_oob") is None
+
+    def test_donor_id_demoted_to_oob_generic_when_no_pattern_in_name(self):
+        """Donor id is always demoted; type falls back to 'oob' when no keyword in name."""
+        from netbox_librenms_plugin.utils import merge_librenms_links
+
+        winner = self._make_dev("eve-ng-02", {"default": {"id": 42}})
+        donor = self._make_dev("eve-ng-03-spare", {"default": {"id": 99}})
+        summary = merge_librenms_links(winner, donor, "default")
+
+        assert winner.custom_field_data["librenms_id"]["default"]["id"] == 42
+        assert winner.custom_field_data["librenms_id"]["default"]["oob"] == {"id": 99, "type": "oob"}
+        assert summary["donor_id_demoted_to_oob"] == {"id": 99, "type": "oob"}
+
+    def test_winner_inherits_donor_oob_when_winner_has_none(self):
+        from netbox_librenms_plugin.utils import merge_librenms_links
+
+        winner = self._make_dev("eve-ng-02", {"default": {"id": 42}})
+        donor = self._make_dev("eve-ng-02-old", {"default": {"oob": {"id": 77, "type": "ipmi"}}})
+        summary = merge_librenms_links(winner, donor, "default")
+
+        assert winner.custom_field_data["librenms_id"]["default"]["oob"] == {"id": 77, "type": "ipmi"}
+        assert summary["oob_from_donor"] == {"id": 77, "type": "ipmi"}
+
+    def test_malformed_donor_oob_id_fails_closed_on_inherit(self):
+        """A corrupt donor oob link ({"oob": {"id": "abc"}}) must not be inherited verbatim;
+        the inherit branch coerces the host id and raises on a non-empty invalid value."""
+        import pytest
+
+        from netbox_librenms_plugin.utils import merge_librenms_links
+
+        winner = self._make_dev("eve-ng-02", {"default": {"id": 42}})
+        donor = self._make_dev("eve-ng-02-old", {"default": {"oob": {"id": "abc", "type": "ipmi"}}})
+        with pytest.raises(ValueError, match="unparseable librenms_id.*oob id"):
+            merge_librenms_links(winner, donor, "default")
+
+    def test_donor_oob_id_coerced_to_int_on_inherit(self):
+        """A numeric-string donor oob id is normalized to int when inherited."""
+        from netbox_librenms_plugin.utils import merge_librenms_links
+
+        winner = self._make_dev("eve-ng-02", {"default": {"id": 42}})
+        donor = self._make_dev("eve-ng-02-old", {"default": {"oob": {"id": "77", "type": "ipmi"}}})
+        summary = merge_librenms_links(winner, donor, "default")
+
+        assert winner.custom_field_data["librenms_id"]["default"]["oob"] == {"id": 77, "type": "ipmi"}
+        assert summary["oob_from_donor"] == {"id": 77, "type": "ipmi"}
+
+    def test_blank_donor_oob_id_is_lenient_and_dropped(self):
+        """A blank/whitespace donor oob id ({"oob": {"id": "   "}}) must be treated as 'no oob
+        id' (lenient) — the same as a blank host id and an absent oob id — not raise like a
+        non-blank corrupt one. The blank id is dropped so the winner inherits the oob (type)
+        without carrying a bogus id string."""
+        from netbox_librenms_plugin.utils import merge_librenms_links
+
+        winner = self._make_dev("eve-ng-02", {"default": {"id": 42}})
+        donor = self._make_dev("idrac-x", {"default": {"oob": {"id": "   ", "type": "drac"}}})
+        summary = merge_librenms_links(winner, donor, "default")
+
+        inherited = winner.custom_field_data["librenms_id"]["default"]["oob"]
+        assert inherited == {"type": "drac"}  # blank id dropped, type preserved
+        assert "id" not in inherited
+        assert summary["oob_from_donor"] == {"type": "drac"}
+
+    def test_winner_oob_never_overwritten(self):
+        from netbox_librenms_plugin.utils import merge_librenms_links
+
+        winner = self._make_dev("eve-ng-02", {"default": {"id": 42, "oob": {"id": 11, "type": "drac"}}})
+        donor = self._make_dev("eve-ng-02-old", {"default": {"oob": {"id": 77, "type": "ipmi"}}})
+        summary = merge_librenms_links(winner, donor, "default")
+
+        assert winner.custom_field_data["librenms_id"]["default"]["oob"] == {"id": 11, "type": "drac"}
+        assert summary["oob_from_donor"] is None
+
+    def test_legacy_bare_int_raises(self):
+        import pytest
+
+        from netbox_librenms_plugin.utils import merge_librenms_links
+
+        winner = MagicMock()
+        winner.custom_field_data = {"librenms_id": 42}
+        donor = self._make_dev("idrac-x", {"default": {"id": 99}})
+        with pytest.raises(ValueError):
+            merge_librenms_links(winner, donor, "default")
+
+    def test_malformed_donor_id_raises_clear_error_in_inherit_branch(self):
+        """coerce_librenms_id raises ValueError with a clear message for non-numeric donor ids."""
+        import pytest
+
+        from netbox_librenms_plugin.utils import merge_librenms_links
+
+        winner = self._make_dev("eve-ng-02", {"default": {}})
+        donor = self._make_dev("router-spare", {"default": {"id": "not-a-number"}})
+        with pytest.raises(ValueError, match="unparseable librenms_id"):
+            merge_librenms_links(winner, donor, "default")
+
+    def test_malformed_per_server_string_id_fails_closed(self):
+        """A bare per-server string entry ({server_key: 'abc'}) that can't be parsed must
+        raise, not silently collapse to {} (which would drop/swap link state)."""
+        import pytest
+
+        from netbox_librenms_plugin.utils import merge_librenms_links
+
+        # Bad winner string id.
+        winner = self._make_dev("eve-ng-02", {"default": "abc"})
+        donor = self._make_dev("router-spare", {"default": {"id": 99}})
+        with pytest.raises(ValueError, match="unparseable librenms_id"):
+            merge_librenms_links(winner, donor, "default")
+
+        # Bad donor string id.
+        winner = self._make_dev("eve-ng-02", {"default": {}})
+        donor = self._make_dev("router-spare", {"default": "xyz"})
+        with pytest.raises(ValueError, match="unparseable librenms_id"):
+            merge_librenms_links(winner, donor, "default")
+
+    def test_empty_per_server_string_id_is_lenient(self):
+        """An empty/whitespace string is treated as 'no id', not a hard error."""
+        from netbox_librenms_plugin.utils import merge_librenms_links
+
+        winner = self._make_dev("eve-ng-02", {"default": "  "})
+        donor = self._make_dev("router-spare", {"default": {"id": 99}})
+        summary = merge_librenms_links(winner, donor, "default")
+        # Winner had no usable id → inherits donor's host id.
+        assert summary["host_id_from_donor"] == 99
+
+    def test_blank_dict_form_id_is_lenient(self):
+        """A blank/whitespace dict-form id ({"id": "   "}) must be treated as 'no id'
+        (lenient), the same as a blank top-level string — not raise like a non-blank
+        corrupt id ('abc'). Equivalent stored states must behave the same."""
+        from netbox_librenms_plugin.utils import merge_librenms_links
+
+        winner = self._make_dev("eve-ng-02", {"default": {"id": "   "}})
+        donor = self._make_dev("router-spare", {"default": {"id": 99}})
+        summary = merge_librenms_links(winner, donor, "default")
+        # Winner's blank id is "no id" → it inherits the donor's host id rather than raising.
+        assert winner.custom_field_data["librenms_id"]["default"]["id"] == 99
+        assert summary["host_id_from_donor"] == 99
+
+    def test_malformed_donor_id_raises_clear_error_in_demote_branch(self):
+        """Same clear error when demoting donor id into winner's oob slot."""
+        import pytest
+
+        from netbox_librenms_plugin.utils import merge_librenms_links
+
+        winner = self._make_dev("eve-ng-02", {"default": {"id": 42}})
+        donor = self._make_dev("idrac-jhw6nc4", {"default": {"id": "bad"}})
+        with pytest.raises(ValueError, match="unparseable librenms_id"):
+            merge_librenms_links(winner, donor, "default")
+
+
+class TestMarkLibreNMSMigrated:
+    """Tests for mark_librenms_migrated()."""
+
+    def test_clears_id_and_oob_and_writes_marker(self):
+        from netbox_librenms_plugin.utils import mark_librenms_migrated
+
+        donor = MagicMock()
+        donor.custom_field_data = {"librenms_id": {"default": {"id": 99, "oob": {"id": 11, "type": "drac"}}}}
+        mark_librenms_migrated(donor, winner_pk=42, server_key="default", at="2025-01-01T00:00:00Z")
+
+        entry = donor.custom_field_data["librenms_id"]["default"]
+        assert "id" not in entry
+        assert "oob" not in entry
+        assert entry["_migrated_to"] == {
+            "device_id": 42,
+            "server_key": "default",
+            "at": "2025-01-01T00:00:00Z",
+        }
+
+    def test_default_timestamp_is_iso_z(self):
+        from netbox_librenms_plugin.utils import mark_librenms_migrated
+
+        donor = MagicMock()
+        donor.custom_field_data = {"librenms_id": {"default": {"id": 99}}}
+        mark_librenms_migrated(donor, winner_pk=42, server_key="default")
+
+        ts = donor.custom_field_data["librenms_id"]["default"]["_migrated_to"]["at"]
+        # Contract: an ISO-8601 UTC string ending in "Z" (tolerate fractional seconds).
+        assert ts.endswith("Z")
+        from datetime import datetime
+
+        datetime.fromisoformat(ts.replace("Z", "+00:00"))  # must parse without raising
+
+    def test_rejects_bool_and_non_positive_winner_pk(self):
+        import pytest
+
+        from netbox_librenms_plugin.utils import mark_librenms_migrated
+
+        for bad in (True, 0, -1):
+            donor = MagicMock()
+            donor.custom_field_data = {"librenms_id": {"default": {"id": 99}}}
+            with pytest.raises(ValueError):
+                mark_librenms_migrated(donor, winner_pk=bad, server_key="default")
+
+    def test_after_marker_find_by_librenms_id_no_longer_matches(self):
+        """Donor with only _migrated_to should not be returned by find_by_librenms_id."""
+        from netbox_librenms_plugin.utils import find_by_librenms_id, mark_librenms_migrated
+
+        donor = MagicMock()
+        donor.custom_field_data = {"librenms_id": {"default": {"id": 99}}}
+        donor.cf = donor.custom_field_data
+        mark_librenms_migrated(donor, winner_pk=42, server_key="default")
+
+        # cf.librenms_id[default] now only has _migrated_to — no id, no oob.
+        # find_by_librenms_id walks cf via the model query, but logic-wise: simulate
+        # by directly inspecting the entry.
+        entry = donor.cf["librenms_id"]["default"]
+        assert entry.get("id") is None
+        assert entry.get("oob") is None
+        # Mock model.objects.filter: should return empty queryset for either id or oob lookup
+        mock_model = MagicMock()
+        mock_model.objects.filter.return_value.__getitem__.return_value = []
+        assert find_by_librenms_id(mock_model, 99, "default") is None
+
+        # Prove the function actually built the lookup (not a vacuous pass): the
+        # combined Q must target the id/oob predicates and must NEVER match on the
+        # _migrated_to marker, so a migrated-only donor can't be returned.
+        # Host and OOB predicates are queried separately now — aggregate across calls.
+        lookups = []
+        for call in mock_model.objects.filter.call_args_list:
+            lookups += [child[0] for child in call[0][0].children]
+        assert any(lk == "custom_field_data__librenms_id__default__id" for lk in lookups)
+        assert any(lk == "custom_field_data__librenms_id__default__oob__id" for lk in lookups)
+        assert all("_migrated_to" not in lk for lk in lookups)

--- a/netbox_librenms_plugin/tests/test_librenms_id.py
+++ b/netbox_librenms_plugin/tests/test_librenms_id.py
@@ -921,6 +921,30 @@ class TestMergeLibreNMSLinks:
         with pytest.raises(ValueError, match="unparseable librenms_id"):
             merge_librenms_links(winner, donor, "default")
 
+    def test_unsupported_winner_entry_shape_fails_closed(self):
+        """A non-None winner entry of an unsupported type (bool/float/list) must raise, not collapse to {} (which would let the winner inherit the donor's id)."""
+        import pytest
+
+        from netbox_librenms_plugin.utils import merge_librenms_links
+
+        for bad in (True, 1.5, [99], (1, 2)):
+            winner = self._make_dev("eve-ng-02", {"default": bad})
+            donor = self._make_dev("router-spare", {"default": {"id": 99}})
+            with pytest.raises(ValueError, match="unsupported librenms_id"):
+                merge_librenms_links(winner, donor, "default")
+
+    def test_unsupported_donor_entry_shape_fails_closed(self):
+        """A non-None donor entry of an unsupported type must raise rather than silently becoming {} (dropping the donor's link during merge)."""
+        import pytest
+
+        from netbox_librenms_plugin.utils import merge_librenms_links
+
+        for bad in (True, 1.5, [99], (1, 2)):
+            winner = self._make_dev("eve-ng-02", {"default": {"id": 42}})
+            donor = self._make_dev("router-spare", {"default": bad})
+            with pytest.raises(ValueError, match="unsupported librenms_id"):
+                merge_librenms_links(winner, donor, "default")
+
 
 class TestMarkLibreNMSMigrated:
     """Tests for mark_librenms_migrated()."""

--- a/netbox_librenms_plugin/tests/test_librenms_id.py
+++ b/netbox_librenms_plugin/tests/test_librenms_id.py
@@ -280,23 +280,6 @@ class TestFindByLibreNMSId:
         mock_model.objects.filter.assert_not_called()
 
 
-class TestIsLegacyLibreNMSId:
-    """is_legacy_librenms_id(): detect the pre-migration bare-int/int-string librenms_id format."""
-
-    def test_legacy_forms_are_detected(self):
-        from netbox_librenms_plugin.utils import is_legacy_librenms_id
-
-        for legacy in (42, "42", "007", -3, "-3"):
-            assert is_legacy_librenms_id(legacy) is True, legacy
-
-    def test_modern_and_invalid_forms_are_not_legacy(self):
-        from netbox_librenms_plugin.utils import is_legacy_librenms_id
-
-        # Multi-server dict (modern), bool (not a real id), None, and non-numeric strings.
-        for modern in ({"default": {"id": 42}}, {}, True, False, None, "abc", "4.2", 4.2):
-            assert is_legacy_librenms_id(modern) is False, modern
-
-
 @pytest.mark.django_db
 class TestMigrateLegacyLibreNMSId:
     """Tests for migrate_legacy_librenms_id() — mutates custom_field_data, never saves."""
@@ -397,12 +380,31 @@ class TestIsLegacyLibreNMSId:
             ({"default": 5}, False),  # multi-server dict
             ({"default": {"id": 5}}, False),
             ([], False),
+            ("007", True),  # zero-padded numeric string is still legacy
+            ("-3", True),  # negative numeric string parses via int()
+            ("4.2", False),  # float-form string is not the legacy int format
+            (4.2, False),  # float is not the legacy format
+            ({}, False),  # empty dict is the (empty) modern form, not legacy
         ],
     )
     def test_classifies_legacy_values(self, value, expected):
         from netbox_librenms_plugin.utils import is_legacy_librenms_id
 
         assert is_legacy_librenms_id(value) is expected
+
+    def test_defined_exactly_once_in_utils(self):
+        """Guard is_legacy_librenms_id has exactly one module-level def (a duplicate silently shadows the other)."""
+        import ast
+        import inspect
+
+        from netbox_librenms_plugin import utils
+
+        defs = [
+            node
+            for node in ast.parse(inspect.getsource(utils)).body
+            if isinstance(node, ast.FunctionDef) and node.name == "is_legacy_librenms_id"
+        ]
+        assert len(defs) == 1, f"is_legacy_librenms_id defined {len(defs)}x — a duplicate shadows the other"
 
 
 @pytest.mark.django_db

--- a/netbox_librenms_plugin/tests/test_librenms_id.py
+++ b/netbox_librenms_plugin/tests/test_librenms_id.py
@@ -815,6 +815,28 @@ class TestMergeLibreNMSLinks:
         with pytest.raises(ValueError, match="unparseable librenms_id.*oob id"):
             merge_librenms_links(winner, donor, "default")
 
+    def test_non_dict_donor_oob_shape_fails_closed(self):
+        """A corrupt non-dict donor oob (e.g. a list) is corrupted state, not 'no OOB link' — fail closed rather than silently drop it during merge."""
+        import pytest
+
+        from netbox_librenms_plugin.utils import merge_librenms_links
+
+        winner = self._make_dev("eve-ng-02", {"default": {"id": 42}})
+        donor = self._make_dev("eve-ng-02-old", {"default": {"id": 7, "oob": ["not", "a", "dict"]}})
+        with pytest.raises(ValueError, match="unsupported librenms_id.*oob shape"):
+            merge_librenms_links(winner, donor, "default")
+
+    def test_non_dict_winner_oob_shape_fails_closed(self):
+        """A corrupt non-dict winner oob (e.g. a string) must fail closed, not be silently overwritten by donor data."""
+        import pytest
+
+        from netbox_librenms_plugin.utils import merge_librenms_links
+
+        winner = self._make_dev("eve-ng-02", {"default": {"id": 42, "oob": "garbage"}})
+        donor = self._make_dev("eve-ng-02-old", {"default": {"oob": {"id": 77, "type": "ipmi"}}})
+        with pytest.raises(ValueError, match="unsupported librenms_id.*oob shape"):
+            merge_librenms_links(winner, donor, "default")
+
     def test_donor_oob_id_coerced_to_int_on_inherit(self):
         """A numeric-string donor oob id is normalized to int when inherited."""
         from netbox_librenms_plugin.utils import merge_librenms_links

--- a/netbox_librenms_plugin/tests/test_librenms_id.py
+++ b/netbox_librenms_plugin/tests/test_librenms_id.py
@@ -1207,6 +1207,34 @@ class TestMarkLibreNMSMigrated:
         assert "id" not in entry
         assert entry["_migrated_to"]["device_id"] == 99
 
+    def test_fails_closed_on_corrupt_nested_oob(self):
+        """A dict entry with a non-dict oob, or an oob with a non-blank unparseable id, must raise."""
+        import pytest
+
+        from netbox_librenms_plugin.utils import mark_librenms_migrated
+
+        for corrupt_oob in ("garbage", ["bad"], 7, {"id": "abc"}):
+            donor = MagicMock()
+            donor.name = "corrupt-oob-donor"
+            donor.custom_field_data = {"librenms_id": {"default": {"oob": corrupt_oob}}}
+            with pytest.raises(ValueError):
+                mark_librenms_migrated(donor, winner_pk=99, server_key="default")
+            # The raise happens before any mutation: no marker stamped, oob preserved to migrate first.
+            assert donor.custom_field_data["librenms_id"]["default"] == {"oob": corrupt_oob}
+
+    def test_valid_or_blank_nested_oob_does_not_raise(self):
+        """A well-formed oob (numeric/blank id, or empty dict) is popped and the marker is stamped."""
+        from netbox_librenms_plugin.utils import mark_librenms_migrated
+
+        for ok_oob in ({"id": 55}, {"id": "55"}, {"id": ""}, {}):
+            donor = MagicMock()
+            donor.name = "ok-oob-donor"
+            donor.custom_field_data = {"librenms_id": {"default": {"oob": ok_oob}}}
+            mark_librenms_migrated(donor, winner_pk=99, server_key="default", at="2025-01-01T00:00:00Z")
+            entry = donor.custom_field_data["librenms_id"]["default"]
+            assert "oob" not in entry
+            assert entry["_migrated_to"]["device_id"] == 99
+
     @pytest.mark.django_db
     def test_after_marker_find_by_librenms_id_no_longer_matches(self):
         """A donor whose librenms_id entry holds only the _migrated_to marker must NOT be returned by find_by_librenms_id, queried against the REAL Device model."""

--- a/netbox_librenms_plugin/tests/test_librenms_id.py
+++ b/netbox_librenms_plugin/tests/test_librenms_id.py
@@ -381,7 +381,7 @@ class TestIsLegacyLibreNMSId:
             ({"default": {"id": 5}}, False),
             ([], False),
             ("007", True),  # zero-padded numeric string is still legacy
-            ("-3", True),  # negative numeric string parses via int()
+            ("-3", False),  # negative numeric string parses to a value < 0 -> not a valid legacy id
             ("4.2", False),  # float-form string is not the legacy int format
             (4.2, False),  # float is not the legacy format
             ({}, False),  # empty dict is the (empty) modern form, not legacy

--- a/netbox_librenms_plugin/tests/test_librenms_id.py
+++ b/netbox_librenms_plugin/tests/test_librenms_id.py
@@ -975,33 +975,24 @@ class TestMarkLibreNMSMigrated:
             with pytest.raises(ValueError):
                 mark_librenms_migrated(donor, winner_pk=bad, server_key="default")
 
+    @pytest.mark.django_db
     def test_after_marker_find_by_librenms_id_no_longer_matches(self):
-        """Donor with only _migrated_to should not be returned by find_by_librenms_id."""
+        """A donor whose librenms_id entry holds only the _migrated_to marker must NOT be returned
+        by find_by_librenms_id, queried against the REAL Device model. winner_pk equals the searched
+        LibreNMS id so an accidental match on the marker's device_id would be caught."""
+        from dcim.models import Device
+
         from netbox_librenms_plugin.utils import find_by_librenms_id, mark_librenms_migrated
 
-        donor = MagicMock()
-        donor.custom_field_data = {"librenms_id": {"default": {"id": 99}}}
-        donor.cf = donor.custom_field_data
-        mark_librenms_migrated(donor, winner_pk=42, server_key="default")
+        donor = _dev({"default": {"id": 99}})
+        mark_librenms_migrated(donor, winner_pk=99, server_key="default")
+        donor.save()
+        donor.refresh_from_db()
 
-        # cf.librenms_id[default] now only has _migrated_to — no id, no oob.
-        # find_by_librenms_id walks cf via the model query, but logic-wise: simulate
-        # by directly inspecting the entry.
+        # The entry now holds only _migrated_to — no id, no oob.
         entry = donor.cf["librenms_id"]["default"]
         assert entry.get("id") is None
         assert entry.get("oob") is None
-        # Mock model.objects.filter: should return empty queryset for either id or oob lookup
-        mock_model = MagicMock()
-        mock_model.objects.filter.return_value.__getitem__.return_value = []
-        assert find_by_librenms_id(mock_model, 99, "default") is None
 
-        # Prove the function actually built the lookup (not a vacuous pass): the
-        # combined Q must target the id/oob predicates and must NEVER match on the
-        # _migrated_to marker, so a migrated-only donor can't be returned.
-        # Host and OOB predicates are queried separately now — aggregate across calls.
-        lookups = []
-        for call in mock_model.objects.filter.call_args_list:
-            lookups += [child[0] for child in call[0][0].children]
-        assert any(lk == "custom_field_data__librenms_id__default__id" for lk in lookups)
-        assert any(lk == "custom_field_data__librenms_id__default__oob__id" for lk in lookups)
-        assert all("_migrated_to" not in lk for lk in lookups)
+        # The real model query must not return the migrated-only donor for id 99.
+        assert find_by_librenms_id(Device, 99, "default") is None

--- a/netbox_librenms_plugin/tests/test_librenms_id.py
+++ b/netbox_librenms_plugin/tests/test_librenms_id.py
@@ -899,6 +899,37 @@ class TestMergeLibreNMSLinks:
         assert "id" not in inherited
         assert summary["oob_from_donor"] == {"type": "drac"}
 
+    def test_metadata_only_donor_oob_does_not_drop_donor_host_id(self):
+        # A donor with a host id AND a metadata-only oob (a type but no usable id) must still
+        # demote its host id into the winner's empty oob slot — the metadata-only oob is not a
+        # real controller link. Treating the truthy-but-idless oob as "occupied" used to skip
+        # demotion and inherit the useless metadata, silently losing the donor host id once the
+        # donor was marked migrated.
+        from netbox_librenms_plugin.utils import merge_librenms_links
+
+        winner = self._make_dev("eve-ng-02", {"default": {"id": 50}})
+        donor = self._make_dev("idrac-host", {"default": {"id": 99, "oob": {"type": "idrac"}}})
+        summary = merge_librenms_links(winner, donor, "default")
+
+        oob = winner.custom_field_data["librenms_id"]["default"]["oob"]
+        assert oob == {"id": 99, "type": "idrac"}  # host id preserved + type metadata folded in
+        assert summary["donor_id_demoted_to_oob"] == {"id": 99, "type": "idrac"}
+        assert summary["oob_from_donor"] is None  # not the useless metadata-only inherit path
+        assert winner.custom_field_data["librenms_id"]["default"]["id"] == 50
+
+    def test_donor_host_id_with_corrupt_oob_id_still_fails_closed(self):
+        # A donor host id paired with a non-blank unparseable oob id must still fail closed: the
+        # up-front oob-id validation runs before demotion, so a corrupt link can't be silently
+        # demoted/dropped just because the donor also carries a host id.
+        import pytest
+
+        from netbox_librenms_plugin.utils import merge_librenms_links
+
+        winner = self._make_dev("eve-ng-02", {"default": {"id": 50}})
+        donor = self._make_dev("idrac-host", {"default": {"id": 99, "oob": {"id": "abc", "type": "idrac"}}})
+        with pytest.raises(ValueError, match="unparseable librenms_id.*oob id"):
+            merge_librenms_links(winner, donor, "default")
+
     def test_winner_oob_never_overwritten(self):
         from netbox_librenms_plugin.utils import merge_librenms_links
 

--- a/netbox_librenms_plugin/tests/test_librenms_id.py
+++ b/netbox_librenms_plugin/tests/test_librenms_id.py
@@ -768,9 +768,7 @@ class TestMergeLibreNMSLinks:
         assert summary["donor_id_demoted_to_oob"] == {"id": 99, "type": "idrac"}
 
     def test_donor_real_oob_preferred_over_demoting_donor_id(self):
-        """Donor shaped {"id": X, "oob": {...}} with the winner already holding a host id:
-        the donor's REAL oob must be inherited, not the donor's host id demoted into oob —
-        otherwise the actual OOB controller is silently lost during merge."""
+        """Donor shaped {"id": X, "oob": {...}} with the winner already holding a host id: the donor's REAL oob must be inherited, not the donor's host id demoted into oob — otherwise the actual OOB controller is silently lost during merge."""
         from netbox_librenms_plugin.utils import merge_librenms_links
 
         winner = self._make_dev("eve-ng-02", {"default": {"id": 42}})
@@ -807,8 +805,7 @@ class TestMergeLibreNMSLinks:
         assert summary["oob_from_donor"] == {"id": 77, "type": "ipmi"}
 
     def test_malformed_donor_oob_id_fails_closed_on_inherit(self):
-        """A corrupt donor oob link ({"oob": {"id": "abc"}}) must not be inherited verbatim;
-        the inherit branch coerces the host id and raises on a non-empty invalid value."""
+        """A corrupt donor oob link ({"oob": {"id": "abc"}}) must not be inherited verbatim; the inherit branch coerces the host id and raises on a non-empty invalid value."""
         import pytest
 
         from netbox_librenms_plugin.utils import merge_librenms_links
@@ -830,10 +827,7 @@ class TestMergeLibreNMSLinks:
         assert summary["oob_from_donor"] == {"id": 77, "type": "ipmi"}
 
     def test_blank_donor_oob_id_is_lenient_and_dropped(self):
-        """A blank/whitespace donor oob id ({"oob": {"id": "   "}}) must be treated as 'no oob
-        id' (lenient) — the same as a blank host id and an absent oob id — not raise like a
-        non-blank corrupt one. The blank id is dropped so the winner inherits the oob (type)
-        without carrying a bogus id string."""
+        """A blank/whitespace donor oob id ({"oob": {"id": " "}}) must be treated as 'no oob id' (lenient) — the same as a blank host id and an absent oob id — not raise like a non-blank corrupt one."""
         from netbox_librenms_plugin.utils import merge_librenms_links
 
         winner = self._make_dev("eve-ng-02", {"default": {"id": 42}})
@@ -878,8 +872,7 @@ class TestMergeLibreNMSLinks:
             merge_librenms_links(winner, donor, "default")
 
     def test_malformed_per_server_string_id_fails_closed(self):
-        """A bare per-server string entry ({server_key: 'abc'}) that can't be parsed must
-        raise, not silently collapse to {} (which would drop/swap link state)."""
+        """A bare per-server string entry ({server_key: 'abc'}) that can't be parsed must raise, not silently collapse to {} (which would drop/swap link state)."""
         import pytest
 
         from netbox_librenms_plugin.utils import merge_librenms_links
@@ -907,9 +900,7 @@ class TestMergeLibreNMSLinks:
         assert summary["host_id_from_donor"] == 99
 
     def test_blank_dict_form_id_is_lenient(self):
-        """A blank/whitespace dict-form id ({"id": "   "}) must be treated as 'no id'
-        (lenient), the same as a blank top-level string — not raise like a non-blank
-        corrupt id ('abc'). Equivalent stored states must behave the same."""
+        """A blank/whitespace dict-form id ({"id": " "}) must be treated as 'no id' (lenient), the same as a blank top-level string — not raise like a non-blank corrupt id ('abc')."""
         from netbox_librenms_plugin.utils import merge_librenms_links
 
         winner = self._make_dev("eve-ng-02", {"default": {"id": "   "}})
@@ -977,9 +968,7 @@ class TestMarkLibreNMSMigrated:
 
     @pytest.mark.django_db
     def test_after_marker_find_by_librenms_id_no_longer_matches(self):
-        """A donor whose librenms_id entry holds only the _migrated_to marker must NOT be returned
-        by find_by_librenms_id, queried against the REAL Device model. winner_pk equals the searched
-        LibreNMS id so an accidental match on the marker's device_id would be caught."""
+        """A donor whose librenms_id entry holds only the _migrated_to marker must NOT be returned by find_by_librenms_id, queried against the REAL Device model."""
         from dcim.models import Device
 
         from netbox_librenms_plugin.utils import find_by_librenms_id, mark_librenms_migrated

--- a/netbox_librenms_plugin/tests/test_librenms_id.py
+++ b/netbox_librenms_plugin/tests/test_librenms_id.py
@@ -1147,6 +1147,25 @@ class TestMarkLibreNMSMigrated:
             with pytest.raises(ValueError):
                 mark_librenms_migrated(donor, winner_pk=bad, server_key="default")
 
+    def test_fails_closed_on_legacy_or_corrupt_top_level_librenms_id(self):
+        """A legacy bare-int/bare-string or corrupt top-level librenms_id must raise, not collapse.
+
+        Collapsing it to {} and stamping the marker would drop the donor's still-resolvable
+        mapping (data loss). The donor's value must be left intact so it stays recoverable.
+        """
+        import pytest
+
+        from netbox_librenms_plugin.utils import mark_librenms_migrated
+
+        for legacy in (42, "42", True, [1, 2]):
+            donor = MagicMock()
+            donor.name = "legacy-donor"
+            donor.custom_field_data = {"librenms_id": legacy}
+            with pytest.raises(ValueError):
+                mark_librenms_migrated(donor, winner_pk=99, server_key="default")
+            # Untouched: no marker stamped, original value preserved for the caller to migrate.
+            assert donor.custom_field_data["librenms_id"] == legacy
+
     @pytest.mark.django_db
     def test_after_marker_find_by_librenms_id_no_longer_matches(self):
         """A donor whose librenms_id entry holds only the _migrated_to marker must NOT be returned by find_by_librenms_id, queried against the REAL Device model."""

--- a/netbox_librenms_plugin/tests/test_librenms_id.py
+++ b/netbox_librenms_plugin/tests/test_librenms_id.py
@@ -921,6 +921,25 @@ class TestMergeLibreNMSLinks:
         with pytest.raises(ValueError, match="unparseable librenms_id"):
             merge_librenms_links(winner, donor, "default")
 
+    def test_falsy_corrupt_top_level_librenms_id_fails_closed(self):
+        """A top-level librenms_id of False/0 must raise, not collapse to {} via `or {}` and merge as 'no mapping'."""
+        import pytest
+
+        from netbox_librenms_plugin.utils import merge_librenms_links
+
+        for bad in (False, 0):
+            # Corrupt winner.
+            winner = self._make_dev("eve-ng-02", bad)
+            donor = self._make_dev("router-spare", {"default": {"id": 99}})
+            with pytest.raises(ValueError, match="legacy bare-integer or corrupt"):
+                merge_librenms_links(winner, donor, "default")
+
+            # Corrupt donor.
+            winner = self._make_dev("eve-ng-02", {"default": {"id": 42}})
+            donor = self._make_dev("router-spare", bad)
+            with pytest.raises(ValueError, match="legacy bare-integer or corrupt"):
+                merge_librenms_links(winner, donor, "default")
+
     def test_unsupported_winner_entry_shape_fails_closed(self):
         """A non-None winner entry of an unsupported type (bool/float/list) must raise, not collapse to {} (which would let the winner inherit the donor's id)."""
         import pytest

--- a/netbox_librenms_plugin/tests/test_migrate_views.py
+++ b/netbox_librenms_plugin/tests/test_migrate_views.py
@@ -1076,6 +1076,24 @@ class TestVlanStaleServerMigratedContext:
         assert result == "rendered"
 
 
+class TestServerKeyFromRequest:
+    """_server_key_from_request must normalize the POSTed server_key."""
+
+    def test_strips_whitespace_padded_key(self):
+        from netbox_librenms_plugin.views.sync.migrate import _server_key_from_request
+
+        request = MagicMock()
+        request.POST = {"server_key": "  prod  "}
+        assert _server_key_from_request(request) == "prod"
+
+    def test_whitespace_only_key_falls_back_to_factory(self):
+        from netbox_librenms_plugin.views.sync.migrate import _server_key_from_request
+
+        request = MagicMock()
+        request.POST = {"server_key": "   "}  # whitespace-only → treated as blank
+        assert _server_key_from_request(request, default_factory=lambda: "sessionkey") == "sessionkey"
+
+
 @pytest.mark.django_db
 class TestMigratedContextServerKeyFallback:
     """When the POSTed server_key fails to rebind (malformed/stale), the cable/IP/interface sync error

--- a/netbox_librenms_plugin/tests/test_migrate_views.py
+++ b/netbox_librenms_plugin/tests/test_migrate_views.py
@@ -1067,10 +1067,8 @@ class TestVlanStaleServerMigratedContext:
 
         with (
             patch("netbox_librenms_plugin.views.base.vlan_table_view.messages"),
-            patch(
-                "netbox_librenms_plugin.views.base.vlan_table_view.build_migrated_context", return_value={}
-            ) as mock_mig,
-            patch("netbox_librenms_plugin.views.base.vlan_table_view.render", return_value="rendered"),
+            patch("netbox_librenms_plugin.utils.build_migrated_context", return_value={}) as mock_mig,
+            patch("netbox_librenms_plugin.views.mixins.render", return_value="rendered"),
         ):
             result = view.post(request, pk=1)
 
@@ -1078,71 +1076,87 @@ class TestVlanStaleServerMigratedContext:
         assert result == "rendered"
 
 
+@pytest.mark.django_db
 class TestMigratedContextServerKeyFallback:
-    """When the POSTed server_key is None (malformed/stale request) and the API rebind fails, the cable/IP sync error render must still resolve the migrated marker — by falling back to the session server key — so a migrated donor's sync controls stay suppressed instead of being silently re-enabled."""
+    """When the POSTed server_key fails to rebind (malformed/stale), the cable/IP/interface sync error
+    render must still resolve the migrated marker — under the SESSION key, not the failed posted key —
+    so a migrated donor's sync controls stay suppressed instead of being silently re-enabled.
 
-    def _post_with_server_key(self, view_cls, module_path, posted):
-        from unittest.mock import MagicMock, patch
+    Real-DB: a real donor+winner+marker and the real build_migrated_context exercise the resolution;
+    only the NetBox template render (needs full request context) and the external LibreNMS rebind are
+    stubbed. Asserts the actual resolved winner, not merely that the helper was called.
+    """
+
+    _counter = 0
+
+    def _assert_resolves_under_session(self, view_cls, posted):
+        from dcim.models import Device
+
+        type(self)._counter += 1
+        n = type(self)._counter
+        winner = make_device(f"sk-winner-{n}")
+        donor = make_device(
+            f"sk-donor-{n}",
+            librenms_cf={
+                "sessionkey": {"_migrated_to": {"device_id": winner.pk, "server_key": "sessionkey", "at": "x"}}
+            },
+        )
 
         view = object.__new__(view_cls)
-        view._librenms_api = MagicMock()
-        view._librenms_api.server_key = "sessionkey"
+        view.model = Device
+        view._librenms_api = MagicMock(server_key="sessionkey")
+        # The posted key fails to rebind (unconfigured/stale) — the external-config boundary.
+        view.rebind_api_for_server = MagicMock(return_value=None)
+        request = _hx_request(posted)
 
-        request = MagicMock()
-        request.POST = posted
-
-        obj = MagicMock()
+        # Stub only the NetBox template render (it needs full request context unavailable in a unit
+        # test); build_migrated_context runs for REAL against the donor's marker.
         with (
-            patch.object(view, "get_object", return_value=obj),
-            patch.object(view, "rebind_api_for_server", return_value=None),  # rebind fails
-            patch(f"{module_path}.messages"),
-            patch(f"{module_path}.render"),
-            patch(f"{module_path}.build_migrated_context", return_value={}) as bmc,
+            patch("netbox_librenms_plugin.views.mixins.render", return_value="rendered") as mock_render,
+            patch("netbox_librenms_plugin.views.base.cables_view.messages"),
+            patch("netbox_librenms_plugin.views.base.ip_addresses_view.messages"),
+            patch("netbox_librenms_plugin.views.base.interfaces_view.messages"),
         ):
-            view.post(request, pk=1)
+            result = view.post(request, pk=donor.pk)
 
-        bmc.assert_called_once()
-        # Always resolve under the session key, never the (failed-to-rebind) POSTed key — a None
-        # key would skip the marker, a non-empty stale key would look it up under the wrong server.
-        assert bmc.call_args.args[1] == "sessionkey"
+        assert result == "rendered"
+        _req, _template, ctx = mock_render.call_args.args
+        # Resolved under the SESSION key → the real winner is found. A wrong/None key would resolve
+        # no winner (migrated_to_winner None), re-enabling the donor's sync controls.
+        assert ctx["migrated_to_marker"]["device_id"] == winner.pk
+        assert ctx["migrated_to_winner"].pk == winner.pk
 
     def test_cables_view_empty_key_uses_session_key(self):
         from netbox_librenms_plugin.views.base.cables_view import BaseCableTableView
 
-        self._post_with_server_key(BaseCableTableView, "netbox_librenms_plugin.views.base.cables_view", {})
+        self._assert_resolves_under_session(BaseCableTableView, {})
 
     def test_cables_view_stale_nonempty_key_uses_session_key(self):
         from netbox_librenms_plugin.views.base.cables_view import BaseCableTableView
 
-        self._post_with_server_key(
-            BaseCableTableView, "netbox_librenms_plugin.views.base.cables_view", {"server_key": "ghost"}
-        )
+        self._assert_resolves_under_session(BaseCableTableView, {"server_key": "ghost"})
 
     def test_ip_view_empty_key_uses_session_key(self):
         from netbox_librenms_plugin.views.base.ip_addresses_view import BaseIPAddressTableView
 
-        self._post_with_server_key(BaseIPAddressTableView, "netbox_librenms_plugin.views.base.ip_addresses_view", {})
+        self._assert_resolves_under_session(BaseIPAddressTableView, {})
 
     def test_ip_view_stale_nonempty_key_uses_session_key(self):
         from netbox_librenms_plugin.views.base.ip_addresses_view import BaseIPAddressTableView
 
-        self._post_with_server_key(
-            BaseIPAddressTableView, "netbox_librenms_plugin.views.base.ip_addresses_view", {"server_key": "ghost"}
-        )
+        self._assert_resolves_under_session(BaseIPAddressTableView, {"server_key": "ghost"})
 
     def test_interfaces_view_empty_key_uses_session_key(self):
         # interfaces_view previously redirected on a stale key (dropping migrated context); it must
-        # now render the partial with migrated context, so build_migrated_context is reached.
+        # now render the partial with migrated context resolved under the session key.
         from netbox_librenms_plugin.views.base.interfaces_view import BaseInterfaceTableView
 
-        self._post_with_server_key(BaseInterfaceTableView, "netbox_librenms_plugin.views.base.interfaces_view", {})
+        self._assert_resolves_under_session(BaseInterfaceTableView, {})
 
     def test_interfaces_view_stale_nonempty_key_uses_session_key(self):
         from netbox_librenms_plugin.views.base.interfaces_view import BaseInterfaceTableView
 
-        self._post_with_server_key(
-            BaseInterfaceTableView, "netbox_librenms_plugin.views.base.interfaces_view", {"server_key": "ghost"}
-        )
+        self._assert_resolves_under_session(BaseInterfaceTableView, {"server_key": "ghost"})
 
     def test_interfaces_view_rebind_fail_avoids_lazy_api_property(self):
         """On rebind failure the migrated-context render must read the cached client key, not the lazy librenms_api property — which can re-construct a missing client and 500 the HTMX error path."""
@@ -1161,8 +1175,8 @@ class TestMigratedContextServerKeyFallback:
             patch.object(view, "rebind_api_for_server", return_value=None),  # stale key → error path
             patch("netbox_librenms_plugin.views.base.interfaces_view.get_interface_name_field", return_value="ifName"),
             patch("netbox_librenms_plugin.views.base.interfaces_view.messages"),
-            patch("netbox_librenms_plugin.views.base.interfaces_view.render"),
-            patch("netbox_librenms_plugin.views.base.interfaces_view.build_migrated_context", return_value={}) as bmc,
+            patch("netbox_librenms_plugin.views.mixins.render"),
+            patch("netbox_librenms_plugin.utils.build_migrated_context", return_value={}) as bmc,
             # The lazy property must NOT be touched on this path; make it explode if it is.
             patch.object(
                 BaseInterfaceTableView,
@@ -1193,8 +1207,8 @@ class TestMigratedContextServerKeyFallback:
             patch.object(view, "get_object", return_value=MagicMock()),
             patch.object(view, "rebind_api_for_server", return_value=None),
             patch("netbox_librenms_plugin.views.base.vlan_table_view.messages"),
-            patch("netbox_librenms_plugin.views.base.vlan_table_view.render"),
-            patch("netbox_librenms_plugin.views.base.vlan_table_view.build_migrated_context", return_value={}) as bmc,
+            patch("netbox_librenms_plugin.views.mixins.render"),
+            patch("netbox_librenms_plugin.utils.build_migrated_context", return_value={}) as bmc,
             patch.object(
                 BaseVLANTableView,
                 "librenms_api",
@@ -1224,8 +1238,8 @@ class TestMigratedContextServerKeyFallback:
             patch.object(view, "get_object", return_value=MagicMock()),
             patch.object(view, "rebind_api_for_server", return_value=None),
             patch("netbox_librenms_plugin.views.base.modules_view.messages"),
-            patch("netbox_librenms_plugin.views.base.modules_view.render"),
-            patch("netbox_librenms_plugin.views.base.modules_view.build_migrated_context", return_value={}) as bmc,
+            patch("netbox_librenms_plugin.views.mixins.render"),
+            patch("netbox_librenms_plugin.utils.build_migrated_context", return_value={}) as bmc,
             patch.object(
                 BaseModuleTableView,
                 "librenms_api",
@@ -1254,8 +1268,8 @@ class TestMigratedContextServerKeyFallback:
             patch.object(view, "get_object", return_value=MagicMock()),
             patch.object(view, "rebind_api_for_server", return_value=None),
             patch("netbox_librenms_plugin.views.base.cables_view.messages"),
-            patch("netbox_librenms_plugin.views.base.cables_view.render"),
-            patch("netbox_librenms_plugin.views.base.cables_view.build_migrated_context", return_value={}) as bmc,
+            patch("netbox_librenms_plugin.views.mixins.render"),
+            patch("netbox_librenms_plugin.utils.build_migrated_context", return_value={}) as bmc,
             patch.object(
                 BaseCableTableView,
                 "librenms_api",
@@ -1284,9 +1298,9 @@ class TestMigratedContextServerKeyFallback:
             patch.object(view, "get_object", return_value=MagicMock()),
             patch.object(view, "rebind_api_for_server", return_value=None),
             patch("netbox_librenms_plugin.views.base.ip_addresses_view.messages"),
-            patch("netbox_librenms_plugin.views.base.ip_addresses_view.render"),
+            patch("netbox_librenms_plugin.views.mixins.render"),
             patch("netbox_librenms_plugin.views.base.ip_addresses_view.resolve_set_primary_ip", return_value=False),
-            patch("netbox_librenms_plugin.views.base.ip_addresses_view.build_migrated_context", return_value={}) as bmc,
+            patch("netbox_librenms_plugin.utils.build_migrated_context", return_value={}) as bmc,
             patch.object(
                 BaseIPAddressTableView,
                 "librenms_api",
@@ -1315,8 +1329,8 @@ class TestMigratedContextServerKeyFallback:
             patch.object(view, "get_object", return_value=MagicMock()),
             patch.object(view, "rebind_api_for_server", return_value=None),  # rebind fails → stale-key fallback
             patch("netbox_librenms_plugin.views.base.ip_addresses_view.messages"),
-            patch("netbox_librenms_plugin.views.base.ip_addresses_view.render") as mock_render,
-            patch("netbox_librenms_plugin.views.base.ip_addresses_view.build_migrated_context", return_value={}),
+            patch("netbox_librenms_plugin.views.mixins.render") as mock_render,
+            patch("netbox_librenms_plugin.utils.build_migrated_context", return_value={}),
         ):
             view.post(request, pk=1)
 
@@ -1341,8 +1355,8 @@ class TestMigratedContextServerKeyFallback:
             patch.object(view, "rebind_api_for_server", return_value="good"),  # rebind OK
             patch.object(view, "_prepare_context", return_value=None),  # live fetch failed
             patch("netbox_librenms_plugin.views.base.ip_addresses_view.messages"),
-            patch("netbox_librenms_plugin.views.base.ip_addresses_view.render") as mock_render,
-            patch("netbox_librenms_plugin.views.base.ip_addresses_view.build_migrated_context", return_value={}),
+            patch("netbox_librenms_plugin.views.mixins.render") as mock_render,
+            patch("netbox_librenms_plugin.utils.build_migrated_context", return_value={}),
         ):
             view.post(request, pk=1)
 

--- a/netbox_librenms_plugin/tests/test_migrate_views.py
+++ b/netbox_librenms_plugin/tests/test_migrate_views.py
@@ -990,3 +990,17 @@ class TestMigratedContextServerKeyFallback:
         self._post_with_server_key(
             BaseIPAddressTableView, "netbox_librenms_plugin.views.base.ip_addresses_view", {"server_key": "ghost"}
         )
+
+    def test_interfaces_view_empty_key_uses_session_key(self):
+        # interfaces_view previously redirected on a stale key (dropping migrated context); it must
+        # now render the partial with migrated context, so build_migrated_context is reached.
+        from netbox_librenms_plugin.views.base.interfaces_view import BaseInterfaceTableView
+
+        self._post_with_server_key(BaseInterfaceTableView, "netbox_librenms_plugin.views.base.interfaces_view", {})
+
+    def test_interfaces_view_stale_nonempty_key_uses_session_key(self):
+        from netbox_librenms_plugin.views.base.interfaces_view import BaseInterfaceTableView
+
+        self._post_with_server_key(
+            BaseInterfaceTableView, "netbox_librenms_plugin.views.base.interfaces_view", {"server_key": "ghost"}
+        )

--- a/netbox_librenms_plugin/tests/test_migrate_views.py
+++ b/netbox_librenms_plugin/tests/test_migrate_views.py
@@ -23,6 +23,7 @@ from netbox_librenms_plugin.tests.conftest import (
     make_device,
     make_interface,
     make_ip,
+    make_superuser,
     make_vm,
 )
 
@@ -1737,13 +1738,18 @@ class TestMoveToWinnerConcurrencyHelpers:
 
         view = object.__new__(MoveInterfaceToWinnerView)
         view._fallback_url = "/x/"
+        # restrict() reads self.request.user; Django binds it in dispatch(), which these
+        # direct-helper calls skip.
+        view.request = self._req()
         return view
 
     def _req(self):
         from django.test import RequestFactory
 
         # HX-Request → _fail returns an HTMX toast response (no messages middleware needed).
-        return RequestFactory().post("/x/", HTTP_HX_REQUEST="true")
+        request = RequestFactory().post("/x/", HTTP_HX_REQUEST="true")
+        request.user = make_superuser()
+        return request
 
     def _migrated_donor_and_winner(self):
         donor = make_device("mv-helper-donor")
@@ -1826,8 +1832,13 @@ class TestMoveEndpointsObjectScope:
         """A real HTMX POST request bound to *user* so the gate and restrict() both run for real."""
         from django.test import RequestFactory
 
+        from django.contrib.messages.storage.fallback import FallbackStorage
+
         request = RequestFactory().post("/move/", {"server_key": "default"}, HTTP_HX_REQUEST="true")
         request.user = user
+        # The success path calls messages.add_message(); RequestFactory skips MessageMiddleware.
+        request.session = {}
+        request._messages = FallbackStorage(request)
         return request
 
     def _drive(self, view_cls, user, **kwargs):
@@ -1908,3 +1919,135 @@ class TestMoveEndpointsObjectScope:
 
         donor.refresh_from_db()
         assert donor.primary_ip4_id == donor_ip.pk  # not transferred
+
+    @staticmethod
+    def _mark(donor, winner):
+        """Write a real ``_migrated_to`` marker so the views resolve *winner* from the donor's cf."""
+        from netbox_librenms_plugin.utils import mark_librenms_migrated
+
+        mark_librenms_migrated(donor, winner.pk, "default")
+        donor.save()
+
+    def test_interface_move_denied_when_a_family_member_is_out_of_scope(self):
+        """The carried lag/parent/bridge family is saved too, so one out-of-scope member must block the whole move."""
+        from dcim.models import Device, Interface
+
+        from netbox_librenms_plugin.views.sync.migrate import MoveInterfaceToWinnerView
+
+        donor = make_device("scope-fam-donor")
+        winner = make_device("scope-fam-winner")
+        master = make_interface(donor, "Eth0")
+        child = Interface.objects.create(device=donor, name="Eth0.100", type="virtual", parent=master)
+        self._mark(donor, winner)
+        # The grant covers the interface the user clicked, but not the child that must move with it.
+        user = self._writer("scoped-family-partial", [(Interface, {"pk": master.pk}), (Device, None)])
+
+        response = self._drive(MoveInterfaceToWinnerView, user, pk=master.pk)
+
+        assert response.headers.get("HX-Refresh") is None  # not the success path
+        master.refresh_from_db()
+        child.refresh_from_db()
+        assert master.device_id == donor.pk  # nothing moved
+        assert child.device_id == donor.pk
+
+    def test_interface_move_carries_the_family_when_all_of_it_is_in_scope(self):
+        """Widening the grant to the whole family lets the move through (no over-block)."""
+        from dcim.models import Device, Interface
+
+        from netbox_librenms_plugin.views.sync.migrate import MoveInterfaceToWinnerView
+
+        donor = make_device("scope-fam-ok-donor")
+        winner = make_device("scope-fam-ok-winner")
+        master = make_interface(donor, "Eth0")
+        child = Interface.objects.create(device=donor, name="Eth0.100", type="virtual", parent=master)
+        self._mark(donor, winner)
+        user = self._writer("scoped-family-whole", [(Interface, {"pk__in": [master.pk, child.pk]}), (Device, None)])
+
+        self._drive(MoveInterfaceToWinnerView, user, pk=master.pk)
+
+        master.refresh_from_db()
+        child.refresh_from_db()
+        assert master.device_id == winner.pk
+        assert child.device_id == winner.pk
+
+    def test_interface_move_denied_when_the_winner_device_is_out_of_scope(self):
+        """The move writes onto the winner device, so a change_device grant that excludes it must block."""
+        from dcim.models import Device, Interface
+
+        from netbox_librenms_plugin.views.sync.migrate import MoveInterfaceToWinnerView
+
+        donor = make_device("scope-win-mi-donor")
+        winner = make_device("scope-win-mi-winner")
+        iface = make_interface(donor, "Eth0")
+        self._mark(donor, winner)
+        user = self._writer("scoped-move-iface-winner", [(Interface, None), (Device, {"pk": donor.pk})])
+
+        response = self._drive(MoveInterfaceToWinnerView, user, pk=iface.pk)
+
+        assert response.headers.get("HX-Refresh") is None
+        iface.refresh_from_db()
+        assert iface.device_id == donor.pk  # not moved onto an unauthorized device
+
+    def test_ip_move_denied_when_the_winner_device_is_out_of_scope(self):
+        """The IP move reconciles both devices' IP FKs, so an out-of-scope winner must block it."""
+        from dcim.models import Device
+        from ipam.models import IPAddress
+
+        from netbox_librenms_plugin.views.sync.migrate import MoveIPAddressToWinnerView
+
+        donor = make_device("scope-win-ip-donor")
+        winner = make_device("scope-win-ip-winner")
+        ip = ip_on(donor, "10.63.0.1/24", "eth0")
+        make_interface(winner, "eth0")
+        self._mark(donor, winner)
+        user = self._writer("scoped-move-ip-winner", [(IPAddress, None), (Device, {"pk": donor.pk})])
+
+        response = self._drive(MoveIPAddressToWinnerView, user, pk=ip.pk)
+
+        assert response.headers.get("HX-Refresh") is None
+        ip.refresh_from_db()
+        assert ip.assigned_object.device_id == donor.pk  # not moved
+
+    def test_device_ip_transfer_denied_when_the_winner_is_out_of_scope(self):
+        """The transfer claims the winner's primary-IP FK, so a donor-only change_device grant must block it."""
+        from dcim.models import Device
+
+        from netbox_librenms_plugin.views.sync.migrate import TransferDeviceIPView
+
+        donor = make_device("scope-xfer-win-donor")
+        winner = make_device("scope-xfer-win-winner")
+        # The address already sits on a winner-owned interface — the state this transfer exists for.
+        ip = ip_on(winner, "10.64.0.1/24", "eth0")
+        Device.objects.filter(pk=donor.pk).update(primary_ip4=ip)
+        donor.refresh_from_db()
+        self._mark(donor, winner)
+        user = self._writer("scoped-xfer-winner", [(Device, {"pk": donor.pk})])
+
+        response = self._drive(TransferDeviceIPView, user, pk=donor.pk, ip_kind="primary4")
+
+        assert response.headers.get("HX-Refresh") is None
+        donor.refresh_from_db()
+        winner.refresh_from_db()
+        assert donor.primary_ip4_id == ip.pk  # donor FK not released
+        assert winner.primary_ip4_id is None  # winner FK not claimed
+
+    def test_device_ip_transfer_runs_when_both_devices_are_in_scope(self):
+        """Widening the grant to the winner lets the same transfer through (no over-block)."""
+        from dcim.models import Device
+
+        from netbox_librenms_plugin.views.sync.migrate import TransferDeviceIPView
+
+        donor = make_device("scope-xfer-ok-donor")
+        winner = make_device("scope-xfer-ok-winner")
+        ip = ip_on(winner, "10.65.0.1/24", "eth0")
+        Device.objects.filter(pk=donor.pk).update(primary_ip4=ip)
+        donor.refresh_from_db()
+        self._mark(donor, winner)
+        user = self._writer("scoped-xfer-both", [(Device, {"pk__in": [donor.pk, winner.pk]})])
+
+        self._drive(TransferDeviceIPView, user, pk=donor.pk, ip_kind="primary4")
+
+        donor.refresh_from_db()
+        winner.refresh_from_db()
+        assert donor.primary_ip4_id is None
+        assert winner.primary_ip4_id == ip.pk

--- a/netbox_librenms_plugin/tests/test_migrate_views.py
+++ b/netbox_librenms_plugin/tests/test_migrate_views.py
@@ -122,6 +122,22 @@ class TestBuildMigratedContext:
 # ── helper: _resolve_winner_for_donor ─────────────────────────────────────
 
 
+class TestParseMarkerWinnerPk:
+    """The shared marker device_id parser used by _resolve_winner_for_donor + _winner_unavailable_reason."""
+
+    def test_accepts_int_and_digit_string(self):
+        from netbox_librenms_plugin.views.sync.migrate import _parse_marker_winner_pk
+
+        assert _parse_marker_winner_pk(5) == 5
+        assert _parse_marker_winner_pk("5") == 5
+
+    def test_rejects_bool_numeric_like_and_non_positive(self):
+        from netbox_librenms_plugin.views.sync.migrate import _parse_marker_winner_pk
+
+        for bad in (True, False, 1.9, "1.9", "  5 ", 0, -3, "0", None, "x", {}):
+            assert _parse_marker_winner_pk(bad) is None, bad
+
+
 @pytest.mark.django_db
 class TestResolveWinnerForDonor:
     def test_returns_winner_and_marker_when_both_exist(self):

--- a/netbox_librenms_plugin/tests/test_migrate_views.py
+++ b/netbox_librenms_plugin/tests/test_migrate_views.py
@@ -1106,6 +1106,129 @@ class TestMigratedContextServerKeyFallback:
         bmc.assert_called_once()
         assert bmc.call_args.args[1] == "sessionkey"  # used the cached client key
 
+    def test_vlan_view_rebind_fail_avoids_lazy_api_property(self):
+        """vlan_table_view rebind-fail render must read the cached client key, not the lazy librenms_api property (which can reconstruct a missing client and 500 the HTMX error path)."""
+        from unittest.mock import MagicMock, PropertyMock, patch
+
+        from netbox_librenms_plugin.views.base.vlan_table_view import BaseVLANTableView
+
+        view = object.__new__(BaseVLANTableView)
+        view._librenms_api = MagicMock()
+        view._librenms_api.server_key = "sessionkey"
+        view._get_error_context = MagicMock(return_value={})
+        request = MagicMock()
+        request.POST = {"server_key": "ghost"}
+
+        with (
+            patch.object(view, "get_object", return_value=MagicMock()),
+            patch.object(view, "rebind_api_for_server", return_value=None),
+            patch("netbox_librenms_plugin.views.base.vlan_table_view.messages"),
+            patch("netbox_librenms_plugin.views.base.vlan_table_view.render"),
+            patch("netbox_librenms_plugin.views.base.vlan_table_view.build_migrated_context", return_value={}) as bmc,
+            patch.object(
+                BaseVLANTableView,
+                "librenms_api",
+                new_callable=PropertyMock,
+                side_effect=AssertionError("lazy librenms_api touched on the rebind-fail path"),
+            ),
+        ):
+            view.post(request, pk=1)
+
+        bmc.assert_called_once()
+        assert bmc.call_args.args[1] == "sessionkey"
+
+    def test_modules_view_rebind_fail_avoids_lazy_api_property(self):
+        """modules_view rebind-fail render must read the cached client key, not the lazy librenms_api property (which can reconstruct a missing client and 500 the HTMX error path)."""
+        from unittest.mock import MagicMock, PropertyMock, patch
+
+        from netbox_librenms_plugin.views.base.modules_view import BaseModuleTableView
+
+        view = object.__new__(BaseModuleTableView)
+        view._librenms_api = MagicMock()
+        view._librenms_api.server_key = "sessionkey"
+        view.has_write_permission = MagicMock(return_value=True)
+        request = MagicMock()
+        request.POST = {"server_key": "ghost"}
+
+        with (
+            patch.object(view, "get_object", return_value=MagicMock()),
+            patch.object(view, "rebind_api_for_server", return_value=None),
+            patch("netbox_librenms_plugin.views.base.modules_view.messages"),
+            patch("netbox_librenms_plugin.views.base.modules_view.render"),
+            patch("netbox_librenms_plugin.views.base.modules_view.build_migrated_context", return_value={}) as bmc,
+            patch.object(
+                BaseModuleTableView,
+                "librenms_api",
+                new_callable=PropertyMock,
+                side_effect=AssertionError("lazy librenms_api touched on the rebind-fail path"),
+            ),
+        ):
+            view.post(request, pk=1)
+
+        bmc.assert_called_once()
+        assert bmc.call_args.args[1] == "sessionkey"
+
+    def test_cables_view_rebind_fail_avoids_lazy_api_property(self):
+        """cables_view rebind-fail render must read the cached client key, not the lazy librenms_api property (which can reconstruct a missing client and 500 the HTMX error path)."""
+        from unittest.mock import MagicMock, PropertyMock, patch
+
+        from netbox_librenms_plugin.views.base.cables_view import BaseCableTableView
+
+        view = object.__new__(BaseCableTableView)
+        view._librenms_api = MagicMock()
+        view._librenms_api.server_key = "sessionkey"
+        request = MagicMock()
+        request.POST = {"server_key": "ghost"}
+
+        with (
+            patch.object(view, "get_object", return_value=MagicMock()),
+            patch.object(view, "rebind_api_for_server", return_value=None),
+            patch("netbox_librenms_plugin.views.base.cables_view.messages"),
+            patch("netbox_librenms_plugin.views.base.cables_view.render"),
+            patch("netbox_librenms_plugin.views.base.cables_view.build_migrated_context", return_value={}) as bmc,
+            patch.object(
+                BaseCableTableView,
+                "librenms_api",
+                new_callable=PropertyMock,
+                side_effect=AssertionError("lazy librenms_api touched on the rebind-fail path"),
+            ),
+        ):
+            view.post(request, pk=1)
+
+        bmc.assert_called_once()
+        assert bmc.call_args.args[1] == "sessionkey"
+
+    def test_ip_view_rebind_fail_avoids_lazy_api_property(self):
+        """ip_addresses_view rebind-fail render must read the cached client key, not the lazy librenms_api property (which can reconstruct a missing client and 500 the HTMX error path)."""
+        from unittest.mock import MagicMock, PropertyMock, patch
+
+        from netbox_librenms_plugin.views.base.ip_addresses_view import BaseIPAddressTableView
+
+        view = object.__new__(BaseIPAddressTableView)
+        view._librenms_api = MagicMock()
+        view._librenms_api.server_key = "sessionkey"
+        request = MagicMock()
+        request.POST = {"server_key": "ghost"}
+
+        with (
+            patch.object(view, "get_object", return_value=MagicMock()),
+            patch.object(view, "rebind_api_for_server", return_value=None),
+            patch("netbox_librenms_plugin.views.base.ip_addresses_view.messages"),
+            patch("netbox_librenms_plugin.views.base.ip_addresses_view.render"),
+            patch("netbox_librenms_plugin.views.base.ip_addresses_view.resolve_set_primary_ip", return_value=False),
+            patch("netbox_librenms_plugin.views.base.ip_addresses_view.build_migrated_context", return_value={}) as bmc,
+            patch.object(
+                BaseIPAddressTableView,
+                "librenms_api",
+                new_callable=PropertyMock,
+                side_effect=AssertionError("lazy librenms_api touched on the rebind-fail path"),
+            ),
+        ):
+            view.post(request, pk=1)
+
+        bmc.assert_called_once()
+        assert bmc.call_args.args[1] == "sessionkey"
+
     def test_ip_view_stale_key_fallback_preserves_set_primary_ip(self):
         """The stale-server-key error fallback must carry set_primary_ip so the template doesn't silently uncheck the user's preference."""
         from unittest.mock import MagicMock, patch

--- a/netbox_librenms_plugin/tests/test_migrate_views.py
+++ b/netbox_librenms_plugin/tests/test_migrate_views.py
@@ -989,6 +989,50 @@ class TestReconcileDonorDeviceIpFks:
         assert donor.primary_ip4_id == ip.pk
         assert notes == []
 
+    def test_transfer_survives_interface_moving_onto_winner_mid_check(self):
+        """A move ONTO the winner landing between the GFK read and the interface lock must not spuriously reject the transfer.
+
+        ip.assigned_object is read (and cached by the GenericForeignKey) before the owning
+        interface is locked; set_device_ip_fk re-reads that cache, so pre-fix the stale
+        pre-move snapshot (device_id != winner.pk) raised ValueError and rolled back an
+        otherwise-valid move — even though the locked-row gate had already validated the
+        CURRENT owner. The race is reproduced by patching the GFK descriptor to serve the
+        pre-move snapshot until the code refreshes it (the setter stores the override), the
+        same freshen-after-lock pattern TransferDeviceIPView already uses.
+        """
+        from dcim.models import Interface
+        from django.db import transaction
+        from ipam.models import IPAddress
+
+        from netbox_librenms_plugin.views.sync.migrate import _reconcile_donor_device_ip_fks
+
+        winner, donor, _ = self._make_devices()
+        ip = ip_on(donor, "10.10.0.3/24", "eth0")  # address starts on a DONOR-owned interface
+        donor.primary_ip4 = ip
+        donor.save()
+
+        stale = Interface.objects.get(pk=ip.assigned_object_id)  # pre-move snapshot (device_id == donor.pk)
+        # The concurrent transaction moves the interface (with its address) onto the winner.
+        Interface.objects.filter(pk=stale.pk).update(device=winner)
+
+        def _gfk_get(self):
+            return self.__dict__.get("_ao_override", stale)
+
+        def _gfk_set(self, value):
+            self.__dict__["_ao_override"] = value
+
+        with (
+            patch.object(IPAddress, "assigned_object", property(_gfk_get, _gfk_set)),
+            transaction.atomic(),
+        ):
+            notes = _reconcile_donor_device_ip_fks(donor, winner)
+
+        winner.refresh_from_db()
+        donor.refresh_from_db()
+        assert winner.primary_ip4_id == ip.pk  # the valid transfer went through
+        assert donor.primary_ip4_id is None
+        assert any("transferred" in n for n in notes)
+
 
 @pytest.mark.django_db
 class TestSetDeviceIpFk:

--- a/netbox_librenms_plugin/tests/test_migrate_views.py
+++ b/netbox_librenms_plugin/tests/test_migrate_views.py
@@ -1,0 +1,910 @@
+"""
+Tests for Stage 2b: get_migrated_to_marker helper + the per-row
+"Move to winner" view endpoints (MoveInterfaceToWinnerView,
+MoveIPAddressToWinnerView, TransferDeviceIPView).
+
+The view tests use light MagicMock-based plumbing — we patch the model
+queryset chain so the views never touch a real database.  This is
+appropriate because the views' job is glue: validate the marker, look
+up the winner, run a small ORM mutation, and return an HTMX response.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Shared real-DB builders (see tests/conftest.py).
+from netbox_librenms_plugin.tests.conftest import ip_on, make_device, make_interface, make_ip
+
+
+# ── helper: get_migrated_to_marker ────────────────────────────────────────
+
+
+def _make_migrate_device(name, librenms_cf=None):
+    """Positional-arg adapter over the shared ``make_device`` builder.
+
+    The marker/winner helpers read the librenms_id custom field through NetBox's ``device.cf``
+    accessor and resolve the winner via ``Device.objects`` — so a real device with a real CF
+    exercises the actual read + ORM lookup. This thin wrapper just preserves the positional
+    ``librenms_cf`` call style used throughout this module.
+    """
+    return make_device(name, librenms_cf=librenms_cf)
+
+
+@pytest.mark.django_db
+class TestGetMigratedToMarker:
+    def test_returns_marker_when_present_and_well_formed(self):
+        from netbox_librenms_plugin.utils import get_migrated_to_marker
+
+        marker_data = {"device_id": 42, "server_key": "default", "at": "2025-01-01T00:00:00Z"}
+        donor = _make_migrate_device("mig-donor", {"default": {"_migrated_to": marker_data}})
+        marker = get_migrated_to_marker(donor, "default")
+        assert marker == marker_data
+
+    def test_returns_none_when_no_cf(self):
+        from netbox_librenms_plugin.utils import get_migrated_to_marker
+
+        donor = _make_migrate_device("mig-no-cf")
+        assert get_migrated_to_marker(donor, "default") is None
+
+    def test_returns_none_when_server_key_missing(self):
+        from netbox_librenms_plugin.utils import get_migrated_to_marker
+
+        donor = _make_migrate_device("mig-wrong-key", {"primary": {"_migrated_to": {"device_id": 42}}})
+        assert get_migrated_to_marker(donor, "default") is None
+
+    def test_returns_none_when_marker_lacks_device_id(self):
+        from netbox_librenms_plugin.utils import get_migrated_to_marker
+
+        donor = _make_migrate_device("mig-no-devid", {"default": {"_migrated_to": {"server_key": "default"}}})
+        assert get_migrated_to_marker(donor, "default") is None
+
+    def test_returns_none_when_legacy_bare_int(self):
+        from netbox_librenms_plugin.utils import get_migrated_to_marker
+
+        donor = _make_migrate_device("mig-bare-int", 42)
+        assert get_migrated_to_marker(donor, "default") is None
+
+    def test_returns_none_for_none_device(self):
+        from netbox_librenms_plugin.utils import get_migrated_to_marker
+
+        assert get_migrated_to_marker(None, "default") is None
+
+    def test_returns_none_when_device_id_is_bool(self):
+        # bool is a subclass of int; a marker with device_id=True must not be
+        # treated as a valid pk (would otherwise map to device #1).
+        from netbox_librenms_plugin.utils import get_migrated_to_marker
+
+        donor = _make_migrate_device(
+            "mig-bool", {"default": {"_migrated_to": {"device_id": True, "server_key": "default"}}}
+        )
+        assert get_migrated_to_marker(donor, "default") is None
+
+    def test_returns_none_when_device_id_not_positive(self):
+        from netbox_librenms_plugin.utils import get_migrated_to_marker
+
+        for i, bad in enumerate((0, -5)):
+            donor = _make_migrate_device(
+                f"mig-nonpos-{i}", {"default": {"_migrated_to": {"device_id": bad, "server_key": "default"}}}
+            )
+            assert get_migrated_to_marker(donor, "default") is None
+
+
+@pytest.mark.django_db
+class TestBuildMigratedContext:
+    def test_no_marker_returns_none_pair(self):
+        from netbox_librenms_plugin.utils import build_migrated_context
+
+        donor = _make_migrate_device("mig-ctx-nomarker")
+        ctx = build_migrated_context(donor, "default")
+        # No marker → the winner lookup is short-circuited (None pair), no winner resolved.
+        assert ctx == {"migrated_to_marker": None, "migrated_to_winner": None}
+
+    def test_marker_present_resolves_winner(self):
+        from netbox_librenms_plugin.utils import build_migrated_context
+
+        winner = _make_migrate_device("mig-ctx-winner")
+        donor = _make_migrate_device(
+            "mig-ctx-donor",
+            {"default": {"_migrated_to": {"device_id": winner.pk, "server_key": "default"}}},
+        )
+        ctx = build_migrated_context(donor, "default")
+        assert ctx["migrated_to_marker"]["device_id"] == winner.pk
+        assert ctx["migrated_to_winner"].pk == winner.pk
+
+
+# ── helper: _resolve_winner_for_donor ─────────────────────────────────────
+
+
+@pytest.mark.django_db
+class TestResolveWinnerForDonor:
+    def test_returns_winner_and_marker_when_both_exist(self):
+        from netbox_librenms_plugin.views.sync.migrate import _resolve_winner_for_donor
+
+        winner = _make_migrate_device("mig-rw-winner")
+        donor = _make_migrate_device(
+            "mig-rw-donor",
+            {"default": {"_migrated_to": {"device_id": winner.pk, "server_key": "default", "at": "x"}}},
+        )
+
+        result_winner, result_marker = _resolve_winner_for_donor(donor, "default")
+
+        assert result_winner.pk == winner.pk
+        assert result_marker["device_id"] == winner.pk
+
+    def test_returns_none_winner_when_winner_deleted(self):
+        from netbox_librenms_plugin.views.sync.migrate import _resolve_winner_for_donor
+
+        # Create then delete a winner so the marker references a now-missing pk.
+        winner = _make_migrate_device("mig-rw-gone")
+        gone_pk = winner.pk
+        donor = _make_migrate_device(
+            "mig-rw-donor2",
+            {"default": {"_migrated_to": {"device_id": gone_pk, "server_key": "default", "at": "x"}}},
+        )
+        type(winner).objects.filter(pk=gone_pk).delete()
+
+        winner_result, marker = _resolve_winner_for_donor(donor, "default")
+
+        assert winner_result is None
+        assert marker["device_id"] == gone_pk
+
+    def test_returns_none_when_no_marker(self):
+        from netbox_librenms_plugin.views.sync.migrate import _resolve_winner_for_donor
+
+        donor = _make_migrate_device("mig-rw-nomarker")
+        winner, marker = _resolve_winner_for_donor(donor, "default")
+        assert winner is None
+        assert marker is None
+
+    def test_self_pointing_marker_returns_none_winner(self):
+        """A marker pointing back at the donor (winner.pk == donor.pk) is corrupt — it would
+        make the move operate on one Device as both donor and winner. Fail closed as stale."""
+        from netbox_librenms_plugin.views.sync.migrate import _resolve_winner_for_donor
+
+        donor = _make_migrate_device("mig-rw-self")
+        # Point the marker at the donor's own pk.
+        donor.custom_field_data["librenms_id"] = {
+            "default": {"_migrated_to": {"device_id": donor.pk, "server_key": "default", "at": "x"}}
+        }
+        donor.save()
+
+        winner, marker = _resolve_winner_for_donor(donor, "default")
+
+        assert winner is None
+        assert marker["device_id"] == donor.pk
+
+
+# ── MoveInterfaceToWinnerView ─────────────────────────────────────────────
+
+
+def _hx_request(post=None):
+    """Build an HTMX request."""
+    req = MagicMock()
+    post = post or {}
+    req.POST = MagicMock()
+    req.POST.get = lambda k, d=None: post.get(k, d)
+    req.headers = {"HX-Request": "true"}
+    req.htmx = True  # pin branch intent: implementations may check `if request.htmx`
+    req.META = {"HTTP_REFERER": "/back"}
+    req.user = MagicMock(is_superuser=True)
+    return req
+
+
+@pytest.mark.django_db
+class TestMoveInterfaceToWinnerView:
+    def _setup_view(self):
+        from netbox_librenms_plugin.views.sync.migrate import MoveInterfaceToWinnerView
+
+        view = MoveInterfaceToWinnerView()
+        # The plugin-write + object-perm gate is exercised separately in
+        # test_perm_gate_short_circuits; null it here so each test drives the real
+        # move logic against real rows.
+        view.require_all_permissions = MagicMock(return_value=None)
+        return view
+
+    @staticmethod
+    def _mark(donor, winner):
+        """Write a real ``_migrated_to`` marker so the view's _resolve_winner_for_donor()
+        reads it from the donor's librenms_id custom field for real."""
+        from netbox_librenms_plugin.utils import mark_librenms_migrated
+
+        mark_librenms_migrated(donor, winner.pk, "default")
+        donor.save()
+
+    def test_rejects_when_donor_has_no_marker(self):
+        # Real donor with no migration marker → the move is refused and the interface
+        # stays put. No queryset patching: the marker read runs against the real cf.
+        view = self._setup_view()
+        donor = make_device("mi-nomark-donor")
+        interface = make_interface(donor, "Eth0")
+        req = _hx_request({"server_key": "default"})
+
+        resp = view.post(req, pk=interface.pk)
+
+        assert resp.status_code == 200
+        assert b"django-messages" in resp.content
+        # Reject path flows through _fail(): HX-Reswap:none and never the success
+        # HX-Refresh header (a regression that "succeeded" would set HX-Refresh=true).
+        assert resp.headers.get("HX-Reswap") == "none"
+        assert resp.headers.get("HX-Refresh") is None
+        interface.refresh_from_db()
+        assert interface.device_id == donor.pk  # not moved
+
+    def test_rejects_on_name_collision(self):
+        # The winner already has a same-named interface → the real collision query finds
+        # it and the move is refused; the donor interface is not reassigned.
+        view = self._setup_view()
+        donor = make_device("mi-coll-donor")
+        winner = make_device("mi-coll-winner")
+        self._mark(donor, winner)
+        interface = make_interface(donor, "Eth0")
+        make_interface(winner, "Eth0")  # collision on the winner side
+        req = _hx_request({"server_key": "default"})
+
+        resp = view.post(req, pk=interface.pk)
+
+        assert resp.status_code == 200
+        assert b"django-messages" in resp.content
+        assert resp.headers.get("HX-Reswap") == "none"
+        assert resp.headers.get("HX-Refresh") is None
+        interface.refresh_from_db()
+        assert interface.device_id == donor.pk  # stayed on the donor
+
+    def test_happy_path_reassigns_device_and_returns_hx_refresh(self):
+        # Real end-to-end move: the interface row's device FK is reassigned to the winner
+        # through the view's full_clean()+save() path, and the reload proves it persisted.
+        view = self._setup_view()
+        donor = make_device("mi-happy-donor")
+        winner = make_device("mi-happy-winner")
+        self._mark(donor, winner)
+        interface = make_interface(donor, "Eth0")
+        req = _hx_request({"server_key": "default"})
+
+        resp = view.post(req, pk=interface.pk)
+
+        assert resp.status_code == 200
+        assert resp.headers.get("HX-Refresh") == "true"
+        interface.refresh_from_db()
+        assert interface.device_id == winner.pk  # really moved to the winner
+
+    def test_cross_device_relationship_rejected_with_409(self):
+        """Real cross-device LAG: the donor interface is a member of a LAG that lives on the
+        donor. Moving only the member to the winner would leave its ``lag`` on the donor —
+        NetBox's real Interface.clean() rejects that, so the move aborts and nothing persists.
+        (Previously this injected the ValidationError via a mock side_effect; now the actual
+        validator runs.)"""
+        view = self._setup_view()
+        donor = make_device("mi-xdev-donor")
+        winner = make_device("mi-xdev-winner")
+        self._mark(donor, winner)
+        donor_lag = make_interface(donor, "Po1", iface_type="lag")
+        member = make_interface(donor, "Eth0")
+        member.lag = donor_lag  # member's LAG lives on the donor
+        member.save()
+        req = _hx_request({"server_key": "default"})
+
+        resp = view.post(req, pk=member.pk)
+
+        # full_clean() failed for real → row not saved, error surfaced via the OOB toast.
+        assert b"django-messages" in resp.content
+        assert resp.status_code == 200
+        assert resp.headers.get("HX-Reswap") == "none"
+        assert resp.headers.get("HX-Refresh") is None
+        member.refresh_from_db()
+        assert member.device_id == donor.pk  # not moved
+        assert member.lag_id == donor_lag.pk  # relationship untouched
+
+    def test_save_integrity_error_rejected_with_409(self):
+        """A concurrent winner-side rename/create can trip a unique constraint at save()
+        time (after our name re-check); surface it as a 409, not a 500."""
+        from django.db import IntegrityError
+
+        view = self._setup_view()
+        req = _hx_request({"server_key": "default"})
+
+        donor = MagicMock(pk=10)
+        winner = MagicMock(pk=20)
+        winner.name = "winner"
+        interface = MagicMock(pk=5, device=donor)
+        interface.name = "Eth0"
+        locked_iface = MagicMock(pk=5, device=donor)
+        locked_iface.name = "Eth0"
+        locked_iface.full_clean.return_value = None
+        locked_iface.save.side_effect = IntegrityError("duplicate key value")
+
+        with (
+            patch("netbox_librenms_plugin.views.sync.migrate.get_object_or_404", return_value=interface),
+            patch(
+                "netbox_librenms_plugin.views.sync.migrate._resolve_winner_for_donor",
+                return_value=(winner, {"device_id": 20, "server_key": "default", "at": "x"}),
+            ),
+            patch("netbox_librenms_plugin.views.sync.migrate.Interface") as mock_iface_cls,
+            patch("netbox_librenms_plugin.views.sync.migrate.Device") as mock_device_cls,
+            patch("netbox_librenms_plugin.views.sync.migrate.transaction"),
+            patch("netbox_librenms_plugin.views.sync.migrate.messages"),
+        ):
+            collision_qs = MagicMock()
+            collision_qs.exists.return_value = False
+            mock_iface_cls.objects.filter.return_value = collision_qs
+            mock_iface_cls.objects.select_for_update.return_value.filter.return_value.first.return_value = locked_iface
+            mock_device_cls.objects.select_for_update.return_value.filter.return_value.order_by.return_value = [
+                donor,
+                winner,
+            ]
+            resp = view.post(req, pk=5)
+
+        # save() raised → surfaced as the collision OOB toast (HTMX path), not a 500.
+        # As above: HTMX errors are an OOB toast at HTTP 200, distinguished from the
+        # success response by the absence of the HX-Refresh header.
+        locked_iface.save.assert_called_once()
+        assert b"django-messages" in resp.content
+        # Error contract (see _fail): HTMX errors are an OOB toast at HTTP 200 with
+        # HX-Reswap:none and no HX-Refresh — never the success refresh response.
+        assert resp.status_code == 200
+        assert resp.headers.get("HX-Reswap") == "none"
+        assert resp.headers.get("HX-Refresh") is None
+
+    def test_marker_repointed_under_lock_is_rejected(self):
+        """If the donor's _migrated_to is repointed between the unlocked resolve
+        and acquiring the row locks, the move must abort instead of targeting the
+        stale winner."""
+        view = self._setup_view()
+        req = _hx_request({"server_key": "default"})
+
+        donor = MagicMock(pk=10)
+        winner = MagicMock(pk=20)
+        winner.name = "winner"
+        other_winner = MagicMock(pk=99)  # marker now points here
+        interface = MagicMock(pk=5, device=donor)
+        interface.name = "Eth0"
+
+        with (
+            patch("netbox_librenms_plugin.views.sync.migrate.get_object_or_404", return_value=interface),
+            patch(
+                "netbox_librenms_plugin.views.sync.migrate._resolve_winner_for_donor",
+                # 1st call (pre-lock) → winner; 2nd call (under lock) → a different winner.
+                side_effect=[
+                    (winner, {"device_id": 20, "server_key": "default", "at": "x"}),
+                    (other_winner, {"device_id": 99, "server_key": "default", "at": "y"}),
+                ],
+            ),
+            patch("netbox_librenms_plugin.views.sync.migrate.Interface") as mock_iface_cls,
+            patch("netbox_librenms_plugin.views.sync.migrate.Device") as mock_device_cls,
+            patch("netbox_librenms_plugin.views.sync.migrate.transaction"),
+            patch("netbox_librenms_plugin.views.sync.migrate.messages"),
+        ):
+            mock_iface_cls.objects.filter.return_value.exists.return_value = False
+            mock_device_cls.objects.select_for_update.return_value.filter.return_value.order_by.return_value = [
+                donor,
+                winner,
+            ]
+            resp = view.post(req, pk=5)
+
+        # Aborts with a conflict toast; the move query is never issued.
+        assert b"django-messages" in resp.content
+        # Reject path flows through _fail(): the HTMX response carries HX-Reswap:none and
+        # never the success HX-Refresh header, so a regression that returned HX-Refresh=true
+        # (refreshing as if the move/transfer succeeded) would be caught here.
+        assert resp.headers.get("HX-Reswap") == "none"
+        assert resp.headers.get("HX-Refresh") is None
+        mock_iface_cls.objects.select_for_update.assert_not_called()
+
+    def test_perm_gate_short_circuits(self):
+        from django.http import HttpResponse
+
+        from netbox_librenms_plugin.views.sync.migrate import MoveInterfaceToWinnerView
+
+        view = MoveInterfaceToWinnerView()
+        view.require_all_permissions = MagicMock(return_value=HttpResponse(status=403))
+        req = _hx_request()
+        resp = view.post(req, pk=5)
+        assert resp.status_code == 403
+
+
+# ── TransferDeviceIPView ──────────────────────────────────────────────────
+
+
+@pytest.mark.django_db
+class TestTransferDeviceIPView:
+    def _setup_view(self):
+        from netbox_librenms_plugin.views.sync.migrate import TransferDeviceIPView
+
+        view = TransferDeviceIPView()
+        view.require_all_permissions = MagicMock(return_value=None)
+        return view
+
+    @staticmethod
+    def _mark(donor, winner):
+        from netbox_librenms_plugin.utils import mark_librenms_migrated
+
+        mark_librenms_migrated(donor, winner.pk, "default")
+        donor.save()
+
+    def test_unknown_ip_kind_rejected(self):
+        # Pure guard clause before any DB work: an unknown ip_kind is rejected outright,
+        # so a bare request (no device needed) is sufficient.
+        view = self._setup_view()
+        req = _hx_request()
+        resp = view.post(req, pk=10, ip_kind="bogus")
+        assert resp.status_code == 200
+        assert b"django-messages" in resp.content
+        assert resp.headers.get("HX-Reswap") == "none"
+        assert resp.headers.get("HX-Refresh") is None
+
+    def test_rejects_when_winner_already_has_field(self):
+        # Real rows: both donor and winner already have a primary IPv4 → the transfer is
+        # refused (the winner slot is occupied) and neither device's FK is touched.
+        view = self._setup_view()
+        donor = make_device("tx-occ-donor")
+        winner = make_device("tx-occ-winner")
+        self._mark(donor, winner)
+        donor_ip = ip_on(donor, "10.0.0.1/24", "mgmt0")
+        winner_ip = ip_on(winner, "10.0.0.99/24", "mgmt0")
+        donor.primary_ip4 = donor_ip
+        donor.save()
+        winner.primary_ip4 = winner_ip
+        winner.save()
+        req = _hx_request({"server_key": "default"})
+
+        resp = view.post(req, pk=donor.pk, ip_kind="primary4")
+
+        assert resp.status_code == 200
+        assert b"django-messages" in resp.content
+        assert resp.headers.get("HX-Reswap") == "none"
+        assert resp.headers.get("HX-Refresh") is None
+        donor.refresh_from_db()
+        winner.refresh_from_db()
+        assert donor.primary_ip4_id == donor_ip.pk  # donor FK intact
+        assert winner.primary_ip4_id == winner_ip.pk  # winner FK intact
+
+    def test_happy_path_transfers_oob_ip(self):
+        """Real unique-constraint ordering: ``Device.oob_ip`` is UNIQUE per address, so the
+        donor must release the FK before the winner claims it. The address already lives on a
+        winner-owned interface (NetBox requires oob_ip on one of the device's own interfaces);
+        the donor's FK dangles at it after a prior interface move. Driving real rows exercises
+        the actual constraint — a reversed save order would trip it for real."""
+        view = self._setup_view()
+        donor = make_device("tx-happy-donor")
+        winner = make_device("tx-happy-winner")
+        self._mark(donor, winner)
+        # Address sits on a WINNER interface; donor.oob_ip dangles at it (save skips clean()).
+        oob_ip = ip_on(winner, "10.0.0.5/24", "mgmt0")
+        donor.oob_ip = oob_ip
+        donor.save()
+        req = _hx_request({"server_key": "default"})
+
+        resp = view.post(req, pk=donor.pk, ip_kind="oob")
+
+        assert resp.headers.get("HX-Refresh") == "true"
+        donor.refresh_from_db()
+        winner.refresh_from_db()
+        assert winner.oob_ip_id == oob_ip.pk  # winner claimed it
+        assert donor.oob_ip_id is None  # donor released it
+
+    def test_rejects_when_address_still_attached_to_donor(self):
+        """The transfer only flips the FK (save skips full_clean), so it must refuse to point
+        the winner at an address still assigned to a DONOR interface — otherwise the winner
+        would own an oob_ip that isn't on one of its interfaces. Driven against real rows:
+        the owning interface's real device_id is what the view checks."""
+        view = self._setup_view()
+        donor = make_device("tx-attached-donor")
+        winner = make_device("tx-attached-winner")
+        self._mark(donor, winner)
+        # Address sits on a DONOR interface (device_id == donor), so the transfer must refuse.
+        oob_ip = ip_on(donor, "10.0.0.5/24", "mgmt0")
+        donor.oob_ip = oob_ip
+        donor.save()
+        req = _hx_request({"server_key": "default"})
+
+        resp = view.post(req, pk=donor.pk, ip_kind="oob")
+
+        assert b"django-messages" in resp.content
+        assert resp.headers.get("HX-Reswap") == "none"
+        assert resp.headers.get("HX-Refresh") is None
+        donor.refresh_from_db()
+        winner.refresh_from_db()
+        assert winner.oob_ip_id is None  # winner never claimed the donor-attached address
+        assert donor.oob_ip_id == oob_ip.pk  # donor FK untouched
+
+    def test_rejects_when_assignment_is_not_an_interface(self):
+        """A non-Interface assignment (e.g. a VMInterface) must fail closed: the Interface
+        re-lock is skipped (GenericForeignKey pks aren't unique across models, so filtering
+        Interface by an unrelated pk could lock the wrong row), so the device_id check sees
+        None and the transfer is refused."""
+        view = self._setup_view()
+        req = _hx_request({"server_key": "default"})
+
+        oob_ip = MagicMock(address="10.0.0.5/24")
+        # NOT spec=Interface → isinstance(assigned, Interface) is False → re-lock skipped.
+        oob_ip.assigned_object = MagicMock(pk=99)
+        donor = MagicMock(pk=10, oob_ip=oob_ip)
+        winner = MagicMock(pk=20, name="winner", oob_ip=None)
+        locked_donor = MagicMock(pk=10, oob_ip=oob_ip)
+        locked_winner = MagicMock(pk=20, name="winner", oob_ip=None)
+
+        with (
+            patch("netbox_librenms_plugin.views.sync.migrate.get_object_or_404", return_value=donor),
+            patch(
+                "netbox_librenms_plugin.views.sync.migrate._resolve_winner_for_donor",
+                return_value=(winner, {"device_id": 20, "server_key": "default", "at": "x"}),
+            ),
+            patch("netbox_librenms_plugin.views.sync.migrate.Device") as mock_device_cls,
+            patch("netbox_librenms_plugin.views.sync.migrate.IPAddress") as mock_ip_cls,
+            patch("netbox_librenms_plugin.views.sync.migrate.Interface.objects") as mock_iface_objects,
+            patch("netbox_librenms_plugin.views.sync.migrate.transaction"),
+            patch("netbox_librenms_plugin.views.sync.migrate.messages"),
+        ):
+            mock_device_cls.objects.select_for_update.return_value.filter.return_value.order_by.return_value = [
+                locked_donor,
+                locked_winner,
+            ]
+            mock_ip_cls.objects.select_for_update.return_value.filter.return_value.first.return_value = oob_ip
+            resp = view.post(req, pk=10, ip_kind="oob")
+
+        # Refused; the Interface manager was never queried (re-lock skipped), nothing saved.
+        assert b"django-messages" in resp.content
+        # Reject path flows through _fail(): the HTMX response carries HX-Reswap:none and
+        # never the success HX-Refresh header, so a regression that returned HX-Refresh=true
+        # (refreshing as if the move/transfer succeeded) would be caught here.
+        assert resp.headers.get("HX-Reswap") == "none"
+        assert resp.headers.get("HX-Refresh") is None
+        mock_iface_objects.select_for_update.assert_not_called()
+        locked_winner.save.assert_not_called()
+        locked_donor.save.assert_not_called()
+
+
+# ── MoveIPAddressToWinnerView ────────────────────────────────────────────
+
+
+@pytest.mark.django_db
+class TestMoveIPAddressToWinnerView:
+    def _setup_view(self):
+        from netbox_librenms_plugin.views.sync.migrate import MoveIPAddressToWinnerView
+
+        view = MoveIPAddressToWinnerView()
+        view.require_all_permissions = MagicMock(return_value=None)
+        return view
+
+    @staticmethod
+    def _mark(donor, winner):
+        from netbox_librenms_plugin.utils import mark_librenms_migrated
+
+        mark_librenms_migrated(donor, winner.pk, "default")
+        donor.save()
+
+    def test_rejects_when_ip_not_assigned_to_interface(self):
+        # A real unassigned IP picked from the donor sync page → no donor relationship to
+        # migrate, so the move is refused and the IP's assignment stays empty.
+        view = self._setup_view()
+        ip = make_ip("10.0.0.1/24")  # unassigned
+        req = _hx_request({"server_key": "default"})
+
+        resp = view.post(req, pk=ip.pk)
+
+        assert resp.status_code == 200
+        assert b"django-messages" in resp.content
+        assert resp.headers.get("HX-Reswap") == "none"
+        assert resp.headers.get("HX-Refresh") is None
+        ip.refresh_from_db()
+        assert ip.assigned_object is None
+
+    def test_rejects_when_winner_lacks_same_name_interface(self):
+        # The IP is on a donor interface whose name does NOT exist on the winner → the real
+        # same-name lookup finds nothing, so the move is refused and the IP stays on the donor.
+        view = self._setup_view()
+        donor = make_device("mip-noname-donor")
+        winner = make_device("mip-noname-winner")  # no matching interface
+        self._mark(donor, winner)
+        donor_iface = make_interface(donor, "Eth0")
+        ip = make_ip("10.0.0.1/24", assigned_object=donor_iface)
+        req = _hx_request({"server_key": "default"})
+
+        resp = view.post(req, pk=ip.pk)
+
+        assert resp.status_code == 200
+        assert b"django-messages" in resp.content
+        assert resp.headers.get("HX-Reswap") == "none"
+        assert resp.headers.get("HX-Refresh") is None
+        ip.refresh_from_db()
+        assert ip.assigned_object == donor_iface  # stayed on the donor interface
+
+    def test_happy_path_reassigns_ip_to_winner_interface(self):
+        """Real DB end-to-end: the IP on the donor's interface is reassigned to the winner's
+        same-named interface. Because the move is driven against real rows, the donor re-lock
+        ``filter(pk=..., device=donor)`` and the winner lookup ``filter(device=winner,
+        name=...)`` must use the correct device/name — a wrong lookup would leave the IP off
+        the winner's interface and the reload assertion would fail (no mock-call inspection
+        needed to pin the exact kwargs)."""
+        view = self._setup_view()
+
+        donor = make_device("donor-device")
+        winner = make_device("winner-device")
+        self._mark(donor, winner)
+
+        donor_iface = make_interface(donor, "Eth0")
+        winner_iface = make_interface(winner, "Eth0")  # same name on the winner
+        ip = make_ip("10.0.0.1/24", assigned_object=donor_iface)
+
+        req = _hx_request({"server_key": "default"})
+        resp = view.post(req, pk=ip.pk)
+
+        assert resp.status_code == 200
+        ip.refresh_from_db()
+        # The IP moved onto the winner's same-named interface — proving both the donor re-lock
+        # and the winner lookup resolved the correct rows.
+        assert ip.assigned_object == winner_iface
+        assert ip.assigned_object.device_id == winner.pk
+        # The donor interface no longer holds the IP.
+        assert ip.assigned_object != donor_iface
+
+
+# ── non-HTMX redirect fallback (preserve tab + server_key) ────────────────────
+
+
+def _nonhtmx_request(post=None, referer=None):
+    """Build a plain (non-HTMX) request; no usable Referer unless *referer* given."""
+    req = MagicMock()
+    post = post or {}
+    req.POST = MagicMock()
+    req.POST.get = lambda k, d=None: post.get(k, d)
+    req.headers = {}  # no HX-Request -> the degraded redirect path
+    req.htmx = False  # pin branch intent: a bare MagicMock.htmx is truthy and would mis-route
+    req.META = {"HTTP_REFERER": referer} if referer else {}
+    req.get_host = lambda: "testserver"
+    req.is_secure = lambda: False
+    req.user = MagicMock(is_superuser=True)
+    req._messages = MagicMock()  # so messages.error() has storage to write to
+    return req
+
+
+@pytest.mark.django_db
+class TestReconcileDonorDeviceIpFks:
+    """Real-DB coverage for _reconcile_donor_device_ip_fks: it locks the owning Interface and
+    re-reads device_id from the locked row before transferring a device-level primary/OOB IP FK,
+    so the winner never ends up owning an address that sits on an interface it doesn't own.
+
+    Exercised against real NetBox models (not mocks) so the FK transfer, the Interface lookup,
+    and the owner comparison are validated against actual ORM behavior end-to-end.
+    """
+
+    @staticmethod
+    def _make_devices():
+        # Three real devices on the shared infra (winner / donor / a third owner).
+        return (
+            make_device("recon-winner"),
+            make_device("recon-donor"),
+            make_device("recon-other"),
+        )
+
+    def test_transfers_primary_ip_when_interface_is_on_winner(self):
+        """The donor's primary_ip4 dangles on an address now sitting on a winner-owned interface;
+        the FK is transferred to the winner and cleared on the donor."""
+        from django.db import transaction
+
+        from netbox_librenms_plugin.views.sync.migrate import _reconcile_donor_device_ip_fks
+
+        winner, donor, _ = self._make_devices()
+        ip = ip_on(winner, "10.10.0.1/24", "eth0")
+        # Dangling FK: donor still points at the moved address (save() skips clean()).
+        donor.primary_ip4 = ip
+        donor.save()
+
+        with transaction.atomic():
+            notes = _reconcile_donor_device_ip_fks(donor, winner)
+
+        winner.refresh_from_db()
+        donor.refresh_from_db()
+        assert winner.primary_ip4_id == ip.pk
+        assert donor.primary_ip4_id is None
+        assert any("transferred" in n for n in notes)
+
+    def test_skips_when_interface_belongs_to_a_different_device(self):
+        """If the address sits on an interface owned by neither the winner (a stale/concurrent
+        state), the locked-row device_id check rejects it: no FK is moved onto the winner."""
+        from django.db import transaction
+
+        from netbox_librenms_plugin.views.sync.migrate import _reconcile_donor_device_ip_fks
+
+        winner, donor, other = self._make_devices()
+        ip = ip_on(other, "10.10.0.2/24", "eth0")
+        donor.primary_ip4 = ip
+        donor.save()
+
+        with transaction.atomic():
+            notes = _reconcile_donor_device_ip_fks(donor, winner)
+
+        winner.refresh_from_db()
+        donor.refresh_from_db()
+        assert winner.primary_ip4_id is None  # interface not on winner → not transferred
+        # The skip path must not clear the donor's IP either — it still points at the address.
+        assert donor.primary_ip4_id == ip.pk
+        assert notes == []
+
+
+@pytest.mark.django_db
+class TestSetDeviceIpFk:
+    """Real-DB coverage for utils.set_device_ip_fk: the single guarded chokepoint every
+    device primary/OOB IP-FK write (which bypass full_clean via update_fields) goes through.
+    It must enforce the NetBox invariant that the address sits on one of the device's OWN
+    interfaces, so a careless caller can never persist an off-device FK."""
+
+    def test_sets_and_saves_fk_when_address_on_device_interface(self):
+        from netbox_librenms_plugin.utils import set_device_ip_fk
+
+        device = make_device("sdf-owner")
+        ip = ip_on(device, "10.20.0.1/24", "eth0")
+        ret = set_device_ip_fk(device, "oob_ip", ip)
+        assert ret == "oob_ip"
+        device.refresh_from_db()
+        assert device.oob_ip_id == ip.pk  # persisted
+
+    def test_raises_and_does_not_persist_when_address_on_another_device(self):
+        # The address lives on a DIFFERENT device's interface → the helper must refuse and
+        # never persist the off-device FK (the bare update_fields save would have accepted it).
+        from netbox_librenms_plugin.utils import set_device_ip_fk
+
+        device = make_device("sdf-dev")
+        other = make_device("sdf-other")
+        ip = ip_on(other, "10.20.0.2/24", "eth0")
+        with pytest.raises(ValueError, match="not assigned to an interface on that device"):
+            set_device_ip_fk(device, "primary_ip4", ip)
+        device.refresh_from_db()
+        assert device.primary_ip4_id is None  # nothing persisted
+
+    def test_clearing_is_always_allowed(self):
+        from netbox_librenms_plugin.utils import set_device_ip_fk
+
+        device = make_device("sdf-clear")
+        ip = ip_on(device, "10.20.0.3/24", "eth0")
+        device.oob_ip = ip
+        device.save()
+        set_device_ip_fk(device, "oob_ip", None)
+        device.refresh_from_db()
+        assert device.oob_ip_id is None
+
+    def test_save_false_assigns_without_persisting(self):
+        # save=False: in-memory assignment + return field, but the DB row is untouched until
+        # the caller runs its own (batched) save — used where oob_ip rides a larger update_fields.
+        from netbox_librenms_plugin.utils import set_device_ip_fk
+
+        device = make_device("sdf-nosave")
+        ip = ip_on(device, "10.20.0.4/24", "eth0")
+        ret = set_device_ip_fk(device, "oob_ip", ip, save=False)
+        assert ret == "oob_ip"
+        assert device.oob_ip_id == ip.pk  # set in memory
+        device.refresh_from_db()
+        assert device.oob_ip_id is None  # not yet persisted
+
+    def test_unsupported_field_raises(self):
+        from netbox_librenms_plugin.utils import set_device_ip_fk
+
+        device = make_device("sdf-badfield")
+        with pytest.raises(ValueError, match="unsupported field"):
+            set_device_ip_fk(device, "name", None)
+
+
+class TestSyncTabUrl:
+    """_sync_tab_url builds the donor device sync URL with tab + server_key."""
+
+    def test_includes_tab_and_server_key(self):
+        from django.urls import reverse
+
+        from netbox_librenms_plugin.views.sync.migrate import _sync_tab_url
+
+        base = reverse("plugins:netbox_librenms_plugin:device_librenms_sync", args=[7])
+        assert _sync_tab_url(7, "ipaddresses", "siteB") == f"{base}?tab=ipaddresses&server_key=siteB"
+
+    def test_quotes_server_key(self):
+        from netbox_librenms_plugin.views.sync.migrate import _sync_tab_url
+
+        assert "server_key=a+b%2Fc" in _sync_tab_url(7, "interfaces", "a b/c")
+
+    def test_omits_server_key_when_empty(self):
+        from netbox_librenms_plugin.views.sync.migrate import _sync_tab_url
+
+        url = _sync_tab_url(7, "interfaces", "")
+        assert url.endswith("?tab=interfaces")
+        assert "server_key=" not in url
+
+
+class TestSafeRefererFallback:
+    """_safe_referer prefers a valid same-site Referer, else the server-built fallback."""
+
+    def _req(self, referer=None):
+        req = MagicMock()
+        req.META = {"HTTP_REFERER": referer} if referer else {}
+        req.get_host = lambda: "testserver"
+        req.is_secure = lambda: False
+        return req
+
+    def test_returns_fallback_when_no_referer(self):
+        from netbox_librenms_plugin.views.sync.migrate import _safe_referer
+
+        assert _safe_referer(self._req(), fallback="/sync/?tab=interfaces") == "/sync/?tab=interfaces"
+
+    def test_valid_same_site_referer_wins_over_fallback(self):
+        from netbox_librenms_plugin.views.sync.migrate import _safe_referer
+
+        req = self._req(referer="http://testserver/p/")
+        assert _safe_referer(req, fallback="/sync/") == "http://testserver/p/"
+
+    def test_external_referer_rejected_uses_fallback(self):
+        # The open-redirect guard must still reject a cross-host Referer, then
+        # land on the internal fallback rather than the attacker URL.
+        from netbox_librenms_plugin.views.sync.migrate import _safe_referer
+
+        req = self._req(referer="http://evil.example/p/")
+        assert _safe_referer(req, fallback="/sync/") == "/sync/"
+
+    def test_no_referer_no_fallback_uses_script_prefix(self):
+        from django.urls import get_script_prefix
+
+        from netbox_librenms_plugin.views.sync.migrate import _safe_referer
+
+        assert _safe_referer(self._req(), fallback=None) == get_script_prefix()
+
+
+class TestNonHtmxFallbackRedirect:
+    """A plain POST with no Referer still lands on the donor sync tab + server."""
+
+    def _setup_view(self):
+        from netbox_librenms_plugin.views.sync.migrate import MoveInterfaceToWinnerView
+
+        view = MoveInterfaceToWinnerView()
+        view.require_all_permissions = MagicMock(return_value=None)
+        return view
+
+    def test_missing_referer_preserves_tab_and_server_key(self):
+        from django.urls import reverse
+
+        view = self._setup_view()
+        req = _nonhtmx_request({"server_key": "siteB"})
+        donor = MagicMock(pk=10, cf={})
+        interface = MagicMock(pk=5, name="Eth0", device=donor)
+
+        with (
+            patch("netbox_librenms_plugin.views.sync.migrate.get_object_or_404", return_value=interface),
+            patch(
+                "netbox_librenms_plugin.views.sync.migrate._resolve_winner_for_donor",
+                return_value=(None, None),
+            ),
+        ):
+            resp = view.post(req, pk=5)
+
+        # Degraded non-HTMX path: a real redirect carrying tab + server context,
+        # not the bare app mount path.
+        expected = reverse("plugins:netbox_librenms_plugin:device_librenms_sync", args=[10])
+        assert resp.status_code in (301, 302)
+        assert resp.url == f"{expected}?tab=interfaces&server_key=siteB"
+
+
+@pytest.mark.django_db
+class TestMigratedTransferIpDeviceOnlyGate:
+    """librenms_sync_base.html serves both Devices and VMs, but the migrated-donor transfer-IP
+    buttons all POST to ``device_transfer_ip`` with ``pk=object.pk`` (a Device lookup). The gate
+    ``object|meta:"model_name" == "device"`` keeps those buttons off VM pages so a VM can't drive
+    a mutation against a same-pk Device. build_migrated_context() doesn't itself gate on Device,
+    so a VM with a stale ``_migrated_to`` marker would otherwise reach the buttons.
+
+    The full template extends generic/object.html (not cheaply renderable in isolation), so this
+    exercises the exact gate predicate from the template via the real ``meta`` filter and real
+    ORM objects.
+    """
+
+    GATE = "{% load helpers %}{% if object|meta:'model_name' == 'device' %}TRANSFER{% endif %}"
+
+    def _render(self, obj):
+        from django.template import engines
+
+        return engines["django"].from_string(self.GATE).render({"object": obj})
+
+    def test_device_page_renders_transfer_block(self):
+        device = make_device("transfer-gate-dev")
+        assert self._render(device) == "TRANSFER"
+
+    def test_vm_page_omits_transfer_block(self):
+        from netbox_librenms_plugin.tests.conftest import make_vm
+
+        vm = make_vm("transfer-gate-vm")
+        assert self._render(vm) == ""

--- a/netbox_librenms_plugin/tests/test_migrate_views.py
+++ b/netbox_librenms_plugin/tests/test_migrate_views.py
@@ -83,6 +83,18 @@ class TestGetMigratedToMarker:
             )
             assert get_migrated_to_marker(donor, "default") is None
 
+    def test_returns_none_when_marker_server_key_mismatches_entry(self):
+        # The marker lives under cf["default"] but its own stamped server_key says "edgelondon"
+        # (malformed or copied across server sub-blocks). Reject it so a stray marker can't force
+        # the donor into migrated mode for the "default" server it does not belong to.
+        from netbox_librenms_plugin.utils import get_migrated_to_marker
+
+        donor = _make_migrate_device(
+            "mig-keymismatch",
+            {"default": {"_migrated_to": {"device_id": 42, "server_key": "edgelondon"}}},
+        )
+        assert get_migrated_to_marker(donor, "default") is None
+
 
 @pytest.mark.django_db
 class TestBuildMigratedContext:

--- a/netbox_librenms_plugin/tests/test_migrate_views.py
+++ b/netbox_librenms_plugin/tests/test_migrate_views.py
@@ -190,6 +190,24 @@ class TestResolveWinnerForDonor:
         # A well-formed positive id whose row is gone is still "deleted".
         assert _winner_unavailable_reason(donor, {"device_id": 999999}) == "deleted"
 
+    def test_numeric_like_winner_id_is_corrupt_not_truncated(self):
+        """int() truncates 1.9 / Decimal('1.9') / '1.9' to 1 — a corrupt marker must NOT resolve the wrong winner; both helpers must reject it."""
+        from decimal import Decimal
+
+        from netbox_librenms_plugin.views.sync.migrate import _resolve_winner_for_donor, _winner_unavailable_reason
+
+        winner = _make_migrate_device("mig-num-winner")  # real device at some pk (e.g. truncation target)
+        donor = _make_migrate_device("mig-num-donor")
+        for bad in (1.9, Decimal("1.9"), "1.9", winner.pk + 0.4):
+            assert _winner_unavailable_reason(donor, {"device_id": bad}) == "corrupt"
+            # _resolve_winner_for_donor must fail closed (no winner), not truncate to a real pk.
+            donor.custom_field_data["librenms_id"] = {
+                "default": {"_migrated_to": {"device_id": bad, "server_key": "default"}}
+            }
+            donor.save()
+            resolved, _marker = _resolve_winner_for_donor(donor, "default")
+            assert resolved is None
+
 
 # ── MoveInterfaceToWinnerView ─────────────────────────────────────────────
 
@@ -1055,6 +1073,38 @@ class TestMigratedContextServerKeyFallback:
         self._post_with_server_key(
             BaseInterfaceTableView, "netbox_librenms_plugin.views.base.interfaces_view", {"server_key": "ghost"}
         )
+
+    def test_interfaces_view_rebind_fail_avoids_lazy_api_property(self):
+        """On rebind failure the migrated-context render must read the cached client key, not the lazy librenms_api property — which can re-construct a missing client and 500 the HTMX error path."""
+        from unittest.mock import MagicMock, PropertyMock, patch
+
+        from netbox_librenms_plugin.views.base.interfaces_view import BaseInterfaceTableView
+
+        view = object.__new__(BaseInterfaceTableView)
+        view._librenms_api = MagicMock()
+        view._librenms_api.server_key = "sessionkey"
+        request = MagicMock()
+        request.POST = {"server_key": "ghost"}
+
+        with (
+            patch.object(view, "get_object", return_value=MagicMock()),
+            patch.object(view, "rebind_api_for_server", return_value=None),  # stale key → error path
+            patch("netbox_librenms_plugin.views.base.interfaces_view.get_interface_name_field", return_value="ifName"),
+            patch("netbox_librenms_plugin.views.base.interfaces_view.messages"),
+            patch("netbox_librenms_plugin.views.base.interfaces_view.render"),
+            patch("netbox_librenms_plugin.views.base.interfaces_view.build_migrated_context", return_value={}) as bmc,
+            # The lazy property must NOT be touched on this path; make it explode if it is.
+            patch.object(
+                BaseInterfaceTableView,
+                "librenms_api",
+                new_callable=PropertyMock,
+                side_effect=AssertionError("lazy librenms_api touched on the rebind-fail path"),
+            ),
+        ):
+            view.post(request, pk=1)
+
+        bmc.assert_called_once()
+        assert bmc.call_args.args[1] == "sessionkey"  # used the cached client key
 
     def test_ip_view_stale_key_fallback_preserves_set_primary_ip(self):
         """The stale-server-key error fallback must carry set_primary_ip so the template doesn't silently uncheck the user's preference."""

--- a/netbox_librenms_plugin/tests/test_migrate_views.py
+++ b/netbox_librenms_plugin/tests/test_migrate_views.py
@@ -301,6 +301,8 @@ class TestMoveInterfaceToWinnerView:
         from netbox_librenms_plugin.views.sync.migrate import MoveInterfaceToWinnerView
 
         view = MoveInterfaceToWinnerView()
+        # Bind a superuser-backed request: restrict() reads self.request.user (Django sets it in dispatch()).
+        view.request = _hx_request()
         # The plugin-write + object-perm gate is exercised separately in
         # test_perm_gate_short_circuits; null it here so each test drives the real
         # move logic against real rows.
@@ -661,6 +663,8 @@ class TestMoveInterfaceToWinnerView:
         from netbox_librenms_plugin.views.sync.migrate import MoveInterfaceToWinnerView
 
         view = MoveInterfaceToWinnerView()
+        # Bind a superuser-backed request: restrict() reads self.request.user (Django sets it in dispatch()).
+        view.request = _hx_request()
         view.require_all_permissions = MagicMock(return_value=HttpResponse(status=403))
         req = _hx_request()
         resp = view.post(req, pk=5)
@@ -687,6 +691,8 @@ class TestTransferDeviceIPView:
         from netbox_librenms_plugin.views.sync.migrate import TransferDeviceIPView
 
         view = TransferDeviceIPView()
+        # Bind a superuser-backed request: restrict() reads self.request.user (Django sets it in dispatch()).
+        view.request = _hx_request()
         view.require_all_permissions = MagicMock(return_value=None)
         return view
 
@@ -841,6 +847,8 @@ class TestMoveIPAddressToWinnerView:
         from netbox_librenms_plugin.views.sync.migrate import MoveIPAddressToWinnerView
 
         view = MoveIPAddressToWinnerView()
+        # Bind a superuser-backed request: restrict() reads self.request.user (Django sets it in dispatch()).
+        view.request = _hx_request()
         view.require_all_permissions = MagicMock(return_value=None)
         return view
 
@@ -1199,6 +1207,8 @@ class TestNonHtmxFallbackRedirect:
         from netbox_librenms_plugin.views.sync.migrate import MoveInterfaceToWinnerView
 
         view = MoveInterfaceToWinnerView()
+        # Bind a superuser-backed request: restrict() reads self.request.user (Django sets it in dispatch()).
+        view.request = _hx_request()
         view.require_all_permissions = MagicMock(return_value=None)
         return view
 
@@ -1214,7 +1224,7 @@ class TestNonHtmxFallbackRedirect:
         interface.name = "Eth0"
 
         with (
-            patch("netbox_librenms_plugin.views.sync.migrate.get_object_or_404", return_value=interface),
+            patch.object(type(view), "restrict_object_or_404", return_value=interface),
             patch(
                 "netbox_librenms_plugin.views.sync.migrate._resolve_winner_for_donor",
                 return_value=(None, None),
@@ -1776,3 +1786,125 @@ class TestMoveToWinnerConcurrencyHelpers:
             d, w, err = self._view()._lock_donor_winner_and_reverify(self._req(), donor, winner, "default")
         assert d is None and w is None
         assert err is not None  # "Donor migration changed concurrently; refresh and retry."
+
+
+@pytest.mark.django_db
+class TestMoveEndpointsObjectScope:
+    """The move-to-winner endpoints must resolve their URL pk through a restricted queryset.
+
+    NetBoxObjectPermissionMixin checks the required ``change`` perms at model level only, so a
+    constrained grant clears the gate; a raw ``get_object_or_404`` would then let it move an
+    interface, IP or device FK it can't see.
+    """
+
+    @staticmethod
+    def _writer(username, specs):
+        """A real non-superuser with plugin write access plus ``specs`` = [(model, constraints|None)] change grants."""
+        from core.models import ObjectType
+        from django.apps import apps
+        from django.contrib.auth import get_user_model
+        from users.models import ObjectPermission
+
+        LibreNMSSettings = apps.get_model("netbox_librenms_plugin", "LibreNMSSettings")
+
+        user = get_user_model().objects.create_user(username=username, password="x")
+        write = ObjectPermission.objects.create(name=f"{username}-plugin-write", actions=["change"])
+        write.object_types.set([ObjectType.objects.get_for_model(LibreNMSSettings)])
+        write.users.set([user])
+
+        for i, (model, constraints) in enumerate(specs):
+            perm = ObjectPermission.objects.create(
+                name=f"{username}-change-{i}", actions=["change"], constraints=constraints
+            )
+            perm.object_types.set([ObjectType.objects.get_for_model(model)])
+            perm.users.set([user])
+
+        return get_user_model().objects.get(pk=user.pk)  # clear the per-request perm cache
+
+    @staticmethod
+    def _request(user):
+        """A real HTMX POST request bound to *user* so the gate and restrict() both run for real."""
+        from django.test import RequestFactory
+
+        request = RequestFactory().post("/move/", {"server_key": "default"}, HTTP_HX_REQUEST="true")
+        request.user = user
+        return request
+
+    def _drive(self, view_cls, user, **kwargs):
+        view = view_cls()
+        request = self._request(user)
+        view.request = request
+        return view.post(request, **kwargs)
+
+    def test_interface_move_404s_an_out_of_scope_interface(self):
+        """A change_interface grant constrained to another interface must not reach the move logic."""
+        from dcim.models import Device, Interface
+        from django.http import Http404
+
+        from netbox_librenms_plugin.views.sync.migrate import MoveInterfaceToWinnerView
+
+        donor = make_device("scope-mi-donor")
+        in_scope = make_interface(make_device("scope-mi-other"), "Eth0")
+        out_of_scope = make_interface(donor, "Eth1")
+        user = self._writer("scoped-move-iface", [(Interface, {"pk": in_scope.pk}), (Device, None)])
+
+        with pytest.raises(Http404):
+            self._drive(MoveInterfaceToWinnerView, user, pk=out_of_scope.pk)
+
+        out_of_scope.refresh_from_db()
+        assert out_of_scope.device_id == donor.pk  # not moved
+
+    def test_interface_move_resolves_the_in_scope_interface(self):
+        """The interface the grant DOES cover resolves and reaches the marker check (no over-block)."""
+        from dcim.models import Device, Interface
+
+        from netbox_librenms_plugin.views.sync.migrate import MoveInterfaceToWinnerView
+
+        donor = make_device("scope-mi-in-donor")
+        iface = make_interface(donor, "Eth0")
+        user = self._writer("scoped-move-iface-ok", [(Interface, {"pk": iface.pk}), (Device, None)])
+
+        response = self._drive(MoveInterfaceToWinnerView, user, pk=iface.pk)
+
+        # No marker on the donor, so the move is refused on its merits — not 404'd at the lookup.
+        assert response.status_code == 200
+        assert b"not marked" in response.content or b"django-messages" in response.content
+
+    def test_ip_move_404s_an_out_of_scope_ip(self):
+        """A change_ipaddress grant constrained to another IP must not reach the move logic."""
+        from dcim.models import Device
+        from django.http import Http404
+        from ipam.models import IPAddress
+
+        from netbox_librenms_plugin.views.sync.migrate import MoveIPAddressToWinnerView
+
+        donor = make_device("scope-ip-donor")
+        in_scope = ip_on(make_device("scope-ip-other"), "10.60.0.1/24", "eth0")
+        out_of_scope = ip_on(donor, "10.60.1.1/24", "eth0")
+        user = self._writer("scoped-move-ip", [(IPAddress, {"pk": in_scope.pk}), (Device, None)])
+
+        with pytest.raises(Http404):
+            self._drive(MoveIPAddressToWinnerView, user, pk=out_of_scope.pk)
+
+        out_of_scope.refresh_from_db()
+        assert out_of_scope.assigned_object.device_id == donor.pk  # not moved
+
+    def test_device_ip_transfer_404s_an_out_of_scope_donor(self):
+        """A pk-constrained change_device grant must not transfer another device's primary IP."""
+        from dcim.models import Device
+        from django.http import Http404
+
+        from netbox_librenms_plugin.views.sync.migrate import TransferDeviceIPView
+
+        in_scope = make_device("scope-xfer-in")
+        donor = make_device("scope-xfer-donor")
+        donor_ip = ip_on(donor, "10.61.0.1/24", "eth0")
+        donor.primary_ip4 = donor_ip
+        donor.save()
+        user = self._writer("scoped-xfer-device", [(Device, {"pk": in_scope.pk})])
+
+        with pytest.raises(Http404):
+            self._drive(TransferDeviceIPView, user, pk=donor.pk, ip_kind="primary4")
+
+        donor.refresh_from_db()
+        assert donor.primary_ip4_id == donor_ip.pk  # not transferred

--- a/netbox_librenms_plugin/tests/test_migrate_views.py
+++ b/netbox_librenms_plugin/tests/test_migrate_views.py
@@ -878,23 +878,62 @@ class TestNonHtmxFallbackRedirect:
         assert resp.url == f"{expected}?tab=interfaces&server_key=siteB"
 
 
-@pytest.mark.django_db
 class TestMigratedTransferIpDeviceOnlyGate:
-    """librenms_sync_base.html serves both Devices and VMs, but the migrated-donor transfer-IP buttons all POST to ``device_transfer_ip`` with ``pk=object.pk`` (a Device lookup)."""
+    """The shipped librenms_sync_base.html must gate the migrated-donor transfer-IP buttons to Devices.
 
-    GATE = "{% load helpers %}{% if object|meta:'model_name' == 'device' %}TRANSFER{% endif %}"
+    These POST to ``device_transfer_ip`` with ``pk=object.pk`` (a Device lookup), so they must not
+    render on a VM page. Assert against the real template SOURCE so the test fails if the guard is
+    dropped — not a hand-copied mini-template that can drift from what ships.
+    """
 
-    def _render(self, obj):
-        from django.template import engines
+    def _template_source(self):
+        from pathlib import Path
 
-        return engines["django"].from_string(self.GATE).render({"object": obj})
+        import netbox_librenms_plugin
 
-    def test_device_page_renders_transfer_block(self):
-        device = make_device("transfer-gate-dev")
-        assert self._render(device) == "TRANSFER"
+        return (
+            Path(netbox_librenms_plugin.__file__).parent
+            / "templates"
+            / "netbox_librenms_plugin"
+            / "librenms_sync_base.html"
+        ).read_text()
 
-    def test_vm_page_omits_transfer_block(self):
-        from netbox_librenms_plugin.tests.conftest import make_vm
+    def test_transfer_ip_buttons_are_gated_to_devices_in_shipped_template(self):
+        source = self._template_source()
+        assert "device_transfer_ip" in source
+        # The device-only guard must open before the transfer-IP controls so a VM page can't
+        # render them; if the guard is dropped, this fails.
+        guard_idx = source.find('object|meta:"model_name" == "device"')
+        assert guard_idx != -1, "device-only guard missing from migrated transfer block"
+        assert guard_idx < source.find("device_transfer_ip"), "transfer-IP controls are not behind the device guard"
 
-        vm = make_vm("transfer-gate-vm")
-        assert self._render(vm) == ""
+
+@pytest.mark.django_db
+class TestVlanStaleServerMigratedContext:
+    """The VLAN stale-server error path resolves migrated context under the session key, not the stale posted key."""
+
+    def test_stale_key_resolves_migrated_context_under_session_key(self):
+        from unittest.mock import MagicMock, patch
+
+        from netbox_librenms_plugin.views.base.vlan_table_view import BaseVLANTableView
+
+        view = object.__new__(BaseVLANTableView)
+        view._librenms_api = MagicMock(server_key="test-server")
+        obj = MagicMock()
+        view.get_object = MagicMock(return_value=obj)
+        view.rebind_api_for_server = MagicMock(return_value=None)  # stale/unconfigured posted key
+        view._get_error_context = MagicMock(return_value={})
+        request = MagicMock()
+        request.POST.get.side_effect = lambda k, d=None: {"server_key": "ghost-server"}.get(k, d)
+
+        with (
+            patch("netbox_librenms_plugin.views.base.vlan_table_view.messages"),
+            patch(
+                "netbox_librenms_plugin.views.base.vlan_table_view.build_migrated_context", return_value={}
+            ) as mock_mig,
+            patch("netbox_librenms_plugin.views.base.vlan_table_view.render", return_value="rendered"),
+        ):
+            result = view.post(request, pk=1)
+
+        mock_mig.assert_called_once_with(obj, "test-server")  # session key, not "ghost-server"
+        assert result == "rendered"

--- a/netbox_librenms_plugin/tests/test_migrate_views.py
+++ b/netbox_librenms_plugin/tests/test_migrate_views.py
@@ -751,6 +751,9 @@ class TestMoveIPAddressToWinnerView:
         resp = view.post(req, pk=ip.pk)
 
         assert resp.status_code == 200
+        # The HTMX refresh contract must fire so the migrated row doesn't linger stale in the UI:
+        # a bare 200 without HX-Refresh would leave the old assignment on screen.
+        assert resp.headers.get("HX-Refresh") == "true"
         ip.refresh_from_db()
         # The IP moved onto the winner's same-named interface — proving both the donor re-lock
         # and the winner lookup resolved the correct rows.

--- a/netbox_librenms_plugin/tests/test_migrate_views.py
+++ b/netbox_librenms_plugin/tests/test_migrate_views.py
@@ -620,6 +620,44 @@ class TestMoveInterfaceToWinnerView:
         interface.refresh_from_db()
         assert interface.device_id == donor.pk
 
+    def test_real_unique_violation_at_save_rolls_back_and_reports_409(self):
+        """A real save-time unique violation reports 409 and rolls back the move."""
+        from dcim.models import Interface
+
+        view = self._setup_view()
+        donor = make_device("mi-realie-donor")
+        winner = make_device("mi-realie-winner")  # no "Eth0" -> pre-check, re-check and full_clean pass
+        self._mark(donor, winner)
+        interface = make_interface(donor, "Eth0")
+        req = _hx_request({"server_key": "default"})
+
+        # Land the winner-side row AFTER full_clean() and BEFORE save(), which is the only window
+        # the IntegrityError handler exists for. Unlike patching save() to raise, the violation
+        # here is the real DB constraint, so the connection really is poisoned afterwards.
+        real_full_clean = Interface.full_clean
+        state = {"raced": False}
+
+        def racing_full_clean(iface, *args, **kwargs):
+            result = real_full_clean(iface, *args, **kwargs)
+            if iface.pk == interface.pk and not state["raced"]:
+                state["raced"] = True
+                Interface.objects.create(device=winner, name=interface.name, type="1000base-t")
+            return result
+
+        with patch.object(Interface, "full_clean", racing_full_clean):
+            resp = view.post(req, pk=interface.pk)
+
+        assert state["raced"]
+        assert resp.status_code == 200
+        assert b"already has an interface named" in resp.content
+        assert resp.headers.get("HX-Reswap") == "none"
+        assert resp.headers.get("HX-Refresh") is None
+        # Everything the transaction touched is gone: the interface never moved and the
+        # racing winner-side row was rolled back with it.
+        interface.refresh_from_db()
+        assert interface.device_id == donor.pk
+        assert not Interface.objects.filter(device=winner, name="Eth0").exists()
+
     def test_marker_repointed_under_lock_is_rejected(self):
         """If the donor's _migrated_to is repointed between the unlocked resolve and the under-lock re-resolve, the move aborts instead of targeting the stale winner."""
         import netbox_librenms_plugin.views.sync.migrate as migrate_mod

--- a/netbox_librenms_plugin/tests/test_migrate_views.py
+++ b/netbox_librenms_plugin/tests/test_migrate_views.py
@@ -1047,7 +1047,10 @@ class TestNonHtmxFallbackRedirect:
         view = self._setup_view()
         req = _nonhtmx_request({"server_key": "siteB"})
         donor = MagicMock(pk=10, cf={})
-        interface = MagicMock(pk=5, name="Eth0", device=donor)
+        # `name` is a reserved MagicMock constructor kwarg (sets the mock's repr, not `.name`),
+        # so set the attribute explicitly — otherwise interface.name is a Mock, not "Eth0".
+        interface = MagicMock(pk=5, device=donor)
+        interface.name = "Eth0"
 
         with (
             patch("netbox_librenms_plugin.views.sync.migrate.get_object_or_404", return_value=interface),

--- a/netbox_librenms_plugin/tests/test_migrate_views.py
+++ b/netbox_librenms_plugin/tests/test_migrate_views.py
@@ -179,6 +179,17 @@ class TestResolveWinnerForDonor:
         assert winner is None
         assert marker["device_id"] == donor.pk
 
+    def test_non_positive_winner_id_classified_corrupt(self):
+        """A marker with a non-positive device_id (0 / negative) is corrupt, not a deleted winner — int() succeeds but it can never be a real Device pk."""
+        from netbox_librenms_plugin.views.sync.migrate import _winner_unavailable_reason
+
+        donor = _make_migrate_device("mig-rw-nonpos")
+        assert _winner_unavailable_reason(donor, {"device_id": 0}) == "corrupt"
+        assert _winner_unavailable_reason(donor, {"device_id": -5}) == "corrupt"
+        assert _winner_unavailable_reason(donor, {"device_id": "0"}) == "corrupt"
+        # A well-formed positive id whose row is gone is still "deleted".
+        assert _winner_unavailable_reason(donor, {"device_id": 999999}) == "deleted"
+
 
 # ── MoveInterfaceToWinnerView ─────────────────────────────────────────────
 

--- a/netbox_librenms_plugin/tests/test_migrate_views.py
+++ b/netbox_librenms_plugin/tests/test_migrate_views.py
@@ -1015,6 +1015,21 @@ class TestSafeRefererFallback:
 
         assert _safe_referer(self._req(), fallback=None) == get_script_prefix()
 
+    def test_referer_validation_delegates_to_shared_barrier(self):
+        """_safe_referer routes the CWE-601 Referer check through the shared validated_referer helper.
+
+        Patching the shared barrier (not a hand-copied inline copy) changes the outcome, so the two
+        redirect helpers can't drift on the open-redirect guard.
+        """
+        from unittest.mock import patch
+
+        from netbox_librenms_plugin.views.sync.migrate import _safe_referer
+
+        with patch("netbox_librenms_plugin.views.sync.migrate.validated_referer", return_value="http://ok/x"):
+            assert _safe_referer(self._req(referer="whatever"), fallback="/sync/") == "http://ok/x"
+        with patch("netbox_librenms_plugin.views.sync.migrate.validated_referer", return_value=None):
+            assert _safe_referer(self._req(referer="whatever"), fallback="/sync/") == "/sync/"
+
 
 class TestNonHtmxFallbackRedirect:
     """A plain POST with no Referer still lands on the donor sync tab + server."""

--- a/netbox_librenms_plugin/tests/test_migrate_views.py
+++ b/netbox_librenms_plugin/tests/test_migrate_views.py
@@ -937,3 +937,56 @@ class TestVlanStaleServerMigratedContext:
 
         mock_mig.assert_called_once_with(obj, "test-server")  # session key, not "ghost-server"
         assert result == "rendered"
+
+
+class TestMigratedContextServerKeyFallback:
+    """When the POSTed server_key is None (malformed/stale request) and the API rebind fails, the cable/IP sync error render must still resolve the migrated marker — by falling back to the session server key — so a migrated donor's sync controls stay suppressed instead of being silently re-enabled."""
+
+    def _post_with_server_key(self, view_cls, module_path, posted):
+        from unittest.mock import MagicMock, patch
+
+        view = object.__new__(view_cls)
+        view._librenms_api = MagicMock()
+        view._librenms_api.server_key = "sessionkey"
+
+        request = MagicMock()
+        request.POST = posted
+
+        obj = MagicMock()
+        with (
+            patch.object(view, "get_object", return_value=obj),
+            patch.object(view, "rebind_api_for_server", return_value=None),  # rebind fails
+            patch(f"{module_path}.messages"),
+            patch(f"{module_path}.render"),
+            patch(f"{module_path}.build_migrated_context", return_value={}) as bmc,
+        ):
+            view.post(request, pk=1)
+
+        bmc.assert_called_once()
+        # Always resolve under the session key, never the (failed-to-rebind) POSTed key — a None
+        # key would skip the marker, a non-empty stale key would look it up under the wrong server.
+        assert bmc.call_args.args[1] == "sessionkey"
+
+    def test_cables_view_empty_key_uses_session_key(self):
+        from netbox_librenms_plugin.views.base.cables_view import BaseCableTableView
+
+        self._post_with_server_key(BaseCableTableView, "netbox_librenms_plugin.views.base.cables_view", {})
+
+    def test_cables_view_stale_nonempty_key_uses_session_key(self):
+        from netbox_librenms_plugin.views.base.cables_view import BaseCableTableView
+
+        self._post_with_server_key(
+            BaseCableTableView, "netbox_librenms_plugin.views.base.cables_view", {"server_key": "ghost"}
+        )
+
+    def test_ip_view_empty_key_uses_session_key(self):
+        from netbox_librenms_plugin.views.base.ip_addresses_view import BaseIPAddressTableView
+
+        self._post_with_server_key(BaseIPAddressTableView, "netbox_librenms_plugin.views.base.ip_addresses_view", {})
+
+    def test_ip_view_stale_nonempty_key_uses_session_key(self):
+        from netbox_librenms_plugin.views.base.ip_addresses_view import BaseIPAddressTableView
+
+        self._post_with_server_key(
+            BaseIPAddressTableView, "netbox_librenms_plugin.views.base.ip_addresses_view", {"server_key": "ghost"}
+        )

--- a/netbox_librenms_plugin/tests/test_migrate_views.py
+++ b/netbox_librenms_plugin/tests/test_migrate_views.py
@@ -1548,3 +1548,67 @@ class TestDeviceIpLabelsSingleSource:
         # fields — the human label is then read from the shared map, so there is no second copy to drift.
         assert set(DEVICE_IP_FK_LABELS) == set(DEVICE_IP_FK_FIELDS)
         assert set(TransferDeviceIPView._IP_KIND_TO_FIELD.values()) == set(DEVICE_IP_FK_FIELDS)
+
+
+@pytest.mark.django_db
+class TestMoveToWinnerConcurrencyHelpers:
+    """The move-to-winner resolve + lock/re-verify TOCTOU guards live in one shared pair of helpers.
+
+    Exercises _resolve_winner_or_fail and _lock_donor_winner_and_reverify directly (all three move
+    endpoints route through them) so the extracted concurrency guard is pinned in one place.
+    """
+
+    def _view(self):
+        from netbox_librenms_plugin.views.sync.migrate import MoveInterfaceToWinnerView
+
+        view = object.__new__(MoveInterfaceToWinnerView)
+        view._fallback_url = "/x/"
+        return view
+
+    def _req(self):
+        from django.test import RequestFactory
+
+        # HX-Request → _fail returns an HTMX toast response (no messages middleware needed).
+        return RequestFactory().post("/x/", HTTP_HX_REQUEST="true")
+
+    def _migrated_donor_and_winner(self):
+        donor = make_device("mv-helper-donor")
+        winner = make_device("mv-helper-winner")
+        donor.custom_field_data["librenms_id"] = {
+            "default": {"_migrated_to": {"device_id": winner.pk, "server_key": "default"}}
+        }
+        donor.save()
+        return donor, winner
+
+    def test_resolve_winner_or_fail_resolves_migrated_winner(self):
+        donor, winner = self._migrated_donor_and_winner()
+        got, err = self._view()._resolve_winner_or_fail(self._req(), donor, "default")
+        assert err is None
+        assert got.pk == winner.pk
+
+    def test_resolve_winner_or_fail_rejects_unmarked_donor(self):
+        donor = make_device("mv-helper-unmarked")
+        got, err = self._view()._resolve_winner_or_fail(self._req(), donor, "default")
+        assert got is None
+        assert err is not None  # "Donor device is not marked as migrated."
+
+    def test_lock_and_reverify_success_returns_locked_pair(self):
+        from django.db import transaction
+
+        donor, winner = self._migrated_donor_and_winner()
+        with transaction.atomic():
+            d, w, err = self._view()._lock_donor_winner_and_reverify(self._req(), donor, winner, "default")
+        assert err is None
+        assert d.pk == donor.pk and w.pk == winner.pk
+
+    def test_lock_and_reverify_detects_marker_cleared_under_lock(self):
+        from django.db import transaction
+
+        donor, winner = self._migrated_donor_and_winner()
+        # Marker cleared between the unlocked resolve and acquiring the row locks (TOCTOU):
+        donor.custom_field_data["librenms_id"] = {"default": {}}
+        donor.save()
+        with transaction.atomic():
+            d, w, err = self._view()._lock_donor_winner_and_reverify(self._req(), donor, winner, "default")
+        assert d is None and w is None
+        assert err is not None  # "Donor migration changed concurrently; refresh and retry."

--- a/netbox_librenms_plugin/tests/test_migrate_views.py
+++ b/netbox_librenms_plugin/tests/test_migrate_views.py
@@ -169,6 +169,21 @@ class TestParseMarkerWinnerPk:
         for bad in (True, False, 1.9, "1.9", "  5 ", 0, -3, "0", None, "x", {}):
             assert _parse_marker_winner_pk(bad) is None, bad
 
+    def test_delegates_positive_int_rule_to_coerce_librenms_id(self):
+        """The int/positive coercion is delegated to coerce_librenms_id; only the marker-specific string strictness is local."""
+        from netbox_librenms_plugin.utils import coerce_librenms_id
+        from netbox_librenms_plugin.views.sync.migrate import _parse_marker_winner_pk
+
+        # For every non-string input the marker parser matches coerce_librenms_id exactly (the shared
+        # bool-reject / positive-int rule) — markers are always stamped as ints in practice.
+        for value in (5, 1, 999999, 0, -3, True, False, None, 1.9):
+            assert _parse_marker_winner_pk(value) == coerce_librenms_id(value), value
+        # A plain digit string agrees; a whitespace-padded one is where the marker parser stays
+        # deliberately stricter than coerce_librenms_id's lenient int() (a tampered marker fails closed).
+        assert _parse_marker_winner_pk("5") == coerce_librenms_id("5") == 5
+        assert _parse_marker_winner_pk("  5 ") is None
+        assert coerce_librenms_id("  5 ") == 5
+
 
 @pytest.mark.django_db
 class TestResolveWinnerForDonor:

--- a/netbox_librenms_plugin/tests/test_migrate_views.py
+++ b/netbox_librenms_plugin/tests/test_migrate_views.py
@@ -21,13 +21,7 @@ from netbox_librenms_plugin.tests.conftest import ip_on, make_device, make_inter
 
 
 def _make_migrate_device(name, librenms_cf=None):
-    """Positional-arg adapter over the shared ``make_device`` builder.
-
-    The marker/winner helpers read the librenms_id custom field through NetBox's ``device.cf``
-    accessor and resolve the winner via ``Device.objects`` — so a real device with a real CF
-    exercises the actual read + ORM lookup. This thin wrapper just preserves the positional
-    ``librenms_cf`` call style used throughout this module.
-    """
+    """Positional-arg adapter over the shared ``make_device`` builder."""
     return make_device(name, librenms_cf=librenms_cf)
 
 
@@ -158,8 +152,7 @@ class TestResolveWinnerForDonor:
         assert marker is None
 
     def test_self_pointing_marker_returns_none_winner(self):
-        """A marker pointing back at the donor (winner.pk == donor.pk) is corrupt — it would
-        make the move operate on one Device as both donor and winner. Fail closed as stale."""
+        """A marker pointing back at the donor (winner.pk == donor.pk) is corrupt — it would make the move operate on one Device as both donor and winner."""
         from netbox_librenms_plugin.views.sync.migrate import _resolve_winner_for_donor
 
         donor = _make_migrate_device("mig-rw-self")
@@ -205,8 +198,7 @@ class TestMoveInterfaceToWinnerView:
 
     @staticmethod
     def _mark(donor, winner):
-        """Write a real ``_migrated_to`` marker so the view's _resolve_winner_for_donor()
-        reads it from the donor's librenms_id custom field for real."""
+        """Write a real ``_migrated_to`` marker so the view's _resolve_winner_for_donor() reads it from the donor's librenms_id custom field for real."""
         from netbox_librenms_plugin.utils import mark_librenms_migrated
 
         mark_librenms_migrated(donor, winner.pk, "default")
@@ -269,11 +261,7 @@ class TestMoveInterfaceToWinnerView:
         assert interface.device_id == winner.pk  # really moved to the winner
 
     def test_cross_device_relationship_rejected_with_409(self):
-        """Real cross-device LAG: the donor interface is a member of a LAG that lives on the
-        donor. Moving only the member to the winner would leave its ``lag`` on the donor —
-        NetBox's real Interface.clean() rejects that, so the move aborts and nothing persists.
-        (Previously this injected the ValidationError via a mock side_effect; now the actual
-        validator runs.)"""
+        """Real cross-device LAG: the donor interface is a member of a LAG that lives on the donor."""
         view = self._setup_view()
         donor = make_device("mi-xdev-donor")
         winner = make_device("mi-xdev-winner")
@@ -296,8 +284,7 @@ class TestMoveInterfaceToWinnerView:
         assert member.lag_id == donor_lag.pk  # relationship untouched
 
     def test_save_integrity_error_rejected_with_409(self):
-        """A concurrent winner-side rename/create can trip a unique constraint at save()
-        time (after our name re-check); surface it as a 409, not a 500."""
+        """A concurrent winner-side rename/create can trip a unique constraint at save() time (after our name re-check); surface it as a 409, not a 500."""
         from django.db import IntegrityError
 
         view = self._setup_view()
@@ -346,9 +333,7 @@ class TestMoveInterfaceToWinnerView:
         assert resp.headers.get("HX-Refresh") is None
 
     def test_marker_repointed_under_lock_is_rejected(self):
-        """If the donor's _migrated_to is repointed between the unlocked resolve
-        and acquiring the row locks, the move must abort instead of targeting the
-        stale winner."""
+        """If the donor's _migrated_to is repointed between the unlocked resolve and acquiring the row locks, the move must abort instead of targeting the stale winner."""
         view = self._setup_view()
         req = _hx_request({"server_key": "default"})
 
@@ -459,11 +444,7 @@ class TestTransferDeviceIPView:
         assert winner.primary_ip4_id == winner_ip.pk  # winner FK intact
 
     def test_happy_path_transfers_oob_ip(self):
-        """Real unique-constraint ordering: ``Device.oob_ip`` is UNIQUE per address, so the
-        donor must release the FK before the winner claims it. The address already lives on a
-        winner-owned interface (NetBox requires oob_ip on one of the device's own interfaces);
-        the donor's FK dangles at it after a prior interface move. Driving real rows exercises
-        the actual constraint — a reversed save order would trip it for real."""
+        """Real unique-constraint ordering: ``Device.oob_ip`` is UNIQUE per address, so the donor must release the FK before the winner claims it."""
         view = self._setup_view()
         donor = make_device("tx-happy-donor")
         winner = make_device("tx-happy-winner")
@@ -483,10 +464,7 @@ class TestTransferDeviceIPView:
         assert donor.oob_ip_id is None  # donor released it
 
     def test_rejects_when_address_still_attached_to_donor(self):
-        """The transfer only flips the FK (save skips full_clean), so it must refuse to point
-        the winner at an address still assigned to a DONOR interface — otherwise the winner
-        would own an oob_ip that isn't on one of its interfaces. Driven against real rows:
-        the owning interface's real device_id is what the view checks."""
+        """The transfer only flips the FK (save skips full_clean), so it must refuse to point the winner at an address still assigned to a DONOR interface — otherwise the winner would own an oob_ip that isn't on one of its interfaces."""
         view = self._setup_view()
         donor = make_device("tx-attached-donor")
         winner = make_device("tx-attached-winner")
@@ -508,10 +486,7 @@ class TestTransferDeviceIPView:
         assert donor.oob_ip_id == oob_ip.pk  # donor FK untouched
 
     def test_rejects_when_assignment_is_not_an_interface(self):
-        """A non-Interface assignment (e.g. a VMInterface) must fail closed: the Interface
-        re-lock is skipped (GenericForeignKey pks aren't unique across models, so filtering
-        Interface by an unrelated pk could lock the wrong row), so the device_id check sees
-        None and the transfer is refused."""
+        """A non-Interface assignment (e.g. a VMInterface) must fail closed: the device_id check sees None and the transfer is refused."""
         view = self._setup_view()
         req = _hx_request({"server_key": "default"})
 
@@ -610,12 +585,7 @@ class TestMoveIPAddressToWinnerView:
         assert ip.assigned_object == donor_iface  # stayed on the donor interface
 
     def test_happy_path_reassigns_ip_to_winner_interface(self):
-        """Real DB end-to-end: the IP on the donor's interface is reassigned to the winner's
-        same-named interface. Because the move is driven against real rows, the donor re-lock
-        ``filter(pk=..., device=donor)`` and the winner lookup ``filter(device=winner,
-        name=...)`` must use the correct device/name — a wrong lookup would leave the IP off
-        the winner's interface and the reload assertion would fail (no mock-call inspection
-        needed to pin the exact kwargs)."""
+        """Real DB end-to-end: the IP on the donor's interface is reassigned to the winner's same-named interface."""
         view = self._setup_view()
 
         donor = make_device("donor-device")
@@ -660,13 +630,7 @@ def _nonhtmx_request(post=None, referer=None):
 
 @pytest.mark.django_db
 class TestReconcileDonorDeviceIpFks:
-    """Real-DB coverage for _reconcile_donor_device_ip_fks: it locks the owning Interface and
-    re-reads device_id from the locked row before transferring a device-level primary/OOB IP FK,
-    so the winner never ends up owning an address that sits on an interface it doesn't own.
-
-    Exercised against real NetBox models (not mocks) so the FK transfer, the Interface lookup,
-    and the owner comparison are validated against actual ORM behavior end-to-end.
-    """
+    """Real-DB coverage for _reconcile_donor_device_ip_fks: it locks the owning Interface and re-reads device_id from the locked row before transferring a device-level primary/OOB IP FK, so the winner never ends up owning an address that sits on an interface it doesn't own."""
 
     @staticmethod
     def _make_devices():
@@ -678,8 +642,7 @@ class TestReconcileDonorDeviceIpFks:
         )
 
     def test_transfers_primary_ip_when_interface_is_on_winner(self):
-        """The donor's primary_ip4 dangles on an address now sitting on a winner-owned interface;
-        the FK is transferred to the winner and cleared on the donor."""
+        """The donor's primary_ip4 dangles on an address now sitting on a winner-owned interface; the FK is transferred to the winner and cleared on the donor."""
         from django.db import transaction
 
         from netbox_librenms_plugin.views.sync.migrate import _reconcile_donor_device_ip_fks
@@ -700,8 +663,7 @@ class TestReconcileDonorDeviceIpFks:
         assert any("transferred" in n for n in notes)
 
     def test_skips_when_interface_belongs_to_a_different_device(self):
-        """If the address sits on an interface owned by neither the winner (a stale/concurrent
-        state), the locked-row device_id check rejects it: no FK is moved onto the winner."""
+        """If the address sits on an interface owned by neither the winner (a stale/concurrent state), the locked-row device_id check rejects it: no FK is moved onto the winner."""
         from django.db import transaction
 
         from netbox_librenms_plugin.views.sync.migrate import _reconcile_donor_device_ip_fks
@@ -724,10 +686,7 @@ class TestReconcileDonorDeviceIpFks:
 
 @pytest.mark.django_db
 class TestSetDeviceIpFk:
-    """Real-DB coverage for utils.set_device_ip_fk: the single guarded chokepoint every
-    device primary/OOB IP-FK write (which bypass full_clean via update_fields) goes through.
-    It must enforce the NetBox invariant that the address sits on one of the device's OWN
-    interfaces, so a careless caller can never persist an off-device FK."""
+    """Real-DB coverage for utils.set_device_ip_fk: the single guarded chokepoint every device primary/OOB IP-FK write (which bypass full_clean via update_fields) goes through."""
 
     def test_sets_and_saves_fk_when_address_on_device_interface(self):
         from netbox_librenms_plugin.utils import set_device_ip_fk
@@ -909,16 +868,7 @@ class TestNonHtmxFallbackRedirect:
 
 @pytest.mark.django_db
 class TestMigratedTransferIpDeviceOnlyGate:
-    """librenms_sync_base.html serves both Devices and VMs, but the migrated-donor transfer-IP
-    buttons all POST to ``device_transfer_ip`` with ``pk=object.pk`` (a Device lookup). The gate
-    ``object|meta:"model_name" == "device"`` keeps those buttons off VM pages so a VM can't drive
-    a mutation against a same-pk Device. build_migrated_context() doesn't itself gate on Device,
-    so a VM with a stale ``_migrated_to`` marker would otherwise reach the buttons.
-
-    The full template extends generic/object.html (not cheaply renderable in isolation), so this
-    exercises the exact gate predicate from the template via the real ``meta`` filter and real
-    ORM objects.
-    """
+    """librenms_sync_base.html serves both Devices and VMs, but the migrated-donor transfer-IP buttons all POST to ``device_transfer_ip`` with ``pk=object.pk`` (a Device lookup)."""
 
     GATE = "{% load helpers %}{% if object|meta:'model_name' == 'device' %}TRANSFER{% endif %}"
 

--- a/netbox_librenms_plugin/tests/test_migrate_views.py
+++ b/netbox_librenms_plugin/tests/test_migrate_views.py
@@ -3,10 +3,13 @@ Tests for Stage 2b: get_migrated_to_marker helper + the per-row
 "Move to winner" view endpoints (MoveInterfaceToWinnerView,
 MoveIPAddressToWinnerView, TransferDeviceIPView).
 
-The view tests use light MagicMock-based plumbing — we patch the model
-queryset chain so the views never touch a real database.  This is
-appropriate because the views' job is glue: validate the marker, look
-up the winner, run a small ORM mutation, and return an HTMX response.
+The view tests are real-DB end-to-end: they build real donor/winner devices,
+interfaces and IPs (conftest make_device/make_interface/make_ip/ip_on), write a
+real ``_migrated_to`` marker, drive the view's full select_for_update /
+full_clean / save move path, and reload from the DB to prove what persisted.
+MagicMock is reserved for the request object and the permission gate (exercised
+separately); a handful of legacy unit tests still stub the ORM and are being
+migrated to real rows.
 """
 
 from unittest.mock import MagicMock, patch
@@ -14,7 +17,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 # Shared real-DB builders (see tests/conftest.py).
-from netbox_librenms_plugin.tests.conftest import ip_on, make_device, make_interface, make_ip
+from netbox_librenms_plugin.tests.conftest import ip_on, make_device, make_interface, make_ip, make_vm
 
 
 # ── helper: get_migrated_to_marker ────────────────────────────────────────
@@ -462,96 +465,78 @@ class TestMoveInterfaceToWinnerView:
         assert member.lag_id == donor_lag.pk  # relationship untouched
 
     def test_save_integrity_error_rejected_with_409(self):
-        """A concurrent winner-side rename/create can trip a unique constraint at save() time (after our name re-check); surface it as a 409, not a 500."""
+        """A winner-side create that trips the (device,name) unique constraint at save() — after every in-transaction check passes — is caught and surfaced as a 409 toast, and the whole move rolls back."""
+        from dcim.models import Interface
         from django.db import IntegrityError
 
         view = self._setup_view()
+        donor = make_device("mi-ie-donor")
+        winner = make_device("mi-ie-winner")  # no "Eth0" -> the pre-check, re-check and full_clean all pass
+        self._mark(donor, winner)
+        interface = make_interface(donor, "Eth0")
         req = _hx_request({"server_key": "default"})
 
-        donor = MagicMock(pk=10)
-        winner = MagicMock(pk=20)
-        winner.name = "winner"
-        interface = MagicMock(pk=5, device=donor)
-        interface.name = "Eth0"
-        locked_iface = MagicMock(pk=5, device=donor)
-        locked_iface.name = "Eth0"
-        locked_iface.full_clean.return_value = None
-        locked_iface.save.side_effect = IntegrityError("duplicate key value")
+        # The IntegrityError handler guards a true concurrency boundary: another transaction creates
+        # the winner's same-named interface AFTER our full_clean() but BEFORE our save(), tripping the
+        # DB unique constraint. That race can't be reproduced single-threaded (full_clean would see an
+        # in-transaction collision first), so simulate only the move save() raising; all rows, locks,
+        # full_clean and the atomic rollback are real.
+        real_save = Interface.save
 
-        with (
-            patch("netbox_librenms_plugin.views.sync.migrate.get_object_or_404", return_value=interface),
-            patch(
-                "netbox_librenms_plugin.views.sync.migrate._resolve_winner_for_donor",
-                return_value=(winner, {"device_id": 20, "server_key": "default", "at": "x"}),
-            ),
-            patch("netbox_librenms_plugin.views.sync.migrate.Interface") as mock_iface_cls,
-            patch("netbox_librenms_plugin.views.sync.migrate.Device") as mock_device_cls,
-            patch("netbox_librenms_plugin.views.sync.migrate.transaction"),
-            patch("netbox_librenms_plugin.views.sync.migrate.messages"),
-        ):
-            collision_qs = MagicMock()
-            collision_qs.exists.return_value = False
-            mock_iface_cls.objects.filter.return_value = collision_qs
-            mock_iface_cls.objects.select_for_update.return_value.filter.return_value.first.return_value = locked_iface
-            mock_device_cls.objects.select_for_update.return_value.filter.return_value.order_by.return_value = [
-                donor,
-                winner,
-            ]
-            resp = view.post(req, pk=5)
+        def boom(self, *args, **kwargs):
+            if self.pk == interface.pk:
+                raise IntegrityError("duplicate key value violates unique constraint")
+            return real_save(self, *args, **kwargs)
 
-        # save() raised → surfaced as the collision OOB toast (HTMX path), not a 500.
-        # As above: HTMX errors are an OOB toast at HTTP 200, distinguished from the
-        # success response by the absence of the HX-Refresh header.
-        locked_iface.save.assert_called_once()
-        assert b"django-messages" in resp.content
-        # Error contract (see _fail): HTMX errors are an OOB toast at HTTP 200 with
-        # HX-Reswap:none and no HX-Refresh — never the success refresh response.
+        with patch.object(Interface, "save", boom):
+            resp = view.post(req, pk=interface.pk)
+
+        # Caught and surfaced as the collision 409 OOB toast (HTTP 200, HX-Reswap:none, no HX-Refresh).
         assert resp.status_code == 200
+        assert b"already has an interface named" in resp.content
         assert resp.headers.get("HX-Reswap") == "none"
         assert resp.headers.get("HX-Refresh") is None
+        # The atomic block rolled back for real: the interface is still on the donor.
+        interface.refresh_from_db()
+        assert interface.device_id == donor.pk
 
     def test_marker_repointed_under_lock_is_rejected(self):
-        """If the donor's _migrated_to is repointed between the unlocked resolve and acquiring the row locks, the move must abort instead of targeting the stale winner."""
+        """If the donor's _migrated_to is repointed between the unlocked resolve and the under-lock re-resolve, the move aborts instead of targeting the stale winner."""
+        import netbox_librenms_plugin.views.sync.migrate as migrate_mod
+        from netbox_librenms_plugin.utils import mark_librenms_migrated
+
         view = self._setup_view()
+        donor = make_device("mi-repoint-donor")
+        winner = make_device("mi-repoint-winner")  # the original (now stale) target
+        other_winner = make_device("mi-repoint-other")  # the marker is concurrently repointed here
+        self._mark(donor, winner)
+        interface = make_interface(donor, "Eth0")
         req = _hx_request({"server_key": "default"})
 
-        donor = MagicMock(pk=10)
-        winner = MagicMock(pk=20)
-        winner.name = "winner"
-        other_winner = MagicMock(pk=99)  # marker now points here
-        interface = MagicMock(pk=5, device=donor)
-        interface.name = "Eth0"
+        # The REAL _resolve_winner_for_donor runs for both calls; between the unlocked resolve and the
+        # under-lock re-resolve we really repoint the donor's marker (a committed write that lands
+        # before the atomic block re-reads it), so the under-lock winner differs and the move aborts.
+        real_resolve = migrate_mod._resolve_winner_for_donor
+        state = {"repointed": False}
 
-        with (
-            patch("netbox_librenms_plugin.views.sync.migrate.get_object_or_404", return_value=interface),
-            patch(
-                "netbox_librenms_plugin.views.sync.migrate._resolve_winner_for_donor",
-                # 1st call (pre-lock) → winner; 2nd call (under lock) → a different winner.
-                side_effect=[
-                    (winner, {"device_id": 20, "server_key": "default", "at": "x"}),
-                    (other_winner, {"device_id": 99, "server_key": "default", "at": "y"}),
-                ],
-            ),
-            patch("netbox_librenms_plugin.views.sync.migrate.Interface") as mock_iface_cls,
-            patch("netbox_librenms_plugin.views.sync.migrate.Device") as mock_device_cls,
-            patch("netbox_librenms_plugin.views.sync.migrate.transaction"),
-            patch("netbox_librenms_plugin.views.sync.migrate.messages"),
-        ):
-            mock_iface_cls.objects.filter.return_value.exists.return_value = False
-            mock_device_cls.objects.select_for_update.return_value.filter.return_value.order_by.return_value = [
-                donor,
-                winner,
-            ]
-            resp = view.post(req, pk=5)
+        def repoint_then_resolve(d, server_key):
+            result = real_resolve(d, server_key)
+            if not state["repointed"]:
+                state["repointed"] = True
+                mark_librenms_migrated(donor, other_winner.pk, "default")
+                donor.save()
+            return result
 
-        # Aborts with a conflict toast; the move query is never issued.
-        assert b"django-messages" in resp.content
-        # Reject path flows through _fail(): the HTMX response carries HX-Reswap:none and
-        # never the success HX-Refresh header, so a regression that returned HX-Refresh=true
-        # (refreshing as if the move/transfer succeeded) would be caught here.
+        with patch.object(migrate_mod, "_resolve_winner_for_donor", side_effect=repoint_then_resolve):
+            resp = view.post(req, pk=interface.pk)
+
+        # Aborted with the concurrency conflict toast; the interface is moved to neither winner.
+        assert resp.status_code == 200
+        assert b"changed concurrently" in resp.content
         assert resp.headers.get("HX-Reswap") == "none"
         assert resp.headers.get("HX-Refresh") is None
-        mock_iface_cls.objects.select_for_update.assert_not_called()
+        interface.refresh_from_db()
+        assert interface.device_id == donor.pk
 
     def test_perm_gate_short_circuits(self):
         from django.http import HttpResponse
@@ -563,6 +548,17 @@ class TestMoveInterfaceToWinnerView:
         req = _hx_request()
         resp = view.post(req, pk=5)
         assert resp.status_code == 403
+
+    def test_fail_htmx_toast_is_the_shared_helper_markup(self):
+        """_fail's HTMX toast is byte-identical to _htmx_error_response (one source of toast markup, not a divergent copy)."""
+        from netbox_librenms_plugin.views.imports.actions import _htmx_error_response
+        from netbox_librenms_plugin.views.sync.migrate import MoveInterfaceToWinnerView
+
+        view = MoveInterfaceToWinnerView()
+        resp = view._fail(_hx_request(), "boom message")
+        expected = _htmx_error_response("boom message")
+        assert resp.content == expected.content
+        assert resp["HX-Reswap"] == expected["HX-Reswap"] == "none"
 
 
 # ── TransferDeviceIPView ──────────────────────────────────────────────────
@@ -690,47 +686,33 @@ class TestTransferDeviceIPView:
         assert winner.primary_ip4_id is None
 
     def test_rejects_when_assignment_is_not_an_interface(self):
-        """A non-Interface assignment (e.g. a VMInterface) must fail closed: the device_id check sees None and the transfer is refused."""
+        """A donor oob_ip whose address lives on a VMInterface (not a dcim Interface) fails closed: isinstance(assigned, Interface) is False, device_id never matches the winner, and nothing transfers."""
+        from virtualization.models import VMInterface
+
         view = self._setup_view()
+        donor = make_device("tx-vmi-donor")
+        winner = make_device("tx-vmi-winner")
+        self._mark(donor, winner)
+        # The donor's oob_ip address is assigned to a real VMInterface (an owned NetBox model,
+        # not an external boundary) — the cross-type case the isinstance guard fails closed on.
+        vm = make_vm("tx-vmi-vm")
+        vmi = VMInterface.objects.create(virtual_machine=vm, name="eth0")
+        oob_ip = make_ip("10.0.0.5/24", assigned_object=vmi)
+        donor.oob_ip = oob_ip
+        donor.save()  # save() skips full_clean(), so the cross-type dangling FK persists
         req = _hx_request({"server_key": "default"})
 
-        oob_ip = MagicMock(address="10.0.0.5/24")
-        # NOT spec=Interface → isinstance(assigned, Interface) is False → re-lock skipped.
-        oob_ip.assigned_object = MagicMock(pk=99)
-        donor = MagicMock(pk=10, oob_ip=oob_ip)
-        winner = MagicMock(pk=20, name="winner", oob_ip=None)
-        locked_donor = MagicMock(pk=10, oob_ip=oob_ip)
-        locked_winner = MagicMock(pk=20, name="winner", oob_ip=None)
+        resp = view.post(req, pk=donor.pk, ip_kind="oob")
 
-        with (
-            patch("netbox_librenms_plugin.views.sync.migrate.get_object_or_404", return_value=donor),
-            patch(
-                "netbox_librenms_plugin.views.sync.migrate._resolve_winner_for_donor",
-                return_value=(winner, {"device_id": 20, "server_key": "default", "at": "x"}),
-            ),
-            patch("netbox_librenms_plugin.views.sync.migrate.Device") as mock_device_cls,
-            patch("netbox_librenms_plugin.views.sync.migrate.IPAddress") as mock_ip_cls,
-            patch("netbox_librenms_plugin.views.sync.migrate.Interface.objects") as mock_iface_objects,
-            patch("netbox_librenms_plugin.views.sync.migrate.transaction"),
-            patch("netbox_librenms_plugin.views.sync.migrate.messages"),
-        ):
-            mock_device_cls.objects.select_for_update.return_value.filter.return_value.order_by.return_value = [
-                locked_donor,
-                locked_winner,
-            ]
-            mock_ip_cls.objects.select_for_update.return_value.filter.return_value.first.return_value = oob_ip
-            resp = view.post(req, pk=10, ip_kind="oob")
-
-        # Refused; the Interface manager was never queried (re-lock skipped), nothing saved.
+        # Reject path flows through _fail(): HX-Reswap:none and never the success HX-Refresh header.
+        assert resp.status_code == 200
         assert b"django-messages" in resp.content
-        # Reject path flows through _fail(): the HTMX response carries HX-Reswap:none and
-        # never the success HX-Refresh header, so a regression that returned HX-Refresh=true
-        # (refreshing as if the move/transfer succeeded) would be caught here.
         assert resp.headers.get("HX-Reswap") == "none"
         assert resp.headers.get("HX-Refresh") is None
-        mock_iface_objects.select_for_update.assert_not_called()
-        locked_winner.save.assert_not_called()
-        locked_donor.save.assert_not_called()
+        donor.refresh_from_db()
+        winner.refresh_from_db()
+        assert winner.oob_ip_id is None  # winner never claimed the VMInterface-attached address
+        assert donor.oob_ip_id == oob_ip.pk  # donor FK untouched
 
 
 # ── MoveIPAddressToWinnerView ────────────────────────────────────────────
@@ -1521,7 +1503,10 @@ class TestMigratedDonorRendersSyncTabs:
         donor.save()
 
         url = reverse("plugins:netbox_librenms_plugin:device_librenms_sync", args=[donor.pk])
-        resp = client.get(url, {"tab": "ipaddresses"})
+        # Pass an explicit ?server_key so the view resolves the server via LibreNMSAPI("default")
+        # (which skips the LibreNMSSettings.selected_server read); otherwise this real-client render
+        # is flaky under a suite where another test leaks a LibreNMSSettings mock.
+        resp = client.get(url, {"tab": "ipaddresses", "server_key": "default"})
 
         assert resp.status_code == 200
         html = resp.content.decode()
@@ -1532,3 +1517,19 @@ class TestMigratedDonorRendersSyncTabs:
         move_url = reverse("plugins:netbox_librenms_plugin:ipaddress_move_to_winner", kwargs={"pk": ip.pk})
         assert move_url in html
         assert "Move IP addresses" in html  # the migrated move card header
+        # The gating-rationale comment must be a {% comment %} block, not a multi-line {# #} (which
+        # Django can't span across lines and would leak into the page as visible text).
+        assert "never found_in_librenms" not in html
+
+
+class TestDeviceIpLabelsSingleSource:
+    """Device IP FK labels live in one map (utils.DEVICE_IP_FK_LABELS); the transfer view derives from it."""
+
+    def test_labels_cover_all_fk_fields_and_view_maps_only_to_them(self):
+        from netbox_librenms_plugin.utils import DEVICE_IP_FK_FIELDS, DEVICE_IP_FK_LABELS
+        from netbox_librenms_plugin.views.sync.migrate import TransferDeviceIPView
+
+        # One label per reconcilable FK field, and the transfer view maps ip_kind kwargs only to those
+        # fields — the human label is then read from the shared map, so there is no second copy to drift.
+        assert set(DEVICE_IP_FK_LABELS) == set(DEVICE_IP_FK_FIELDS)
+        assert set(TransferDeviceIPView._IP_KIND_TO_FIELD.values()) == set(DEVICE_IP_FK_FIELDS)

--- a/netbox_librenms_plugin/tests/test_migrate_views.py
+++ b/netbox_librenms_plugin/tests/test_migrate_views.py
@@ -414,6 +414,30 @@ class TestMoveInterfaceToWinnerView:
         interface.refresh_from_db()
         assert interface.device_id == winner.pk  # really moved to the winner
 
+    def test_missing_server_key_falls_back_without_constructing_api(self):
+        """A no-server_key POST resolves the marker via active_server_key, never constructing LibreNMSAPI() (a misconfigured default would 500 the move)."""
+        view = self._setup_view()
+        donor = make_device("mi-nokey-donor")
+        winner = make_device("mi-nokey-winner")  # no "Eth0" -> the move can proceed
+        self._mark(donor, winner)  # marker namespaced under "default"
+        interface = make_interface(donor, "Eth0")
+        req = _hx_request({})  # POST omits server_key -> default_factory fires
+
+        # Simulate a misconfigured default server: constructing the client raises ValueError,
+        # exactly as the lazy librenms_api property would on a bad deployment. The fixed view
+        # must not touch it; the unfixed view calls self.librenms_api.server_key and 500s.
+        with patch(
+            "netbox_librenms_plugin.views.mixins.LibreNMSAPI",
+            side_effect=ValueError("LibreNMS URL or API token is not configured for server 'default'."),
+        ) as api_ctor:
+            resp = view.post(req, pk=interface.pk)
+
+        api_ctor.assert_not_called()  # the fix never builds the (broken) client
+        assert resp.status_code == 200
+        assert resp.headers.get("HX-Refresh") == "true"  # the move still happened
+        interface.refresh_from_db()
+        assert interface.device_id == winner.pk
+
     def test_cross_device_relationship_rejected_with_409(self):
         """Real cross-device LAG: the donor interface is a member of a LAG that lives on the donor."""
         view = self._setup_view()
@@ -1412,3 +1436,99 @@ class TestMigratedContextServerKeyFallback:
 
         ip_sync = mock_render.call_args.args[2]["ip_sync"]
         assert ip_sync["set_primary_ip"] is True
+
+
+@pytest.mark.django_db
+class TestMovableIpsForMigration:
+    """_movable_ips_for_migration lists a migrated donor's interface-assigned IPs (Move-to-winner candidates)."""
+
+    @staticmethod
+    def _movable(donor, server_key="default"):
+        from netbox_librenms_plugin.views.object_sync.devices import DeviceIPAddressTableView
+
+        return DeviceIPAddressTableView._movable_ips_for_migration(donor, server_key)
+
+    def test_empty_when_not_migrated(self):
+        donor = make_device("mv-nomark")
+        ip_on(donor, "10.10.0.5/24", "eth0")  # real IP on a real interface, but no marker
+        assert self._movable(donor) == []
+
+    def test_lists_interface_assigned_ips_when_migrated(self):
+        from netbox_librenms_plugin.utils import mark_librenms_migrated
+
+        winner = make_device("mv-winner")
+        donor = make_device("mv-donor")
+        ip = ip_on(donor, "10.10.0.5/24", "eth0")
+        mark_librenms_migrated(donor, winner.pk, "default")
+        donor.save()
+
+        result = self._movable(donor)
+        assert len(result) == 1
+        assert result[0]["id"] == ip.pk
+        assert result[0]["address"] == "10.10.0.5/24"
+        assert result[0]["interface_name"] == "eth0"
+
+    def test_excludes_unassigned_ip(self):
+        from netbox_librenms_plugin.tests.conftest import make_ip
+        from netbox_librenms_plugin.utils import mark_librenms_migrated
+
+        winner = make_device("mv-winner2")
+        donor = make_device("mv-donor2")
+        ip_on(donor, "10.10.0.6/24", "eth0")  # assigned -> candidate
+        make_ip("10.10.0.99/24")  # unassigned -> not a candidate
+        mark_librenms_migrated(donor, winner.pk, "default")
+        donor.save()
+
+        assert [r["address"] for r in self._movable(donor)] == ["10.10.0.6/24"]
+
+    def test_scoped_to_marker_server_key(self):
+        from netbox_librenms_plugin.utils import mark_librenms_migrated
+
+        winner = make_device("mv-winner3")
+        donor = make_device("mv-donor3")
+        ip_on(donor, "10.10.0.7/24", "eth0")
+        mark_librenms_migrated(donor, winner.pk, "edgelondon")  # marker under a non-default server
+        donor.save()
+
+        # The marker's own key surfaces the candidates; an unrelated key sees none.
+        assert self._movable(donor, "default") == []
+        assert len(self._movable(donor, "edgelondon")) == 1
+
+
+@pytest.mark.django_db
+class TestMigratedDonorRendersSyncTabs:
+    """A migrated (not-found) donor must render the sync tabs so the per-row Move-to-winner controls are reachable.
+
+    The merge clears the donor's active librenms_id, so it is never found_in_librenms; without gating the
+    tabs on migrated_to_marker too, the banner promises per-row interface/IP move actions that never render.
+    Full HTTP request -> view -> DB -> template, no LibreNMS API (librenms_id is None for a migrated donor).
+    """
+
+    def test_full_page_shows_tabs_and_reachable_ip_move_button(self, client):
+        from django.contrib.auth import get_user_model
+        from django.urls import reverse
+
+        from netbox_librenms_plugin.tests.conftest import ip_on, make_device
+        from netbox_librenms_plugin.utils import mark_librenms_migrated
+
+        user = get_user_model().objects.create_superuser("mig-tabs-admin", "a@b.c", "pw")
+        client.force_login(user)
+
+        winner = make_device("mt-winner")
+        donor = make_device("mt-donor")
+        ip = ip_on(donor, "10.50.0.5/24", "eth0")  # a real interface-assigned IP to move
+        mark_librenms_migrated(donor, winner.pk, "default")  # clears the active id -> donor not found
+        donor.save()
+
+        url = reverse("plugins:netbox_librenms_plugin:device_librenms_sync", args=[donor.pk])
+        resp = client.get(url, {"tab": "ipaddresses"})
+
+        assert resp.status_code == 200
+        html = resp.content.decode()
+        # Migrated mode now renders the tab structure (not the "device not found, match it" dead-end)...
+        assert 'id="librenmsTabContent"' in html
+        assert "To match a device, use one of these methods" not in html
+        # ...so the per-row IP "Move to winner" button is actually reachable.
+        move_url = reverse("plugins:netbox_librenms_plugin:ipaddress_move_to_winner", kwargs={"pk": ip.pk})
+        assert move_url in html
+        assert "Move IP addresses" in html  # the migrated move card header

--- a/netbox_librenms_plugin/tests/test_migrate_views.py
+++ b/netbox_librenms_plugin/tests/test_migrate_views.py
@@ -95,6 +95,21 @@ class TestGetMigratedToMarker:
         )
         assert get_migrated_to_marker(donor, "default") is None
 
+    def test_returns_self_pointing_marker_unchanged(self):
+        # get_migrated_to_marker() deliberately does NOT reject a self-pointing marker: the move
+        # views read it via _resolve_winner_for_donor() and need the marker present to classify it
+        # as "stale/corrupt" rather than "not migrated". The self-pointing fail-closed lives in
+        # build_migrated_context() (see TestBuildMigratedContext) instead.
+        from netbox_librenms_plugin.utils import get_migrated_to_marker
+
+        donor = _make_migrate_device("mig-selfpoint")
+        donor.custom_field_data["librenms_id"] = {
+            "default": {"_migrated_to": {"device_id": donor.pk, "server_key": "default"}}
+        }
+        donor.save()
+        marker = get_migrated_to_marker(donor, "default")
+        assert marker["device_id"] == donor.pk
+
 
 @pytest.mark.django_db
 class TestBuildMigratedContext:
@@ -117,6 +132,20 @@ class TestBuildMigratedContext:
         ctx = build_migrated_context(donor, "default")
         assert ctx["migrated_to_marker"]["device_id"] == winner.pk
         assert ctx["migrated_to_winner"].pk == winner.pk
+
+    def test_self_pointing_marker_does_not_enter_migrated_mode(self):
+        # build_migrated_context() reads get_migrated_to_marker() directly (not the move views'
+        # _resolve_winner_for_donor), so a self-pointing marker must be rejected here too — otherwise
+        # the donor's sync page flips into migrated mode and resolves the "winner" to itself.
+        from netbox_librenms_plugin.utils import build_migrated_context
+
+        donor = _make_migrate_device("mig-ctx-selfpoint")
+        donor.custom_field_data["librenms_id"] = {
+            "default": {"_migrated_to": {"device_id": donor.pk, "server_key": "default"}}
+        }
+        donor.save()
+        ctx = build_migrated_context(donor, "default")
+        assert ctx == {"migrated_to_marker": None, "migrated_to_winner": None}
 
 
 # ── helper: _resolve_winner_for_donor ─────────────────────────────────────

--- a/netbox_librenms_plugin/tests/test_migrate_views.py
+++ b/netbox_librenms_plugin/tests/test_migrate_views.py
@@ -235,6 +235,46 @@ class TestMoveInterfaceToWinnerView:
         interface.refresh_from_db()
         assert interface.device_id == donor.pk  # not moved
 
+    def test_corrupt_self_pointing_marker_reports_stale_not_deleted(self):
+        """A self-pointing _migrated_to marker is corrupt state, not a deleted winner — the error must say so for recovery."""
+        view = self._setup_view()
+        donor = make_device("mi-corrupt-donor")
+        # Marker points at the donor's own pk → corrupt (would move a device onto itself).
+        donor.custom_field_data["librenms_id"] = {
+            "default": {"_migrated_to": {"device_id": donor.pk, "server_key": "default", "at": "x"}}
+        }
+        donor.save()
+        interface = make_interface(donor, "Eth0")
+        req = _hx_request({"server_key": "default"})
+
+        resp = view.post(req, pk=interface.pk)
+
+        assert resp.status_code == 200
+        assert b"stale or corrupt" in resp.content
+        assert b"Winner device no longer exists" not in resp.content
+        interface.refresh_from_db()
+        assert interface.device_id == donor.pk  # not moved
+
+    def test_deleted_winner_marker_reports_winner_gone(self):
+        """A well-formed marker whose winner row was deleted still reports the winner as gone — distinct from a corrupt marker."""
+        from dcim.models import Device
+
+        view = self._setup_view()
+        donor = make_device("mi-delwin-donor")
+        winner = make_device("mi-delwin-winner")
+        self._mark(donor, winner)
+        Device.objects.filter(pk=winner.pk).delete()
+        interface = make_interface(donor, "Eth0")
+        req = _hx_request({"server_key": "default"})
+
+        resp = view.post(req, pk=interface.pk)
+
+        assert resp.status_code == 200
+        assert b"Winner device no longer exists" in resp.content
+        assert b"stale or corrupt" not in resp.content
+        interface.refresh_from_db()
+        assert interface.device_id == donor.pk  # not moved
+
     def test_rejects_on_name_collision(self):
         # The winner already has a same-named interface → the real collision query finds
         # it and the move is refused; the donor interface is not reassigned.
@@ -1004,3 +1044,53 @@ class TestMigratedContextServerKeyFallback:
         self._post_with_server_key(
             BaseInterfaceTableView, "netbox_librenms_plugin.views.base.interfaces_view", {"server_key": "ghost"}
         )
+
+    def test_ip_view_stale_key_fallback_preserves_set_primary_ip(self):
+        """The stale-server-key error fallback must carry set_primary_ip so the template doesn't silently uncheck the user's preference."""
+        from unittest.mock import MagicMock, patch
+
+        from netbox_librenms_plugin.views.base.ip_addresses_view import BaseIPAddressTableView
+
+        view = object.__new__(BaseIPAddressTableView)
+        view._librenms_api = MagicMock()
+        view._librenms_api.server_key = "sessionkey"
+        request = MagicMock()
+        request.POST = {"server_key": "ghost", "set-primary-ip-toggle": "on"}
+
+        with (
+            patch.object(view, "get_object", return_value=MagicMock()),
+            patch.object(view, "rebind_api_for_server", return_value=None),  # rebind fails → stale-key fallback
+            patch("netbox_librenms_plugin.views.base.ip_addresses_view.messages"),
+            patch("netbox_librenms_plugin.views.base.ip_addresses_view.render") as mock_render,
+            patch("netbox_librenms_plugin.views.base.ip_addresses_view.build_migrated_context", return_value={}),
+        ):
+            view.post(request, pk=1)
+
+        ip_sync = mock_render.call_args.args[2]["ip_sync"]
+        assert "set_primary_ip" in ip_sync  # the field was omitted before, silently unchecking the box
+        assert ip_sync["set_primary_ip"] is True  # reflects the POSTed toggle
+
+    def test_ip_view_failed_refresh_fallback_preserves_set_primary_ip(self):
+        """The failed-live-refresh error fallback must also carry set_primary_ip."""
+        from unittest.mock import MagicMock, patch
+
+        from netbox_librenms_plugin.views.base.ip_addresses_view import BaseIPAddressTableView
+
+        view = object.__new__(BaseIPAddressTableView)
+        view._librenms_api = MagicMock()
+        view._librenms_api.server_key = "good"
+        request = MagicMock()
+        request.POST = {"server_key": "good", "set-primary-ip-toggle": "on"}
+
+        with (
+            patch.object(view, "get_object", return_value=MagicMock()),
+            patch.object(view, "rebind_api_for_server", return_value="good"),  # rebind OK
+            patch.object(view, "_prepare_context", return_value=None),  # live fetch failed
+            patch("netbox_librenms_plugin.views.base.ip_addresses_view.messages"),
+            patch("netbox_librenms_plugin.views.base.ip_addresses_view.render") as mock_render,
+            patch("netbox_librenms_plugin.views.base.ip_addresses_view.build_migrated_context", return_value={}),
+        ):
+            view.post(request, pk=1)
+
+        ip_sync = mock_render.call_args.args[2]["ip_sync"]
+        assert ip_sync["set_primary_ip"] is True

--- a/netbox_librenms_plugin/tests/test_migrate_views.py
+++ b/netbox_librenms_plugin/tests/test_migrate_views.py
@@ -264,6 +264,34 @@ class TestMoveInterfaceToWinnerView:
         interface.refresh_from_db()
         assert interface.device_id == donor.pk  # not moved
 
+    def test_reconcile_family_mismatch_fails_closed_and_rolls_back_move(self):
+        """If reconciling a moved interface's donor FK hits a corrupt family (primary_ip4 → IPv6), the whole move fails closed with a 409 and rolls back, never a 500."""
+        view = self._setup_view()
+        donor = make_device("mi-fam-donor")
+        winner = make_device("mi-fam-winner")
+        self._mark(donor, winner)
+        # eth0 on the donor carries an IPv6 address that is (corruptly) the donor's primary_ip4.
+        bad_ip = ip_on(donor, "2001:db8::7/128", "eth0")
+        iface = bad_ip.assigned_object
+        donor.primary_ip4 = bad_ip
+        donor.save()
+        req = _hx_request({"server_key": "default"})
+
+        resp = view.post(req, pk=iface.pk)
+
+        assert resp.status_code == 200
+        assert b"django-messages" in resp.content
+        assert resp.headers.get("HX-Reswap") == "none"
+        assert resp.headers.get("HX-Refresh") is None
+        # Whole move rolled back: interface stays on the donor, the donor FK is intact, and
+        # the winner never claimed the mismatched address.
+        iface.refresh_from_db()
+        donor.refresh_from_db()
+        winner.refresh_from_db()
+        assert iface.device_id == donor.pk
+        assert donor.primary_ip4_id == bad_ip.pk
+        assert winner.primary_ip4_id is None
+
     def test_corrupt_self_pointing_marker_reports_stale_not_deleted(self):
         """A self-pointing _migrated_to marker is corrupt state, not a deleted winner — the error must say so for recovery."""
         view = self._setup_view()
@@ -565,6 +593,32 @@ class TestTransferDeviceIPView:
         winner.refresh_from_db()
         assert winner.oob_ip_id is None  # winner never claimed the donor-attached address
         assert donor.oob_ip_id == oob_ip.pk  # donor FK untouched
+
+    def test_family_mismatch_fails_closed_not_500(self):
+        """A corrupt donor FK (primary_ip4 referencing an IPv6 address) makes set_device_ip_fk refuse the claim; the view returns a graceful 409 toast and rolls back, never a 500."""
+        view = self._setup_view()
+        donor = make_device("tx-fam-donor")
+        winner = make_device("tx-fam-winner")
+        self._mark(donor, winner)
+        # An IPv6 address on a WINNER interface, wrongly designated as the donor's primary_ip4
+        # (save() skips full_clean(), so the family-mismatched FK persists).
+        bad_ip = ip_on(winner, "2001:db8::5/128", "mgmt6")
+        donor.primary_ip4 = bad_ip
+        donor.save()
+        req = _hx_request({"server_key": "default"})
+
+        resp = view.post(req, pk=donor.pk, ip_kind="primary4")
+
+        # Graceful HTMX error toast, not an uncaught 500.
+        assert resp.status_code == 200
+        assert b"django-messages" in resp.content
+        assert resp.headers.get("HX-Reswap") == "none"
+        assert resp.headers.get("HX-Refresh") is None
+        # Rolled back: donor still holds the (corrupt) FK, winner never claimed it.
+        donor.refresh_from_db()
+        winner.refresh_from_db()
+        assert donor.primary_ip4_id == bad_ip.pk
+        assert winner.primary_ip4_id is None
 
     def test_rejects_when_assignment_is_not_an_interface(self):
         """A non-Interface assignment (e.g. a VMInterface) must fail closed: the device_id check sees None and the transfer is refused."""

--- a/netbox_librenms_plugin/tests/test_migrate_views.py
+++ b/netbox_librenms_plugin/tests/test_migrate_views.py
@@ -17,7 +17,14 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 # Shared real-DB builders (see tests/conftest.py).
-from netbox_librenms_plugin.tests.conftest import ip_on, make_device, make_interface, make_ip, make_vm
+from netbox_librenms_plugin.tests.conftest import (
+    cable_together,
+    ip_on,
+    make_device,
+    make_interface,
+    make_ip,
+    make_vm,
+)
 
 
 # ── helper: get_migrated_to_marker ────────────────────────────────────────
@@ -478,6 +485,101 @@ class TestMoveInterfaceToWinnerView:
         member.refresh_from_db()
         assert member.device_id == donor.pk  # not moved
         assert member.lag_id == donor_lag.pk  # relationship untouched
+
+    def test_moving_lag_master_carries_donor_side_members(self):
+        """Moving a LAG interface must carry its donor-side members, not orphan them behind a cross-device lag FK NetBox forbids creating."""
+        view = self._setup_view()
+        donor = make_device("mi-lagcasc-donor")
+        winner = make_device("mi-lagcasc-winner")
+        self._mark(donor, winner)
+        lag = make_interface(donor, "Po1", iface_type="lag")
+        member = make_interface(donor, "Eth0")
+        member.lag = lag
+        member.save()
+        req = _hx_request({"server_key": "default"})
+
+        resp = view.post(req, pk=lag.pk)
+
+        assert resp.status_code == 200
+        lag.refresh_from_db()
+        member.refresh_from_db()
+        assert lag.device_id == winner.pk
+        # The member followed in the same transaction — it never persists as a donor-side
+        # interface whose lag lives on another device (a state only its NEXT save would reject).
+        assert member.device_id == winner.pk
+        assert member.lag_id == lag.pk
+
+    def test_moving_parent_carries_child_and_bridged_interfaces(self):
+        """Moving a parent/bridge target interface carries its donor-side children and bridged peers too."""
+        view = self._setup_view()
+        donor = make_device("mi-parcasc-donor")
+        winner = make_device("mi-parcasc-winner")
+        self._mark(donor, winner)
+        parent = make_interface(donor, "eth0")
+        child = make_interface(donor, "eth0.100", iface_type="virtual")
+        child.parent = parent
+        child.save()
+        bridged = make_interface(donor, "eth7")
+        bridged.bridge = parent
+        bridged.save()
+        req = _hx_request({"server_key": "default"})
+
+        resp = view.post(req, pk=parent.pk)
+
+        assert resp.status_code == 200
+        parent.refresh_from_db()
+        child.refresh_from_db()
+        bridged.refresh_from_db()
+        assert parent.device_id == winner.pk
+        assert child.device_id == winner.pk and child.parent_id == parent.pk
+        assert bridged.device_id == winner.pk and bridged.bridge_id == parent.pk
+
+    def test_moving_lag_master_with_colliding_member_name_rolls_back_family(self):
+        """A winner-side name collision on ANY family member 409s and rolls back the whole family move."""
+        view = self._setup_view()
+        donor = make_device("mi-lagcoll-donor")
+        winner = make_device("mi-lagcoll-winner")
+        self._mark(donor, winner)
+        lag = make_interface(donor, "Po1", iface_type="lag")
+        member = make_interface(donor, "Eth0")
+        member.lag = lag
+        member.save()
+        make_interface(winner, "Eth0")  # collides with the member, not the master
+        req = _hx_request({"server_key": "default"})
+
+        resp = view.post(req, pk=lag.pk)
+
+        assert resp.status_code == 200
+        assert b"django-messages" in resp.content
+        assert resp.headers.get("HX-Reswap") == "none"
+        assert resp.headers.get("HX-Refresh") is None
+        lag.refresh_from_db()
+        member.refresh_from_db()
+        # Nothing moved: the master must not land on the winner while its member stays behind.
+        assert lag.device_id == donor.pk
+        assert member.device_id == donor.pk and member.lag_id == lag.pk
+
+    def test_moved_interface_cable_termination_cache_points_at_winner(self):
+        """The cable's denormalized CableTermination._device must follow the move — the winner's cable lists filter on it (NetBox #9788 class)."""
+        from dcim.models import CableTermination
+
+        view = self._setup_view()
+        donor = make_device("mi-ctcache-donor")
+        winner = make_device("mi-ctcache-winner")
+        peer = make_device("mi-ctcache-peer")
+        self._mark(donor, winner)
+        iface = make_interface(donor, "Eth0")
+        peer_iface = make_interface(peer, "Eth0")
+        cable_together(iface, peer_iface)
+        req = _hx_request({"server_key": "default"})
+
+        resp = view.post(req, pk=iface.pk)
+
+        assert resp.status_code == 200
+        iface.refresh_from_db()
+        assert iface.device_id == winner.pk
+        ct = CableTermination.objects.get(termination_type__model="interface", termination_id=iface.pk)
+        assert ct._device_id == winner.pk
 
     def test_save_integrity_error_rejected_with_409(self):
         """A winner-side create that trips the (device,name) unique constraint at save() — after every in-transaction check passes — is caught and surfaced as a 409 toast, and the whole move rolls back."""

--- a/netbox_librenms_plugin/tests/test_migrate_views.py
+++ b/netbox_librenms_plugin/tests/test_migrate_views.py
@@ -787,18 +787,41 @@ class TestSetDeviceIpFk:
 class TestSyncTabUrl:
     """_sync_tab_url builds the donor device sync URL with tab + server_key."""
 
-    def test_includes_tab_and_server_key(self):
+    def test_includes_tab_and_configured_server_key(self):
         from django.urls import reverse
 
         from netbox_librenms_plugin.views.sync.migrate import _sync_tab_url
 
         base = reverse("plugins:netbox_librenms_plugin:device_librenms_sync", args=[7])
-        assert _sync_tab_url(7, "ipaddresses", "siteB") == f"{base}?tab=ipaddresses&server_key=siteB"
+        # Only reflect a server_key that matches a configured server (allowlist re-source).
+        with patch(
+            "netbox_librenms_plugin.librenms_api.LibreNMSAPI.get_available_servers",
+            return_value={"siteB": "Site B"},
+        ):
+            assert _sync_tab_url(7, "ipaddresses", "siteB") == f"{base}?tab=ipaddresses&server_key=siteB"
 
-    def test_quotes_server_key(self):
+    def test_quotes_configured_server_key(self):
         from netbox_librenms_plugin.views.sync.migrate import _sync_tab_url
 
-        assert "server_key=a+b%2Fc" in _sync_tab_url(7, "interfaces", "a b/c")
+        # quote_plus still applies to a configured key (defense-in-depth against odd chars).
+        with patch(
+            "netbox_librenms_plugin.librenms_api.LibreNMSAPI.get_available_servers",
+            return_value={"a b/c": "Weird"},
+        ):
+            assert "server_key=a+b%2Fc" in _sync_tab_url(7, "interfaces", "a b/c")
+
+    def test_omits_unconfigured_server_key(self):
+        # A stale/tampered key that isn't a configured server is dropped, not reflected into
+        # the redirect target. Mirrors device_fields._sync_redirect's allowlist guard.
+        from netbox_librenms_plugin.views.sync.migrate import _sync_tab_url
+
+        with patch(
+            "netbox_librenms_plugin.librenms_api.LibreNMSAPI.get_available_servers",
+            return_value={"default": "Default Server"},
+        ):
+            url = _sync_tab_url(7, "interfaces", "siteB")
+        assert url.endswith("?tab=interfaces")
+        assert "server_key=" not in url
 
     def test_omits_server_key_when_empty(self):
         from netbox_librenms_plugin.views.sync.migrate import _sync_tab_url
@@ -868,6 +891,11 @@ class TestNonHtmxFallbackRedirect:
             patch(
                 "netbox_librenms_plugin.views.sync.migrate._resolve_winner_for_donor",
                 return_value=(None, None),
+            ),
+            # siteB must be a configured server for the fallback URL to reflect it (allowlist).
+            patch(
+                "netbox_librenms_plugin.librenms_api.LibreNMSAPI.get_available_servers",
+                return_value={"siteB": "Site B"},
             ),
         ):
             resp = view.post(req, pk=5)

--- a/netbox_librenms_plugin/tests/test_mixins.py
+++ b/netbox_librenms_plugin/tests/test_mixins.py
@@ -265,6 +265,16 @@ class TestResolveConfiguredServerKey:
         ):
             assert resolve_configured_server_key("ghost") is None
 
+    def test_returns_none_for_a_non_string_key(self):
+        """A non-string configured key is rejected before the server allowlist lookup."""
+        from netbox_librenms_plugin.views.mixins import resolve_configured_server_key
+
+        with patch(
+            "netbox_librenms_plugin.librenms_api.LibreNMSAPI.get_available_servers",
+            return_value={"siteB": "Site B"},
+        ):
+            assert resolve_configured_server_key(["siteB"]) is None
+
     def test_blank_or_none_short_circuits_before_touching_config(self):
         from netbox_librenms_plugin.views.mixins import resolve_configured_server_key
 

--- a/netbox_librenms_plugin/tests/test_mixins.py
+++ b/netbox_librenms_plugin/tests/test_mixins.py
@@ -242,3 +242,35 @@ class TestRedirectWithServerKey:
             resp = redirect_with_server_key(self._request(), "/sync/1/", "prod")
         assert resp.url == "/sync/1/"
         assert "server_key" not in resp.url
+
+
+class TestResolveConfiguredServerKey:
+    """resolve_configured_server_key: the shared allowlist re-sourcing a key from trusted config."""
+
+    def test_returns_key_when_it_names_a_configured_server(self):
+        from netbox_librenms_plugin.views.mixins import resolve_configured_server_key
+
+        with patch(
+            "netbox_librenms_plugin.librenms_api.LibreNMSAPI.get_available_servers",
+            return_value={"siteB": "Site B"},
+        ):
+            assert resolve_configured_server_key("siteB") == "siteB"
+
+    def test_returns_none_for_a_stale_or_tampered_key(self):
+        from netbox_librenms_plugin.views.mixins import resolve_configured_server_key
+
+        with patch(
+            "netbox_librenms_plugin.librenms_api.LibreNMSAPI.get_available_servers",
+            return_value={"siteB": "Site B"},
+        ):
+            assert resolve_configured_server_key("ghost") is None
+
+    def test_blank_or_none_short_circuits_before_touching_config(self):
+        from netbox_librenms_plugin.views.mixins import resolve_configured_server_key
+
+        with patch(
+            "netbox_librenms_plugin.librenms_api.LibreNMSAPI.get_available_servers",
+        ) as servers:
+            for key in (None, ""):
+                assert resolve_configured_server_key(key) is None
+            servers.assert_not_called()

--- a/netbox_librenms_plugin/tests/test_modules_view.py
+++ b/netbox_librenms_plugin/tests/test_modules_view.py
@@ -390,6 +390,7 @@ class TestMergeTransceiverDataPortIdentity:
             patch("netbox_librenms_plugin.views.base.modules_view.cache") as mock_cache,
             patch("netbox_librenms_plugin.views.base.modules_view.messages") as mock_messages,
             patch("netbox_librenms_plugin.views.base.modules_view.render", return_value=MagicMock()),
+            patch("netbox_librenms_plugin.views.base.modules_view.build_migrated_context", return_value={}),
         ):
             view.post(request, pk=1)
 
@@ -419,6 +420,7 @@ class TestMergeTransceiverDataPortIdentity:
             patch("netbox_librenms_plugin.views.base.modules_view.cache") as mock_cache,
             patch("netbox_librenms_plugin.views.base.modules_view.messages") as mock_messages,
             patch("netbox_librenms_plugin.views.base.modules_view.render", return_value=MagicMock()),
+            patch("netbox_librenms_plugin.views.base.modules_view.build_migrated_context", return_value={}),
         ):
             view.post(request, pk=1)
 

--- a/netbox_librenms_plugin/tests/test_modules_view.py
+++ b/netbox_librenms_plugin/tests/test_modules_view.py
@@ -402,12 +402,13 @@ class TestMergeTransceiverDataPortIdentity:
         mock_cache.delete.assert_called_once_with("test_cache_key")
         view._librenms_api.get_ports.assert_not_called()
 
-    def test_post_stale_server_key_resolves_migrated_context_with_fallback(self):
-        """When the POSTed server_key is stale (rebind fails) and absent from POST, the migrated context must still resolve via the session server-key fallback, not None — otherwise a migrated donor loses migrated mode and its sync controls are re-enabled."""
+    def test_post_stale_server_key_resolves_migrated_context_with_session_key(self):
+        """When the POSTed server_key is stale (rebind fails), the migrated context must resolve under the session/active key — NOT the stale posted key (which would miss the marker and re-enable a donor's sync controls)."""
         view = _make_view()
         obj = MagicMock()
         request = MagicMock()
-        request.POST.get.side_effect = lambda key, default=None: default  # no server_key posted
+        # A NON-EMPTY but stale/unconfigured key is posted (rebind returns None for it).
+        request.POST.get.side_effect = lambda key, default=None: {"server_key": "ghost-server"}.get(key, default)
         view.get_object = MagicMock(return_value=obj)
         view.rebind_api_for_server = MagicMock(return_value=None)  # stale key → rebind fails
         view.has_write_permission = MagicMock(return_value=False)
@@ -423,7 +424,7 @@ class TestMergeTransceiverDataPortIdentity:
         ):
             result = view.post(request, pk=1)
 
-        # Resolved via the session server-key fallback ("test-server"), not None.
+        # Resolved under the session/active server key ("test-server"), NOT the stale "ghost-server".
         mock_migrated.assert_called_once_with(obj, "test-server")
         assert result == "rendered"
 

--- a/netbox_librenms_plugin/tests/test_modules_view.py
+++ b/netbox_librenms_plugin/tests/test_modules_view.py
@@ -402,6 +402,31 @@ class TestMergeTransceiverDataPortIdentity:
         mock_cache.delete.assert_called_once_with("test_cache_key")
         view._librenms_api.get_ports.assert_not_called()
 
+    def test_post_stale_server_key_resolves_migrated_context_with_fallback(self):
+        """When the POSTed server_key is stale (rebind fails) and absent from POST, the migrated context must still resolve via the session server-key fallback, not None — otherwise a migrated donor loses migrated mode and its sync controls are re-enabled."""
+        view = _make_view()
+        obj = MagicMock()
+        request = MagicMock()
+        request.POST.get.side_effect = lambda key, default=None: default  # no server_key posted
+        view.get_object = MagicMock(return_value=obj)
+        view.rebind_api_for_server = MagicMock(return_value=None)  # stale key → rebind fails
+        view.has_write_permission = MagicMock(return_value=False)
+        view.partial_template_name = "x.html"
+
+        with (
+            patch("netbox_librenms_plugin.views.base.modules_view.messages"),
+            patch(
+                "netbox_librenms_plugin.views.base.modules_view.build_migrated_context",
+                return_value={"migrated_to_marker": None},
+            ) as mock_migrated,
+            patch("netbox_librenms_plugin.views.base.modules_view.render", return_value="rendered"),
+        ):
+            result = view.post(request, pk=1)
+
+        # Resolved via the session server-key fallback ("test-server"), not None.
+        mock_migrated.assert_called_once_with(obj, "test-server")
+        assert result == "rendered"
+
     def test_post_treats_non_dict_inventory_entry_as_fetch_failure(self):
         """A list payload that carries non-dict entries (e.g."""
         view = _make_view()

--- a/netbox_librenms_plugin/tests/test_modules_view.py
+++ b/netbox_librenms_plugin/tests/test_modules_view.py
@@ -373,7 +373,7 @@ class TestMergeTransceiverDataPortIdentity:
         assert mock_enrich.call_args.kwargs.get("ports_data") == ports_payload
 
     def test_post_treats_non_list_inventory_as_fetch_failure(self):
-        """get_device_inventory is an external boundary: a success flag with a non-list payload (e.g."""
+        """get_device_inventory is an external boundary: a success flag with a non-list payload (e.g. an error dict) is treated as a fetch failure."""
         view = _make_view()
         view.model = MagicMock()
         obj = MagicMock()
@@ -429,7 +429,7 @@ class TestMergeTransceiverDataPortIdentity:
         assert result == "rendered"
 
     def test_post_treats_non_dict_inventory_entry_as_fetch_failure(self):
-        """A list payload that carries non-dict entries (e.g."""
+        """A list payload that carries non-dict entries (e.g. None) is treated as a fetch failure."""
         view = _make_view()
         view.model = MagicMock()
         obj = MagicMock()
@@ -644,7 +644,7 @@ class TestMergeTransceiverDataPortIdentity:
         assert "777" not in warn_msg and "999" not in warn_msg and "OOB id" not in warn_msg
 
     def test_post_treats_non_dict_oob_inventory_entry_as_fetch_failure(self):
-        """The OOB inventory merge offsets indices and sets item["_source"] on every entry, so a success flag with non-dict elements (e.g."""
+        """The OOB inventory merge offsets indices and sets item["_source"] on every entry, so a success flag with non-dict elements (e.g. None) is treated as a fetch failure."""
         view = _make_view()
         view.model = MagicMock()
         obj = MagicMock()

--- a/netbox_librenms_plugin/tests/test_modules_view.py
+++ b/netbox_librenms_plugin/tests/test_modules_view.py
@@ -360,7 +360,7 @@ class TestMergeTransceiverDataPortIdentity:
         with (
             patch("netbox_librenms_plugin.views.base.modules_view.cache"),
             patch("netbox_librenms_plugin.views.base.modules_view.messages"),
-            patch("netbox_librenms_plugin.views.base.modules_view.render", return_value=MagicMock()),
+            patch("netbox_librenms_plugin.views.mixins.render", return_value=MagicMock()),
             patch.object(view, "_merge_transceiver_data", wraps=view._merge_transceiver_data) as mock_merge,
             patch.object(
                 view, "_enrich_inventory_port_identity", wraps=view._enrich_inventory_port_identity
@@ -389,8 +389,8 @@ class TestMergeTransceiverDataPortIdentity:
         with (
             patch("netbox_librenms_plugin.views.base.modules_view.cache") as mock_cache,
             patch("netbox_librenms_plugin.views.base.modules_view.messages") as mock_messages,
-            patch("netbox_librenms_plugin.views.base.modules_view.render", return_value=MagicMock()),
-            patch("netbox_librenms_plugin.views.base.modules_view.build_migrated_context", return_value={}),
+            patch("netbox_librenms_plugin.views.mixins.render", return_value=MagicMock()),
+            patch("netbox_librenms_plugin.utils.build_migrated_context", return_value={}),
         ):
             view.post(request, pk=1)
 
@@ -417,10 +417,10 @@ class TestMergeTransceiverDataPortIdentity:
         with (
             patch("netbox_librenms_plugin.views.base.modules_view.messages"),
             patch(
-                "netbox_librenms_plugin.views.base.modules_view.build_migrated_context",
+                "netbox_librenms_plugin.utils.build_migrated_context",
                 return_value={"migrated_to_marker": None},
             ) as mock_migrated,
-            patch("netbox_librenms_plugin.views.base.modules_view.render", return_value="rendered"),
+            patch("netbox_librenms_plugin.views.mixins.render", return_value="rendered"),
         ):
             result = view.post(request, pk=1)
 
@@ -445,8 +445,8 @@ class TestMergeTransceiverDataPortIdentity:
         with (
             patch("netbox_librenms_plugin.views.base.modules_view.cache") as mock_cache,
             patch("netbox_librenms_plugin.views.base.modules_view.messages") as mock_messages,
-            patch("netbox_librenms_plugin.views.base.modules_view.render", return_value=MagicMock()),
-            patch("netbox_librenms_plugin.views.base.modules_view.build_migrated_context", return_value={}),
+            patch("netbox_librenms_plugin.views.mixins.render", return_value=MagicMock()),
+            patch("netbox_librenms_plugin.utils.build_migrated_context", return_value={}),
         ):
             view.post(request, pk=1)
 
@@ -555,7 +555,7 @@ class TestMergeTransceiverDataPortIdentity:
         with (
             patch("netbox_librenms_plugin.views.base.modules_view.cache"),
             patch("netbox_librenms_plugin.views.base.modules_view.messages") as mock_messages,
-            patch("netbox_librenms_plugin.views.base.modules_view.render", return_value=MagicMock()),
+            patch("netbox_librenms_plugin.views.mixins.render", return_value=MagicMock()),
         ):
             view.post(request, pk=1)
 
@@ -589,7 +589,7 @@ class TestMergeTransceiverDataPortIdentity:
         with (
             patch("netbox_librenms_plugin.views.base.modules_view.cache") as mock_cache,
             patch("netbox_librenms_plugin.views.base.modules_view.messages") as mock_messages,
-            patch("netbox_librenms_plugin.views.base.modules_view.render", return_value=MagicMock()),
+            patch("netbox_librenms_plugin.views.mixins.render", return_value=MagicMock()),
             patch("netbox_librenms_plugin.views.base.modules_view.get_librenms_oob", return_value=None),
         ):
             view.post(request, pk=1)
@@ -629,7 +629,7 @@ class TestMergeTransceiverDataPortIdentity:
         with (
             patch("netbox_librenms_plugin.views.base.modules_view.cache") as mock_cache,
             patch("netbox_librenms_plugin.views.base.modules_view.messages") as mock_messages,
-            patch("netbox_librenms_plugin.views.base.modules_view.render", return_value=MagicMock()),
+            patch("netbox_librenms_plugin.views.mixins.render", return_value=MagicMock()),
             patch("netbox_librenms_plugin.views.base.modules_view.get_librenms_oob", return_value={"id": 999}),
         ):
             view.post(request, pk=1)
@@ -669,7 +669,7 @@ class TestMergeTransceiverDataPortIdentity:
         with (
             patch("netbox_librenms_plugin.views.base.modules_view.cache") as mock_cache,
             patch("netbox_librenms_plugin.views.base.modules_view.messages") as mock_messages,
-            patch("netbox_librenms_plugin.views.base.modules_view.render", return_value=MagicMock()),
+            patch("netbox_librenms_plugin.views.mixins.render", return_value=MagicMock()),
             patch("netbox_librenms_plugin.views.base.modules_view.get_librenms_oob", return_value={"id": 999}),
         ):
             view.post(request, pk=1)
@@ -850,7 +850,7 @@ class TestMergeTransceiverDataPortIdentity:
         with (
             patch("netbox_librenms_plugin.views.base.modules_view.cache") as mock_cache,
             patch("netbox_librenms_plugin.views.base.modules_view.messages"),
-            patch("netbox_librenms_plugin.views.base.modules_view.render", return_value=MagicMock()),
+            patch("netbox_librenms_plugin.views.mixins.render", return_value=MagicMock()),
             patch("netbox_librenms_plugin.views.base.modules_view.get_librenms_oob", return_value=None),
         ):
             view.post(request, pk=1)

--- a/netbox_librenms_plugin/tests/test_modules_view.py
+++ b/netbox_librenms_plugin/tests/test_modules_view.py
@@ -1840,6 +1840,17 @@ class TestBuildRowSerialMismatch:
             "entPhysicalIndex": 100,
         }
 
+    @pytest.mark.parametrize(("raw_serial", "expected"), [(123456, "123456"), (0, "0")])
+    def test_numeric_inventory_serial_is_preserved_as_text(self, raw_serial, expected):
+        """LibreNMS JSON may decode all-digit serials as numbers; row construction must not crash or discard zero."""
+        view = self._view()
+        item = self._make_item(serial=raw_serial)
+        item["_source"] = "oob"  # the real informational-row path needs no bay/type fixtures
+
+        row = view._build_row(item, {}, {}, {})
+
+        assert row["serial"] == expected
+
     def test_serial_match_sets_installed_status(self):
         """When ENTITY-MIB serial matches NetBox serial, status is Installed."""
         view = self._view()
@@ -2510,6 +2521,13 @@ class TestCheckIgnoreRules:
         rule = self._rule(match_type="serial_matches_device", pattern="", action="skip")
         item = {"entPhysicalName": "0/RP0/CPU0", "entPhysicalSerialNum": "FOC2418NHRK"}
         assert self._check(item, None, [rule], device_serial="FOC2418NHRK") == "skip"
+
+    def test_numeric_serial_matches_device_after_normalization(self):
+        """Numeric ENTITY serials use the same text normalization as the device serial."""
+        rule = self._rule(match_type="serial_matches_device", pattern="", action="transparent")
+        item = {"entPhysicalName": "0/RP0/CPU0", "entPhysicalSerialNum": 123456}
+
+        assert self._check(item, None, [rule], device_serial="123456") == "transparent"
 
     def test_serial_matches_device_no_match(self):
         """serial_matches_device: item serial differs from device serial → no match."""
@@ -4198,6 +4216,27 @@ class TestFindIntegratingAncestor:
         idx = self._index([xiom, mda])
         ancestor = BaseModuleTableView._find_integrating_ancestor(mda, idx)
         assert ancestor is xiom
+
+    def test_numeric_serial_finds_integrating_ancestor(self):
+        """Numeric ENTITY serials are normalized before integrated parent/child comparison."""
+        from netbox_librenms_plugin.views.base.modules_view import BaseModuleTableView
+
+        xiom = {
+            "entPhysicalIndex": 100,
+            "entPhysicalClass": "xioModule",
+            "entPhysicalSerialNum": 123456,
+            "entPhysicalModelName": "3HE18883AARB01",
+            "entPhysicalContainedIn": 0,
+        }
+        mda = {
+            "entPhysicalIndex": 200,
+            "entPhysicalClass": "mdaModule",
+            "entPhysicalSerialNum": 123456,
+            "entPhysicalModelName": "3HE18883AARB01",
+            "entPhysicalContainedIn": 100,
+        }
+
+        assert BaseModuleTableView._find_integrating_ancestor(mda, self._index([xiom, mda])) is xiom
 
     def test_returns_none_when_serial_differs(self):
         from netbox_librenms_plugin.views.base.modules_view import BaseModuleTableView

--- a/netbox_librenms_plugin/tests/test_modules_view.py
+++ b/netbox_librenms_plugin/tests/test_modules_view.py
@@ -5022,6 +5022,82 @@ class TestGetContextDataOOBCacheFingerprint:
         mock_cache.delete.assert_called_once_with("test_cache_key")
         assert ctx["table"] is None
 
+    def test_invalidates_when_main_id_poisoned_bool(self):
+        """A poisoned True custom-field id must not pass the fingerprint (True == 1 in Python).
+
+        post() coerces and fails closed on this exact state; the GET compare must mirror it
+        instead of serving the id-1 snapshot for a linkage post() would refuse.
+        """
+        from unittest.mock import MagicMock, patch
+
+        view = _make_view()
+        obj = MagicMock(pk=1)
+        view._get_sync_device = MagicMock(return_value=obj)
+        view._librenms_api.get_librenms_id = MagicMock(return_value=True)
+        view._build_context = MagicMock()
+        cached = {"inventory": [{"x": 1}], "librenms_id": 1, "oob_librenms_id": None}
+        with (
+            patch("netbox_librenms_plugin.views.base.modules_view.cache") as mock_cache,
+            patch("netbox_librenms_plugin.views.base.modules_view.get_librenms_oob", return_value=None),
+        ):
+            mock_cache.get.return_value = cached
+            ctx = view.get_context_data(MagicMock(GET={}), obj)
+
+        mock_cache.delete.assert_called_once_with("test_cache_key")
+        assert ctx["table"] is None
+        view._build_context.assert_not_called()
+
+    def test_keeps_cache_when_main_id_stored_as_string(self):
+        """A string-backed custom-field id ("10") must fingerprint-match the cached int 10.
+
+        Same normalization the OOB side already does — without it every GET wrongly treats
+        the snapshot as stale and the module table renders empty until a manual refresh.
+        """
+        from unittest.mock import MagicMock, patch
+
+        view = _make_view()
+        obj = MagicMock(pk=1)
+        view._get_sync_device = MagicMock(return_value=obj)
+        view._librenms_api.get_librenms_id = MagicMock(return_value="10")
+        view._build_context = MagicMock(return_value={"built": True})
+        cached = {"inventory": [{"x": 1}], "librenms_id": 10, "oob_librenms_id": None}
+        request = MagicMock(GET={})
+        with (
+            patch("netbox_librenms_plugin.views.base.modules_view.cache") as mock_cache,
+            patch("netbox_librenms_plugin.views.base.modules_view.get_librenms_oob", return_value=None),
+        ):
+            mock_cache.get.return_value = cached
+            ctx = view.get_context_data(request, obj)
+
+        assert ctx == {"built": True}
+        mock_cache.delete.assert_not_called()
+
+    def test_invalidates_when_oob_link_corrupt(self):
+        """A linked-but-corrupt OOB id must invalidate, not collapse to the no-OOB fingerprint.
+
+        post() takes the partial-outcome path (never caches) for this state; the GET compare
+        must not quietly serve a prior no-OOB snapshot while the device nominally has an OOB
+        controller linked.
+        """
+        from unittest.mock import MagicMock, patch
+
+        view = _make_view()
+        obj = MagicMock(pk=1)
+        view._get_sync_device = MagicMock(return_value=obj)
+        view._librenms_api.get_librenms_id = MagicMock(return_value=10)
+        view._build_context = MagicMock()
+        cached = {"inventory": [{"x": 1}], "librenms_id": 10, "oob_librenms_id": None}
+        with (
+            patch("netbox_librenms_plugin.views.base.modules_view.cache") as mock_cache,
+            patch("netbox_librenms_plugin.views.base.modules_view.get_librenms_oob", return_value={"id": "garbage"}),
+        ):
+            mock_cache.get.return_value = cached
+            ctx = view.get_context_data(MagicMock(GET={}), obj)
+
+        mock_cache.delete.assert_called_once_with("test_cache_key")
+        assert ctx["table"] is None
+        view._build_context.assert_not_called()
+
     def test_keeps_cache_when_oob_unchanged(self):
         from unittest.mock import MagicMock, patch
 

--- a/netbox_librenms_plugin/tests/test_multiserver_get_cache_scoping.py
+++ b/netbox_librenms_plugin/tests/test_multiserver_get_cache_scoping.py
@@ -17,7 +17,7 @@ from django.contrib.auth import get_user_model
 from django.core.cache import cache as real_cache
 from django.test import RequestFactory
 
-from netbox_librenms_plugin.tests.conftest import make_device
+from netbox_librenms_plugin.tests.conftest import make_device, make_interface, make_ip
 
 # A real cache backend that does NOT expose .ttl() (Django's default LocMemCache, like
 # Memcached/DB backends — only django-redis exposes ttl()). Used to prove the cable tab's
@@ -268,6 +268,18 @@ class TestUnresolvedServerKeyRendersEmpty:
         from netbox_librenms_plugin.views.object_sync.devices import DeviceIPAddressTableView
 
         device = make_device("ghost-ip-actions")
+        winner = make_device("ghost-ip-actions-winner")
+        device.custom_field_data["librenms_id"] = {
+            "ghost": {
+                "_migrated_to": {
+                    "device_id": winner.pk,
+                    "server_key": "ghost",
+                }
+            }
+        }
+        device.save(update_fields=["custom_field_data"])
+        interface = make_interface(device, "eth0")
+        ip = make_ip("198.18.0.1/24", assigned_object=interface)
         view = DeviceIPAddressTableView()
         view._librenms_api = MagicMock(server_key="default")
         view.request = self._ghost_request()
@@ -275,7 +287,13 @@ class TestUnresolvedServerKeyRendersEmpty:
         with patch("netbox_librenms_plugin.librenms_api.build_librenms_api", return_value=None):
             ctx = view.get_context_data(view.request, device)
 
-        assert ctx["movable_ips"] == []
+        assert ctx["movable_ips"] == [
+            {
+                "id": ip.pk,
+                "address": "198.18.0.1/24",
+                "interface_name": "eth0",
+            }
+        ]
         assert ctx["set_primary_ip"] is False
 
     # The two tests above seed the DEFAULT-server cache and prove the request doesn't fall back to

--- a/netbox_librenms_plugin/tests/test_multiserver_get_cache_scoping.py
+++ b/netbox_librenms_plugin/tests/test_multiserver_get_cache_scoping.py
@@ -263,6 +263,21 @@ class TestUnresolvedServerKeyRendersEmpty:
         finally:
             real_cache.delete(default_key)
 
+    def test_ip_tab_unresolved_key_preserves_action_context(self):
+        """An unresolved IP render keeps the move candidates and set-primary preference."""
+        from netbox_librenms_plugin.views.object_sync.devices import DeviceIPAddressTableView
+
+        device = make_device("ghost-ip-actions")
+        view = DeviceIPAddressTableView()
+        view._librenms_api = MagicMock(server_key="default")
+        view.request = self._ghost_request()
+
+        with patch("netbox_librenms_plugin.librenms_api.build_librenms_api", return_value=None):
+            ctx = view.get_context_data(view.request, device)
+
+        assert ctx["movable_ips"] == []
+        assert ctx["set_primary_ip"] is False
+
     # The two tests above seed the DEFAULT-server cache and prove the request doesn't fall back to
     # it — but they pass even unfixed, because the read is already scoped to the requested key so
     # default's cache never surfaces. The real regression is subtler: when the UNRESOLVED requested

--- a/netbox_librenms_plugin/tests/test_sync_modules.py
+++ b/netbox_librenms_plugin/tests/test_sync_modules.py
@@ -2251,7 +2251,7 @@ class TestSingleInstallInterfaceBinding:
         assert response is not None
 
     def test_update_module_interface_view_skips_adoption_on_bind_conflict(self):
-        """A hard bind conflict must NOT trigger template adoption — we don't mutate past an unresolved problem (e.g."""
+        """A hard bind conflict must NOT trigger template adoption — we don't mutate past an unresolved problem (e.g. an interface bound to another module)."""
         from netbox_librenms_plugin.views.sync.modules import UpdateModuleInterfaceView
 
         view = object.__new__(UpdateModuleInterfaceView)

--- a/netbox_librenms_plugin/tests/test_sync_modules.py
+++ b/netbox_librenms_plugin/tests/test_sync_modules.py
@@ -2030,6 +2030,55 @@ class TestSingleInstallInterfaceBinding:
         mock_messages.success.assert_called_once()
         assert response is not None
 
+    def test_update_module_interface_view_reports_when_no_bind_or_adoption_is_needed(self):
+        """A duplicate request still gets the helper's explicit no-op success message."""
+        from netbox_librenms_plugin.views.sync.modules import UpdateModuleInterfaceView
+
+        view = object.__new__(UpdateModuleInterfaceView)
+        view.required_object_permissions = {}
+        view._librenms_api = MagicMock(server_key="production")
+        device = _make_device()
+
+        module = MagicMock()
+        module.pk = 322
+        module.module_type.model = "SFP-10G-SR"
+        module.module_bay.name = "SFP 2"
+        request = _make_request(
+            "POST",
+            data={"module_id": "322", "server_key": "production", "ent_index": "78"},
+        )
+
+        with (
+            patch.object(view, "require_all_permissions", return_value=None),
+            patch(
+                "netbox_librenms_plugin.views.sync.modules.get_object_or_404",
+                side_effect=[device, module],
+            ),
+            patch("netbox_librenms_plugin.views.sync.modules.reverse", return_value="/sync/"),
+            patch.object(view, "get_cache_key", return_value="inv-key"),
+            patch("netbox_librenms_plugin.views.sync.modules.cache") as mock_cache,
+            patch("netbox_librenms_plugin.views.sync.modules.get_librenms_device_id", return_value=999),
+            patch(
+                "netbox_librenms_plugin.views.sync.modules._bind_interface_librenms_id",
+                return_value=None,
+            ),
+            patch(
+                "netbox_librenms_plugin.views.sync.modules._adopt_existing_template_interfaces",
+                return_value={"status": "bound", "adopted_count": 0, "interfaces": []},
+            ),
+            patch("netbox_librenms_plugin.views.sync.modules.messages") as mock_messages,
+            patch("netbox_librenms_plugin.views.sync.modules._modules_redirect_response", return_value="redirected"),
+        ):
+            mock_cache.get.return_value = {
+                "inventory": [{"entPhysicalIndex": 78, "_librenms_port_id": 43, "_librenms_ifname": "Te1/1/2"}],
+                "librenms_id": 999,
+            }
+            response = view.post(request, pk=24)
+
+        mock_messages.success.assert_called_once()
+        assert "No interface changes were needed" in mock_messages.success.call_args.args[1]
+        assert response == "redirected"
+
     def test_update_module_interface_view_adopts_template_interfaces_when_no_port_binding_exists(self):
         from netbox_librenms_plugin.views.sync.modules import UpdateModuleInterfaceView
 

--- a/netbox_librenms_plugin/tests/test_sync_modules.py
+++ b/netbox_librenms_plugin/tests/test_sync_modules.py
@@ -5799,6 +5799,14 @@ class TestModuleInterfaceUpdateMessage:
         msg = self._msg({"status": "bound", "interface": "Et1/1", "adopted_count": 0})
         assert msg == "Updated interface Et1/1 for QSFP-100G in Bay 1."
 
+    def test_no_bind_no_adopt_is_a_clean_no_op_message(self):
+        # Pure-adoption path where a concurrent/duplicate request already adopted the interfaces:
+        # neither an interface name nor a positive adopted_count is present. The message must NOT
+        # fall through to "Updated interface None for ...".
+        msg = self._msg({"status": "bound", "adopted_count": 0})
+        assert "None" not in msg
+        assert msg == "No interface changes were needed for QSFP-100G in Bay 1."
+
 
 class TestReplaceModuleRedirectServerKey:
     """ReplaceModuleView computes `server_key = POST or self.librenms_api.server_key`, so its redirects must pass that computed key — otherwise the helper falls back to POST/GET only and drops the active-server context when the POST field is absent, landing on a blank/default modules tab and reading/mutating a different cache namespace."""

--- a/netbox_librenms_plugin/tests/test_sync_modules.py
+++ b/netbox_librenms_plugin/tests/test_sync_modules.py
@@ -5864,6 +5864,18 @@ class TestModuleInterfaceUpdateMessage:
         assert "None" not in msg
         assert msg == "No interface changes were needed for QSFP-100G in Bay 1."
 
+    def test_unchanged_interface_bind_is_a_clean_no_op_message(self):
+        msg = self._msg(
+            {
+                "status": "bound",
+                "interface": "Et1/1",
+                "port_id": 42,
+                "changed": False,
+                "adopted_count": 0,
+            }
+        )
+        assert msg == "No interface changes were needed for QSFP-100G in Bay 1."
+
 
 class TestReplaceModuleRedirectServerKey:
     """ReplaceModuleView computes `server_key = POST or self.librenms_api.server_key`, so its redirects must pass that computed key — otherwise the helper falls back to POST/GET only and drops the active-server context when the POST field is absent, landing on a blank/default modules tab and reading/mutating a different cache namespace."""

--- a/netbox_librenms_plugin/tests/test_sync_modules.py
+++ b/netbox_librenms_plugin/tests/test_sync_modules.py
@@ -2927,6 +2927,7 @@ class TestInstallViewsDoNotDeleteCache:
 
         view = object.__new__(InstallBranchView)
         view.required_object_permissions = {}
+        view._librenms_api = MagicMock(server_key="default")
         device = _make_device()
 
         request = _make_request("POST", data={"parent_index": "100", "server_key": "default"})
@@ -2972,6 +2973,7 @@ class TestInstallViewsDoNotDeleteCache:
 
         view = object.__new__(InstallSelectedView)
         view.required_object_permissions = {}
+        view._librenms_api = MagicMock(server_key="default")
         device = _make_device()
 
         request = _make_request("POST", data={"server_key": "default"})
@@ -3020,6 +3022,7 @@ class TestInstallViewsDoNotDeleteCache:
 
         view = object.__new__(InstallBranchView)
         view.required_object_permissions = {}
+        view._librenms_api = MagicMock(server_key="default")
         device = _make_device()
 
         request = _make_request("POST", data={"parent_index": "100", "server_key": "default"})
@@ -3047,6 +3050,7 @@ class TestInstallViewsDoNotDeleteCache:
 
         view = object.__new__(InstallSelectedView)
         view.required_object_permissions = {}
+        view._librenms_api = MagicMock(server_key="default")
         device = _make_device()
 
         request = _make_request("POST", data={"server_key": "default"})
@@ -3078,6 +3082,7 @@ class TestInstallViewsDoNotDeleteCache:
 
         view = object.__new__(InstallBranchView)
         view.required_object_permissions = {}
+        view._librenms_api = MagicMock(server_key="default")
         device = _make_device()
 
         request = _make_request("POST", data={"parent_index": "100", "server_key": "default"})
@@ -3121,6 +3126,7 @@ class TestInstallViewsDoNotDeleteCache:
 
         view = object.__new__(InstallSelectedView)
         view.required_object_permissions = {}
+        view._librenms_api = MagicMock(server_key="default")
         device = _make_device()
 
         request = _make_request("POST", data={"server_key": "default"})
@@ -3168,6 +3174,7 @@ class TestInstallViewsDoNotDeleteCache:
 
         view = object.__new__(InstallBranchView)
         view.required_object_permissions = {}
+        view._librenms_api = MagicMock(server_key="default")
         device = _make_device()
 
         request = _make_request("POST", data={"parent_index": "100", "server_key": "default"})
@@ -3220,6 +3227,7 @@ class TestInstallViewsDoNotDeleteCache:
 
         view = object.__new__(InstallSelectedView)
         view.required_object_permissions = {}
+        view._librenms_api = MagicMock(server_key="default")
         device = _make_device()
 
         request = _make_request("POST", data={"server_key": "default"})
@@ -5841,3 +5849,79 @@ class TestReplaceModuleRedirectServerKey:
         # Pre-fix the redirect dropped the computed fallback (POST had no server_key); now it
         # carries server_key=prod so the action stays on the active server's modules tab.
         assert "server_key=prod" in resp["HX-Redirect"]
+
+
+class TestUpdateModuleInterfaceRedirectServerKey:
+    """UpdateModuleInterfaceView must redirect under its resolved active server scope."""
+
+    @staticmethod
+    def _view():
+        from netbox_librenms_plugin.views.sync.modules import UpdateModuleInterfaceView
+
+        view = object.__new__(UpdateModuleInterfaceView)
+        view.required_object_permissions = {}
+        view._librenms_api = MagicMock(server_key="prod")
+        return view
+
+    @staticmethod
+    def _request(data):
+        from django.test import RequestFactory
+
+        return RequestFactory().post("/update-interface/", data, HTTP_HX_REQUEST="true")
+
+    def test_invalid_module_id_redirect_preserves_fallback_server_key(self):
+        view = self._view()
+        request = self._request({"ent_index": "77"})
+        device = _make_device()
+
+        with (
+            patch.object(view, "require_all_permissions", return_value=None),
+            patch("netbox_librenms_plugin.views.sync.modules.get_object_or_404", return_value=device),
+            patch(
+                "netbox_librenms_plugin.views.sync.modules._resolve_target_device_with_validation",
+                return_value=(device, False),
+            ),
+            patch(
+                "netbox_librenms_plugin.views.sync.modules._resolve_single_install_binding_item",
+                return_value=None,
+            ),
+            patch("netbox_librenms_plugin.views.sync.modules.reverse", return_value="/sync/url/"),
+            patch("netbox_librenms_plugin.views.sync.modules.messages"),
+        ):
+            response = view.post(request, pk=device.pk)
+
+        assert "server_key=prod" in response["HX-Redirect"]
+
+    def test_success_redirect_preserves_fallback_server_key(self):
+        view = self._view()
+        request = self._request({"module_id": "321", "ent_index": "77"})
+        device = _make_device()
+        module = MagicMock()
+        module.pk = 321
+        module.module_type.model = "SFP-10G-SR"
+        module.module_bay.name = "SFP 1"
+
+        with (
+            patch.object(view, "require_all_permissions", return_value=None),
+            patch(
+                "netbox_librenms_plugin.views.sync.modules.get_object_or_404",
+                side_effect=[device, module],
+            ),
+            patch(
+                "netbox_librenms_plugin.views.sync.modules._resolve_target_device_with_validation",
+                return_value=(device, False),
+            ),
+            patch(
+                "netbox_librenms_plugin.views.sync.modules._resolve_single_install_binding_item",
+                return_value=None,
+            ),
+            patch(
+                "netbox_librenms_plugin.views.sync.modules._adopt_existing_template_interfaces",
+                return_value={"status": "bound", "adopted_count": 0},
+            ),
+            patch("netbox_librenms_plugin.views.sync.modules.reverse", return_value="/sync/url/"),
+            patch("netbox_librenms_plugin.views.sync.modules.messages"),
+        ):
+            response = view.post(request, pk=device.pk)
+
+        assert "server_key=prod" in response["HX-Redirect"]

--- a/netbox_librenms_plugin/tests/test_sync_page_server_key_forms.py
+++ b/netbox_librenms_plugin/tests/test_sync_page_server_key_forms.py
@@ -193,6 +193,48 @@ class TestSyncPageMisconfiguredDefaultDegrades:
         assert response.status_code == 200
         assert "not configured correctly" in response.content.decode()
 
+    def test_get_with_stale_server_key_and_broken_default_renders_degraded_page(self):
+        """A stale ?server_key combined with a broken default must also degrade, not 500.
+
+        The unresolved path deliberately skips get()'s degraded-render return (the page
+        must still render, e.g. the migrated banner scoped to the requested key), so it
+        reaches get_context_data() with NO client bound. Every server_key read there must
+        use the resolved render key / active_server_key fallback — a lazy librenms_api
+        touch reconstructs LibreNMSAPI() and re-raises the misconfiguration as a 500.
+        """
+        from django.contrib.auth import get_user_model
+        from django.contrib.messages.storage.fallback import FallbackStorage
+
+        from netbox_librenms_plugin.views.object_sync.devices import DeviceLibreNMSSyncView
+
+        device = make_device("sync-page-degraded-stale")
+        user = get_user_model().objects.create_superuser(username="sync-degraded-stale-su")
+
+        request = RequestFactory().get("/x/", {"server_key": "gone-server"})
+        request.user = user
+        request.htmx = False
+        request.session = {}
+        request._messages = FallbackStorage(request)
+
+        view = DeviceLibreNMSSyncView()
+        view.setup(request, pk=device.pk)
+
+        with (
+            # Neither the requested key nor the default can build a client...
+            patch("netbox_librenms_plugin.librenms_api.build_librenms_api", return_value=None),
+            # ...so any lazy LibreNMSAPI() reconstruction would raise, as in production.
+            patch(
+                "netbox_librenms_plugin.views.mixins.LibreNMSAPI",
+                side_effect=ValueError("LibreNMS URL or API token is not configured"),
+            ),
+        ):
+            response = view.get(request, pk=device.pk)
+
+        assert response.status_code == 200
+        # The header's server-info block degrades to the configuration-error display
+        # (get_server_info's fail-soft branch) instead of the page 500ing.
+        assert "Configuration error" in response.content.decode()
+
 
 class TestUpdateDeviceLocationRebindsServer:
     """UpdateDeviceLocationView must write to the POSTed server, not the global default."""

--- a/netbox_librenms_plugin/tests/test_sync_page_server_key_forms.py
+++ b/netbox_librenms_plugin/tests/test_sync_page_server_key_forms.py
@@ -210,6 +210,8 @@ class TestSyncPageMisconfiguredDefaultDegrades:
         device = make_device("sync-page-degraded-stale")
         user = get_user_model().objects.create_superuser(username="sync-degraded-stale-su")
 
+        assert "gone-server" not in TWO_SERVERS  # the key really is stale under the pinned config
+
         request = RequestFactory().get("/x/", {"server_key": "gone-server"})
         request.user = user
         request.htmx = False
@@ -220,8 +222,14 @@ class TestSyncPageMisconfiguredDefaultDegrades:
         view.setup(request, pk=device.pk)
 
         with (
+            # Pin the configured servers (as _render_sync_page does) so "gone-server" is stale
+            # against a real two-server config rather than an unconfigured plugin.
+            patch(
+                "netbox_librenms_plugin.librenms_api.get_plugin_config",
+                side_effect=lambda _plugin, key, default=None: TWO_SERVERS if key == "servers" else default,
+            ),
             # Neither the requested key nor the default can build a client...
-            patch("netbox_librenms_plugin.librenms_api.build_librenms_api", return_value=None),
+            patch("netbox_librenms_plugin.librenms_api.build_librenms_api", return_value=None) as mock_build,
             # ...so any lazy LibreNMSAPI() reconstruction would raise, as in production.
             patch(
                 "netbox_librenms_plugin.views.mixins.LibreNMSAPI",
@@ -230,10 +238,20 @@ class TestSyncPageMisconfiguredDefaultDegrades:
         ):
             response = view.get(request, pk=device.pk)
 
+        # The stale key was routed to the factory (so the unresolved branch is the one taken),
+        # and the broken default was then tried as the fallback bind.
+        build_keys = [c.args[0] for c in mock_build.call_args_list]
+        assert "gone-server" in build_keys
+        assert None in build_keys
         assert response.status_code == 200
         # The header's server-info block degrades to the configuration-error display
-        # (get_server_info's fail-soft branch) instead of the page 500ing.
+        # (get_server_info's fail-soft branch) instead of the page 500ing...
         assert "Configuration error" in response.content.decode()
+        # ...and the page is NOT the minimal early-return render the *blank*-key branch produces
+        # (the unresolved path must still render the tabbed page scoped to the requested key).
+        assert view._server_key_unresolved is True
+        assert view._render_server_key == "gone-server"
+        assert view.librenms_id is None  # failed closed: no default-server mapping attributed
 
 
 class TestUpdateDeviceLocationRebindsServer:

--- a/netbox_librenms_plugin/tests/test_sync_page_server_key_forms.py
+++ b/netbox_librenms_plugin/tests/test_sync_page_server_key_forms.py
@@ -250,7 +250,7 @@ class TestSyncPageMisconfiguredDefaultDegrades:
         # ...and the page is NOT the minimal early-return render the *blank*-key branch produces
         # (the unresolved path must still render the tabbed page scoped to the requested key).
         assert view._server_key_unresolved is True
-        assert view._render_server_key == "gone-server"
+        assert view._scoped_render_server_key == "gone-server"
         assert view.librenms_id is None  # failed closed: no default-server mapping attributed
 
 

--- a/netbox_librenms_plugin/tests/test_utils.py
+++ b/netbox_librenms_plugin/tests/test_utils.py
@@ -1480,6 +1480,15 @@ class TestNormalizeDeviceSerialsMigration:
         assert Device.objects.get(pk=blank.pk).serial == ""
         assert Device.objects.get(pk=unchanged.pk).serial == "SN-MIG-2"
 
+    def test_serial_rewrite_is_not_wrapped_in_one_migration_transaction(self):
+        """Each idempotent batch commits independently so a large Device table is not locked for the full rewrite."""
+        import importlib
+
+        module = importlib.import_module("netbox_librenms_plugin.migrations.0012_normalize_device_serials")
+
+        assert module.Migration.atomic is False
+        assert module.Migration.operations[0].atomic is False
+
     def test_plain_serial_index_exists(self):
         """The migration adds the ordinary B-tree index used by exact serial equality lookups."""
         from django.db import connection

--- a/netbox_librenms_plugin/tests/test_utils.py
+++ b/netbox_librenms_plugin/tests/test_utils.py
@@ -1488,6 +1488,7 @@ class TestNormalizeDeviceSerialsMigration:
 
         assert module.Migration.atomic is False
         assert module.Migration.operations[0].atomic is False
+        assert module.Migration.operations[1].atomic is False
 
     def test_plain_serial_index_exists(self):
         """The migration adds the ordinary B-tree index used by exact serial equality lookups."""

--- a/netbox_librenms_plugin/tests/test_utils_shared_helpers.py
+++ b/netbox_librenms_plugin/tests/test_utils_shared_helpers.py
@@ -78,3 +78,37 @@ class TestResolveServerMappingDisplayId:
 
     def test_dict_oob_not_a_dict(self):
         assert resolve_server_mapping_display_id({"id": 0, "oob": 5}) == (None, False)
+
+
+class TestRenderVcMemberOptions:
+    """The shared VC-member <option> builder used by the interface/cable/module tables."""
+
+    class _Member:
+        def __init__(self, pk, name):
+            self.id = pk
+            self.name = name
+
+    def test_marks_the_selected_member(self):
+        from netbox_librenms_plugin.utils import render_vc_member_options
+
+        html = render_vc_member_options([self._Member(1, "sw1"), self._Member(2, "sw2")], 2)
+        assert '<option value="1">sw1</option>' in html
+        assert '<option value="2" selected>sw2</option>' in html
+
+    def test_string_selected_id_matches_int_member_id(self):
+        # The module table's cached selected id can be a string; it must still match.
+        from netbox_librenms_plugin.utils import render_vc_member_options
+
+        html = render_vc_member_options([self._Member(3, "sw3")], "3")
+        assert '<option value="3" selected>sw3</option>' in html
+
+    def test_member_names_are_escaped(self):
+        from django.utils.safestring import SafeString
+
+        from netbox_librenms_plugin.utils import render_vc_member_options
+
+        html = render_vc_member_options([self._Member(1, '<img src=x onerror=alert(1)>"')], None)
+        assert "<img" not in html
+        assert "&lt;img src=x onerror=alert(1)&gt;&quot;" in html
+        # SafeString so format_html() callers embed it without double-escaping.
+        assert isinstance(html, SafeString)

--- a/netbox_librenms_plugin/tests/test_utils_shared_helpers.py
+++ b/netbox_librenms_plugin/tests/test_utils_shared_helpers.py
@@ -112,3 +112,35 @@ class TestRenderVcMemberOptions:
         assert "&lt;img src=x onerror=alert(1)&gt;&quot;" in html
         # SafeString so format_html() callers embed it without double-escaping.
         assert isinstance(html, SafeString)
+
+
+class TestOobBadgeHtml:
+    """The shared OOB-source badge used by the interface/module/cable tables and cable verify."""
+
+    def test_oob_row_gets_the_badge(self):
+        from django.utils.safestring import SafeString
+
+        from netbox_librenms_plugin.constants import OOB_BADGE_HTML
+        from netbox_librenms_plugin.utils import oob_badge_html
+
+        html = oob_badge_html({"_source": "oob"})
+        assert html == OOB_BADGE_HTML
+        # SafeString so format_html() callers embed the trusted markup un-escaped.
+        assert isinstance(html, SafeString)
+
+    def test_leading_space_prefixes_the_badge(self):
+        from django.utils.safestring import SafeString
+
+        from netbox_librenms_plugin.constants import OOB_BADGE_HTML
+        from netbox_librenms_plugin.utils import oob_badge_html
+
+        html = oob_badge_html({"_source": "oob"}, leading_space=True)
+        assert html == " " + OOB_BADGE_HTML
+        assert isinstance(html, SafeString)
+
+    @pytest.mark.parametrize("record", [{}, {"_source": "main"}, {"_source": None}, {"_source": "OOB"}])
+    def test_non_oob_rows_get_no_badge(self, record):
+        from netbox_librenms_plugin.utils import oob_badge_html
+
+        assert oob_badge_html(record) == ""
+        assert oob_badge_html(record, leading_space=True) == ""

--- a/netbox_librenms_plugin/tests/test_vlan_sync.py
+++ b/netbox_librenms_plugin/tests/test_vlan_sync.py
@@ -512,6 +512,7 @@ class TestVLANPostServerKeyScoping:
             # The POST rebinds the API to the posted server before anything else.
             patch("netbox_librenms_plugin.librenms_api.build_librenms_api", return_value=rebound_api),
             patch("netbox_librenms_plugin.utils.build_migrated_context", return_value={}) as mock_bmc,
+            patch("netbox_librenms_plugin.views.base.vlan_table_view.cache"),
             patch("netbox_librenms_plugin.views.base.vlan_table_view.messages"),
             patch("netbox_librenms_plugin.views.mixins.render"),
         ):

--- a/netbox_librenms_plugin/tests/test_vlan_sync.py
+++ b/netbox_librenms_plugin/tests/test_vlan_sync.py
@@ -511,11 +511,9 @@ class TestVLANPostServerKeyScoping:
         with (
             # The POST rebinds the API to the posted server before anything else.
             patch("netbox_librenms_plugin.librenms_api.build_librenms_api", return_value=rebound_api),
-            patch(
-                "netbox_librenms_plugin.views.base.vlan_table_view.build_migrated_context", return_value={}
-            ) as mock_bmc,
+            patch("netbox_librenms_plugin.utils.build_migrated_context", return_value={}) as mock_bmc,
             patch("netbox_librenms_plugin.views.base.vlan_table_view.messages"),
-            patch("netbox_librenms_plugin.views.base.vlan_table_view.render"),
+            patch("netbox_librenms_plugin.views.mixins.render"),
         ):
             view.post(req, pk=1)
 
@@ -549,10 +547,10 @@ class TestVLANPostServerKeyScoping:
 
         with (
             patch("netbox_librenms_plugin.librenms_api.build_librenms_api", return_value=rebound_api),
-            patch("netbox_librenms_plugin.views.base.vlan_table_view.build_migrated_context", return_value={}),
+            patch("netbox_librenms_plugin.utils.build_migrated_context", return_value={}),
             patch("netbox_librenms_plugin.views.base.vlan_table_view.cache"),
             patch("netbox_librenms_plugin.views.base.vlan_table_view.messages"),
-            patch("netbox_librenms_plugin.views.base.vlan_table_view.render"),
+            patch("netbox_librenms_plugin.views.mixins.render"),
         ):
             view.post(req, pk=1)
 
@@ -602,10 +600,10 @@ class TestVlanRefreshFailureClearsCache:
 
         with (
             patch("netbox_librenms_plugin.librenms_api.build_librenms_api", return_value=rebound_api),
-            patch("netbox_librenms_plugin.views.base.vlan_table_view.build_migrated_context", return_value={}),
+            patch("netbox_librenms_plugin.utils.build_migrated_context", return_value={}),
             patch("netbox_librenms_plugin.views.base.vlan_table_view.cache") as mock_cache,
             patch("netbox_librenms_plugin.views.base.vlan_table_view.messages"),
-            patch("netbox_librenms_plugin.views.base.vlan_table_view.render"),
+            patch("netbox_librenms_plugin.views.mixins.render"),
         ):
             view.post(req, pk=1)
         return view, mock_cache

--- a/netbox_librenms_plugin/tests/test_vlan_sync.py
+++ b/netbox_librenms_plugin/tests/test_vlan_sync.py
@@ -488,6 +488,42 @@ class TestVlanEntryDictGuardInSync:
 class TestVLANPostServerKeyScoping:
     """The refresh POST must scope migrated context (and cache) to the POSTed server_key, not the session-active server, in multi-server setups."""
 
+    def test_post_uses_post_server_key_for_migrated_context(self):
+        from unittest.mock import MagicMock, patch
+
+        from netbox_librenms_plugin.views.base.vlan_table_view import BaseVLANTableView
+
+        view = object.__new__(BaseVLANTableView)
+        obj = MagicMock(pk=1)
+        view.get_object = MagicMock(return_value=obj)
+        view._get_error_context = MagicMock(return_value={})
+        # Seed the session client on _librenms_api and use the REAL librenms_api property so
+        # rebind_api_for_server() actually swaps the client post() uses — a property override
+        # would pin post() to the session client and mask whether the rebind took effect.
+        mock_api = MagicMock(server_key="default")
+        view._librenms_api = mock_api
+        rebound_api = MagicMock(server_key="prod")
+        rebound_api.get_librenms_id.return_value = None  # short-circuit before fetch/cache
+
+        req = MagicMock()
+        req.POST.get.side_effect = lambda k, d=None: {"server_key": "prod"}.get(k, d)
+
+        with (
+            # The POST rebinds the API to the posted server before anything else.
+            patch("netbox_librenms_plugin.librenms_api.build_librenms_api", return_value=rebound_api),
+            patch(
+                "netbox_librenms_plugin.views.base.vlan_table_view.build_migrated_context", return_value={}
+            ) as mock_bmc,
+            patch("netbox_librenms_plugin.views.base.vlan_table_view.messages"),
+            patch("netbox_librenms_plugin.views.base.vlan_table_view.render"),
+        ):
+            view.post(req, pk=1)
+
+        mock_bmc.assert_called_once_with(obj, "prod")
+        # The id lookup ran on the REBOUND client, never the session one.
+        rebound_api.get_librenms_id.assert_called_once_with(obj)
+        mock_api.get_librenms_id.assert_not_called()
+
     def test_post_scopes_cache_keys_to_post_server_key(self):
         """Drive the request past the short-circuit into cache-key construction: a regression that namespaced the cache under the session server (not the POSTed one) must fail here."""
         from unittest.mock import MagicMock, patch
@@ -513,6 +549,7 @@ class TestVLANPostServerKeyScoping:
 
         with (
             patch("netbox_librenms_plugin.librenms_api.build_librenms_api", return_value=rebound_api),
+            patch("netbox_librenms_plugin.views.base.vlan_table_view.build_migrated_context", return_value={}),
             patch("netbox_librenms_plugin.views.base.vlan_table_view.cache"),
             patch("netbox_librenms_plugin.views.base.vlan_table_view.messages"),
             patch("netbox_librenms_plugin.views.base.vlan_table_view.render"),
@@ -565,6 +602,7 @@ class TestVlanRefreshFailureClearsCache:
 
         with (
             patch("netbox_librenms_plugin.librenms_api.build_librenms_api", return_value=rebound_api),
+            patch("netbox_librenms_plugin.views.base.vlan_table_view.build_migrated_context", return_value={}),
             patch("netbox_librenms_plugin.views.base.vlan_table_view.cache") as mock_cache,
             patch("netbox_librenms_plugin.views.base.vlan_table_view.messages"),
             patch("netbox_librenms_plugin.views.base.vlan_table_view.render"),

--- a/netbox_librenms_plugin/urls.py
+++ b/netbox_librenms_plugin/urls.py
@@ -15,6 +15,11 @@ from .views import (
     AddAsOOBView,
     AddDeviceTypeMappingView,
     AddPlatformMappingView,
+    PromoteToHostView,
+    MergeNetBoxDevicesView,
+    MoveInterfaceToWinnerView,
+    MoveIPAddressToWinnerView,
+    TransferDeviceIPView,
     AssignVCSerialView,
     BulkImportConfirmView,
     BulkImportDevicesView,
@@ -436,6 +441,31 @@ urlpatterns = [
         "device-import/add-as-oob/<int:device_id>/",
         AddAsOOBView.as_view(),
         name="device_add_as_oob",
+    ),
+    path(
+        "device-import/promote-to-host/<int:device_id>/",
+        PromoteToHostView.as_view(),
+        name="device_promote_to_host",
+    ),
+    path(
+        "device-import/merge-netbox-devices/<int:device_id>/",
+        MergeNetBoxDevicesView.as_view(),
+        name="device_merge_netbox_devices",
+    ),
+    path(
+        "interface/<int:pk>/move-to-winner/",
+        MoveInterfaceToWinnerView.as_view(),
+        name="interface_move_to_winner",
+    ),
+    path(
+        "ipaddress/<int:pk>/move-to-winner/",
+        MoveIPAddressToWinnerView.as_view(),
+        name="ipaddress_move_to_winner",
+    ),
+    path(
+        "device/<int:pk>/transfer-ip/<str:ip_kind>/",
+        TransferDeviceIPView.as_view(),
+        name="device_transfer_ip",
     ),
     path(
         "device-import/add-device-type-mapping/<int:device_id>/",

--- a/netbox_librenms_plugin/utils.py
+++ b/netbox_librenms_plugin/utils.py
@@ -1940,8 +1940,16 @@ def merge_librenms_links(winner, donor, server_key: str = "default") -> dict:
         winner_entry = {"id": _coerced} if _coerced else {}
     elif isinstance(winner_entry, dict):
         winner_entry = dict(winner_entry)
-    else:
+    elif winner_entry is None:
         winner_entry = {}
+    else:
+        # An unsupported shape (bool/float/list/…) is corrupted state, not "no link". Fail closed
+        # like the string branch rather than collapsing to {}, which could silently change the
+        # merge (e.g. the winner inheriting the donor's id).
+        raise ValueError(
+            f"winner '{winner.name}' has an unsupported librenms_id[{server_key!r}] of type "
+            f"{type(winner_entry).__name__} — expected a positive integer, numeric string, or mapping."
+        )
 
     donor_entry = donor_cf.get(server_key)
     if isinstance(donor_entry, int) and not isinstance(donor_entry, bool):
@@ -1954,8 +1962,15 @@ def merge_librenms_links(winner, donor, server_key: str = "default") -> dict:
                 f"{donor_entry!r} — expected a positive integer or numeric string."
             )
         donor_entry = {"id": _coerced} if _coerced else {}
-    elif not isinstance(donor_entry, dict):
+    elif isinstance(donor_entry, dict):
+        pass
+    elif donor_entry is None:
         donor_entry = {}
+    else:
+        raise ValueError(
+            f"donor '{donor.name}' has an unsupported librenms_id[{server_key!r}] of type "
+            f"{type(donor_entry).__name__} — expected a positive integer, numeric string, or mapping."
+        )
 
     donor_id = donor_entry.get("id")
     donor_oob = donor_entry.get("oob") if isinstance(donor_entry.get("oob"), dict) else None

--- a/netbox_librenms_plugin/utils.py
+++ b/netbox_librenms_plugin/utils.py
@@ -2144,6 +2144,16 @@ def merge_librenms_links(winner, donor, server_key: str = "default") -> dict:
         )
         donor_oob_has_valid_id = _donor_oob_id is not None
 
+    # The winner has only one free link slot (oob), while the donor carries two distinct links
+    # (its host id and a real oob id). Choosing either donor link would silently orphan the other
+    # once mark_librenms_migrated() clears the donor entry, so require the operator to unlink one
+    # side first rather than applying a lossy preference.
+    if winner_id is not None and donor_id is not None and donor_id != winner_id and donor_oob_has_valid_id:
+        raise ValueError(
+            f"Cannot merge: donor '{donor.name}' has two distinct LibreNMS links but winner "
+            f"'{winner.name}' has only one free link slot. Unlink one donor link first."
+        )
+
     # Fail closed when the donor's host id has nowhere to go: the winner already occupies BOTH
     # its host-id slot (winner_id) AND its oob slot (winner_oob), so neither the inherit-id branch
     # (needs an empty winner host slot) nor the demote branch (needs an empty winner oob slot) can

--- a/netbox_librenms_plugin/utils.py
+++ b/netbox_librenms_plugin/utils.py
@@ -9,6 +9,8 @@ from django.core.exceptions import ObjectDoesNotExist, ValidationError
 from django.db.models import Count, Max, Q
 from django.http import HttpRequest
 from django.utils.functional import SimpleLazyObject
+from django.utils.html import escape
+from django.utils.safestring import mark_safe
 from netbox.config import get_config
 from netbox.plugins import get_plugin_config
 from utilities.paginator import get_paginate_count as netbox_get_paginate_count
@@ -1193,6 +1195,32 @@ def coerce_librenms_id(value) -> int | None:
         except ValueError:
             return None
     return None
+
+
+def render_vc_member_options(members, selected_id):
+    """
+    Build the ``<option>`` list for a Virtual Chassis member dropdown.
+
+    Shared by the VC interface/cable/module tables' ``render_device_selection`` so the
+    member-name escaping and selected-flag logic cannot drift between per-table copies
+    (the XSS escaping was previously added to each copy separately). Ids are compared as
+    strings because the module table's selected id can arrive as a string from cached
+    row data, while the other tables pass ints — ``str()`` makes both compare correctly.
+
+    Args:
+        members: Iterable of VC member devices (anything with ``.id`` and ``.name``).
+        selected_id: The member id to mark selected (int or numeric string).
+
+    Returns:
+        SafeString: The concatenated ``<option>`` elements, member names escaped.
+    """
+    return mark_safe(  # noqa: S308 — names escaped above; ids are model pks
+        "".join(
+            f'<option value="{member.id}"{" selected" if str(member.id) == str(selected_id) else ""}>'
+            f"{escape(member.name)}</option>"
+            for member in members
+        )
+    )
 
 
 def is_valid_ports_payload(payload) -> bool:

--- a/netbox_librenms_plugin/utils.py
+++ b/netbox_librenms_plugin/utils.py
@@ -2075,6 +2075,23 @@ def merge_librenms_links(winner, donor, server_key: str = "default") -> dict:
             )
         donor_oob_has_valid_id = _donor_oob_id is not None
 
+    # Fail closed when the donor's host id has nowhere to go: the winner already occupies BOTH
+    # its host-id slot (winner_id) AND its oob slot (winner_oob), so neither the inherit-id branch
+    # (needs an empty winner host slot) nor the demote branch (needs an empty winner oob slot) can
+    # place a distinct donor id. Proceeding would silently drop the donor's LibreNMS host link and
+    # orphan that device once the donor is marked migrated — the same data loss every other branch
+    # here fails closed on, and exactly what the merge modal's "Moved to winner" promise forbids.
+    # A donor id EQUAL to the winner's is the same host linkage (a duplicate mapping), not an
+    # orphan, so it is allowed through; a donor that carries its own real oob is inherited by the
+    # branch below when the winner's oob slot is free (winner_oob is None), so this only fires when
+    # the winner's oob is genuinely occupied.
+    if winner_id is not None and donor_id is not None and donor_id != winner_id and winner_oob is not None:
+        raise ValueError(
+            f"Cannot merge: winner '{winner.name}' already holds both a LibreNMS host id and an "
+            f"OOB link, so donor '{donor.name}' host id {donor_id} has nowhere to move. "
+            "Unlink one side first."
+        )
+
     if winner_id is None and donor_id is not None:
         winner_entry["id"] = donor_id
         summary["host_id_from_donor"] = donor_id

--- a/netbox_librenms_plugin/utils.py
+++ b/netbox_librenms_plugin/utils.py
@@ -8,6 +8,7 @@ from dcim.models import Device
 from django.core.exceptions import ObjectDoesNotExist, ValidationError
 from django.db.models import Count, Max, Q
 from django.http import HttpRequest
+from django.utils.functional import SimpleLazyObject
 from netbox.config import get_config
 from netbox.plugins import get_plugin_config
 from utilities.paginator import get_paginate_count as netbox_get_paginate_count
@@ -1879,6 +1880,50 @@ def ip_family(ip):
     return address.version
 
 
+def _normalize_merge_entry(entry, *, owner_label, owner_name, server_key, copy_dict):
+    """
+    Coerce one device's per-server ``librenms_id`` entry to a dict, failing closed on corrupt shapes.
+
+    Shared by :func:`merge_librenms_links` for the winner and donor entries so their per-server
+    shape validation can't drift. A bare int (or numeric string) becomes ``{"id": N}``; a blank/None
+    entry becomes ``{}``; a *non-blank* unparseable string, or an unsupported type (bool/float/list),
+    is corrupted state and raises ``ValueError`` rather than silently collapsing to "no link".
+
+    ``copy_dict`` controls whether a dict entry is returned as a shallow copy (the winner entry is
+    mutated downstream and must not alias the stored dict) or as-is (the donor entry is read-only).
+    ``mark_librenms_migrated`` deliberately does NOT use this helper: it adds nested id/oob validation
+    and emits action-specific "migrate it first" guidance.
+
+    Args:
+        entry: The raw ``custom_field_data['librenms_id'][server_key]`` value.
+        owner_label (str): "winner" or "donor", for the error message.
+        owner_name (str): The device name, for the error message.
+        server_key (str): The LibreNMS server key the entry is namespaced under.
+        copy_dict (bool): Shallow-copy a dict entry (True) or return it as-is (False).
+
+    Returns:
+        dict: The normalized entry (``{"id": N}``, ``{}``, or the original/copied dict).
+    """
+    if isinstance(entry, int) and not isinstance(entry, bool):
+        return {"id": entry}
+    if isinstance(entry, str):
+        coerced = coerce_librenms_id(entry)
+        if coerced is None and entry.strip():
+            raise ValueError(
+                f"{owner_label} '{owner_name}' has an unparseable librenms_id[{server_key!r}] "
+                f"{entry!r} — expected a positive integer or numeric string."
+            )
+        return {"id": coerced} if coerced else {}
+    if isinstance(entry, dict):
+        return dict(entry) if copy_dict else entry
+    if entry is None:
+        return {}
+    raise ValueError(
+        f"{owner_label} '{owner_name}' has an unsupported librenms_id[{server_key!r}] of type "
+        f"{type(entry).__name__} — expected a positive integer, numeric string, or mapping."
+    )
+
+
 def merge_librenms_links(winner, donor, server_key: str = "default") -> dict:
     """
     Merge donor's ``librenms_id[server_key]`` link state into winner's.
@@ -1933,53 +1978,22 @@ def merge_librenms_links(winner, donor, server_key: str = "default") -> dict:
         # repaired/migrated by the caller before merging — never silently treated as "no link".
         raise ValueError("Cannot merge: one or both devices have a legacy bare-integer or corrupt librenms_id.")
 
-    winner_entry = winner_cf.get(server_key)
-    if isinstance(winner_entry, int) and not isinstance(winner_entry, bool):
-        winner_entry = {"id": winner_entry}
-    elif isinstance(winner_entry, str):
-        _coerced = coerce_librenms_id(winner_entry)
-        # Fail closed on corrupted stored state: a non-empty string that can't be
-        # parsed must surface, not silently collapse to "no id" (which would let the
-        # winner inherit the donor's id or drop the link). Mirrors the dict-form guard.
-        if _coerced is None and winner_entry.strip():
-            raise ValueError(
-                f"winner '{winner.name}' has an unparseable librenms_id[{server_key!r}] "
-                f"{winner_entry!r} — expected a positive integer or numeric string."
-            )
-        winner_entry = {"id": _coerced} if _coerced else {}
-    elif isinstance(winner_entry, dict):
-        winner_entry = dict(winner_entry)
-    elif winner_entry is None:
-        winner_entry = {}
-    else:
-        # An unsupported shape (bool/float/list/…) is corrupted state, not "no link". Fail closed
-        # like the string branch rather than collapsing to {}, which could silently change the
-        # merge (e.g. the winner inheriting the donor's id).
-        raise ValueError(
-            f"winner '{winner.name}' has an unsupported librenms_id[{server_key!r}] of type "
-            f"{type(winner_entry).__name__} — expected a positive integer, numeric string, or mapping."
-        )
-
-    donor_entry = donor_cf.get(server_key)
-    if isinstance(donor_entry, int) and not isinstance(donor_entry, bool):
-        donor_entry = {"id": donor_entry}
-    elif isinstance(donor_entry, str):
-        _coerced = coerce_librenms_id(donor_entry)
-        if _coerced is None and donor_entry.strip():
-            raise ValueError(
-                f"donor '{donor.name}' has an unparseable librenms_id[{server_key!r}] "
-                f"{donor_entry!r} — expected a positive integer or numeric string."
-            )
-        donor_entry = {"id": _coerced} if _coerced else {}
-    elif isinstance(donor_entry, dict):
-        pass
-    elif donor_entry is None:
-        donor_entry = {}
-    else:
-        raise ValueError(
-            f"donor '{donor.name}' has an unsupported librenms_id[{server_key!r}] of type "
-            f"{type(donor_entry).__name__} — expected a positive integer, numeric string, or mapping."
-        )
+    # The winner entry is copied (it is mutated below); the donor entry is read-only. Both share the
+    # same fail-closed shape validation via _normalize_merge_entry so they can't drift apart.
+    winner_entry = _normalize_merge_entry(
+        winner_cf.get(server_key),
+        owner_label="winner",
+        owner_name=winner.name,
+        server_key=server_key,
+        copy_dict=True,
+    )
+    donor_entry = _normalize_merge_entry(
+        donor_cf.get(server_key),
+        owner_label="donor",
+        owner_name=donor.name,
+        server_key=server_key,
+        copy_dict=False,
+    )
 
     def _extract_oob_entry(owner_label, owner_name, entry):
         # Validate the nested oob shape the same way the top-level/per-server shapes are
@@ -2119,6 +2133,10 @@ def merge_librenms_links(winner, donor, server_key: str = "default") -> dict:
 # Stage-2b "move to winner" actions. NetBox requires each to reference an address assigned to
 # one of THAT device's own interfaces.
 DEVICE_IP_FK_FIELDS = ("primary_ip4", "primary_ip6", "oob_ip")
+
+# Human-readable labels for the device IP FK fields, used in user-facing transfer/reconcile messages.
+# Single source so the per-field reconcile notes and the TransferDeviceIPView buttons can't disagree.
+DEVICE_IP_FK_LABELS = {"primary_ip4": "primary IPv4", "primary_ip6": "primary IPv6", "oob_ip": "OOB IP"}
 
 
 def set_device_ip_fk(device, field, ip, *, save=True):
@@ -2357,25 +2375,38 @@ def build_migrated_context(obj, server_key: str = "default") -> dict:
         obj: The donor device to build migrated-mode context for.
         server_key (str): The LibreNMS server key the marker is namespaced under.
 
+    ``migrated_to_winner`` is a lazy proxy: the winner ``Device`` row is fetched only when a template
+    actually reads it (the interface/IP partials, which render the per-row "Move to winner" controls).
+    The cable/module/VLAN partials render only the marker banner and never touch it, so they avoid the
+    lookup on every HTMX refresh. The self-pointing suppression is done in memory (``device_id ==
+    obj.pk``) so it never forces that fetch — the donor always exists, so the old ``Device`` lookup
+    could only ever have returned ``obj`` itself.
+
+    Args:
+        obj: The donor device to build migrated-mode context for.
+        server_key (str): The LibreNMS server key the marker is namespaced under.
+
     Returns:
-        dict: ``{migrated_to_marker, migrated_to_winner}``; both None when the device
-            is not in migrated mode.
+        dict: ``{migrated_to_marker, migrated_to_winner}``. Both None when not in migrated mode (no
+            marker, or a corrupt self-pointing marker). ``migrated_to_winner`` is a lazy ``Device``
+            proxy (truthiness/attribute access resolves it; it proxies None if the winner row was
+            since deleted) — test it via truthiness in templates, not ``is None``.
     """
     marker = get_migrated_to_marker(obj, server_key)
-    if not marker:
-        return {"migrated_to_marker": None, "migrated_to_winner": None}
-    from dcim.models import Device
-
-    # device_id is guaranteed a positive int by get_migrated_to_marker().
-    winner = Device.objects.filter(pk=marker["device_id"]).first()
     # A self-pointing marker (winner == this donor) is corrupt: it would flip the donor's own sync
     # page into migrated mode resolving the "winner" to itself, hiding the ordinary sync controls.
-    # Fail closed to the non-migrated result. The marker is deliberately NOT rejected in
-    # get_migrated_to_marker(): the move views read it via _resolve_winner_for_donor() and need it
-    # present to report a self-pointing marker as "stale/corrupt" rather than "not migrated".
-    if winner is not None and winner.pk == getattr(obj, "pk", None):
+    # Suppress it in memory (no Device fetch) — the donor always exists, so resolving device_id would
+    # only ever return obj. The marker is deliberately NOT rejected in get_migrated_to_marker(): the
+    # move views read it via _resolve_winner_for_donor() to report it as "stale/corrupt".
+    if not marker or marker.get("device_id") == getattr(obj, "pk", None):
         return {"migrated_to_marker": None, "migrated_to_winner": None}
-    return {"migrated_to_marker": marker, "migrated_to_winner": winner}
+
+    # device_id is guaranteed a positive int by get_migrated_to_marker(). Defer the row fetch until a
+    # template reads the winner (cable/module/VLAN never do), saving a query per HTMX refresh.
+    return {
+        "migrated_to_marker": marker,
+        "migrated_to_winner": SimpleLazyObject(lambda: Device.objects.filter(pk=marker["device_id"]).first()),
+    }
 
 
 def has_nested_name_conflict(module_type, module_bay, sibling_counts=None):

--- a/netbox_librenms_plugin/utils.py
+++ b/netbox_librenms_plugin/utils.py
@@ -1918,11 +1918,20 @@ def merge_librenms_links(winner, donor, server_key: str = "default") -> dict:
         "donor_id_demoted_to_oob": None,
     }
 
-    winner_cf = winner.custom_field_data.get("librenms_id") or {}
-    donor_cf = donor.custom_field_data.get("librenms_id") or {}
+    # Read with an explicit None check rather than ``or {}``: a falsy-but-corrupt value
+    # (``False`` from a bad bool write, or ``0``) must NOT collapse to ``{}`` and be merged as
+    # "no mapping" — it has to reach the dict guard below and fail closed. Only a genuinely
+    # absent field (None) is treated as "no link".
+    winner_cf = winner.custom_field_data.get("librenms_id")
+    donor_cf = donor.custom_field_data.get("librenms_id")
+    if winner_cf is None:
+        winner_cf = {}
+    if donor_cf is None:
+        donor_cf = {}
     if not isinstance(winner_cf, dict) or not isinstance(donor_cf, dict):
-        # Legacy bare-int forms must be migrated by the caller before merging.
-        raise ValueError("Cannot merge: one or both devices have a legacy bare-integer librenms_id.")
+        # Legacy bare-int forms (and corrupt non-mapping values such as a bool/0) must be
+        # repaired/migrated by the caller before merging — never silently treated as "no link".
+        raise ValueError("Cannot merge: one or both devices have a legacy bare-integer or corrupt librenms_id.")
 
     winner_entry = winner_cf.get(server_key)
     if isinstance(winner_entry, int) and not isinstance(winner_entry, bool):

--- a/netbox_librenms_plugin/utils.py
+++ b/netbox_librenms_plugin/utils.py
@@ -2371,10 +2371,6 @@ def build_migrated_context(obj, server_key: str = "default") -> dict:
     render and after a tab refresh (the partial-render views build their own context
     and would otherwise drop the marker).
 
-    Args:
-        obj: The donor device to build migrated-mode context for.
-        server_key (str): The LibreNMS server key the marker is namespaced under.
-
     ``migrated_to_winner`` is a lazy proxy: the winner ``Device`` row is fetched only when a template
     actually reads it (the interface/IP partials, which render the per-row "Move to winner" controls).
     The cable/module/VLAN partials render only the marker banner and never touch it, so they avoid the

--- a/netbox_librenms_plugin/utils.py
+++ b/netbox_librenms_plugin/utils.py
@@ -2209,9 +2209,19 @@ def mark_librenms_migrated(donor, winner_pk: int, server_key: str = "default", a
     if isinstance(winner_pk, bool) or not isinstance(winner_pk, int) or winner_pk <= 0:
         raise ValueError(f"winner_pk must be a positive integer, got {winner_pk!r}")
 
-    cf_value = donor.custom_field_data.get("librenms_id") or {}
-    if not isinstance(cf_value, dict):
+    cf_value = donor.custom_field_data.get("librenms_id")
+    if cf_value is None:
         cf_value = {}
+    elif not isinstance(cf_value, dict):
+        # Fail closed on a legacy bare-int/bare-string or corrupt top-level librenms_id rather
+        # than silently collapsing it to {} and stamping the marker: that drops the donor's
+        # still-resolvable mapping (find_by_librenms_id can no longer locate the old owner),
+        # converting recoverable state into data loss. The caller must migrate the legacy form
+        # first — mirrors merge_librenms_links(), which rejects the same shapes.
+        raise ValueError(
+            f"Cannot mark '{getattr(donor, 'name', donor)}' migrated: librenms_id is a legacy "
+            f"bare-integer or corrupt value ({cf_value!r}); migrate it to the dict form first."
+        )
     entry = cf_value.get(server_key)
     if isinstance(entry, int) and not isinstance(entry, bool):
         entry = {"id": entry}

--- a/netbox_librenms_plugin/utils.py
+++ b/netbox_librenms_plugin/utils.py
@@ -1910,7 +1910,7 @@ def merge_librenms_links(winner, donor, server_key: str = "default") -> dict:
         ``oob_from_donor`` (None or dict), ``donor_id_demoted_to_oob``
         (None or dict).  Useful for audit logging and tests.
     """
-    from netbox_librenms_plugin.constants import OOB_TYPE_PATTERN
+    from netbox_librenms_plugin.constants import normalize_oob_type
 
     summary = {
         "host_id_from_donor": None,
@@ -2082,8 +2082,11 @@ def merge_librenms_links(winner, donor, server_key: str = "default") -> dict:
         demoted = dict(donor_oob) if donor_oob else {}
         demoted.pop("id", None)
         if not demoted.get("type"):
-            match = OOB_TYPE_PATTERN.search(donor.name or "")
-            demoted["type"] = match.group(1).lower() if match else "oob"
+            # Resolve the type via normalize_oob_type (vendor token wins over the generic 'oob')
+            # for parity with the import-path OOB detection (device_operations._detect_oob_type_from_name),
+            # instead of a raw first-match search that would pick 'oob' from a name like
+            # 'leaf01-oob-idrac9'. Fall back to the generic 'oob' when no vendor token matches.
+            demoted["type"] = normalize_oob_type(donor.name or "", "") or "oob"
         demoted["id"] = donor_id
         winner_entry["oob"] = demoted
         summary["donor_id_demoted_to_oob"] = demoted

--- a/netbox_librenms_plugin/utils.py
+++ b/netbox_librenms_plugin/utils.py
@@ -153,38 +153,48 @@ def validate_regex_field(value, field_name):
         raise ValidationError({field_name: f"Invalid regex: {exc}"}) from exc
 
 
-def get_virtual_chassis_member(device: Device, port_name: str) -> Device:
+def get_virtual_chassis_member(
+    device: Device,
+    port_name: str,
+    *,
+    return_device_on_failure: bool = True,
+) -> Device | None:
     """
     Determines the likely virtual chassis member based on the device's vc_position and port name.
 
     Args:
         device (Device): The NetBox device instance.
         port_name (str): The name of the port (e.g., 'Ethernet1').
+        return_device_on_failure: Return ``device`` when member matching fails. Callers
+            resolving a remote VC endpoint can disable this fallback to avoid binding the
+            advertised port against the wrong member.
 
     Returns:
-        Device: The virtual chassis member device corresponding to the port.
-                Returns the original device if not part of a virtual chassis or if matching fails.
+        Device | None: The matching virtual chassis member. By default, returns the
+            original device if matching fails; returns ``None`` instead when
+            ``return_device_on_failure`` is false.
     """
+    fallback = device if return_device_on_failure else None
     if not hasattr(device, "virtual_chassis") or not device.virtual_chassis:
-        return device
+        return fallback
 
     # A port row can lack the selected name field entirely (port.get(...) -> None) — or carry a
     # non-string value from a malformed payload. re.match() raises TypeError on those, which the
     # except tuple below deliberately doesn't cover (it must not mask real bugs), so guard here
     # and fall back to the viewed device like any other unmatchable name.
     if not isinstance(port_name, str):
-        return device
+        return fallback
 
     try:
         match = re.match(r"^[A-Za-z]+(\d+)", port_name)
         if not match:
-            return device
+            return fallback
 
         # Get the port number and use it
         vc_position = int(match.group(1))
         return device.virtual_chassis.members.get(vc_position=vc_position)
     except (re.error, ValueError, ObjectDoesNotExist):
-        return device
+        return fallback
 
 
 def get_virtual_chassis_members(device: Device) -> list:

--- a/netbox_librenms_plugin/utils.py
+++ b/netbox_librenms_plugin/utils.py
@@ -2239,6 +2239,27 @@ def mark_librenms_migrated(donor, winner_pk: int, server_key: str = "default", a
         entry = {"id": coerced} if coerced else {}
     elif isinstance(entry, dict):
         entry = dict(entry)
+        # Validate the nested oob before it is popped below, the same way
+        # merge_librenms_links() does: a non-dict oob, or an oob carrying a
+        # non-blank unparseable id, is corrupt-but-recoverable state. Failing
+        # closed here stops a donor like {"oob": "garbage"} or
+        # {"oob": {"id": "abc"}} from being silently converted to marker-only
+        # state (erasing the link data) instead of being migrated first.
+        raw_oob = entry.get("oob")
+        if raw_oob is not None:
+            if not isinstance(raw_oob, dict):
+                raise ValueError(
+                    f"Cannot mark '{getattr(donor, 'name', donor)}' migrated: "
+                    f"librenms_id[{server_key!r}] has unsupported oob type {type(raw_oob).__name__}."
+                )
+            raw_oob_id = raw_oob.get("id")
+            if isinstance(raw_oob_id, str) and not raw_oob_id.strip():
+                raw_oob_id = None
+            if raw_oob_id is not None and coerce_librenms_id(raw_oob_id) is None:
+                raise ValueError(
+                    f"Cannot mark '{getattr(donor, 'name', donor)}' migrated: "
+                    f"librenms_id[{server_key!r}] has an unparseable oob id ({raw_oob_id!r}); migrate it first."
+                )
     elif entry is None:
         entry = {}
     else:

--- a/netbox_librenms_plugin/utils.py
+++ b/netbox_librenms_plugin/utils.py
@@ -2040,6 +2040,27 @@ def merge_librenms_links(winner, donor, server_key: str = "default") -> dict:
                 f"{_raw_winner_oob_id!r} — expected a positive integer or numeric string."
             )
 
+    # Validate the donor's oob id up-front (mirroring the winner_oob check above) so a corrupt
+    # non-blank id fails closed regardless of which branch fires below, and so a metadata-only
+    # donor oob (a type but no usable id) is NOT mistaken for a real controller link. Treating
+    # any truthy donor_oob as "occupied" would skip demoting the donor's host id into the empty
+    # oob slot, silently losing that host link once the donor is marked migrated. Only meaningful
+    # when the winner has no oob of its own (otherwise donor_oob is ignored); a blank/whitespace
+    # id is treated leniently as "no id".
+    donor_oob_has_valid_id = False
+    _donor_oob_id = None
+    if winner_oob is None and donor_oob is not None:
+        _raw_donor_oob_id = donor_oob.get("id")
+        if isinstance(_raw_donor_oob_id, str) and not _raw_donor_oob_id.strip():
+            _raw_donor_oob_id = None
+        _donor_oob_id = coerce_librenms_id(_raw_donor_oob_id) if _raw_donor_oob_id is not None else None
+        if _raw_donor_oob_id is not None and _donor_oob_id is None:
+            raise ValueError(
+                f"donor '{donor.name}' has an unparseable librenms_id[{server_key!r}] oob id "
+                f"{_raw_donor_oob_id!r} — expected a positive integer or numeric string."
+            )
+        donor_oob_has_valid_id = _donor_oob_id is not None
+
     if winner_id is None and donor_id is not None:
         winner_entry["id"] = donor_id
         summary["host_id_from_donor"] = donor_id
@@ -2048,43 +2069,34 @@ def merge_librenms_links(winner, donor, server_key: str = "default") -> dict:
         and donor_id is not None
         and donor_id != winner_id
         and winner_oob is None
-        and not donor_oob
+        and not donor_oob_has_valid_id
     ):
-        # Demote donor's host id into winner's oob slot — but ONLY when the donor has no real
-        # OOB and the donor host id actually differs from the winner's. Equal ids are the same
-        # host linkage (a duplicate mapping), not an OOB controller, so demoting them would
-        # fabricate a fake OOB link on the merged device.
-        # If the donor is shaped like {"id": ..., "oob": {...}}, its actual OOB
-        # controller (inherited by the donor_oob path below) takes precedence over demoting the
-        # donor's host id, otherwise the real OOB link would be lost. Infer type from donor name.
-        match = OOB_TYPE_PATTERN.search(donor.name or "")
-        inferred_type = match.group(1).lower() if match else "oob"
-        demoted = {"id": donor_id, "type": inferred_type}
+        # Demote donor's host id into winner's oob slot — but ONLY when the donor has no real OOB
+        # controller (no usable oob id) and the donor host id actually differs from the winner's.
+        # Equal ids are the same host linkage (a duplicate mapping), not an OOB controller, so
+        # demoting them would fabricate a fake OOB link on the merged device.
+        # A donor shaped {"id": ..., "oob": {<valid id>}} has a REAL controller, which the
+        # donor_oob inheritance path below takes precedence over — so it is excluded here. But a
+        # metadata-only donor oob ({"type": ...} with no usable id) is NOT a real link: fold its
+        # metadata (type) into the demoted block so it survives, then preserve the donor host id.
+        demoted = dict(donor_oob) if donor_oob else {}
+        demoted.pop("id", None)
+        if not demoted.get("type"):
+            match = OOB_TYPE_PATTERN.search(donor.name or "")
+            demoted["type"] = match.group(1).lower() if match else "oob"
+        demoted["id"] = donor_id
         winner_entry["oob"] = demoted
         summary["donor_id_demoted_to_oob"] = demoted
         winner_oob = demoted
 
     if donor_oob and winner_oob is None:
-        # Coerce the donor's oob host id before inheriting it: the helper fails closed on
-        # malformed host ids elsewhere, so don't let a corrupt donor link (e.g. {"id": "abc"})
-        # propagate verbatim into the winner. A blank/whitespace id is treated as "no id"
-        # (lenient) — the same as a blank host id above and the same as an absent oob id —
-        # so only a *non-blank* unparseable value fails closed. A blank id is dropped so the
-        # winner inherits the oob (type, etc.) without carrying a bogus id string.
-        _raw_oob_id = donor_oob.get("id")
-        if isinstance(_raw_oob_id, str) and not _raw_oob_id.strip():
-            _raw_oob_id = None
-        _coerced_oob_id = coerce_librenms_id(_raw_oob_id) if _raw_oob_id is not None else None
-        if _raw_oob_id is not None and _coerced_oob_id is None:
-            raise ValueError(
-                f"donor '{donor.name}' has an unparseable librenms_id[{server_key!r}] oob id "
-                f"{_raw_oob_id!r} — expected a positive integer or numeric string."
-            )
+        # Inherit the donor's oob. Its id was already validated/coerced up-front (a non-blank
+        # unparseable id fails closed there); a blank/absent id is dropped so the winner inherits
+        # the oob metadata (type, etc.) without carrying a bogus id string.
         inherited_oob = dict(donor_oob)
-        if _coerced_oob_id is not None:
-            inherited_oob["id"] = _coerced_oob_id
+        if _donor_oob_id is not None:
+            inherited_oob["id"] = _donor_oob_id
         else:
-            # Blank/absent id → don't carry a bogus value into the winner.
             inherited_oob.pop("id", None)
         winner_entry["oob"] = dict(inherited_oob)
         summary["oob_from_donor"] = dict(inherited_oob)

--- a/netbox_librenms_plugin/utils.py
+++ b/netbox_librenms_plugin/utils.py
@@ -2190,6 +2190,12 @@ def get_migrated_to_marker(device, server_key: str = "default") -> dict | None:
     marker = entry.get("_migrated_to")
     if not isinstance(marker, dict):
         return None
+    # The marker is namespaced under cf[server_key] and mark_librenms_migrated() always
+    # stamps its own server_key. Reject a marker whose stamped server_key doesn't match the
+    # entry it lives under (malformed or copied across server sub-blocks) so a stray marker
+    # can't force the donor into migrated mode for the wrong server.
+    if marker.get("server_key") != server_key:
+        return None
     device_id = marker.get("device_id")
     # bool is a subclass of int; reject it and non-positive ids so migrated-mode
     # logic never targets a bogus device from a malformed marker.

--- a/netbox_librenms_plugin/utils.py
+++ b/netbox_librenms_plugin/utils.py
@@ -2123,8 +2123,9 @@ def mark_librenms_migrated(donor, winner_pk: int, server_key: str = "default", a
         donor: NetBox Device being absorbed by the winner.
         winner_pk: Primary key of the winning device.
         server_key: LibreNMS server key whose link state is being cleared.
-        at: ISO timestamp string. When None, ``datetime.utcnow().isoformat()``
-            with a ``Z`` suffix is used.
+        at: ISO timestamp string. When None, a timezone-aware UTC timestamp
+            (``datetime.now(timezone.utc)`` formatted as ``YYYY-MM-DDTHH:MM:SSZ``)
+            is used.
     """
     from datetime import datetime, timezone
 

--- a/netbox_librenms_plugin/utils.py
+++ b/netbox_librenms_plugin/utils.py
@@ -2155,17 +2155,20 @@ def mark_librenms_migrated(donor, winner_pk: int, server_key: str = "default", a
 
 def get_migrated_to_marker(device, server_key: str = "default") -> dict | None:
     """
-    Read the ``_migrated_to`` marker (Stage 2b) from the device's
-    ``librenms_id[server_key]`` sub-block.
+    Read the ``_migrated_to`` marker (Stage 2b) from a device's librenms_id block.
 
-    Returns the marker dict ``{device_id, server_key, at}`` when the donor
-    was previously merged into another NetBox device via
-    :func:`mark_librenms_migrated`, or ``None`` when no marker is present
-    (or the cf is malformed).
+    Used by the librenms-sync UI to switch a donor device into "migrated mode":
+    disable sync actions and surface per-row "Move to winner" buttons. A live host or
+    OOB link takes precedence over a stale marker.
 
-    Used by the librenms-sync UI to switch a donor device into "migrated
-    mode": disable sync actions and surface per-row "Move to winner"
-    buttons.
+    Args:
+        device: The donor device whose ``librenms_id[server_key]`` sub-block is read.
+        server_key (str): The LibreNMS server key the marker is namespaced under.
+
+    Returns:
+        dict | None: The marker dict ``{device_id, server_key, at}`` when the donor
+            was previously merged via :func:`mark_librenms_migrated`, or None when no
+            valid marker is present (missing, malformed, or superseded by a live link).
     """
     if device is None:
         return None
@@ -2197,12 +2200,20 @@ def get_migrated_to_marker(device, server_key: str = "default") -> dict | None:
 
 def build_migrated_context(obj, server_key: str = "default") -> dict:
     """
-    Donor "migrated mode" context: ``{migrated_to_marker, migrated_to_winner}``.
+    Build the donor "migrated mode" template context.
 
-    Shared by the full sync page and the HTMX tab partials so a merged donor
-    shows the migration UI — and hides ordinary sync actions — consistently on
-    both the initial render and after a tab refresh (the partial-render views
-    build their own context and would otherwise drop the marker).
+    Shared by the full sync page and the HTMX tab partials so a merged donor shows the
+    migration UI — and hides ordinary sync actions — consistently on both the initial
+    render and after a tab refresh (the partial-render views build their own context
+    and would otherwise drop the marker).
+
+    Args:
+        obj: The donor device to build migrated-mode context for.
+        server_key (str): The LibreNMS server key the marker is namespaced under.
+
+    Returns:
+        dict: ``{migrated_to_marker, migrated_to_winner}``; both None when the device
+            is not in migrated mode.
     """
     marker = get_migrated_to_marker(obj, server_key)
     if not marker:

--- a/netbox_librenms_plugin/utils.py
+++ b/netbox_librenms_plugin/utils.py
@@ -1981,8 +1981,23 @@ def merge_librenms_links(winner, donor, server_key: str = "default") -> dict:
             f"{type(donor_entry).__name__} — expected a positive integer, numeric string, or mapping."
         )
 
+    def _extract_oob_entry(owner_label, owner_name, entry):
+        # Validate the nested oob shape the same way the top-level/per-server shapes are
+        # validated above: a non-dict, non-null oob is corrupted state, not "no OOB link".
+        # Silently treating it as None could let donor data overwrite it, or drop it when the
+        # donor is later marked migrated — so fail closed instead.
+        raw_oob = entry.get("oob")
+        if raw_oob is None:
+            return None
+        if isinstance(raw_oob, dict):
+            return raw_oob
+        raise ValueError(
+            f"{owner_label} '{owner_name}' has an unsupported librenms_id[{server_key!r}] oob shape "
+            f"{type(raw_oob).__name__} — expected a mapping or null."
+        )
+
     donor_id = donor_entry.get("id")
-    donor_oob = donor_entry.get("oob") if isinstance(donor_entry.get("oob"), dict) else None
+    donor_oob = _extract_oob_entry("donor", donor.name, donor_entry)
 
     # Coerce both IDs before branching so that a malformed but truthy winner_id
     # (e.g. "abc") does not incorrectly trigger the "demote donor" path.
@@ -2008,7 +2023,7 @@ def merge_librenms_links(winner, donor, server_key: str = "default") -> dict:
             f"donor '{donor.name}' has an unparseable librenms_id[{server_key!r}] id "
             f"{_raw_donor_id!r} — expected a positive integer or numeric string."
         )
-    winner_oob = winner_entry.get("oob") if isinstance(winner_entry.get("oob"), dict) else None
+    winner_oob = _extract_oob_entry("winner", winner.name, winner_entry)
 
     if winner_id is None and donor_id is not None:
         winner_entry["id"] = donor_id

--- a/netbox_librenms_plugin/utils.py
+++ b/netbox_librenms_plugin/utils.py
@@ -2239,6 +2239,19 @@ def mark_librenms_migrated(donor, winner_pk: int, server_key: str = "default", a
         entry = {"id": coerced} if coerced else {}
     elif isinstance(entry, dict):
         entry = dict(entry)
+        # Validate the host id itself before it is popped below, the same way the bare-int and
+        # bare-string branches above do: a non-blank but unparseable id ({"id": "abc"}, {"id": 0},
+        # {"id": True}) is corrupt-but-recoverable state, not "no link". Without this the dict
+        # branch would silently pop it and stamp _migrated_to, erasing the recoverable mapping. A
+        # blank/None id ({}, {"id": None}) is a genuine "no active link" and proceeds.
+        raw_id = entry.get("id")
+        if isinstance(raw_id, str) and not raw_id.strip():
+            raw_id = None
+        if raw_id is not None and coerce_librenms_id(raw_id) is None:
+            raise ValueError(
+                f"Cannot mark '{getattr(donor, 'name', donor)}' migrated: "
+                f"librenms_id[{server_key!r}] has an unparseable id ({raw_id!r}); migrate it first."
+            )
         # Validate the nested oob before it is popped below, the same way
         # merge_librenms_links() does: a non-dict oob, or an oob carrying a
         # non-blank unparseable id, is corrupt-but-recoverable state. Failing

--- a/netbox_librenms_plugin/utils.py
+++ b/netbox_librenms_plugin/utils.py
@@ -2101,8 +2101,14 @@ def merge_librenms_links(winner, donor, server_key: str = "default") -> dict:
             inherited_oob["id"] = _donor_oob_id
         else:
             inherited_oob.pop("id", None)
-        winner_entry["oob"] = dict(inherited_oob)
-        summary["oob_from_donor"] = dict(inherited_oob)
+        # Don't persist an empty {} oob: a donor oob carrying only a blank/absent id (no type or
+        # other metadata) collapses to {} once the bogus id is dropped. A later merge reads that
+        # empty dict as an OCCUPIED oob slot (winner_oob is not None) and refuses to demote a
+        # subsequent donor host id into it — silently losing that mapping. Only inherit when
+        # something meaningful (a valid id or other oob metadata) actually remains.
+        if inherited_oob:
+            winner_entry["oob"] = dict(inherited_oob)
+            summary["oob_from_donor"] = dict(inherited_oob)
 
     winner_cf[server_key] = winner_entry
     winner.custom_field_data["librenms_id"] = winner_cf

--- a/netbox_librenms_plugin/utils.py
+++ b/netbox_librenms_plugin/utils.py
@@ -2024,6 +2024,21 @@ def merge_librenms_links(winner, donor, server_key: str = "default") -> dict:
             f"{_raw_donor_id!r} — expected a positive integer or numeric string."
         )
     winner_oob = _extract_oob_entry("winner", winner.name, winner_entry)
+    # _extract_oob_entry only validates the oob *shape* (dict/null), not its id. A corrupt
+    # non-blank winner oob id (e.g. "abc", 0) would otherwise make the slot look "occupied"
+    # (winner_oob is not None) below, skipping donor OOB inheritance/demotion and silently
+    # losing the donor's real controller link once the donor is marked migrated — while the
+    # winner keeps an unusable oob. Fail closed, mirroring the winner_id/donor_id checks above;
+    # a blank/whitespace id is treated leniently as "no id".
+    if winner_oob is not None:
+        _raw_winner_oob_id = winner_oob.get("id")
+        if isinstance(_raw_winner_oob_id, str) and not _raw_winner_oob_id.strip():
+            _raw_winner_oob_id = None
+        if _raw_winner_oob_id is not None and coerce_librenms_id(_raw_winner_oob_id) is None:
+            raise ValueError(
+                f"winner '{winner.name}' has an unparseable librenms_id[{server_key!r}] oob id "
+                f"{_raw_winner_oob_id!r} — expected a positive integer or numeric string."
+            )
 
     if winner_id is None and donor_id is not None:
         winner_entry["id"] = donor_id

--- a/netbox_librenms_plugin/utils.py
+++ b/netbox_librenms_plugin/utils.py
@@ -2355,6 +2355,13 @@ def build_migrated_context(obj, server_key: str = "default") -> dict:
 
     # device_id is guaranteed a positive int by get_migrated_to_marker().
     winner = Device.objects.filter(pk=marker["device_id"]).first()
+    # A self-pointing marker (winner == this donor) is corrupt: it would flip the donor's own sync
+    # page into migrated mode resolving the "winner" to itself, hiding the ordinary sync controls.
+    # Fail closed to the non-migrated result. The marker is deliberately NOT rejected in
+    # get_migrated_to_marker(): the move views read it via _resolve_winner_for_donor() and need it
+    # present to report a self-pointing marker as "stale/corrupt" rather than "not migrated".
+    if winner is not None and winner.pk == getattr(obj, "pk", None):
+        return {"migrated_to_marker": None, "migrated_to_winner": None}
     return {"migrated_to_marker": marker, "migrated_to_winner": winner}
 
 

--- a/netbox_librenms_plugin/utils.py
+++ b/netbox_librenms_plugin/utils.py
@@ -2225,8 +2225,29 @@ def mark_librenms_migrated(donor, winner_pk: int, server_key: str = "default", a
     entry = cf_value.get(server_key)
     if isinstance(entry, int) and not isinstance(entry, bool):
         entry = {"id": entry}
-    elif not isinstance(entry, dict):
+    elif isinstance(entry, str):
+        # Mirror merge_librenms_links()'s per-entry validation: a non-empty string that can't be
+        # parsed to a positive id is corrupt donor state, not "no link" — fail closed instead of
+        # collapsing it to {} and stamping the donor migrated (which would hide the malformed value
+        # behind _migrated_to and drop any recoverable mapping).
+        coerced = coerce_librenms_id(entry)
+        if coerced is None and entry.strip():
+            raise ValueError(
+                f"Cannot mark '{getattr(donor, 'name', donor)}' migrated: "
+                f"librenms_id[{server_key!r}] is unparseable ({entry!r}); migrate it first."
+            )
+        entry = {"id": coerced} if coerced else {}
+    elif isinstance(entry, dict):
+        entry = dict(entry)
+    elif entry is None:
         entry = {}
+    else:
+        # An unsupported shape (bool/float/list/…) is corrupt state, not "no mapping". Fail closed
+        # like the top-level guard rather than collapsing to {} and marking the donor migrated.
+        raise ValueError(
+            f"Cannot mark '{getattr(donor, 'name', donor)}' migrated: "
+            f"librenms_id[{server_key!r}] has unsupported type {type(entry).__name__}."
+        )
     entry.pop("id", None)
     entry.pop("oob", None)
     entry["_migrated_to"] = {

--- a/netbox_librenms_plugin/utils.py
+++ b/netbox_librenms_plugin/utils.py
@@ -1977,6 +1977,38 @@ def _normalize_merge_entry(entry, *, owner_label, owner_name, server_key, copy_d
     )
 
 
+def _coerce_link_id_or_raise(raw, *, owner, name, server_key, kind):
+    """
+    Coerce a librenms_id host/oob id field to a positive int, or raise on a non-blank unparseable value.
+
+    Treats a blank/whitespace string as absent (returns None) — lenient, matching the top-level string
+    branch that collapses empty strings to "no id". A non-blank value that :func:`coerce_librenms_id`
+    can't turn into a positive int (``"abc"``, ``0``, ``True``) is corrupt-but-present link state: fail
+    closed with a message naming the owner/kind rather than silently dropping the link. Shared by the
+    four id checks in :func:`merge_librenms_links` (winner/donor host id, winner/donor oob id) so the
+    blank-strip / coerce / fail-closed rule can't drift between the copies.
+
+    Args:
+        raw: The raw id read from the entry (``entry["id"]`` or ``entry["oob"]["id"]``).
+        owner: ``"winner"`` or ``"donor"`` — names the side in the error message.
+        name: The device name, for the error message.
+        server_key: The server key the entry is namespaced under.
+        kind: ``"id"`` or ``"oob id"`` — names the field in the error message.
+
+    Returns:
+        int | None: The positive integer id, or None when the value is blank/absent.
+    """
+    if isinstance(raw, str) and not raw.strip():
+        raw = None
+    coerced = coerce_librenms_id(raw) if raw is not None else None
+    if raw is not None and coerced is None:
+        raise ValueError(
+            f"{owner} '{name}' has an unparseable librenms_id[{server_key!r}] {kind} "
+            f"{raw!r} — expected a positive integer or numeric string."
+        )
+    return coerced
+
+
 def merge_librenms_links(winner, donor, server_key: str = "default") -> dict:
     """
     Merge donor's ``librenms_id[server_key]`` link state into winner's.
@@ -2066,30 +2098,15 @@ def merge_librenms_links(winner, donor, server_key: str = "default") -> dict:
     donor_id = donor_entry.get("id")
     donor_oob = _extract_oob_entry("donor", donor.name, donor_entry)
 
-    # Coerce both IDs before branching so that a malformed but truthy winner_id
-    # (e.g. "abc") does not incorrectly trigger the "demote donor" path.
-    _raw_winner_id = winner_entry.get("id")
-    _raw_donor_id = donor_id
-    # Treat a blank/whitespace string id as "no id" (lenient), matching the top-level
-    # string branch above which collapses empty strings to {}. Only a *non-blank*
-    # unparseable value (e.g. "abc") fails closed below — a blank one must not block
-    # a merge just because it arrived wrapped in dict form.
-    if isinstance(_raw_winner_id, str) and not _raw_winner_id.strip():
-        _raw_winner_id = None
-    if isinstance(_raw_donor_id, str) and not _raw_donor_id.strip():
-        _raw_donor_id = None
-    winner_id = coerce_librenms_id(_raw_winner_id) if _raw_winner_id is not None else None
-    donor_id = coerce_librenms_id(_raw_donor_id) if _raw_donor_id is not None else None
-    if _raw_winner_id is not None and winner_id is None:
-        raise ValueError(
-            f"winner '{winner.name}' has an unparseable librenms_id[{server_key!r}] id "
-            f"{_raw_winner_id!r} — expected a positive integer or numeric string."
-        )
-    if _raw_donor_id is not None and donor_id is None:
-        raise ValueError(
-            f"donor '{donor.name}' has an unparseable librenms_id[{server_key!r}] id "
-            f"{_raw_donor_id!r} — expected a positive integer or numeric string."
-        )
+    # Coerce both IDs before branching so that a malformed but truthy winner_id (e.g. "abc") does
+    # not incorrectly trigger the "demote donor" path. A blank/whitespace string id is treated as
+    # "no id" (lenient, matching the top-level string branch above which collapses empty strings to
+    # {}); only a non-blank unparseable value fails closed. winner is checked before donor so a
+    # corrupt winner id surfaces first, as before.
+    winner_id = _coerce_link_id_or_raise(
+        winner_entry.get("id"), owner="winner", name=winner.name, server_key=server_key, kind="id"
+    )
+    donor_id = _coerce_link_id_or_raise(donor_id, owner="donor", name=donor.name, server_key=server_key, kind="id")
     winner_oob = _extract_oob_entry("winner", winner.name, winner_entry)
     # _extract_oob_entry only validates the oob *shape* (dict/null), not its id. A corrupt
     # non-blank winner oob id (e.g. "abc", 0) would otherwise make the slot look "occupied"
@@ -2098,14 +2115,9 @@ def merge_librenms_links(winner, donor, server_key: str = "default") -> dict:
     # winner keeps an unusable oob. Fail closed, mirroring the winner_id/donor_id checks above;
     # a blank/whitespace id is treated leniently as "no id".
     if winner_oob is not None:
-        _raw_winner_oob_id = winner_oob.get("id")
-        if isinstance(_raw_winner_oob_id, str) and not _raw_winner_oob_id.strip():
-            _raw_winner_oob_id = None
-        if _raw_winner_oob_id is not None and coerce_librenms_id(_raw_winner_oob_id) is None:
-            raise ValueError(
-                f"winner '{winner.name}' has an unparseable librenms_id[{server_key!r}] oob id "
-                f"{_raw_winner_oob_id!r} — expected a positive integer or numeric string."
-            )
+        _coerce_link_id_or_raise(
+            winner_oob.get("id"), owner="winner", name=winner.name, server_key=server_key, kind="oob id"
+        )
 
     # Validate the donor's oob id up-front (mirroring the winner_oob check above) so a corrupt
     # non-blank id fails closed regardless of which branch fires below, and so a metadata-only
@@ -2117,15 +2129,9 @@ def merge_librenms_links(winner, donor, server_key: str = "default") -> dict:
     donor_oob_has_valid_id = False
     _donor_oob_id = None
     if winner_oob is None and donor_oob is not None:
-        _raw_donor_oob_id = donor_oob.get("id")
-        if isinstance(_raw_donor_oob_id, str) and not _raw_donor_oob_id.strip():
-            _raw_donor_oob_id = None
-        _donor_oob_id = coerce_librenms_id(_raw_donor_oob_id) if _raw_donor_oob_id is not None else None
-        if _raw_donor_oob_id is not None and _donor_oob_id is None:
-            raise ValueError(
-                f"donor '{donor.name}' has an unparseable librenms_id[{server_key!r}] oob id "
-                f"{_raw_donor_oob_id!r} — expected a positive integer or numeric string."
-            )
+        _donor_oob_id = _coerce_link_id_or_raise(
+            donor_oob.get("id"), owner="donor", name=donor.name, server_key=server_key, kind="oob id"
+        )
         donor_oob_has_valid_id = _donor_oob_id is not None
 
     # Fail closed when the donor's host id has nowhere to go: the winner already occupies BOTH

--- a/netbox_librenms_plugin/utils.py
+++ b/netbox_librenms_plugin/utils.py
@@ -1879,6 +1879,167 @@ def ip_family(ip):
     return address.version
 
 
+def merge_librenms_links(winner, donor, server_key: str = "default") -> dict:
+    """
+    Merge donor's ``librenms_id[server_key]`` link state into winner's.
+
+    Used by the Stage-2 "two NetBox devices represent the same physical box"
+    flow.  This function **only mutates the winner's** ``custom_field_data``.
+    The donor is not modified here — callers must call
+    :func:`mark_librenms_migrated` separately (and save both objects
+    themselves) to clear the donor's active link and stamp the
+    ``_migrated_to`` marker.
+
+    Conflict policy (winner-wins for already-populated fields):
+
+    * If winner already has ``id`` set, donor's ``id`` is moved into the
+      ``oob`` slot (only when winner has no ``oob`` yet, with type derived
+      from the donor's name when possible).
+    * If winner has no ``id`` and donor does, winner inherits ``id``.
+    * If donor has an ``oob`` sub-block and winner has none, winner
+      inherits it verbatim.
+    * Winner's existing ``oob`` is never overwritten.
+
+    Args:
+        winner: NetBox Device that will hold the merged link state.
+        donor: NetBox Device whose link state will be absorbed.
+        server_key: LibreNMS server key to scope the merge to.
+
+    Returns:
+        A dict describing what was actually merged: keys ``host_id_from_donor``,
+        ``oob_from_donor`` (None or dict), ``donor_id_demoted_to_oob``
+        (None or dict).  Useful for audit logging and tests.
+    """
+    from netbox_librenms_plugin.constants import OOB_TYPE_PATTERN
+
+    summary = {
+        "host_id_from_donor": None,
+        "oob_from_donor": None,
+        "donor_id_demoted_to_oob": None,
+    }
+
+    winner_cf = winner.custom_field_data.get("librenms_id") or {}
+    donor_cf = donor.custom_field_data.get("librenms_id") or {}
+    if not isinstance(winner_cf, dict) or not isinstance(donor_cf, dict):
+        # Legacy bare-int forms must be migrated by the caller before merging.
+        raise ValueError("Cannot merge: one or both devices have a legacy bare-integer librenms_id.")
+
+    winner_entry = winner_cf.get(server_key)
+    if isinstance(winner_entry, int) and not isinstance(winner_entry, bool):
+        winner_entry = {"id": winner_entry}
+    elif isinstance(winner_entry, str):
+        _coerced = coerce_librenms_id(winner_entry)
+        # Fail closed on corrupted stored state: a non-empty string that can't be
+        # parsed must surface, not silently collapse to "no id" (which would let the
+        # winner inherit the donor's id or drop the link). Mirrors the dict-form guard.
+        if _coerced is None and winner_entry.strip():
+            raise ValueError(
+                f"winner '{winner.name}' has an unparseable librenms_id[{server_key!r}] "
+                f"{winner_entry!r} — expected a positive integer or numeric string."
+            )
+        winner_entry = {"id": _coerced} if _coerced else {}
+    elif isinstance(winner_entry, dict):
+        winner_entry = dict(winner_entry)
+    else:
+        winner_entry = {}
+
+    donor_entry = donor_cf.get(server_key)
+    if isinstance(donor_entry, int) and not isinstance(donor_entry, bool):
+        donor_entry = {"id": donor_entry}
+    elif isinstance(donor_entry, str):
+        _coerced = coerce_librenms_id(donor_entry)
+        if _coerced is None and donor_entry.strip():
+            raise ValueError(
+                f"donor '{donor.name}' has an unparseable librenms_id[{server_key!r}] "
+                f"{donor_entry!r} — expected a positive integer or numeric string."
+            )
+        donor_entry = {"id": _coerced} if _coerced else {}
+    elif not isinstance(donor_entry, dict):
+        donor_entry = {}
+
+    donor_id = donor_entry.get("id")
+    donor_oob = donor_entry.get("oob") if isinstance(donor_entry.get("oob"), dict) else None
+
+    # Coerce both IDs before branching so that a malformed but truthy winner_id
+    # (e.g. "abc") does not incorrectly trigger the "demote donor" path.
+    _raw_winner_id = winner_entry.get("id")
+    _raw_donor_id = donor_id
+    # Treat a blank/whitespace string id as "no id" (lenient), matching the top-level
+    # string branch above which collapses empty strings to {}. Only a *non-blank*
+    # unparseable value (e.g. "abc") fails closed below — a blank one must not block
+    # a merge just because it arrived wrapped in dict form.
+    if isinstance(_raw_winner_id, str) and not _raw_winner_id.strip():
+        _raw_winner_id = None
+    if isinstance(_raw_donor_id, str) and not _raw_donor_id.strip():
+        _raw_donor_id = None
+    winner_id = coerce_librenms_id(_raw_winner_id) if _raw_winner_id is not None else None
+    donor_id = coerce_librenms_id(_raw_donor_id) if _raw_donor_id is not None else None
+    if _raw_winner_id is not None and winner_id is None:
+        raise ValueError(
+            f"winner '{winner.name}' has an unparseable librenms_id[{server_key!r}] id "
+            f"{_raw_winner_id!r} — expected a positive integer or numeric string."
+        )
+    if _raw_donor_id is not None and donor_id is None:
+        raise ValueError(
+            f"donor '{donor.name}' has an unparseable librenms_id[{server_key!r}] id "
+            f"{_raw_donor_id!r} — expected a positive integer or numeric string."
+        )
+    winner_oob = winner_entry.get("oob") if isinstance(winner_entry.get("oob"), dict) else None
+
+    if winner_id is None and donor_id is not None:
+        winner_entry["id"] = donor_id
+        summary["host_id_from_donor"] = donor_id
+    elif (
+        winner_id is not None
+        and donor_id is not None
+        and donor_id != winner_id
+        and winner_oob is None
+        and not donor_oob
+    ):
+        # Demote donor's host id into winner's oob slot — but ONLY when the donor has no real
+        # OOB and the donor host id actually differs from the winner's. Equal ids are the same
+        # host linkage (a duplicate mapping), not an OOB controller, so demoting them would
+        # fabricate a fake OOB link on the merged device.
+        # If the donor is shaped like {"id": ..., "oob": {...}}, its actual OOB
+        # controller (inherited by the donor_oob path below) takes precedence over demoting the
+        # donor's host id, otherwise the real OOB link would be lost. Infer type from donor name.
+        match = OOB_TYPE_PATTERN.search(donor.name or "")
+        inferred_type = match.group(1).lower() if match else "oob"
+        demoted = {"id": donor_id, "type": inferred_type}
+        winner_entry["oob"] = demoted
+        summary["donor_id_demoted_to_oob"] = demoted
+        winner_oob = demoted
+
+    if donor_oob and winner_oob is None:
+        # Coerce the donor's oob host id before inheriting it: the helper fails closed on
+        # malformed host ids elsewhere, so don't let a corrupt donor link (e.g. {"id": "abc"})
+        # propagate verbatim into the winner. A blank/whitespace id is treated as "no id"
+        # (lenient) — the same as a blank host id above and the same as an absent oob id —
+        # so only a *non-blank* unparseable value fails closed. A blank id is dropped so the
+        # winner inherits the oob (type, etc.) without carrying a bogus id string.
+        _raw_oob_id = donor_oob.get("id")
+        if isinstance(_raw_oob_id, str) and not _raw_oob_id.strip():
+            _raw_oob_id = None
+        _coerced_oob_id = coerce_librenms_id(_raw_oob_id) if _raw_oob_id is not None else None
+        if _raw_oob_id is not None and _coerced_oob_id is None:
+            raise ValueError(
+                f"donor '{donor.name}' has an unparseable librenms_id[{server_key!r}] oob id "
+                f"{_raw_oob_id!r} — expected a positive integer or numeric string."
+            )
+        inherited_oob = dict(donor_oob)
+        if _coerced_oob_id is not None:
+            inherited_oob["id"] = _coerced_oob_id
+        else:
+            # Blank/absent id → don't carry a bogus value into the winner.
+            inherited_oob.pop("id", None)
+        winner_entry["oob"] = dict(inherited_oob)
+        summary["oob_from_donor"] = dict(inherited_oob)
+
+    winner_cf[server_key] = winner_entry
+    winner.custom_field_data["librenms_id"] = winner_cf
+    return summary
+
+
 # The device-level IP foreign keys this plugin re-homes during OOB linking, merges, and the
 # Stage-2b "move to winner" actions. NetBox requires each to reference an address assigned to
 # one of THAT device's own interfaces.
@@ -1945,6 +2106,111 @@ def set_device_ip_fk(device, field, ip, *, save=True):
     if save:
         device.save(update_fields=[field])
     return field
+
+
+def mark_librenms_migrated(donor, winner_pk: int, server_key: str = "default", at: str | None = None) -> None:
+    """
+    Mark *donor* as migrated to the device with primary key *winner_pk*.
+
+    Removes any active ``id`` / ``oob`` keys from ``donor.custom_field_data
+    ['librenms_id'][server_key]`` (so the device is no longer matched by
+    ``find_by_librenms_id``) and writes a ``_migrated_to`` sub-key with the
+    target device pk, server key, and ISO-8601 UTC timestamp.
+
+    Does **not** call ``donor.save()`` — caller is responsible for persisting.
+
+    Args:
+        donor: NetBox Device being absorbed by the winner.
+        winner_pk: Primary key of the winning device.
+        server_key: LibreNMS server key whose link state is being cleared.
+        at: ISO timestamp string. When None, ``datetime.utcnow().isoformat()``
+            with a ``Z`` suffix is used.
+    """
+    from datetime import datetime, timezone
+
+    # bool is a subclass of int (int(True) == 1); reject it and non-positive
+    # ids so a malformed marker can never target the wrong device.
+    if isinstance(winner_pk, bool) or not isinstance(winner_pk, int) or winner_pk <= 0:
+        raise ValueError(f"winner_pk must be a positive integer, got {winner_pk!r}")
+
+    cf_value = donor.custom_field_data.get("librenms_id") or {}
+    if not isinstance(cf_value, dict):
+        cf_value = {}
+    entry = cf_value.get(server_key)
+    if isinstance(entry, int) and not isinstance(entry, bool):
+        entry = {"id": entry}
+    elif not isinstance(entry, dict):
+        entry = {}
+    entry.pop("id", None)
+    entry.pop("oob", None)
+    entry["_migrated_to"] = {
+        "device_id": int(winner_pk),
+        "server_key": server_key,
+        "at": at or datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+    }
+    cf_value[server_key] = entry
+    donor.custom_field_data["librenms_id"] = cf_value
+
+
+def get_migrated_to_marker(device, server_key: str = "default") -> dict | None:
+    """
+    Read the ``_migrated_to`` marker (Stage 2b) from the device's
+    ``librenms_id[server_key]`` sub-block.
+
+    Returns the marker dict ``{device_id, server_key, at}`` when the donor
+    was previously merged into another NetBox device via
+    :func:`mark_librenms_migrated`, or ``None`` when no marker is present
+    (or the cf is malformed).
+
+    Used by the librenms-sync UI to switch a donor device into "migrated
+    mode": disable sync actions and surface per-row "Move to winner"
+    buttons.
+    """
+    if device is None:
+        return None
+    cf_value = device.cf.get("librenms_id") if hasattr(device, "cf") else None
+    if not isinstance(cf_value, dict):
+        return None
+    entry = cf_value.get(server_key)
+    if not isinstance(entry, dict):
+        return None
+    # A live host or OOB link takes precedence over a stale _migrated_to marker: if the
+    # same entry still resolves via find_by_librenms_id(), leaving the donor in migrated
+    # mode is a contradictory state. Treat the marker as obsolete when an active id/oob
+    # link exists on the entry.
+    if coerce_librenms_id(entry.get("id")) is not None:
+        return None
+    oob = entry.get("oob")
+    if isinstance(oob, dict) and coerce_librenms_id(oob.get("id")) is not None:
+        return None
+    marker = entry.get("_migrated_to")
+    if not isinstance(marker, dict):
+        return None
+    device_id = marker.get("device_id")
+    # bool is a subclass of int; reject it and non-positive ids so migrated-mode
+    # logic never targets a bogus device from a malformed marker.
+    if isinstance(device_id, bool) or not isinstance(device_id, int) or device_id <= 0:
+        return None
+    return marker
+
+
+def build_migrated_context(obj, server_key: str = "default") -> dict:
+    """
+    Donor "migrated mode" context: ``{migrated_to_marker, migrated_to_winner}``.
+
+    Shared by the full sync page and the HTMX tab partials so a merged donor
+    shows the migration UI — and hides ordinary sync actions — consistently on
+    both the initial render and after a tab refresh (the partial-render views
+    build their own context and would otherwise drop the marker).
+    """
+    marker = get_migrated_to_marker(obj, server_key)
+    if not marker:
+        return {"migrated_to_marker": None, "migrated_to_winner": None}
+    from dcim.models import Device
+
+    # device_id is guaranteed a positive int by get_migrated_to_marker().
+    winner = Device.objects.filter(pk=marker["device_id"]).first()
+    return {"migrated_to_marker": marker, "migrated_to_winner": winner}
 
 
 def has_nested_name_conflict(module_type, module_bay, sibling_counts=None):

--- a/netbox_librenms_plugin/utils.py
+++ b/netbox_librenms_plugin/utils.py
@@ -15,6 +15,8 @@ from netbox.config import get_config
 from netbox.plugins import get_plugin_config
 from utilities.paginator import get_paginate_count as netbox_get_paginate_count
 
+from netbox_librenms_plugin.constants import OOB_BADGE_HTML
+
 logger = logging.getLogger(__name__)
 
 
@@ -1221,6 +1223,29 @@ def render_vc_member_options(members, selected_id):
             for member in members
         )
     )
+
+
+def oob_badge_html(record, leading_space=False):
+    """
+    Return the OOB-source badge for a row merged from the linked OOB controller.
+
+    Shared by the interface/module/cable tables and the cable-verify formatter so the
+    ``_source == "oob"`` check and the badge markup cannot drift between per-site copies
+    (each previously carried its own conditional).
+
+    Args:
+        record: A row dict from the merged host+OOB data.
+        leading_space: Prepend a space when the badge follows inline text (the cable
+            port-name column).
+
+    Returns:
+        SafeString: The badge markup, or ``""`` when the row is not OOB-sourced.
+    """
+    if record.get("_source") != "oob":
+        return ""
+    # Static trusted markup — mark_safe, not format_html (which requires interpolation
+    # args and raises TypeError when given a bare string).
+    return mark_safe((" " if leading_space else "") + OOB_BADGE_HTML)  # noqa: S308
 
 
 def is_valid_ports_payload(payload) -> bool:

--- a/netbox_librenms_plugin/views/__init__.py
+++ b/netbox_librenms_plugin/views/__init__.py
@@ -114,6 +114,8 @@ from .imports.actions import (  # noqa: F401
     AddAsOOBView,
     AddDeviceTypeMappingView,
     AddPlatformMappingView,
+    MergeNetBoxDevicesView,
+    PromoteToHostView,
 )
 from .object_sync import (  # noqa: F401
     DeviceCableTableView,
@@ -148,4 +150,9 @@ from .sync.devices import AddDeviceToLibreNMSView, UpdateDeviceLocationView  # n
 from .sync.interfaces import DeleteNetBoxInterfacesView, SyncInterfacesView  # noqa: F401
 from .sync.ip_addresses import SyncIPAddressesView  # noqa: F401
 from .sync.locations import SyncSiteLocationView  # noqa: F401
+from .sync.migrate import (  # noqa: F401
+    MoveInterfaceToWinnerView,
+    MoveIPAddressToWinnerView,
+    TransferDeviceIPView,
+)
 from .sync.vlans import SyncVLANsView  # noqa: F401

--- a/netbox_librenms_plugin/views/base/cables_view.py
+++ b/netbox_librenms_plugin/views/base/cables_view.py
@@ -744,13 +744,16 @@ class BaseCableTableView(LibreNMSPermissionMixin, LibreNMSAPIMixin, CacheMixin, 
             messages.error(request, "Selected LibreNMS server is no longer configured.")
             # Keep migrated-donor context so the template still suppresses the live POST
             # form/button — a stale server_key must not silently re-enable cable sync on a
-            # migrated donor. Resolve the marker from the POSTed key (the rebind failed).
+            # migrated donor. Resolve the marker from the active session key (the POSTed key is
+            # now known-invalid after the failed rebind).
             return render(
                 request,
                 self.partial_template_name,
                 {
                     "cable_sync": {"object": obj, "table": None, "cache_expiry": None, "server_key": None},
-                    **build_migrated_context(obj, posted_server_key),
+                    **build_migrated_context(
+                        obj, self.librenms_api.server_key
+                    ),  # session key, not the stale POSTed key
                 },
             )
         context = self._prepare_context(request, obj, fetch_fresh=True, server_key=server_key)

--- a/netbox_librenms_plugin/views/base/cables_view.py
+++ b/netbox_librenms_plugin/views/base/cables_view.py
@@ -14,7 +14,6 @@ from django.utils import timezone
 from django.utils.html import escape
 from django.views import View
 
-from netbox_librenms_plugin.constants import OOB_BADGE_HTML
 from netbox_librenms_plugin.utils import (
     cache_remaining_ttl,
     build_librenms_id_qs,
@@ -23,6 +22,7 @@ from netbox_librenms_plugin.utils import (
     get_librenms_oob,
     get_librenms_sync_device,
     get_virtual_chassis_member,
+    oob_badge_html,
 )
 from netbox_librenms_plugin.views.mixins import (
     CacheMixin,
@@ -879,13 +879,9 @@ class SingleCableVerifyView(NetBoxObjectPermissionMixin, BaseCableTableView):
                     # The verify response returns formatted_row HTML directly (it does not pass
                     # through LibreNMSCableTable.render_local_port), so re-apply the OOB badge
                     # here to match the initial render — otherwise a verified OOB cable row loses
-                    # the badge and looks like a plain host-port row. Markup mirrors
-                    # tables/cables.py render_local_port.
-                    oob_badge = (
-                        " " + OOB_BADGE_HTML  # leading space: it follows the port name
-                        if link_data.get("_source") == "oob"
-                        else ""
-                    )
+                    # the badge and looks like a plain host-port row. Same helper as the table
+                    # render, so the two can't drift.
+                    oob_badge = oob_badge_html(link_data, leading_space=True)
 
                     # Re-enrich remote side from current NetBox state
                     remote_hostname = link_data.get("remote_device", "")

--- a/netbox_librenms_plugin/views/base/cables_view.py
+++ b/netbox_librenms_plugin/views/base/cables_view.py
@@ -894,10 +894,9 @@ class SingleCableVerifyView(NetBoxObjectPermissionMixin, BaseCableTableView):
                             link_data, remote_hostname, link_data.get("remote_device_id"), server_key=server_key
                         )
 
-                    # Normalize None → "" (link_data.get(..., "") still returns None when the key
-                    # is present-but-None, e.g. an OOB row whose port name couldn't be resolved).
-                    # Otherwise the unmatched-interface branch renders escape(None) == "None" as the
-                    # port label — the same defect tables/cables.py render_local_port was fixed for.
+                    # `or ""` (not a .get default): the OOB-merge path stores local_port=None when
+                    # the port name can't be resolved, and a present-but-None value would otherwise
+                    # render the literal string "None" via escape() below.
                     local_port = link_data.get("local_port") or ""
                     formatted_row["local_port"] = local_port
 
@@ -930,7 +929,7 @@ class SingleCableVerifyView(NetBoxObjectPermissionMixin, BaseCableTableView):
 
                         # Escape LibreNMS-sourced labels to prevent XSS
                         safe_local_port = escape(local_port)
-                        remote_port_name = link_data.get("remote_port_name", link_data.get("remote_port", ""))
+                        remote_port_name = link_data.get("remote_port_name") or link_data.get("remote_port") or ""
                         safe_remote_port = escape(remote_port_name)
                         remote_device_name = link_data.get("remote_device", "")
                         safe_remote_device = escape(remote_device_name)
@@ -973,7 +972,7 @@ class SingleCableVerifyView(NetBoxObjectPermissionMixin, BaseCableTableView):
                     else:
                         formatted_row["local_port"] = f"{escape(local_port)}{oob_badge}"
                         # Keep remote port name visible, add URL if available
-                        remote_port_name = link_data.get("remote_port_name", link_data.get("remote_port", ""))
+                        remote_port_name = link_data.get("remote_port_name") or link_data.get("remote_port") or ""
                         safe_remote_port = escape(remote_port_name)
                         formatted_row["remote_port"] = (
                             f'<a href="{link_data["remote_port_url"]}">{safe_remote_port}</a>'

--- a/netbox_librenms_plugin/views/base/cables_view.py
+++ b/netbox_librenms_plugin/views/base/cables_view.py
@@ -525,32 +525,20 @@ class BaseCableTableView(LibreNMSPermissionMixin, LibreNMSAPIMixin, CacheMixin, 
             if server_key is None:
                 server_key = self._render_server_key()
 
-            # Handle virtual chassis case
+            # Same id-beats-name resolution as the local end — reuse the shared resolver so a fix
+            # in one path can't miss the other again (the drift risk _resolve_local_interface was
+            # extracted to close). VC-member selection stays here because the remote side leaves the
+            # interface unresolved when the member lookup fails.
             if hasattr(device, "virtual_chassis") and device.virtual_chassis:
-                # Get the appropriate chassis member based on the port name
                 chassis_member = get_virtual_chassis_member(device, remote_port)
-
                 if chassis_member:
-                    # First try to find interface by librenms_id
-                    if librenms_remote_port_id:
-                        netbox_remote_interface = chassis_member.interfaces.filter(
-                            _librenms_id_q(server_key, librenms_remote_port_id)
-                        ).first()
-
-                    # If not found by librenms_id, fall back to name matching on the correct chassis member
-                    if not netbox_remote_interface:
-                        netbox_remote_interface = chassis_member.interfaces.filter(name=remote_port).first()
+                    netbox_remote_interface = _resolve_local_interface(
+                        chassis_member, server_key, librenms_remote_port_id, [remote_port]
+                    )
             else:
-                # Non-virtual chassis case
-                # First try to find interface by librenms_id
-                if librenms_remote_port_id:
-                    netbox_remote_interface = device.interfaces.filter(
-                        _librenms_id_q(server_key, librenms_remote_port_id)
-                    ).first()
-
-                # If not found by librenms_id, fall back to name matching
-                if not netbox_remote_interface:
-                    netbox_remote_interface = device.interfaces.filter(name=remote_port).first()
+                netbox_remote_interface = _resolve_local_interface(
+                    device, server_key, librenms_remote_port_id, [remote_port]
+                )
 
             if netbox_remote_interface:
                 link["remote_port_url"] = reverse("dcim:interface", args=[netbox_remote_interface.pk])

--- a/netbox_librenms_plugin/views/base/cables_view.py
+++ b/netbox_librenms_plugin/views/base/cables_view.py
@@ -454,6 +454,13 @@ class BaseCableTableView(LibreNMSPermissionMixin, LibreNMSAPIMixin, CacheMixin, 
 
     def enrich_local_port(self, link, obj, server_key=None):
         """Add local port URL if interface exists in NetBox"""
+        # Merged OOB-controller rows are context-only: their local port lives on the
+        # CONTROLLER, not the host, so a shared name (or colliding stored librenms_id)
+        # must not bind a host interface — that would render a wrong local_port_url and
+        # cable state. Sync and the actions column already refuse OOB rows; leave the
+        # local end unresolved here too.
+        if link.get("_source") == "oob":
+            return
         if local_port := link.get("local_port"):
             interface = None
             local_port_id = link.get("local_port_id")

--- a/netbox_librenms_plugin/views/base/cables_view.py
+++ b/netbox_librenms_plugin/views/base/cables_view.py
@@ -18,6 +18,7 @@ from netbox_librenms_plugin.constants import OOB_BADGE_HTML
 from netbox_librenms_plugin.utils import (
     cache_remaining_ttl,
     build_librenms_id_qs,
+    build_migrated_context,
     coerce_librenms_id,
     get_interface_name_field,
     get_librenms_oob,
@@ -741,11 +742,15 @@ class BaseCableTableView(LibreNMSPermissionMixin, LibreNMSAPIMixin, CacheMixin, 
         server_key = self.rebind_api_for_server(posted_server_key)
         if server_key is None:
             messages.error(request, "Selected LibreNMS server is no longer configured.")
+            # Keep migrated-donor context so the template still suppresses the live POST
+            # form/button — a stale server_key must not silently re-enable cable sync on a
+            # migrated donor. Resolve the marker from the POSTed key (the rebind failed).
             return render(
                 request,
                 self.partial_template_name,
                 {
                     "cable_sync": {"object": obj, "table": None, "cache_expiry": None, "server_key": None},
+                    **build_migrated_context(obj, posted_server_key),
                 },
             )
         context = self._prepare_context(request, obj, fetch_fresh=True, server_key=server_key)
@@ -767,6 +772,7 @@ class BaseCableTableView(LibreNMSPermissionMixin, LibreNMSAPIMixin, CacheMixin, 
                         "cache_expiry": None,
                         "server_key": server_key,
                     },
+                    **build_migrated_context(obj, server_key),
                 },
             )
 
@@ -795,7 +801,7 @@ class BaseCableTableView(LibreNMSPermissionMixin, LibreNMSAPIMixin, CacheMixin, 
         return render(
             request,
             self.partial_template_name,
-            {"cable_sync": context},
+            {"cable_sync": context, **build_migrated_context(obj, server_key)},
         )
 
 

--- a/netbox_librenms_plugin/views/base/cables_view.py
+++ b/netbox_librenms_plugin/views/base/cables_view.py
@@ -745,7 +745,7 @@ class BaseCableTableView(LibreNMSPermissionMixin, LibreNMSAPIMixin, CacheMixin, 
             # rebind_api_for_server() returned None to avoid building a missing/misconfigured
             # default client; reading the lazy `librenms_api` property here would reconstruct it
             # and can raise (a 500 on this HTMX error path). Use the already-cached client's key.
-            active_server_key = getattr(getattr(self, "_librenms_api", None), "server_key", None) or "default"
+            active_server_key = self.active_server_key
             # Keep migrated-donor context so the template still suppresses the live POST
             # form/button — a stale server_key must not silently re-enable cable sync on a
             # migrated donor. Resolve the marker from the active session key (the POSTed key is

--- a/netbox_librenms_plugin/views/base/cables_view.py
+++ b/netbox_librenms_plugin/views/base/cables_view.py
@@ -8,7 +8,7 @@ from django.core.exceptions import MultipleObjectsReturned
 from django.db.models import Q
 from django.http import JsonResponse
 from django.middleware.csrf import get_token
-from django.shortcuts import get_object_or_404, render
+from django.shortcuts import get_object_or_404
 from django.urls import reverse
 from django.utils import timezone
 from django.utils.html import escape
@@ -18,7 +18,6 @@ from netbox_librenms_plugin.constants import OOB_BADGE_HTML
 from netbox_librenms_plugin.utils import (
     cache_remaining_ttl,
     build_librenms_id_qs,
-    build_migrated_context,
     coerce_librenms_id,
     get_interface_name_field,
     get_librenms_oob,
@@ -746,17 +745,14 @@ class BaseCableTableView(LibreNMSPermissionMixin, LibreNMSAPIMixin, CacheMixin, 
             # default client; reading the lazy `librenms_api` property here would reconstruct it
             # and can raise (a 500 on this HTMX error path). Use the already-cached client's key.
             active_server_key = self.active_server_key
-            # Keep migrated-donor context so the template still suppresses the live POST
-            # form/button — a stale server_key must not silently re-enable cable sync on a
-            # migrated donor. Resolve the marker from the active session key (the POSTed key is
-            # now known-invalid after the failed rebind).
-            return render(
+            # render_sync_partial injects the migrated-donor context (resolved from the active
+            # session key, since the POSTed key is now known-invalid) so a stale server_key can't
+            # silently re-enable cable sync on a migrated donor.
+            return self.render_sync_partial(
                 request,
-                self.partial_template_name,
-                {
-                    "cable_sync": {"object": obj, "table": None, "cache_expiry": None, "server_key": None},
-                    **build_migrated_context(obj, active_server_key),  # session key, not the stale POSTed key
-                },
+                obj,
+                active_server_key,
+                {"cable_sync": {"object": obj, "table": None, "cache_expiry": None, "server_key": None}},
             )
         context = self._prepare_context(request, obj, fetch_fresh=True, server_key=server_key)
 
@@ -767,18 +763,11 @@ class BaseCableTableView(LibreNMSPermissionMixin, LibreNMSAPIMixin, CacheMixin, 
                 messages.error(request, f"Failed to fetch links from LibreNMS: {self._links_fetch_error}")
             else:
                 messages.error(request, "No links found in LibreNMS")
-            return render(
+            return self.render_sync_partial(
                 request,
-                self.partial_template_name,
-                {
-                    "cable_sync": {
-                        "object": obj,
-                        "table": None,
-                        "cache_expiry": None,
-                        "server_key": server_key,
-                    },
-                    **build_migrated_context(obj, server_key),
-                },
+                obj,
+                server_key,
+                {"cable_sync": {"object": obj, "table": None, "cache_expiry": None, "server_key": server_key}},
             )
 
         messages.success(request, "Cable data refreshed successfully.")
@@ -803,11 +792,7 @@ class BaseCableTableView(LibreNMSPermissionMixin, LibreNMSAPIMixin, CacheMixin, 
                 "Cables refreshed, but OOB controller links fetch failed; "
                 "showing host cables only. See server logs for details.",
             )
-        return render(
-            request,
-            self.partial_template_name,
-            {"cable_sync": context, **build_migrated_context(obj, server_key)},
-        )
+        return self.render_sync_partial(request, obj, server_key, {"cable_sync": context})
 
 
 class SingleCableVerifyView(NetBoxObjectPermissionMixin, BaseCableTableView):

--- a/netbox_librenms_plugin/views/base/cables_view.py
+++ b/netbox_librenms_plugin/views/base/cables_view.py
@@ -742,6 +742,10 @@ class BaseCableTableView(LibreNMSPermissionMixin, LibreNMSAPIMixin, CacheMixin, 
         server_key = self.rebind_api_for_server(posted_server_key)
         if server_key is None:
             messages.error(request, "Selected LibreNMS server is no longer configured.")
+            # rebind_api_for_server() returned None to avoid building a missing/misconfigured
+            # default client; reading the lazy `librenms_api` property here would reconstruct it
+            # and can raise (a 500 on this HTMX error path). Use the already-cached client's key.
+            active_server_key = getattr(getattr(self, "_librenms_api", None), "server_key", None) or "default"
             # Keep migrated-donor context so the template still suppresses the live POST
             # form/button — a stale server_key must not silently re-enable cable sync on a
             # migrated donor. Resolve the marker from the active session key (the POSTed key is
@@ -751,9 +755,7 @@ class BaseCableTableView(LibreNMSPermissionMixin, LibreNMSAPIMixin, CacheMixin, 
                 self.partial_template_name,
                 {
                     "cable_sync": {"object": obj, "table": None, "cache_expiry": None, "server_key": None},
-                    **build_migrated_context(
-                        obj, self.librenms_api.server_key
-                    ),  # session key, not the stale POSTed key
+                    **build_migrated_context(obj, active_server_key),  # session key, not the stale POSTed key
                 },
             )
         context = self._prepare_context(request, obj, fetch_fresh=True, server_key=server_key)

--- a/netbox_librenms_plugin/views/base/cables_view.py
+++ b/netbox_librenms_plugin/views/base/cables_view.py
@@ -907,21 +907,31 @@ class SingleCableVerifyView(NetBoxObjectPermissionMixin, BaseCableTableView):
                     _sk = server_key
                     interface = None
                     lookup_device = selected_device
-                    if local_port and hasattr(selected_device, "virtual_chassis") and selected_device.virtual_chassis:
-                        chassis_member = get_virtual_chassis_member(selected_device, local_port)
-                        if chassis_member:
-                            lookup_device = chassis_member
-                    if local_port_id:
-                        interface = lookup_device.interfaces.filter(_librenms_id_q(_sk, local_port_id)).first()
+                    # Merged OOB-controller rows are context-only: their local port lives on the
+                    # CONTROLLER, so a shared name (or colliding stored librenms_id) must not bind
+                    # a HOST interface here — mirrors enrich_local_port's guard on the initial
+                    # render. Left unresolved, the row takes the labelled, badge-carrying
+                    # unresolved branch below instead of linking the wrong interface.
+                    if link_data.get("_source") != "oob":
+                        if (
+                            local_port
+                            and hasattr(selected_device, "virtual_chassis")
+                            and selected_device.virtual_chassis
+                        ):
+                            chassis_member = get_virtual_chassis_member(selected_device, local_port)
+                            if chassis_member:
+                                lookup_device = chassis_member
+                        if local_port_id:
+                            interface = lookup_device.interfaces.filter(_librenms_id_q(_sk, local_port_id)).first()
 
-                    # If not found by librenms_id, try the displayed name or the alternate
-                    # LibreNMS field (issue #88) — mirror enrich_local_port's dual-name fallback
-                    # so verify resolves a row whose NetBox interface is named from the field the
-                    # user isn't currently displaying (ifName vs ifDescr).
-                    if not interface:
-                        name_candidates = [n for n in (local_port, link_data.get("local_port_alt")) if n]
-                        if name_candidates:
-                            interface = lookup_device.interfaces.filter(name__in=name_candidates).first()
+                        # If not found by librenms_id, try the displayed name or the alternate
+                        # LibreNMS field (issue #88) — mirror enrich_local_port's dual-name fallback
+                        # so verify resolves a row whose NetBox interface is named from the field the
+                        # user isn't currently displaying (ifName vs ifDescr).
+                        if not interface:
+                            name_candidates = [n for n in (local_port, link_data.get("local_port_alt")) if n]
+                            if name_candidates:
+                                interface = lookup_device.interfaces.filter(name__in=name_candidates).first()
 
                     if interface:
                         link_data["netbox_local_interface_id"] = interface.pk

--- a/netbox_librenms_plugin/views/base/cables_view.py
+++ b/netbox_librenms_plugin/views/base/cables_view.py
@@ -530,7 +530,11 @@ class BaseCableTableView(LibreNMSPermissionMixin, LibreNMSAPIMixin, CacheMixin, 
             # extracted to close). VC-member selection stays here because the remote side leaves the
             # interface unresolved when the member lookup fails.
             if hasattr(device, "virtual_chassis") and device.virtual_chassis:
-                chassis_member = get_virtual_chassis_member(device, remote_port)
+                chassis_member = get_virtual_chassis_member(
+                    device,
+                    remote_port,
+                    return_device_on_failure=False,
+                )
                 if chassis_member:
                     netbox_remote_interface = _resolve_local_interface(
                         chassis_member, server_key, librenms_remote_port_id, [remote_port]

--- a/netbox_librenms_plugin/views/base/cables_view.py
+++ b/netbox_librenms_plugin/views/base/cables_view.py
@@ -112,6 +112,35 @@ def _extract_cached_links(cached, cache_key=None):
     return links
 
 
+def _resolve_local_interface(device, server_key, local_port_id, name_candidates):
+    """
+    Resolve a link row's local Interface on *device*: stable librenms_id first, then name.
+
+    The id-beats-name precedence and the dual ifName/ifDescr candidate fallback (issue #88)
+    are the drift-prone core shared by ``enrich_local_port`` and ``SingleCableVerifyView``'s
+    re-resolution — one implementation so a fix in one path can't miss the other again (the
+    issue #88 fallback and the OOB skip were each patched in both copies separately before
+    this was extracted). VC-member selection and the OOB skip stay at the call sites: the two
+    paths deliberately differ there (the initial render leaves a VC row unresolved when the
+    member lookup fails; verify falls back to the selected device).
+
+    Args:
+        device: The NetBox device (or VC member) whose interfaces are searched.
+        server_key (str): LibreNMS server key scoping the librenms_id match.
+        local_port_id: The LibreNMS port_id; falsy skips the id match.
+        name_candidates (list): Interface names for the fallback; empty skips the name match.
+
+    Returns:
+        Interface | None: The resolved interface, or None when neither match hits.
+    """
+    interface = None
+    if local_port_id:
+        interface = device.interfaces.filter(_librenms_id_q(server_key, local_port_id)).first()
+    if not interface and name_candidates:
+        interface = device.interfaces.filter(name__in=name_candidates).first()
+    return interface
+
+
 # The raw (un-enriched) link fields a cached/replayed link is stripped down to before
 # re-enrichment — derived fields (netbox_*_id, *_url, cable_status, …) are dropped so stale
 # IDs/URLs can't cause DoesNotExist after the underlying NetBox objects are deleted. Defined
@@ -480,21 +509,9 @@ class BaseCableTableView(LibreNMSPermissionMixin, LibreNMSAPIMixin, CacheMixin, 
                 chassis_member = get_virtual_chassis_member(obj, local_port)
 
                 if chassis_member:
-                    # First try to find interface by librenms_id
-                    if local_port_id:
-                        interface = chassis_member.interfaces.filter(_librenms_id_q(server_key, local_port_id)).first()
-
-                    # Only if librenms_id match fails, try matching by name
-                    if not interface:
-                        interface = chassis_member.interfaces.filter(name__in=name_candidates).first()
+                    interface = _resolve_local_interface(chassis_member, server_key, local_port_id, name_candidates)
             else:
-                # First try to find interface by librenms_id
-                if local_port_id:
-                    interface = obj.interfaces.filter(_librenms_id_q(server_key, local_port_id)).first()
-
-                # Only if librenms_id match fails, try matching by name
-                if not interface:
-                    interface = obj.interfaces.filter(name__in=name_candidates).first()
+                interface = _resolve_local_interface(obj, server_key, local_port_id, name_candidates)
 
             if interface:
                 link["local_port_url"] = reverse("dcim:interface", args=[interface.pk])
@@ -903,8 +920,7 @@ class SingleCableVerifyView(NetBoxObjectPermissionMixin, BaseCableTableView):
                     local_port = link_data.get("local_port") or ""
                     formatted_row["local_port"] = local_port
 
-                    # First try to find interface by librenms_id (handle VC members)
-                    _sk = server_key
+                    # Resolve the local interface (handle VC members)
                     interface = None
                     lookup_device = selected_device
                     # Merged OOB-controller rows are context-only: their local port lives on the
@@ -921,17 +937,10 @@ class SingleCableVerifyView(NetBoxObjectPermissionMixin, BaseCableTableView):
                             chassis_member = get_virtual_chassis_member(selected_device, local_port)
                             if chassis_member:
                                 lookup_device = chassis_member
-                        if local_port_id:
-                            interface = lookup_device.interfaces.filter(_librenms_id_q(_sk, local_port_id)).first()
-
-                        # If not found by librenms_id, try the displayed name or the alternate
-                        # LibreNMS field (issue #88) — mirror enrich_local_port's dual-name fallback
-                        # so verify resolves a row whose NetBox interface is named from the field the
-                        # user isn't currently displaying (ifName vs ifDescr).
-                        if not interface:
-                            name_candidates = [n for n in (local_port, link_data.get("local_port_alt")) if n]
-                            if name_candidates:
-                                interface = lookup_device.interfaces.filter(name__in=name_candidates).first()
+                        # Shared id→dual-name resolution core (issue #88 fallback included), so
+                        # this path can't drift from enrich_local_port's again.
+                        name_candidates = [n for n in (local_port, link_data.get("local_port_alt")) if n]
+                        interface = _resolve_local_interface(lookup_device, server_key, local_port_id, name_candidates)
 
                     if interface:
                         link_data["netbox_local_interface_id"] = interface.pk

--- a/netbox_librenms_plugin/views/base/interfaces_view.py
+++ b/netbox_librenms_plugin/views/base/interfaces_view.py
@@ -162,13 +162,18 @@ class BaseInterfaceTableView(VlanAssignmentMixin, LibreNMSAPIMixin, LibreNMSPerm
             # re-enabling sync controls on a migrated donor. Render the partial with migrated
             # context resolved under the active session key (the POSTed key is now known-invalid),
             # mirroring the ip/cables/modules/vlan stale-key error paths.
+            # rebind_api_for_server() returned None precisely to avoid constructing a missing/
+            # misconfigured default client, so don't touch the lazy `librenms_api` property here —
+            # it could raise and turn this HTMX error path back into a 500. Read the already-cached
+            # client's key (else "default").
+            active_server_key = getattr(getattr(self, "_librenms_api", None), "server_key", None) or "default"
             return render(
                 request,
                 self.partial_template_name,
                 {
                     "interface_sync": {"object": obj, "table": None, "cache_expiry": None, "server_key": None},
                     "interface_name_field": interface_name_field,
-                    **build_migrated_context(obj, self.librenms_api.server_key),
+                    **build_migrated_context(obj, active_server_key),
                 },
             )
 

--- a/netbox_librenms_plugin/views/base/interfaces_view.py
+++ b/netbox_librenms_plugin/views/base/interfaces_view.py
@@ -157,25 +157,18 @@ class BaseInterfaceTableView(VlanAssignmentMixin, LibreNMSAPIMixin, LibreNMSPerm
         post_server_key = self.rebind_api_for_server(request.POST.get("server_key"))
         if post_server_key is None:
             messages.error(request, "Selected LibreNMS server is no longer configured.")
-            # Render the fragment with the message (like the cables/ip/modules/vlan
-            # failed-rebind branches) — a redirect here points at this same POST-only URL,
-            # which the hx-post XHR transparently follows with a GET: 405, no swap, a dead
-            # button, and the queued error only surfacing on a later full page load.
+            # This POST is HTMX (the success path swaps in the partial), so a bare redirect would
+            # swap a full page into the partial target AND drop the migrated-donor context —
+            # re-enabling sync controls on a migrated donor. Render the partial with migrated
+            # context resolved under the active session key (the POSTed key is now known-invalid),
+            # mirroring the ip/cables/modules/vlan stale-key error paths.
             return render(
                 request,
                 self.partial_template_name,
                 {
-                    "interface_sync": {
-                        "table": None,
-                        "object": obj,
-                        "cache_expiry": None,
-                        "last_fetched": None,
-                        # Explicit None so the fragment doesn't silently fall back to the
-                        # session/default server for the next retry (mirrors vlan_table_view's
-                        # stale-server branch).
-                        "server_key": None,
-                    },
+                    "interface_sync": {"object": obj, "table": None, "cache_expiry": None, "server_key": None},
                     "interface_name_field": interface_name_field,
+                    **build_migrated_context(obj, self.librenms_api.server_key),
                 },
             )
 

--- a/netbox_librenms_plugin/views/base/interfaces_view.py
+++ b/netbox_librenms_plugin/views/base/interfaces_view.py
@@ -468,6 +468,15 @@ class BaseInterfaceTableView(VlanAssignmentMixin, LibreNMSAPIMixin, LibreNMSPerm
         # snapshot (via an inline banner) so the missing OOB rows are never silently absent.
         oob_incomplete = bool(cached_data.get("oob_incomplete")) if isinstance(cached_data, dict) else False
 
+        # Same persistent-warning treatment as oob_incomplete, for a port_stack (LAG / sub-interface
+        # relationship) fetch that failed on the last refresh: the snapshot is cached WITHOUT
+        # relationship data, so a transient Django message shown once at refresh time leaves later
+        # cached renders silently missing the Parent / LAG relationships. Surface it on every render
+        # instead. The flag is set by the refresh path when get_port_stack fails.
+        relationship_data_incomplete = (
+            bool(cached_data.get("relationship_data_incomplete")) if isinstance(cached_data, dict) else False
+        )
+
         # Get VLAN groups for dropdown
         vlan_groups = self.get_vlan_groups_for_device(obj)
         lookup_maps = self._build_vlan_lookup_maps(vlan_groups)
@@ -620,6 +629,7 @@ class BaseInterfaceTableView(VlanAssignmentMixin, LibreNMSAPIMixin, LibreNMSPerm
             "netbox_only_interfaces": netbox_only_interfaces,
             "server_key": server_key,
             "oob_incomplete": oob_incomplete,
+            "relationship_data_incomplete": relationship_data_incomplete,
         }
 
     def _add_vlan_group_selection(self, port, lookup_maps, device, vlan_group_overrides=None):

--- a/netbox_librenms_plugin/views/base/interfaces_view.py
+++ b/netbox_librenms_plugin/views/base/interfaces_view.py
@@ -7,6 +7,7 @@ from django.utils import timezone
 from django.views import View
 
 from netbox_librenms_plugin.utils import (
+    build_migrated_context,
     cache_remaining_ttl,
     coerce_librenms_id,
     get_interface_name_field,
@@ -358,6 +359,9 @@ class BaseInterfaceTableView(VlanAssignmentMixin, LibreNMSAPIMixin, LibreNMSPerm
         )
         context = {"interface_sync": context}
         context["interface_name_field"] = interface_name_field
+        # Keep migrated-donor mode (hidden sync button + Migrate column) consistent
+        # with the full page after an HTMX tab refresh.
+        context.update(build_migrated_context(obj, _server_key))
 
         return render(request, self.partial_template_name, context)
 

--- a/netbox_librenms_plugin/views/base/interfaces_view.py
+++ b/netbox_librenms_plugin/views/base/interfaces_view.py
@@ -468,15 +468,6 @@ class BaseInterfaceTableView(VlanAssignmentMixin, LibreNMSAPIMixin, LibreNMSPerm
         # snapshot (via an inline banner) so the missing OOB rows are never silently absent.
         oob_incomplete = bool(cached_data.get("oob_incomplete")) if isinstance(cached_data, dict) else False
 
-        # Same persistent-warning treatment as oob_incomplete, for a port_stack (LAG / sub-interface
-        # relationship) fetch that failed on the last refresh: the snapshot is cached WITHOUT
-        # relationship data, so a transient Django message shown once at refresh time leaves later
-        # cached renders silently missing the Parent / LAG relationships. Surface it on every render
-        # instead. The flag is set by the refresh path when get_port_stack fails.
-        relationship_data_incomplete = (
-            bool(cached_data.get("relationship_data_incomplete")) if isinstance(cached_data, dict) else False
-        )
-
         # Get VLAN groups for dropdown
         vlan_groups = self.get_vlan_groups_for_device(obj)
         lookup_maps = self._build_vlan_lookup_maps(vlan_groups)
@@ -629,7 +620,6 @@ class BaseInterfaceTableView(VlanAssignmentMixin, LibreNMSAPIMixin, LibreNMSPerm
             "netbox_only_interfaces": netbox_only_interfaces,
             "server_key": server_key,
             "oob_incomplete": oob_incomplete,
-            "relationship_data_incomplete": relationship_data_incomplete,
         }
 
     def _add_vlan_group_selection(self, port, lookup_maps, device, vlan_group_overrides=None):

--- a/netbox_librenms_plugin/views/base/interfaces_view.py
+++ b/netbox_librenms_plugin/views/base/interfaces_view.py
@@ -166,7 +166,7 @@ class BaseInterfaceTableView(VlanAssignmentMixin, LibreNMSAPIMixin, LibreNMSPerm
             # misconfigured default client, so don't touch the lazy `librenms_api` property here —
             # it could raise and turn this HTMX error path back into a 500. Read the already-cached
             # client's key (else "default").
-            active_server_key = getattr(getattr(self, "_librenms_api", None), "server_key", None) or "default"
+            active_server_key = self.active_server_key
             return render(
                 request,
                 self.partial_template_name,

--- a/netbox_librenms_plugin/views/base/interfaces_view.py
+++ b/netbox_librenms_plugin/views/base/interfaces_view.py
@@ -2,12 +2,11 @@ import logging
 
 from django.contrib import messages
 from django.core.cache import cache
-from django.shortcuts import get_object_or_404, render
+from django.shortcuts import get_object_or_404
 from django.utils import timezone
 from django.views import View
 
 from netbox_librenms_plugin.utils import (
-    build_migrated_context,
     cache_remaining_ttl,
     coerce_librenms_id,
     get_interface_name_field,
@@ -167,13 +166,13 @@ class BaseInterfaceTableView(VlanAssignmentMixin, LibreNMSAPIMixin, LibreNMSPerm
             # it could raise and turn this HTMX error path back into a 500. Read the already-cached
             # client's key (else "default").
             active_server_key = self.active_server_key
-            return render(
+            return self.render_sync_partial(
                 request,
-                self.partial_template_name,
+                obj,
+                active_server_key,
                 {
                     "interface_sync": {"object": obj, "table": None, "cache_expiry": None, "server_key": None},
                     "interface_name_field": interface_name_field,
-                    **build_migrated_context(obj, active_server_key),
                 },
             )
 
@@ -357,11 +356,9 @@ class BaseInterfaceTableView(VlanAssignmentMixin, LibreNMSAPIMixin, LibreNMSPerm
         )
         context = {"interface_sync": context}
         context["interface_name_field"] = interface_name_field
-        # Keep migrated-donor mode (hidden sync button + Migrate column) consistent
-        # with the full page after an HTMX tab refresh.
-        context.update(build_migrated_context(obj, _server_key))
-
-        return render(request, self.partial_template_name, context)
+        # render_sync_partial injects the migrated-donor flags (hidden sync button + Migrate
+        # column) so the HTMX tab refresh stays consistent with the full page.
+        return self.render_sync_partial(request, obj, _server_key, context)
 
     def _enrich_ports_with_vlan_data(self, ports, interface_name_field):
         """

--- a/netbox_librenms_plugin/views/base/ip_addresses_view.py
+++ b/netbox_librenms_plugin/views/base/ip_addresses_view.py
@@ -570,6 +570,13 @@ class BaseIPAddressTableView(LibreNMSPermissionMixin, LibreNMSAPIMixin, CacheMix
                         # checkbox to ip_sync.set_primary_ip, so omitting it silently unchecks it
                         # on this error re-render.
                         "set_primary_ip": resolve_set_primary_ip(request),
+                        # Keep the "Move IP addresses to <winner>" card on this error re-render too:
+                        # the per-row moves are pure NetBox operations, and the template gates the
+                        # card on ip_sync.movable_ips — omitting it (as the fetch-failure and success
+                        # branches do not) would make a migrated donor's move card vanish just
+                        # because the POSTed server_key was stale. Resolved against active_server_key,
+                        # matching the migrated context rendered on this branch.
+                        "movable_ips": self._movable_ips_for_migration(obj, active_server_key),
                     },
                 },
             )

--- a/netbox_librenms_plugin/views/base/ip_addresses_view.py
+++ b/netbox_librenms_plugin/views/base/ip_addresses_view.py
@@ -520,7 +520,16 @@ class BaseIPAddressTableView(LibreNMSPermissionMixin, LibreNMSAPIMixin, CacheMix
                 request,
                 self.partial_template_name,
                 {
-                    "ip_sync": {"object": obj, "table": None, "cache_expiry": None, "server_key": None},
+                    "ip_sync": {
+                        "object": obj,
+                        "table": None,
+                        "cache_expiry": None,
+                        "server_key": None,
+                        # Preserve the user's set-primary-IP preference: the template binds the
+                        # checkbox to ip_sync.set_primary_ip, so omitting it silently unchecks it
+                        # on this error re-render.
+                        "set_primary_ip": resolve_set_primary_ip(request),
+                    },
                     **build_migrated_context(
                         obj, self.librenms_api.server_key
                     ),  # session key, not the stale POSTed key
@@ -542,6 +551,9 @@ class BaseIPAddressTableView(LibreNMSPermissionMixin, LibreNMSAPIMixin, CacheMix
                         "table": None,
                         "cache_expiry": None,
                         "server_key": server_key,
+                        # Preserve the set-primary-IP checkbox state across a failed refresh
+                        # (the template binds it to ip_sync.set_primary_ip).
+                        "set_primary_ip": resolve_set_primary_ip(request),
                     },
                     **build_migrated_context(obj, server_key),
                 },

--- a/netbox_librenms_plugin/views/base/ip_addresses_view.py
+++ b/netbox_librenms_plugin/views/base/ip_addresses_view.py
@@ -516,7 +516,7 @@ class BaseIPAddressTableView(LibreNMSPermissionMixin, LibreNMSAPIMixin, CacheMix
             # rebind_api_for_server() returned None to avoid building a missing/misconfigured
             # default client; reading the lazy `librenms_api` property here would reconstruct it
             # and can raise (a 500 on this HTMX error path). Use the already-cached client's key.
-            active_server_key = getattr(getattr(self, "_librenms_api", None), "server_key", None) or "default"
+            active_server_key = self.active_server_key
             # Keep migrated-donor context (resolved from the active session key, since the POSTed
             # key is now known-invalid) so the template still suppresses the live sync form/button —
             # a stale server_key must not silently re-enable IP sync on a migrated donor. Mirrors cables_view.

--- a/netbox_librenms_plugin/views/base/ip_addresses_view.py
+++ b/netbox_librenms_plugin/views/base/ip_addresses_view.py
@@ -513,6 +513,10 @@ class BaseIPAddressTableView(LibreNMSPermissionMixin, LibreNMSAPIMixin, CacheMix
         server_key = self.rebind_api_for_server(posted_server_key)
         if server_key is None:
             messages.error(request, "Selected LibreNMS server is no longer configured.")
+            # rebind_api_for_server() returned None to avoid building a missing/misconfigured
+            # default client; reading the lazy `librenms_api` property here would reconstruct it
+            # and can raise (a 500 on this HTMX error path). Use the already-cached client's key.
+            active_server_key = getattr(getattr(self, "_librenms_api", None), "server_key", None) or "default"
             # Keep migrated-donor context (resolved from the active session key, since the POSTed
             # key is now known-invalid) so the template still suppresses the live sync form/button —
             # a stale server_key must not silently re-enable IP sync on a migrated donor. Mirrors cables_view.
@@ -530,9 +534,7 @@ class BaseIPAddressTableView(LibreNMSPermissionMixin, LibreNMSAPIMixin, CacheMix
                         # on this error re-render.
                         "set_primary_ip": resolve_set_primary_ip(request),
                     },
-                    **build_migrated_context(
-                        obj, self.librenms_api.server_key
-                    ),  # session key, not the stale POSTed key
+                    **build_migrated_context(obj, active_server_key),  # session key, not the stale POSTed key
                 },
             )
         context = self._prepare_context(request, obj, interface_name_field, fetch_fresh=True, server_key=server_key)

--- a/netbox_librenms_plugin/views/base/ip_addresses_view.py
+++ b/netbox_librenms_plugin/views/base/ip_addresses_view.py
@@ -479,7 +479,38 @@ class BaseIPAddressTableView(LibreNMSPermissionMixin, LibreNMSAPIMixin, CacheMix
             "cache_expiry": cache_expiry,
             "server_key": server_key,
             "set_primary_ip": resolve_set_primary_ip(request),
+            # Donor "Move IP to winner" candidates (empty unless this device carries a
+            # _migrated_to marker for server_key); drives the migrated-mode action card.
+            "movable_ips": self._movable_ips_for_migration(obj, server_key),
         }
+
+    @staticmethod
+    def _movable_ips_for_migration(obj, server_key):
+        """
+        List the donor's interface-assigned IPs as Move-to-winner candidates (empty unless migrated).
+
+        Only NetBox Device ``Interface`` assignments are listed: MoveIPAddressToWinnerView re-homes an
+        IP from a donor interface to the winner's same-named interface and rejects non-Interface (e.g.
+        VMInterface) assignments, so VM-owned IPs are intentionally excluded. Gated on the marker so a
+        non-migrated device pays no extra query.
+        """
+        from dcim.models import Device, Interface
+        from django.contrib.contenttypes.models import ContentType
+
+        from netbox_librenms_plugin.utils import get_migrated_to_marker
+
+        if not isinstance(obj, Device) or not get_migrated_to_marker(obj, server_key):
+            return []
+        name_by_id = {iface.pk: iface.name for iface in obj.interfaces.all()}
+        if not name_by_id:
+            return []
+        iface_ct = ContentType.objects.get_for_model(Interface)
+        return [
+            {"id": ip.pk, "address": str(ip.address), "interface_name": name_by_id.get(ip.assigned_object_id, "")}
+            for ip in IPAddress.objects.filter(
+                assigned_object_type=iface_ct, assigned_object_id__in=list(name_by_id)
+            ).order_by("address")
+        ]
 
     def get_context_data(self, request, obj):
         """Get the context data for the IP address sync view."""
@@ -498,8 +529,14 @@ class BaseIPAddressTableView(LibreNMSPermissionMixin, LibreNMSAPIMixin, CacheMix
             return {"table": None, "object": obj, "cache_expiry": None, "server_key": scoped}
         context = self._prepare_context(request, obj, interface_name_field, fetch_fresh=False, server_key=scoped)
         if context is None:
-            # No data found; return context with empty table
-            context = {"table": None, "object": obj, "cache_expiry": None, "server_key": scoped}
+            # No data found; return context with empty table (still surface migrated move actions).
+            context = {
+                "table": None,
+                "object": obj,
+                "cache_expiry": None,
+                "server_key": scoped,
+                "movable_ips": self._movable_ips_for_migration(obj, scoped),
+            }
         return context
 
     def post(self, request, pk):

--- a/netbox_librenms_plugin/views/base/ip_addresses_view.py
+++ b/netbox_librenms_plugin/views/base/ip_addresses_view.py
@@ -6,7 +6,7 @@ from dcim.models import Device
 from django.contrib import messages
 from django.core.cache import cache
 from django.http import Http404, JsonResponse
-from django.shortcuts import get_object_or_404, render
+from django.shortcuts import get_object_or_404
 from django.utils import timezone
 from django.views import View
 from ipam.models import VRF, IPAddress
@@ -14,7 +14,6 @@ from virtualization.models import VirtualMachine
 
 from netbox_librenms_plugin.tables.ipaddresses import IPAddressTable
 from netbox_librenms_plugin.utils import (
-    build_migrated_context,
     cache_remaining_ttl,
     coerce_librenms_id,
     get_interface_name_field,
@@ -517,12 +516,13 @@ class BaseIPAddressTableView(LibreNMSPermissionMixin, LibreNMSAPIMixin, CacheMix
             # default client; reading the lazy `librenms_api` property here would reconstruct it
             # and can raise (a 500 on this HTMX error path). Use the already-cached client's key.
             active_server_key = self.active_server_key
-            # Keep migrated-donor context (resolved from the active session key, since the POSTed
-            # key is now known-invalid) so the template still suppresses the live sync form/button —
-            # a stale server_key must not silently re-enable IP sync on a migrated donor. Mirrors cables_view.
-            return render(
+            # render_sync_partial injects the migrated-donor context (resolved from the active
+            # session key, since the POSTed key is now known-invalid) so a stale server_key can't
+            # silently re-enable IP sync on a migrated donor.
+            return self.render_sync_partial(
                 request,
-                self.partial_template_name,
+                obj,
+                active_server_key,
                 {
                     "ip_sync": {
                         "object": obj,
@@ -534,7 +534,6 @@ class BaseIPAddressTableView(LibreNMSPermissionMixin, LibreNMSAPIMixin, CacheMix
                         # on this error re-render.
                         "set_primary_ip": resolve_set_primary_ip(request),
                     },
-                    **build_migrated_context(obj, active_server_key),  # session key, not the stale POSTed key
                 },
             )
         context = self._prepare_context(request, obj, interface_name_field, fetch_fresh=True, server_key=server_key)
@@ -544,9 +543,10 @@ class BaseIPAddressTableView(LibreNMSPermissionMixin, LibreNMSAPIMixin, CacheMix
             # LibreNMS fetch failed (a genuine empty result yields a context with an
             # empty table). Report the failure rather than a misleading "no data".
             messages.error(request, "Failed to fetch IP addresses from LibreNMS; see server logs for details.")
-            return render(
+            return self.render_sync_partial(
                 request,
-                self.partial_template_name,
+                obj,
+                server_key,
                 {
                     "ip_sync": {
                         "object": obj,
@@ -557,16 +557,11 @@ class BaseIPAddressTableView(LibreNMSPermissionMixin, LibreNMSAPIMixin, CacheMix
                         # (the template binds it to ip_sync.set_primary_ip).
                         "set_primary_ip": resolve_set_primary_ip(request),
                     },
-                    **build_migrated_context(obj, server_key),
                 },
             )
 
         messages.success(request, "IP address data refreshed successfully.")
-        return render(
-            request,
-            self.partial_template_name,
-            {"ip_sync": context, **build_migrated_context(obj, server_key)},
-        )
+        return self.render_sync_partial(request, obj, server_key, {"ip_sync": context})
 
 
 class SingleIPAddressVerifyView(NetBoxObjectPermissionMixin, LibreNMSPermissionMixin, CacheMixin, View):

--- a/netbox_librenms_plugin/views/base/ip_addresses_view.py
+++ b/netbox_librenms_plugin/views/base/ip_addresses_view.py
@@ -14,6 +14,7 @@ from virtualization.models import VirtualMachine
 
 from netbox_librenms_plugin.tables.ipaddresses import IPAddressTable
 from netbox_librenms_plugin.utils import (
+    build_migrated_context,
     cache_remaining_ttl,
     coerce_librenms_id,
     get_interface_name_field,
@@ -512,11 +513,15 @@ class BaseIPAddressTableView(LibreNMSPermissionMixin, LibreNMSAPIMixin, CacheMix
         server_key = self.rebind_api_for_server(posted_server_key)
         if server_key is None:
             messages.error(request, "Selected LibreNMS server is no longer configured.")
+            # Keep migrated-donor context (resolved from the POSTed key, since rebind failed)
+            # so the template still suppresses the live sync form/button — a stale server_key
+            # must not silently re-enable IP sync on a migrated donor. Mirrors cables_view.
             return render(
                 request,
                 self.partial_template_name,
                 {
                     "ip_sync": {"object": obj, "table": None, "cache_expiry": None, "server_key": None},
+                    **build_migrated_context(obj, posted_server_key),
                 },
             )
         context = self._prepare_context(request, obj, interface_name_field, fetch_fresh=True, server_key=server_key)
@@ -536,6 +541,7 @@ class BaseIPAddressTableView(LibreNMSPermissionMixin, LibreNMSAPIMixin, CacheMix
                         "cache_expiry": None,
                         "server_key": server_key,
                     },
+                    **build_migrated_context(obj, server_key),
                 },
             )
 
@@ -543,7 +549,7 @@ class BaseIPAddressTableView(LibreNMSPermissionMixin, LibreNMSAPIMixin, CacheMix
         return render(
             request,
             self.partial_template_name,
-            {"ip_sync": context},
+            {"ip_sync": context, **build_migrated_context(obj, server_key)},
         )
 
 

--- a/netbox_librenms_plugin/views/base/ip_addresses_view.py
+++ b/netbox_librenms_plugin/views/base/ip_addresses_view.py
@@ -593,6 +593,12 @@ class BaseIPAddressTableView(LibreNMSPermissionMixin, LibreNMSAPIMixin, CacheMix
                         # Preserve the set-primary-IP checkbox state across a failed refresh
                         # (the template binds it to ip_sync.set_primary_ip).
                         "set_primary_ip": resolve_set_primary_ip(request),
+                        # Keep the "Move IP addresses to <winner>" card available on a LibreNMS
+                        # fetch failure: the per-row moves (MoveIPAddressToWinnerView) are pure
+                        # NetBox operations that don't touch LibreNMS, and every other exit surfaces
+                        # movable_ips — omitting it here would make a migrated donor's move card
+                        # vanish just because LibreNMS was briefly unreachable.
+                        "movable_ips": self._movable_ips_for_migration(obj, server_key),
                     },
                 },
             )

--- a/netbox_librenms_plugin/views/base/ip_addresses_view.py
+++ b/netbox_librenms_plugin/views/base/ip_addresses_view.py
@@ -513,15 +513,17 @@ class BaseIPAddressTableView(LibreNMSPermissionMixin, LibreNMSAPIMixin, CacheMix
         server_key = self.rebind_api_for_server(posted_server_key)
         if server_key is None:
             messages.error(request, "Selected LibreNMS server is no longer configured.")
-            # Keep migrated-donor context (resolved from the POSTed key, since rebind failed)
-            # so the template still suppresses the live sync form/button — a stale server_key
-            # must not silently re-enable IP sync on a migrated donor. Mirrors cables_view.
+            # Keep migrated-donor context (resolved from the active session key, since the POSTed
+            # key is now known-invalid) so the template still suppresses the live sync form/button —
+            # a stale server_key must not silently re-enable IP sync on a migrated donor. Mirrors cables_view.
             return render(
                 request,
                 self.partial_template_name,
                 {
                     "ip_sync": {"object": obj, "table": None, "cache_expiry": None, "server_key": None},
-                    **build_migrated_context(obj, posted_server_key),
+                    **build_migrated_context(
+                        obj, self.librenms_api.server_key
+                    ),  # session key, not the stale POSTed key
                 },
             )
         context = self._prepare_context(request, obj, interface_name_field, fetch_fresh=True, server_key=server_key)

--- a/netbox_librenms_plugin/views/base/ip_addresses_view.py
+++ b/netbox_librenms_plugin/views/base/ip_addresses_view.py
@@ -526,7 +526,14 @@ class BaseIPAddressTableView(LibreNMSPermissionMixin, LibreNMSAPIMixin, CacheMix
             # snapshot may still be cached, but the failed rebind left self.librenms_api bound to the
             # DEFAULT server; render an empty table scoped to the requested key rather than that
             # stale server's cached IPs (mirrors modules_view.get_context_data's unresolved guard).
-            return {"table": None, "object": obj, "cache_expiry": None, "server_key": scoped}
+            return {
+                "table": None,
+                "object": obj,
+                "cache_expiry": None,
+                "server_key": scoped,
+                "set_primary_ip": resolve_set_primary_ip(request),
+                "movable_ips": self._movable_ips_for_migration(obj, scoped),
+            }
         context = self._prepare_context(request, obj, interface_name_field, fetch_fresh=False, server_key=scoped)
         if context is None:
             # No data found; return context with empty table (still surface migrated move actions).
@@ -535,6 +542,7 @@ class BaseIPAddressTableView(LibreNMSPermissionMixin, LibreNMSAPIMixin, CacheMix
                 "object": obj,
                 "cache_expiry": None,
                 "server_key": scoped,
+                "set_primary_ip": resolve_set_primary_ip(request),
                 "movable_ips": self._movable_ips_for_migration(obj, scoped),
             }
         return context

--- a/netbox_librenms_plugin/views/base/librenms_sync_view.py
+++ b/netbox_librenms_plugin/views/base/librenms_sync_view.py
@@ -213,8 +213,12 @@ class BaseLibreNMSSyncView(LibreNMSPermissionMixin, LibreNMSAPIMixin, generic.Ob
                 # Active server key, so the create-platform modal (included without `only`, hence
                 # inheriting this context) forwards it as a hidden field — otherwise
                 # CreateAndAssignPlatformView redirects back to the default-server tab, dropping
-                # the non-default server context the user was acting on.
-                "server_key": self.librenms_api.server_key,
+                # the non-default server context the user was acting on. Use the resolved render
+                # key, NOT the lazy librenms_api property: on the stale-?server_key path with a
+                # misconfigured default no client is bound, so the property would reconstruct
+                # LibreNMSAPI() and 500 the degraded render; the render key also keeps the page's
+                # forms scoped to the requested (gone) server so they fail closed server-side.
+                "server_key": self._render_server_key or self.active_server_key,
                 "v1v2form": AddToLIbreSNMPV1V2(prefix="v1v2"),
                 "v3form": AddToLIbreSNMPV3(prefix="v3"),
                 "librenms_device_id": self.librenms_id,
@@ -226,7 +230,10 @@ class BaseLibreNMSSyncView(LibreNMSPermissionMixin, LibreNMSAPIMixin, generic.Ob
                 "platform_info": platform_info,
                 "vc_inventory_serials": librenms_info["librenms_device_details"].get("vc_inventory_serials", []),
                 "manufacturers": manufacturers,
-                "all_server_mappings": self._build_all_server_mappings(_lookup_device, self.librenms_api.server_key),
+                # Same safe accessor as "server_key" above — only the is_active highlight needs it.
+                "all_server_mappings": self._build_all_server_mappings(
+                    _lookup_device, self._render_server_key or self.active_server_key
+                ),
                 "librenms_id_is_legacy": librenms_id_is_legacy,
                 "librenms_id_serial_confirmed": librenms_id_serial_confirmed,
                 # Lookup device may differ from object (e.g. VC master vs member).

--- a/netbox_librenms_plugin/views/base/librenms_sync_view.py
+++ b/netbox_librenms_plugin/views/base/librenms_sync_view.py
@@ -241,19 +241,19 @@ class BaseLibreNMSSyncView(LibreNMSPermissionMixin, LibreNMSAPIMixin, generic.Ob
         """
         Build Stage 2b "donor migrated mode" context.
 
-        Returns a dict with:
-        * ``migrated_to_marker`` — the marker dict (``{device_id, server_key, at}``)
-          when this device was previously merged into another via
-          :func:`mark_librenms_migrated`, else ``None``.
-        * ``migrated_to_winner`` — the winner :class:`Device` instance (or
-          ``None`` if it has been deleted since the marker was written).
+        When ``migrated_to_marker`` is set, all sync action buttons should be hidden
+        and per-row "Move to winner" actions should be shown instead. Delegates to
+        :func:`utils.build_migrated_context` so the full page and the HTMX tab partials
+        share one implementation.
 
-        When ``migrated_to_marker`` is set, all sync action buttons should
-        be hidden and per-row "Move to winner" actions should be shown
-        instead.
+        Args:
+            obj: The donor device to build migrated-mode context for.
+            server_key: The LibreNMS server key the marker is namespaced under.
 
-        Delegates to :func:`utils.build_migrated_context` so the full page and
-        the HTMX tab partials share one implementation.
+        Returns:
+            dict: ``{migrated_to_marker, migrated_to_winner}`` — the marker dict
+                ``{device_id, server_key, at}`` (or None), and the winner
+                :class:`Device` (or None if deleted since the marker was written).
         """
         from netbox_librenms_plugin.utils import build_migrated_context
 

--- a/netbox_librenms_plugin/views/base/librenms_sync_view.py
+++ b/netbox_librenms_plugin/views/base/librenms_sync_view.py
@@ -33,7 +33,7 @@ class BaseLibreNMSSyncView(LibreNMSPermissionMixin, LibreNMSAPIMixin, generic.Ob
     template_name = "netbox_librenms_plugin/librenms_sync_base.html"
     # Render server key resolved in get(); read by get_context_data for the migrated-mode banner.
     # None until get() runs (e.g. a direct get_context_data() call), then active_server_key is used.
-    _render_server_key = None
+    _scoped_render_server_key = None
 
     def get(self, request, pk, context=None):
         """Handle GET request for the LibreNMS sync view."""
@@ -50,7 +50,7 @@ class BaseLibreNMSSyncView(LibreNMSPermissionMixin, LibreNMSAPIMixin, generic.Ob
         # rebind declines and self.librenms_api.server_key falls back to "default" — using that for
         # the marker lookup would hide a real migration (marker under the requested server) or show
         # a spurious one (unrelated "default" marker). _scoped_key keeps the page self-consistent.
-        self._render_server_key = _scoped_key
+        self._scoped_render_server_key = _scoped_key
 
         # The resolve can decline WITHOUT binding a client: a blank/absent key with a
         # misconfigured default (build_librenms_api(None) → None), or an unresolved
@@ -218,7 +218,7 @@ class BaseLibreNMSSyncView(LibreNMSPermissionMixin, LibreNMSAPIMixin, generic.Ob
                 # misconfigured default no client is bound, so the property would reconstruct
                 # LibreNMSAPI() and 500 the degraded render; the render key also keeps the page's
                 # forms scoped to the requested (gone) server so they fail closed server-side.
-                "server_key": self._render_server_key or self.active_server_key,
+                "server_key": self._scoped_render_server_key or self.active_server_key,
                 "v1v2form": AddToLIbreSNMPV1V2(prefix="v1v2"),
                 "v3form": AddToLIbreSNMPV3(prefix="v3"),
                 "librenms_device_id": self.librenms_id,
@@ -232,7 +232,7 @@ class BaseLibreNMSSyncView(LibreNMSPermissionMixin, LibreNMSAPIMixin, generic.Ob
                 "manufacturers": manufacturers,
                 # Same safe accessor as "server_key" above — only the is_active highlight needs it.
                 "all_server_mappings": self._build_all_server_mappings(
-                    _lookup_device, self._render_server_key or self.active_server_key
+                    _lookup_device, self._scoped_render_server_key or self.active_server_key
                 ),
                 "librenms_id_is_legacy": librenms_id_is_legacy,
                 "librenms_id_serial_confirmed": librenms_id_serial_confirmed,
@@ -251,7 +251,7 @@ class BaseLibreNMSSyncView(LibreNMSPermissionMixin, LibreNMSAPIMixin, generic.Ob
                 # on the sync sibling, whose sync page is where its migrated controls surface.
                 # Use the resolved render key (not the lazy librenms_api property, which re-derives
                 # the global default and mis-namespaces the marker on the stale-?server_key path).
-                **self._build_migrated_context(obj, self._render_server_key or self.active_server_key),
+                **self._build_migrated_context(obj, self._scoped_render_server_key or self.active_server_key),
             }
         )
 

--- a/netbox_librenms_plugin/views/base/librenms_sync_view.py
+++ b/netbox_librenms_plugin/views/base/librenms_sync_view.py
@@ -31,6 +31,9 @@ class BaseLibreNMSSyncView(LibreNMSPermissionMixin, LibreNMSAPIMixin, generic.Ob
     model = None  # Will be set in subclasses
     tab = None  # Will be set in subclasses
     template_name = "netbox_librenms_plugin/librenms_sync_base.html"
+    # Render server key resolved in get(); read by get_context_data for the migrated-mode banner.
+    # None until get() runs (e.g. a direct get_context_data() call), then active_server_key is used.
+    _render_server_key = None
 
     def get(self, request, pk, context=None):
         """Handle GET request for the LibreNMS sync view."""
@@ -42,6 +45,12 @@ class BaseLibreNMSSyncView(LibreNMSPermissionMixin, LibreNMSAPIMixin, generic.Ob
         # — an internally inconsistent page. A blank/absent key keeps the session/default client, so
         # single-server and default renders are unchanged.
         _scoped_key, unresolved = self.resolve_get_render_server_key(request)
+        # Stash the resolved render key so get_context_data builds the migrated-mode banner under
+        # the SAME namespace as the header/tabs. On the unresolved (stale ?server_key) path the
+        # rebind declines and self.librenms_api.server_key falls back to "default" — using that for
+        # the marker lookup would hide a real migration (marker under the requested server) or show
+        # a spurious one (unrelated "default" marker). _scoped_key keeps the page self-consistent.
+        self._render_server_key = _scoped_key
 
         # The resolve can decline WITHOUT binding a client: a blank/absent key with a
         # misconfigured default (build_librenms_api(None) → None), or an unresolved
@@ -230,7 +239,9 @@ class BaseLibreNMSSyncView(LibreNMSPermissionMixin, LibreNMSAPIMixin, generic.Ob
                 # The _migrated_to marker lives on the viewed device itself, not on
                 # the VC sync/lookup device — build migrated mode from obj so a
                 # VC-member donor renders consistently with the HTMX tab partials.
-                **self._build_migrated_context(obj, self.librenms_api.server_key),
+                # Use the resolved render key (not the lazy librenms_api property, which re-derives
+                # the global default and mis-namespaces the marker on the stale-?server_key path).
+                **self._build_migrated_context(obj, self._render_server_key or self.active_server_key),
             }
         )
 

--- a/netbox_librenms_plugin/views/base/librenms_sync_view.py
+++ b/netbox_librenms_plugin/views/base/librenms_sync_view.py
@@ -227,10 +227,37 @@ class BaseLibreNMSSyncView(LibreNMSPermissionMixin, LibreNMSAPIMixin, generic.Ob
                     _lookup_device._meta.model_name if _lookup_device else obj._meta.model_name
                 ),
                 "object_model_name": obj._meta.model_name,
+                # The _migrated_to marker lives on the viewed device itself, not on
+                # the VC sync/lookup device — build migrated mode from obj so a
+                # VC-member donor renders consistently with the HTMX tab partials.
+                **self._build_migrated_context(obj, self.librenms_api.server_key),
             }
         )
 
         return context
+
+    @staticmethod
+    def _build_migrated_context(obj, server_key):
+        """
+        Build Stage 2b "donor migrated mode" context.
+
+        Returns a dict with:
+        * ``migrated_to_marker`` — the marker dict (``{device_id, server_key, at}``)
+          when this device was previously merged into another via
+          :func:`mark_librenms_migrated`, else ``None``.
+        * ``migrated_to_winner`` — the winner :class:`Device` instance (or
+          ``None`` if it has been deleted since the marker was written).
+
+        When ``migrated_to_marker`` is set, all sync action buttons should
+        be hidden and per-row "Move to winner" actions should be shown
+        instead.
+
+        Delegates to :func:`utils.build_migrated_context` so the full page and
+        the HTMX tab partials share one implementation.
+        """
+        from netbox_librenms_plugin.utils import build_migrated_context
+
+        return build_migrated_context(obj, server_key)
 
     @staticmethod
     def _build_all_server_mappings(obj, active_server_key):

--- a/netbox_librenms_plugin/views/base/librenms_sync_view.py
+++ b/netbox_librenms_plugin/views/base/librenms_sync_view.py
@@ -243,9 +243,12 @@ class BaseLibreNMSSyncView(LibreNMSPermissionMixin, LibreNMSAPIMixin, generic.Ob
                     _lookup_device._meta.model_name if _lookup_device else obj._meta.model_name
                 ),
                 "object_model_name": obj._meta.model_name,
-                # The _migrated_to marker lives on the viewed device itself, not on
-                # the VC sync/lookup device — build migrated mode from obj so a
-                # VC-member donor renders consistently with the HTMX tab partials.
+                # Build migrated mode from obj (the viewed device), NOT a re-resolved sync/lookup
+                # device, so the full page and the HTMX tab partials — which also pass obj — stay
+                # consistent. The merge stamps the _migrated_to marker on whichever device holds the
+                # LibreNMS link (get_librenms_sync_device): that IS obj for a non-VC device or the
+                # link-holding VC member (the common case); for a non-sync VC member the marker lands
+                # on the sync sibling, whose sync page is where its migrated controls surface.
                 # Use the resolved render key (not the lazy librenms_api property, which re-derives
                 # the global default and mis-namespaces the marker on the stale-?server_key path).
                 **self._build_migrated_context(obj, self._render_server_key or self.active_server_key),

--- a/netbox_librenms_plugin/views/base/modules_view.py
+++ b/netbox_librenms_plugin/views/base/modules_view.py
@@ -358,10 +358,7 @@ class BaseModuleTableView(LibreNMSPermissionMixin, LibreNMSAPIMixin, CacheMixin,
                 request,
                 obj,
                 active_server_key,
-                {
-                    "module_sync": {"object": obj, "table": None, "cache_expiry": None, "server_key": None},
-                    "has_write_permission": self.has_write_permission(),
-                },
+                {"module_sync": {"object": obj, "table": None, "cache_expiry": None, "server_key": None}},
             )
         sync_device = self._get_sync_device(obj, server_key=server_key)
 
@@ -376,10 +373,7 @@ class BaseModuleTableView(LibreNMSPermissionMixin, LibreNMSAPIMixin, CacheMixin,
                 request,
                 obj,
                 server_key,
-                {
-                    "module_sync": {"object": obj, "table": None, "cache_expiry": None, "server_key": server_key},
-                    "has_write_permission": self.has_write_permission(),
-                },
+                {"module_sync": {"object": obj, "table": None, "cache_expiry": None, "server_key": server_key}},
             )
 
         success, inventory_data = self.librenms_api.get_device_inventory(self.librenms_id)
@@ -400,10 +394,7 @@ class BaseModuleTableView(LibreNMSPermissionMixin, LibreNMSAPIMixin, CacheMixin,
                 request,
                 obj,
                 server_key,
-                {
-                    "module_sync": {"object": obj, "table": None, "cache_expiry": None, "server_key": server_key},
-                    "has_write_permission": self.has_write_permission(),
-                },
+                {"module_sync": {"object": obj, "table": None, "cache_expiry": None, "server_key": server_key}},
             )
 
         for item in inventory_data:
@@ -539,7 +530,7 @@ class BaseModuleTableView(LibreNMSPermissionMixin, LibreNMSAPIMixin, CacheMixin,
             request,
             obj,
             server_key,
-            {"module_sync": context, "has_write_permission": self.has_write_permission()},
+            {"module_sync": context},
         )
 
     def get_context_data(self, request, obj):

--- a/netbox_librenms_plugin/views/base/modules_view.py
+++ b/netbox_librenms_plugin/views/base/modules_view.py
@@ -8,6 +8,7 @@ from django.utils import timezone
 from django.views import View
 
 from netbox_librenms_plugin.utils import (
+    build_migrated_context,
     cache_remaining_ttl,
     coerce_librenms_id,
     get_librenms_device_id,
@@ -353,6 +354,9 @@ class BaseModuleTableView(LibreNMSPermissionMixin, LibreNMSAPIMixin, CacheMixin,
                 {
                     "module_sync": {"object": obj, "table": None, "cache_expiry": None, "server_key": None},
                     "has_write_permission": self.has_write_permission(),
+                    # Keep donor-mode flags on this render too — resolve from the posted key
+                    # (server_key is None here) so a migrated donor doesn't lose context.
+                    **build_migrated_context(obj, request.POST.get("server_key")),
                 },
             )
         sync_device = self._get_sync_device(obj, server_key=server_key)
@@ -375,6 +379,7 @@ class BaseModuleTableView(LibreNMSPermissionMixin, LibreNMSAPIMixin, CacheMixin,
                         "server_key": server_key,
                     },
                     "has_write_permission": self.has_write_permission(),
+                    **build_migrated_context(obj, server_key),
                 },
             )
 
@@ -403,6 +408,7 @@ class BaseModuleTableView(LibreNMSPermissionMixin, LibreNMSAPIMixin, CacheMixin,
                         "server_key": server_key,
                     },
                     "has_write_permission": self.has_write_permission(),
+                    **build_migrated_context(obj, server_key),
                 },
             )
 
@@ -541,6 +547,7 @@ class BaseModuleTableView(LibreNMSPermissionMixin, LibreNMSAPIMixin, CacheMixin,
             {
                 "module_sync": context,
                 "has_write_permission": self.has_write_permission(),
+                **build_migrated_context(obj, server_key),
             },
         )
 

--- a/netbox_librenms_plugin/views/base/modules_view.py
+++ b/netbox_librenms_plugin/views/base/modules_view.py
@@ -354,9 +354,11 @@ class BaseModuleTableView(LibreNMSPermissionMixin, LibreNMSAPIMixin, CacheMixin,
                 {
                     "module_sync": {"object": obj, "table": None, "cache_expiry": None, "server_key": None},
                     "has_write_permission": self.has_write_permission(),
-                    # Keep donor-mode flags on this render too — resolve from the posted key
-                    # (server_key is None here) so a migrated donor doesn't lose context.
-                    **build_migrated_context(obj, request.POST.get("server_key")),
+                    # Keep donor-mode flags on this render too. request.POST.get("server_key") can
+                    # be None (malformed/stale request); fall back to the session server key so
+                    # build_migrated_context still resolves the marker and the template keeps the
+                    # donor's sync controls suppressed. Mirrors ip_addresses_view.
+                    **build_migrated_context(obj, request.POST.get("server_key") or self.librenms_api.server_key),
                 },
             )
         sync_device = self._get_sync_device(obj, server_key=server_key)

--- a/netbox_librenms_plugin/views/base/modules_view.py
+++ b/netbox_librenms_plugin/views/base/modules_view.py
@@ -581,8 +581,12 @@ class BaseModuleTableView(LibreNMSPermissionMixin, LibreNMSAPIMixin, CacheMixin,
             return {"table": None, "object": obj, "cache_expiry": None, "server_key": scoped_server}
         # Validate that the cached inventory was built for the same LibreNMS device.
         # If the object has been remapped to a different device, discard stale inventory.
-        current_librenms_id = self.librenms_api.get_librenms_id(sync_device)
-        if cached_payload.get("librenms_id") != current_librenms_id:
+        # Coerce like post() does: a raw compare both accepts a poisoned bool (True == 1 in
+        # Python, serving a snapshot post() would fail closed on) and rejects a string-backed
+        # id ("10" != 10, emptying the table until a manual refresh). None (unlinked or
+        # uncoercible) never matches — post() can't cache without a valid id.
+        current_librenms_id = coerce_librenms_id(self.librenms_api.get_librenms_id(sync_device))
+        if current_librenms_id is None or cached_payload.get("librenms_id") != current_librenms_id:
             cache.delete(cache_key)
             return {"table": None, "object": obj, "cache_expiry": None, "server_key": scoped_server}
         # Same for the linked OOB controller: a re-link (or unlink) to a different
@@ -594,6 +598,12 @@ class BaseModuleTableView(LibreNMSPermissionMixin, LibreNMSAPIMixin, CacheMixin,
         # stale on every GET and the module table renders empty until a manual refresh. The write
         # side (post()) now caches the coerced value, so this matches it.
         current_oob_id = coerce_librenms_id(current_oob.get("id")) if isinstance(current_oob, dict) else None
+        # A linked-but-corrupt OOB id must not collapse to the no-OOB fingerprint: post()
+        # takes the partial-outcome path (never caches) for this state, so the GET compare
+        # can't quietly serve a prior no-OOB snapshot while an OOB controller is linked.
+        if current_oob and current_oob_id is None:
+            cache.delete(cache_key)
+            return {"table": None, "object": obj, "cache_expiry": None, "server_key": scoped_server}
         if cached_payload.get("oob_librenms_id") != current_oob_id:
             cache.delete(cache_key)
             return {"table": None, "object": obj, "cache_expiry": None, "server_key": scoped_server}

--- a/netbox_librenms_plugin/views/base/modules_view.py
+++ b/netbox_librenms_plugin/views/base/modules_view.py
@@ -136,9 +136,7 @@ def _check_ignore_rules(
         Traversal stops at the first non-empty serial encountered to avoid false
         positives deeper in the tree.
     """
-    item_serial = (item.get("entPhysicalSerialNum") or "").strip()
-    if item_serial.lower() in _PLACEHOLDER_VALUES:
-        item_serial = ""
+    item_serial = _clean_librenms_value(item.get("entPhysicalSerialNum"))
     if device_serial.lower() in _PLACEHOLDER_VALUES:
         device_serial = ""
     name = (item.get("entPhysicalName") or "").strip()
@@ -176,9 +174,7 @@ def _check_ignore_rules(
                 if current_idx in visited:
                     break
                 visited.add(current_idx)
-            ancestor_serial = (current.get("entPhysicalSerialNum") or "").strip()
-            if ancestor_serial.lower() in _PLACEHOLDER_VALUES:
-                ancestor_serial = ""
+            ancestor_serial = _clean_librenms_value(current.get("entPhysicalSerialNum"))
             if ancestor_serial:
                 if ancestor_serial == item_serial:
                     return rule.action
@@ -2357,7 +2353,7 @@ class BaseModuleTableView(LibreNMSPermissionMixin, LibreNMSAPIMixin, CacheMixin,
         )
 
         model_name = (item.get("entPhysicalModelName", "") or "").strip()
-        serial = (item.get("entPhysicalSerialNum", "") or "").strip()
+        serial = _clean_librenms_value(item.get("entPhysicalSerialNum"))
         phys_class = item.get("entPhysicalClass", "")
         name = item.get("entPhysicalName", "") or "-"
         description = item.get("entPhysicalDescr", "") or ""
@@ -3181,8 +3177,8 @@ class BaseModuleTableView(LibreNMSPermissionMixin, LibreNMSAPIMixin, CacheMixin,
         item_class = (item.get("entPhysicalClass") or "").strip()
         if item_class not in INVENTORY_CLASSES or item_class in {"container", "powerSupply", "fan"}:
             return None
-        item_serial = (item.get("entPhysicalSerialNum") or "").strip()
-        if not item_serial or item_serial.lower() in _PLACEHOLDER_VALUES:
+        item_serial = _clean_librenms_value(item.get("entPhysicalSerialNum"))
+        if not item_serial:
             return None
         item_model = (item.get("entPhysicalModelName") or "").strip().lower()
         if not item_model or item_model in _PLACEHOLDER_VALUES:
@@ -3200,15 +3196,9 @@ class BaseModuleTableView(LibreNMSPermissionMixin, LibreNMSAPIMixin, CacheMixin,
             if anc_class == "chassis":
                 return None
             if anc_class in INVENTORY_CLASSES and anc_class not in {"container", "powerSupply", "fan"}:
-                anc_serial = (ancestor.get("entPhysicalSerialNum") or "").strip()
+                anc_serial = _clean_librenms_value(ancestor.get("entPhysicalSerialNum"))
                 anc_model = (ancestor.get("entPhysicalModelName") or "").strip().lower()
-                if (
-                    anc_serial
-                    and anc_serial.lower() not in _PLACEHOLDER_VALUES
-                    and anc_serial == item_serial
-                    and anc_model
-                    and anc_model == item_model
-                ):
+                if anc_serial and anc_serial == item_serial and anc_model and anc_model == item_model:
                     return ancestor
             current_idx = ancestor.get("entPhysicalContainedIn", 0)
         return None

--- a/netbox_librenms_plugin/views/base/modules_view.py
+++ b/netbox_librenms_plugin/views/base/modules_view.py
@@ -351,7 +351,7 @@ class BaseModuleTableView(LibreNMSPermissionMixin, LibreNMSAPIMixin, CacheMixin,
             # rebind_api_for_server() returned None to avoid building a missing/misconfigured
             # default client; reading the lazy `librenms_api` property here would reconstruct it
             # and can raise (a 500 on this HTMX error path). Use the already-cached client's key.
-            active_server_key = getattr(getattr(self, "_librenms_api", None), "server_key", None) or "default"
+            active_server_key = self.active_server_key
             return render(
                 request,
                 self.partial_template_name,

--- a/netbox_librenms_plugin/views/base/modules_view.py
+++ b/netbox_librenms_plugin/views/base/modules_view.py
@@ -3,12 +3,11 @@ import re
 
 from django.contrib import messages
 from django.core.cache import cache
-from django.shortcuts import get_object_or_404, render
+from django.shortcuts import get_object_or_404
 from django.utils import timezone
 from django.views import View
 
 from netbox_librenms_plugin.utils import (
-    build_migrated_context,
     cache_remaining_ttl,
     coerce_librenms_id,
     get_librenms_device_id,
@@ -352,17 +351,16 @@ class BaseModuleTableView(LibreNMSPermissionMixin, LibreNMSAPIMixin, CacheMixin,
             # default client; reading the lazy `librenms_api` property here would reconstruct it
             # and can raise (a 500 on this HTMX error path). Use the already-cached client's key.
             active_server_key = self.active_server_key
-            return render(
+            # render_sync_partial injects the donor-mode flags, resolved under the session/active
+            # key — NOT the POSTed key, which failed to rebind and would miss the marker and
+            # re-enable a donor's sync controls.
+            return self.render_sync_partial(
                 request,
-                self.partial_template_name,
+                obj,
+                active_server_key,
                 {
                     "module_sync": {"object": obj, "table": None, "cache_expiry": None, "server_key": None},
                     "has_write_permission": self.has_write_permission(),
-                    # Keep donor-mode flags on this render too. Resolve the marker under the
-                    # session/active server key — NOT the POSTed key, which failed to rebind
-                    # (stale/unconfigured) and would miss the marker, re-enabling a donor's sync
-                    # controls. Mirrors ip_addresses_view / cables_view / vlan_table_view.
-                    **build_migrated_context(obj, active_server_key),
                 },
             )
         sync_device = self._get_sync_device(obj, server_key=server_key)
@@ -374,18 +372,13 @@ class BaseModuleTableView(LibreNMSPermissionMixin, LibreNMSAPIMixin, CacheMixin,
         if self.librenms_id is None:
             cache.delete(self.get_cache_key(sync_device, "inventory", server_key=server_key))
             messages.error(request, "Device not found in LibreNMS.")
-            return render(
+            return self.render_sync_partial(
                 request,
-                self.partial_template_name,
+                obj,
+                server_key,
                 {
-                    "module_sync": {
-                        "object": obj,
-                        "table": None,
-                        "cache_expiry": None,
-                        "server_key": server_key,
-                    },
+                    "module_sync": {"object": obj, "table": None, "cache_expiry": None, "server_key": server_key},
                     "has_write_permission": self.has_write_permission(),
-                    **build_migrated_context(obj, server_key),
                 },
             )
 
@@ -403,18 +396,13 @@ class BaseModuleTableView(LibreNMSPermissionMixin, LibreNMSAPIMixin, CacheMixin,
             cache.delete(self.get_cache_key(sync_device, "inventory", server_key=server_key))
             logger.error("Failed to fetch inventory from LibreNMS for device %s: %s", self.librenms_id, inventory_data)
             messages.error(request, "Failed to fetch inventory from LibreNMS; see server logs for details.")
-            return render(
+            return self.render_sync_partial(
                 request,
-                self.partial_template_name,
+                obj,
+                server_key,
                 {
-                    "module_sync": {
-                        "object": obj,
-                        "table": None,
-                        "cache_expiry": None,
-                        "server_key": server_key,
-                    },
+                    "module_sync": {"object": obj, "table": None, "cache_expiry": None, "server_key": server_key},
                     "has_write_permission": self.has_write_permission(),
-                    **build_migrated_context(obj, server_key),
                 },
             )
 
@@ -547,14 +535,11 @@ class BaseModuleTableView(LibreNMSPermissionMixin, LibreNMSAPIMixin, CacheMixin,
             )
         if not txr_error and not oob_failed and not ports_error:
             messages.success(request, "Inventory data refreshed successfully.")
-        return render(
+        return self.render_sync_partial(
             request,
-            self.partial_template_name,
-            {
-                "module_sync": context,
-                "has_write_permission": self.has_write_permission(),
-                **build_migrated_context(obj, server_key),
-            },
+            obj,
+            server_key,
+            {"module_sync": context, "has_write_permission": self.has_write_permission()},
         )
 
     def get_context_data(self, request, obj):

--- a/netbox_librenms_plugin/views/base/modules_view.py
+++ b/netbox_librenms_plugin/views/base/modules_view.py
@@ -348,6 +348,10 @@ class BaseModuleTableView(LibreNMSPermissionMixin, LibreNMSAPIMixin, CacheMixin,
         server_key = self.rebind_api_for_server(request.POST.get("server_key"))
         if server_key is None:
             messages.error(request, "Selected LibreNMS server is no longer configured.")
+            # rebind_api_for_server() returned None to avoid building a missing/misconfigured
+            # default client; reading the lazy `librenms_api` property here would reconstruct it
+            # and can raise (a 500 on this HTMX error path). Use the already-cached client's key.
+            active_server_key = getattr(getattr(self, "_librenms_api", None), "server_key", None) or "default"
             return render(
                 request,
                 self.partial_template_name,
@@ -358,7 +362,7 @@ class BaseModuleTableView(LibreNMSPermissionMixin, LibreNMSAPIMixin, CacheMixin,
                     # session/active server key — NOT the POSTed key, which failed to rebind
                     # (stale/unconfigured) and would miss the marker, re-enabling a donor's sync
                     # controls. Mirrors ip_addresses_view / cables_view / vlan_table_view.
-                    **build_migrated_context(obj, self.librenms_api.server_key),
+                    **build_migrated_context(obj, active_server_key),
                 },
             )
         sync_device = self._get_sync_device(obj, server_key=server_key)

--- a/netbox_librenms_plugin/views/base/modules_view.py
+++ b/netbox_librenms_plugin/views/base/modules_view.py
@@ -354,11 +354,11 @@ class BaseModuleTableView(LibreNMSPermissionMixin, LibreNMSAPIMixin, CacheMixin,
                 {
                     "module_sync": {"object": obj, "table": None, "cache_expiry": None, "server_key": None},
                     "has_write_permission": self.has_write_permission(),
-                    # Keep donor-mode flags on this render too. request.POST.get("server_key") can
-                    # be None (malformed/stale request); fall back to the session server key so
-                    # build_migrated_context still resolves the marker and the template keeps the
-                    # donor's sync controls suppressed. Mirrors ip_addresses_view.
-                    **build_migrated_context(obj, request.POST.get("server_key") or self.librenms_api.server_key),
+                    # Keep donor-mode flags on this render too. Resolve the marker under the
+                    # session/active server key — NOT the POSTed key, which failed to rebind
+                    # (stale/unconfigured) and would miss the marker, re-enabling a donor's sync
+                    # controls. Mirrors ip_addresses_view / cables_view / vlan_table_view.
+                    **build_migrated_context(obj, self.librenms_api.server_key),
                 },
             )
         sync_device = self._get_sync_device(obj, server_key=server_key)

--- a/netbox_librenms_plugin/views/base/vlan_table_view.py
+++ b/netbox_librenms_plugin/views/base/vlan_table_view.py
@@ -1,13 +1,12 @@
 from django.contrib import messages
 from django.core.cache import cache
-from django.shortcuts import get_object_or_404, render
+from django.shortcuts import get_object_or_404
 from django.utils import timezone
 from django.views import View
 
 from netbox_librenms_plugin.constants import LIBRENMS_VLAN_STATE_ACTIVE
 from netbox_librenms_plugin.tables.vlans import LibreNMSVLANTable
 from netbox_librenms_plugin.utils import (
-    build_migrated_context,
     cache_remaining_ttl,
     coerce_librenms_id,
     is_list_of_dicts,
@@ -55,19 +54,19 @@ class BaseVLANTableView(VlanAssignmentMixin, LibreNMSAPIMixin, LibreNMSPermissio
             # Pass server_key=None explicitly so the fragment doesn't silently fall back to
             # the session/default server (which would re-render with the wrong server selected
             # and let the next retry sync VLANs against the wrong LibreNMS instance).
-            context = {
-                "vlan_sync": self._get_error_context(
-                    obj, "Selected LibreNMS server is no longer configured.", server_key=None
-                ),
-                # Preserve migrated-context flags on this error exit too (every other POST
-                # path includes them); otherwise a donor/winner device loses its migration
-                # controls on a stale-server refresh until the next full reload. Resolve the
-                # marker under the session/active server key — NOT the POSTed key, which failed
-                # to rebind (stale/unconfigured) and would miss the marker entirely.
-                **build_migrated_context(obj, active_server_key),
-            }
-            return render(request, self.partial_template_name, context)
-        migrated = build_migrated_context(obj, server_key)
+            # Resolve the marker under the session/active server key — NOT the POSTed key, which
+            # failed to rebind (stale/unconfigured) and would miss the marker entirely. render_sync_partial
+            # always injects the migrated-context flags so the donor keeps its migration controls.
+            return self.render_sync_partial(
+                request,
+                obj,
+                active_server_key,
+                {
+                    "vlan_sync": self._get_error_context(
+                        obj, "Selected LibreNMS server is no longer configured.", server_key=None
+                    )
+                },
+            )
 
         # Get librenms_id (now scoped to the POSTed server). coerce_librenms_id fails closed on a
         # poisoned cached value (bool/zero/negative/garbage) — the device-id cache path of
@@ -82,11 +81,12 @@ class BaseVLANTableView(VlanAssignmentMixin, LibreNMSAPIMixin, LibreNMSPermissio
             cache.delete(self.get_cache_key(obj, "vlans", server_key))
             cache.delete(self.get_last_fetched_key(obj, "vlans", server_key))
             messages.error(request, "Device not found in LibreNMS.")
-            context = {
-                "vlan_sync": self._get_error_context(obj, "Device not found in LibreNMS", server_key=server_key),
-                **migrated,
-            }
-            return render(request, self.partial_template_name, context)
+            return self.render_sync_partial(
+                request,
+                obj,
+                server_key,
+                {"vlan_sync": self._get_error_context(obj, "Device not found in LibreNMS", server_key=server_key)},
+            )
 
         # Fetch VLAN data from LibreNMS
         success, error_msg = self._fetch_and_cache_vlan_data(obj, server_key)
@@ -94,13 +94,15 @@ class BaseVLANTableView(VlanAssignmentMixin, LibreNMSAPIMixin, LibreNMSPermissio
             cache.delete(self.get_cache_key(obj, "vlans", server_key))
             cache.delete(self.get_last_fetched_key(obj, "vlans", server_key))
             messages.error(request, error_msg)
-            context = {"vlan_sync": self._get_error_context(obj, error_msg, server_key=server_key), **migrated}
-            return render(request, self.partial_template_name, context)
+            return self.render_sync_partial(
+                request, obj, server_key, {"vlan_sync": self._get_error_context(obj, error_msg, server_key=server_key)}
+            )
 
         messages.success(request, "VLAN data refreshed successfully.")
 
-        context = {"vlan_sync": self.get_vlan_context(request, obj, server_key), **migrated}
-        return render(request, self.partial_template_name, context)
+        return self.render_sync_partial(
+            request, obj, server_key, {"vlan_sync": self.get_vlan_context(request, obj, server_key)}
+        )
 
     def _fetch_and_cache_vlan_data(self, obj, server_key=None):
         """

--- a/netbox_librenms_plugin/views/base/vlan_table_view.py
+++ b/netbox_librenms_plugin/views/base/vlan_table_view.py
@@ -47,6 +47,11 @@ class BaseVLANTableView(VlanAssignmentMixin, LibreNMSAPIMixin, LibreNMSPermissio
         server_key = self.rebind_api_for_server(request.POST.get("server_key"))
         if server_key is None:
             messages.error(request, "Selected LibreNMS server is no longer configured.")
+            # rebind_api_for_server() returned None precisely to avoid constructing a missing/
+            # misconfigured default client, so don't touch the lazy `librenms_api` property here —
+            # it would reconstruct LibreNMSAPI() and can raise, turning this HTMX error path into a
+            # 500. Read the already-cached client's key (else "default").
+            active_server_key = getattr(getattr(self, "_librenms_api", None), "server_key", None) or "default"
             # Pass server_key=None explicitly so the fragment doesn't silently fall back to
             # the session/default server (which would re-render with the wrong server selected
             # and let the next retry sync VLANs against the wrong LibreNMS instance).
@@ -59,7 +64,7 @@ class BaseVLANTableView(VlanAssignmentMixin, LibreNMSAPIMixin, LibreNMSPermissio
                 # controls on a stale-server refresh until the next full reload. Resolve the
                 # marker under the session/active server key — NOT the POSTed key, which failed
                 # to rebind (stale/unconfigured) and would miss the marker entirely.
-                **build_migrated_context(obj, self.librenms_api.server_key),
+                **build_migrated_context(obj, active_server_key),
             }
             return render(request, self.partial_template_name, context)
         migrated = build_migrated_context(obj, server_key)

--- a/netbox_librenms_plugin/views/base/vlan_table_view.py
+++ b/netbox_librenms_plugin/views/base/vlan_table_view.py
@@ -6,7 +6,12 @@ from django.views import View
 
 from netbox_librenms_plugin.constants import LIBRENMS_VLAN_STATE_ACTIVE
 from netbox_librenms_plugin.tables.vlans import LibreNMSVLANTable
-from netbox_librenms_plugin.utils import cache_remaining_ttl, coerce_librenms_id, is_list_of_dicts
+from netbox_librenms_plugin.utils import (
+    build_migrated_context,
+    cache_remaining_ttl,
+    coerce_librenms_id,
+    is_list_of_dicts,
+)
 from netbox_librenms_plugin.views.mixins import (
     CacheMixin,
     LibreNMSAPIMixin,
@@ -49,8 +54,13 @@ class BaseVLANTableView(VlanAssignmentMixin, LibreNMSAPIMixin, LibreNMSPermissio
                 "vlan_sync": self._get_error_context(
                     obj, "Selected LibreNMS server is no longer configured.", server_key=None
                 ),
+                # Preserve migrated-context flags on this error exit too (every other POST
+                # path includes them); otherwise a donor/winner device loses its migration
+                # controls on a stale-server refresh until the next full reload.
+                **build_migrated_context(obj, request.POST.get("server_key")),
             }
             return render(request, self.partial_template_name, context)
+        migrated = build_migrated_context(obj, server_key)
 
         # Get librenms_id (now scoped to the POSTed server). coerce_librenms_id fails closed on a
         # poisoned cached value (bool/zero/negative/garbage) — the device-id cache path of
@@ -67,6 +77,7 @@ class BaseVLANTableView(VlanAssignmentMixin, LibreNMSAPIMixin, LibreNMSPermissio
             messages.error(request, "Device not found in LibreNMS.")
             context = {
                 "vlan_sync": self._get_error_context(obj, "Device not found in LibreNMS", server_key=server_key),
+                **migrated,
             }
             return render(request, self.partial_template_name, context)
 
@@ -76,12 +87,12 @@ class BaseVLANTableView(VlanAssignmentMixin, LibreNMSAPIMixin, LibreNMSPermissio
             cache.delete(self.get_cache_key(obj, "vlans", server_key))
             cache.delete(self.get_last_fetched_key(obj, "vlans", server_key))
             messages.error(request, error_msg)
-            context = {"vlan_sync": self._get_error_context(obj, error_msg, server_key=server_key)}
+            context = {"vlan_sync": self._get_error_context(obj, error_msg, server_key=server_key), **migrated}
             return render(request, self.partial_template_name, context)
 
         messages.success(request, "VLAN data refreshed successfully.")
 
-        context = {"vlan_sync": self.get_vlan_context(request, obj, server_key)}
+        context = {"vlan_sync": self.get_vlan_context(request, obj, server_key), **migrated}
         return render(request, self.partial_template_name, context)
 
     def _fetch_and_cache_vlan_data(self, obj, server_key=None):

--- a/netbox_librenms_plugin/views/base/vlan_table_view.py
+++ b/netbox_librenms_plugin/views/base/vlan_table_view.py
@@ -56,8 +56,10 @@ class BaseVLANTableView(VlanAssignmentMixin, LibreNMSAPIMixin, LibreNMSPermissio
                 ),
                 # Preserve migrated-context flags on this error exit too (every other POST
                 # path includes them); otherwise a donor/winner device loses its migration
-                # controls on a stale-server refresh until the next full reload.
-                **build_migrated_context(obj, request.POST.get("server_key")),
+                # controls on a stale-server refresh until the next full reload. Resolve the
+                # marker under the session/active server key — NOT the POSTed key, which failed
+                # to rebind (stale/unconfigured) and would miss the marker entirely.
+                **build_migrated_context(obj, self.librenms_api.server_key),
             }
             return render(request, self.partial_template_name, context)
         migrated = build_migrated_context(obj, server_key)

--- a/netbox_librenms_plugin/views/base/vlan_table_view.py
+++ b/netbox_librenms_plugin/views/base/vlan_table_view.py
@@ -51,7 +51,7 @@ class BaseVLANTableView(VlanAssignmentMixin, LibreNMSAPIMixin, LibreNMSPermissio
             # misconfigured default client, so don't touch the lazy `librenms_api` property here —
             # it would reconstruct LibreNMSAPI() and can raise, turning this HTMX error path into a
             # 500. Read the already-cached client's key (else "default").
-            active_server_key = getattr(getattr(self, "_librenms_api", None), "server_key", None) or "default"
+            active_server_key = self.active_server_key
             # Pass server_key=None explicitly so the fragment doesn't silently fall back to
             # the session/default server (which would re-render with the wrong server selected
             # and let the next retry sync VLANs against the wrong LibreNMS instance).

--- a/netbox_librenms_plugin/views/imports/actions.py
+++ b/netbox_librenms_plugin/views/imports/actions.py
@@ -3232,27 +3232,10 @@ class PromoteToHostView(
                 existing_device.platform = override_platform
                 update_fields.append("platform")
 
-            # _save_device() persists via update_fields, which skips full_clean() — so an override
-            # device_type/platform the user just picked would be stored without NetBox's
-            # Device.clean() cross-field check. When an override actually changes the type or
-            # platform, enforce the one invariant clean() applies to that pair (a platform's
-            # manufacturer must match the device type's) so an incompatible override is rejected
-            # with a clear message rather than silently persisted. Gated on a real override so the
-            # update_fields contract of not blocking on unrelated pre-existing issues is preserved.
-            if "device_type" in update_fields or "platform" in update_fields:
-                eff_dt = existing_device.device_type
-                eff_platform = existing_device.platform
-                if (
-                    eff_platform is not None
-                    and eff_platform.manufacturer_id is not None
-                    and eff_dt is not None
-                    and eff_platform.manufacturer_id != eff_dt.manufacturer_id
-                ):
-                    return _htmx_error_response(
-                        f"Platform '{eff_platform}' is not compatible with device type "
-                        f"'{eff_dt}': their manufacturers differ. Choose a matching platform or device type."
-                    )
-
+            # _save_device() persists via update_fields (skipping full_clean()) but re-runs the
+            # platform/device_type manufacturer invariant via _platform_device_type_mismatch()
+            # whenever those columns are written, so an incompatible override is rejected there —
+            # no inline duplicate (which would only drift in wording from the shared check).
             if err := _save_device(existing_device, update_fields=update_fields, request=request):
                 return err
 

--- a/netbox_librenms_plugin/views/imports/actions.py
+++ b/netbox_librenms_plugin/views/imports/actions.py
@@ -92,7 +92,14 @@ def _attach_messages_oob(response, request):
     except Exception:  # pragma: no cover - defensive: don't break HTMX response on render error
         logger.debug("Failed to render inc/messages.html for OOB toast attach", exc_info=True)
         return response
-    response.content = response.content + rendered.encode("utf-8")
+    # Compose the two trusted HTML fragments (existing response bytes + the rendered
+    # inc/messages.html) through format_html()/mark_safe() — the repo's CodeQL-safe HTML
+    # envelope — rather than concatenating raw bytes.
+    response.content = format_html(
+        "{}{}",
+        mark_safe(response.content.decode(response.charset)),
+        mark_safe(rendered),
+    ).encode(response.charset)
     return response
 
 

--- a/netbox_librenms_plugin/views/imports/actions.py
+++ b/netbox_librenms_plugin/views/imports/actions.py
@@ -371,33 +371,6 @@ def _device_type_rack_fit_error(device) -> HttpResponse | None:
     return None
 
 
-def _rebind_api_for_posted_server(view, request) -> HttpResponse | None:
-    """
-    Rebind ``view._librenms_api`` to the POSTed ``server_key``, or return an HTMX error.
-
-    A blank/absent ``server_key`` leaves the session/default client in place. An
-    unknown/tampered key would otherwise raise the first time the API client is used
-    (turning the action into a 500), so build it eagerly here and surface the same
-    fragment error every POST action view uses.
-
-    Args:
-        view: The view whose ``_librenms_api`` is (re)bound on a posted key.
-        request: The current HTTP request (its POST body is read).
-
-    Returns:
-        HttpResponse: The error response to return verbatim when the posted key is
-            unknown, or ``None`` when the key is blank or successfully resolved.
-    """
-    from netbox_librenms_plugin.librenms_api import build_librenms_api
-
-    post_server_key = (request.POST.get("server_key") or "").strip()
-    if post_server_key:
-        view._librenms_api = build_librenms_api(post_server_key)
-        if view._librenms_api is None:
-            return _htmx_error_response("Selected LibreNMS server is no longer configured.")
-    return None
-
-
 def _save_device(device, update_fields: list[str] | None = None, request=None) -> HttpResponse | None:
     """
     Persist a Device row, returning an HttpResponse on failure or None on success.
@@ -3086,8 +3059,10 @@ class PromoteToHostView(
         if not existing_device_id:
             return _htmx_error_response("Missing existing_device_id")
 
-        if err := _rebind_api_for_posted_server(self, request):
-            return err
+        # Fail closed on a blank/unknown/misconfigured key (the mixin validates the default too)
+        # so a broken default can't 500 via the lazy self.librenms_api property later.
+        if self.rebind_api_for_server(request.POST.get("server_key")) is None:
+            return _htmx_error_response("Selected LibreNMS server is no longer configured.")
 
         try:
             existing_device = Device.objects.get(pk=int(existing_device_id))
@@ -3339,8 +3314,10 @@ class MergeNetBoxDevicesView(
             merge_librenms_links,
         )
 
-        if err := _rebind_api_for_posted_server(self, request):
-            return err
+        # Fail closed on a blank/unknown/misconfigured key (the mixin validates the default too)
+        # so a broken default can't 500 via the lazy self.librenms_api property later.
+        if self.rebind_api_for_server(request.POST.get("server_key")) is None:
+            return _htmx_error_response("Selected LibreNMS server is no longer configured.")
 
         winner_pk_raw = request.POST.get("winner_pk")
         if not winner_pk_raw:

--- a/netbox_librenms_plugin/views/imports/actions.py
+++ b/netbox_librenms_plugin/views/imports/actions.py
@@ -505,7 +505,9 @@ def _get_hostname_for_action(request, validation: dict, libre_device: dict) -> s
 class DeviceImportHelperMixin:
     """Mixin providing common validation and rendering helpers for device import views."""
 
-    def get_validated_device_with_selections(self, device_id: int, request) -> tuple[dict | None, dict | None, dict]:
+    def get_validated_device_with_selections(
+        self, device_id: int, request, *, libre_device: dict | None = None
+    ) -> tuple[dict | None, dict | None, dict]:
         """
         Get LibreNMS device, validate it, and apply user selections.
 
@@ -514,13 +516,20 @@ class DeviceImportHelperMixin:
         Args:
             device_id: LibreNMS device ID
             request: Django request object
+            libre_device: Optional pre-fetched LibreNMS device data. The LibreNMS side is
+                invariant within a single request, so the post-commit re-validation after a
+                promote/merge can pass the device fetched earlier to skip a redundant
+                ``fetch_device_with_cache`` call. The NetBox-side ``validate_device_for_import``
+                is still re-run so the refreshed row reflects the just-committed state.
 
         Returns:
             Tuple of (libre_device, validation, selections)
             Returns (None, None, selections) if device not found
         """
-        # Try to use cached device data from table load (eliminates redundant API calls)
-        libre_device = fetch_device_with_cache(device_id, self.librenms_api)
+        # Reuse a caller-supplied device, else use cached device data from the table load
+        # (both eliminate redundant API calls).
+        if libre_device is None:
+            libre_device = fetch_device_with_cache(device_id, self.librenms_api)
 
         if not libre_device:
             return None, None, extract_device_selections(request, device_id)
@@ -3292,7 +3301,11 @@ class PromoteToHostView(
         cache_key = get_import_device_cache_key(device_id, server_key)
         cache.delete(cache_key)
 
-        libre_device, validation, selections = self.get_validated_device_with_selections(device_id, request)
+        # Reuse the LibreNMS device already fetched above (invariant within this request); only the
+        # NetBox-side validation needs to re-run to reflect the just-committed promotion/merge.
+        libre_device, validation, selections = self.get_validated_device_with_selections(
+            device_id, request, libre_device=libre_device
+        )
         if not libre_device:
             # Promotion already committed; a post-commit reload miss must not report failure.
             return self.post_commit_refresh_fallback(
@@ -3485,7 +3498,11 @@ class MergeNetBoxDevicesView(
         cache_key = get_import_device_cache_key(device_id, server_key)
         cache.delete(cache_key)
 
-        libre_device, validation, selections = self.get_validated_device_with_selections(device_id, request)
+        # Reuse the LibreNMS device already fetched above (invariant within this request); only the
+        # NetBox-side validation needs to re-run to reflect the just-committed promotion/merge.
+        libre_device, validation, selections = self.get_validated_device_with_selections(
+            device_id, request, libre_device=libre_device
+        )
         if not libre_device:
             # Merge already committed; a post-commit reload miss must not report failure
             # (the donor is already absorbed — a retry would target stale/invalid state).

--- a/netbox_librenms_plugin/views/imports/actions.py
+++ b/netbox_librenms_plugin/views/imports/actions.py
@@ -3105,15 +3105,13 @@ class PromoteToHostView(
         if validated_existing.pk != existing_device.pk:
             return _htmx_error_response("Device ID mismatch: existing_device_id does not match validation result")
 
-        new_host_id = libre_device.get("device_id")
-        if isinstance(new_host_id, bool):
+        from netbox_librenms_plugin.utils import coerce_librenms_id
+
+        # coerce_librenms_id centralizes the bool/int/str/positive checks (rejects bools,
+        # non-numeric strings, zero/negatives) in one place — same guard used elsewhere.
+        new_host_id = coerce_librenms_id(libre_device.get("device_id"))
+        if new_host_id is None:
             return _htmx_error_response("Invalid or missing LibreNMS device_id")
-        try:
-            new_host_id = int(new_host_id)
-        except (TypeError, ValueError):
-            return _htmx_error_response("Invalid or missing LibreNMS device_id")
-        if new_host_id <= 0:
-            return _htmx_error_response("Invalid LibreNMS device_id")
 
         existing_libre_id = promote.get("existing_libre_id")
         try:
@@ -3153,7 +3151,6 @@ class PromoteToHostView(
 
             from netbox_librenms_plugin.utils import (
                 AmbiguousLibreNMSIdError,
-                coerce_librenms_id,
                 find_by_librenms_id,
                 get_librenms_device_id,
                 get_librenms_oob,

--- a/netbox_librenms_plugin/views/imports/actions.py
+++ b/netbox_librenms_plugin/views/imports/actions.py
@@ -3437,10 +3437,10 @@ class MergeNetBoxDevicesView(
                 )
 
             # merge_librenms_links(), set_device_ip_fk() and mark_librenms_migrated() all raise
-            # ValueError on corrupt link shapes or an ownership violation. Guard the whole group,
-            # not just the first call: none of them persist anything (the save block is below), so
-            # a ValueError from the oob transfer or the migration marker must fail closed with a
-            # toast exactly like a merge_librenms_links() rejection — never bubble up as a 500.
+            # ValueError on corrupt link shapes or an ownership violation. The locked OOB-IP reads
+            # can also raise DatabaseError (for example, a lock timeout). Guard the whole group:
+            # none of it persists anything (the save block is below), so every failure must return
+            # a safe toast and roll back rather than bubbling up as a 500.
             try:
                 summary = merge_librenms_links(winner_sync, donor_sync, server_key=server_key)
 
@@ -3485,13 +3485,19 @@ class MergeNetBoxDevicesView(
                 # back defensively before returning the fail-closed toast.
                 transaction.set_rollback(True)
                 return _htmx_error_response(f"Cannot merge: {escape(str(exc))}")
+            except DatabaseError:
+                logger.exception(
+                    "MergeNetBoxDevicesView: database failure preparing merge winner=%s donor=%s",
+                    winner.pk,
+                    donor.pk,
+                )
+                transaction.set_rollback(True)
+                return _htmx_error_response("Cannot merge because the database operation failed. Please retry.")
 
-            # Persist only the fields we actually touched.  Calling
-            # ``full_clean()`` here (or relying on it via ``_save_device``)
-            # would re-validate every field on the device — which is
-            # undesirable when the rows hold pre-existing inconsistencies
-            # (e.g. ``face`` set without ``rack``) that are unrelated to
-            # this merge.  See issue surfaced during eve-ng-02 merge.
+            # Persist only the fields we actually touched. Calling ``full_clean()`` here (or calling
+            # ``_save_device`` without update_fields) would re-validate every field on the device —
+            # undesirable when the rows hold pre-existing inconsistencies (e.g. ``face`` set without
+            # ``rack``) that are unrelated to this merge. See issue surfaced during eve-ng-02 merge.
             # Persist only the fields we actually touched, per row. The LibreNMS link merge +
             # migration marker land on the sync devices (custom_field_data); the oob_ip transfer
             # lands on the selected winner/donor. When a selected device IS its own sync device
@@ -3518,22 +3524,19 @@ class MergeNetBoxDevicesView(
             winner_extra = [winner_sync] if winner_sync.pk != winner.pk else []
             save_order = [donor, *donor_extra, *winner_extra, winner]
             saved = set()
-            try:
-                for dev in save_order:
-                    if dev.pk in saved:
-                        continue
-                    saved.add(dev.pk)
-                    fields = fields_by_pk.get(dev.pk)
-                    if fields:
-                        dev.save(update_fields=sorted(fields))
-            except Exception:  # pragma: no cover - defensive
-                logger.exception(
-                    "MergeNetBoxDevicesView: failed to persist merge winner=%s donor=%s",
-                    winner.pk,
-                    donor.pk,
-                )
-                transaction.set_rollback(True)
-                return _htmx_error_response("Unable to save the merge changes. Please try again.")
+            for dev in save_order:
+                if dev.pk in saved:
+                    continue
+                saved.add(dev.pk)
+                fields = fields_by_pk.get(dev.pk)
+                if fields and (error := _save_device(dev, update_fields=sorted(fields), request=request)):
+                    logger.error(
+                        "MergeNetBoxDevicesView: failed to persist merge winner=%s donor=%s",
+                        winner.pk,
+                        donor.pk,
+                    )
+                    transaction.set_rollback(True)
+                    return error
 
         logger.info(
             "Merged NetBox device '%s' (pk=%d) into '%s' (pk=%d) on server %s. Summary: %s; oob_ip_transferred=%s",

--- a/netbox_librenms_plugin/views/imports/actions.py
+++ b/netbox_librenms_plugin/views/imports/actions.py
@@ -2629,8 +2629,7 @@ class AddAsOOBView(
                 )
             if oob_conflict is not None and oob_conflict.pk != sync_device.pk:
                 return _htmx_error_response(
-                    f"LibreNMS device #{librenms_id} is already linked to '{escape(oob_conflict.name)}'; "
-                    "refresh and retry."
+                    f"LibreNMS device #{librenms_id} is already linked to '{oob_conflict.name}'; refresh and retry."
                 )
 
             try:
@@ -2641,7 +2640,7 @@ class AddAsOOBView(
                     oob_type=oob_type,
                 )
             except ValueError as exc:
-                return _htmx_error_response(f"Invalid OOB data: {escape(str(exc))}")
+                return _htmx_error_response(f"Invalid OOB data: {exc}")
 
             update_fields = ["custom_field_data"]
 
@@ -3219,8 +3218,7 @@ class PromoteToHostView(
                 )
             if host_conflict is not None and host_conflict.pk != existing_device.pk:
                 return _htmx_error_response(
-                    f"LibreNMS device #{new_host_id} is already linked to '{escape(host_conflict.name)}'; "
-                    "refresh and retry."
+                    f"LibreNMS device #{new_host_id} is already linked to '{host_conflict.name}'; refresh and retry."
                 )
 
             try:
@@ -3239,7 +3237,7 @@ class PromoteToHostView(
                     oob_type=oob_type,
                 )
             except ValueError as exc:
-                return _htmx_error_response(f"Invalid promotion data: {escape(str(exc))}")
+                return _htmx_error_response(f"Invalid promotion data: {exc}")
 
             # Promotion re-points the LibreNMS host/OOB linkage only. NetBox
             # requires primary_ip4/6 and oob_ip to be assigned to one of the
@@ -3503,7 +3501,7 @@ class MergeNetBoxDevicesView(
                 # Nothing was persisted yet, but locks were taken under this atomic block — roll
                 # back defensively before returning the fail-closed toast.
                 transaction.set_rollback(True)
-                return _htmx_error_response(f"Cannot merge: {escape(str(exc))}")
+                return _htmx_error_response(f"Cannot merge: {exc}")
             except DatabaseError:
                 return _database_failure_response()
 

--- a/netbox_librenms_plugin/views/imports/actions.py
+++ b/netbox_librenms_plugin/views/imports/actions.py
@@ -3113,10 +3113,10 @@ class PromoteToHostView(
         if new_host_id is None:
             return _htmx_error_response("Invalid or missing LibreNMS device_id")
 
-        existing_libre_id = promote.get("existing_libre_id")
-        try:
-            existing_libre_id = int(existing_libre_id)
-        except (TypeError, ValueError):
+        # Use coerce_librenms_id (not int()) so a boolean True/False in the JSON CF can't be
+        # coerced to 1/0 and treated as a real device id — mirrors the new_host_id guard above.
+        existing_libre_id = coerce_librenms_id(promote.get("existing_libre_id"))
+        if existing_libre_id is None:
             return _htmx_error_response("Invalid existing LibreNMS id in promotion data")
         if existing_libre_id == new_host_id:
             return _htmx_error_response("Existing link already points at this LibreNMS device")
@@ -3143,18 +3143,34 @@ class PromoteToHostView(
                 "Device has a legacy bare-integer librenms_id; use 'Convert mapping' to migrate first."
             )
 
-        with transaction.atomic():
-            try:
-                existing_device = Device.objects.select_for_update().get(pk=existing_device.pk)
-            except Device.DoesNotExist:
-                return _htmx_error_response("Device no longer exists; it may have been deleted concurrently.")
+        from netbox_librenms_plugin.utils import (
+            AmbiguousLibreNMSIdError,
+            find_by_librenms_id,
+            get_librenms_device_id,
+            get_librenms_oob,
+        )
 
-            from netbox_librenms_plugin.utils import (
-                AmbiguousLibreNMSIdError,
-                find_by_librenms_id,
-                get_librenms_device_id,
-                get_librenms_oob,
+        # Pre-resolve any device already linked to new_host_id WITHOUT locking, so the
+        # transaction can lock every row it touches in one deterministic pk order (mirrors the
+        # merge flow). Locking existing_device first and the conflict second would let two
+        # concurrent opposite-direction promotions each hold one row and block on the other
+        # (lock-order deadlock).
+        try:
+            pre_conflict = find_by_librenms_id(Device, new_host_id, server_key)
+        except AmbiguousLibreNMSIdError:
+            return _htmx_error_response(
+                f"LibreNMS device #{new_host_id} is ambiguous — it matches more than one NetBox "
+                "device. Resolve the duplicate assignment before promoting."
             )
+        lock_pks = {existing_device.pk}
+        if pre_conflict is not None:
+            lock_pks.add(pre_conflict.pk)
+
+        with transaction.atomic():
+            locked = {d.pk: d for d in Device.objects.select_for_update().filter(pk__in=lock_pks).order_by("pk")}
+            existing_device = locked.get(existing_device.pk)
+            if existing_device is None:
+                return _htmx_error_response("Device no longer exists; it may have been deleted concurrently.")
 
             current_host_id = get_librenms_device_id(existing_device, server_key=server_key, auto_save=False)
             current_oob = get_librenms_oob(existing_device, server_key=server_key)
@@ -3164,11 +3180,9 @@ class PromoteToHostView(
                 return _htmx_error_response(
                     "OOB link already set; this device may have been promoted by a concurrent request."
                 )
-            # Another device may have claimed new_host_id since validation ran. Re-check
-            # inside the transaction and abort on a non-self conflict so we don't create a
-            # duplicate host mapping. select_for_update locks the competing owner row so a
-            # concurrent promote/attach of the same id serializes against it; best-effort like
-            # the serial guard (no unique constraint on the JSON cf to fully close the window).
+            # Re-verify the conflict under lock (TOCTOU): a device could have gained or lost
+            # new_host_id between the unlocked pre-lookup and acquiring the row locks. The rows
+            # in lock_pks are already locked in pk order, so this re-check doesn't reorder locks.
             try:
                 host_conflict = find_by_librenms_id(Device, new_host_id, server_key, select_for_update=True)
             except AmbiguousLibreNMSIdError:

--- a/netbox_librenms_plugin/views/imports/actions.py
+++ b/netbox_librenms_plugin/views/imports/actions.py
@@ -3234,6 +3234,27 @@ class PromoteToHostView(
                 existing_device.platform = override_platform
                 update_fields.append("platform")
 
+            # _save_device() persists via update_fields, which skips full_clean() — so an override
+            # device_type/platform the user just picked would be stored without NetBox's
+            # Device.clean() cross-field check. When an override actually changes the type or
+            # platform, enforce the one invariant clean() applies to that pair (a platform's
+            # manufacturer must match the device type's) so an incompatible override is rejected
+            # with a clear message rather than silently persisted. Gated on a real override so the
+            # update_fields contract of not blocking on unrelated pre-existing issues is preserved.
+            if "device_type" in update_fields or "platform" in update_fields:
+                eff_dt = existing_device.device_type
+                eff_platform = existing_device.platform
+                if (
+                    eff_platform is not None
+                    and eff_platform.manufacturer_id is not None
+                    and eff_dt is not None
+                    and eff_platform.manufacturer_id != eff_dt.manufacturer_id
+                ):
+                    return _htmx_error_response(
+                        f"Platform '{eff_platform}' is not compatible with device type "
+                        f"'{eff_dt}': their manufacturers differ. Choose a matching platform or device type."
+                    )
+
             if err := _save_device(existing_device, update_fields=update_fields, request=request):
                 return err
 

--- a/netbox_librenms_plugin/views/imports/actions.py
+++ b/netbox_librenms_plugin/views/imports/actions.py
@@ -3372,6 +3372,15 @@ class MergeNetBoxDevicesView(
 
         server_key = self.librenms_api.server_key
 
+        def _database_failure_response():
+            logger.exception(
+                "MergeNetBoxDevicesView: database failure merging winner=%s donor=%s",
+                winner.pk,
+                donor.pk,
+            )
+            transaction.set_rollback(True)
+            return _htmx_error_response("Cannot merge because the database operation failed. Please retry.")
+
         # LibreNMS treats a Virtual Chassis as one logical device, so the host/OOB link lives on the
         # single sync member (get_librenms_sync_device) — which may differ from the winner/donor the
         # user selected when a candidate matched a NON-sync VC member by serial/hostname. Merge the
@@ -3388,13 +3397,16 @@ class MergeNetBoxDevicesView(
             # it from unlocked rows would let a concurrent VC edit (a member joining/leaving, or the
             # id moving between members) shift the sync member to a row we never locked — splitting
             # the link across the VC. Non-VC merges add no members, so they lock the same two rows.
-            lock_pks = {winner.pk, donor.pk}
-            for candidate in (winner, donor):
-                vc = getattr(candidate, "virtual_chassis", None)
-                if vc:
-                    lock_pks.update(vc.members.values_list("pk", flat=True))
-            lock_pks = sorted(lock_pks)
-            locked = list(Device.objects.select_for_update().filter(pk__in=lock_pks).order_by("pk"))
+            try:
+                lock_pks = {winner.pk, donor.pk}
+                for candidate in (winner, donor):
+                    vc = getattr(candidate, "virtual_chassis", None)
+                    if vc:
+                        lock_pks.update(vc.members.values_list("pk", flat=True))
+                lock_pks = sorted(lock_pks)
+                locked = list(Device.objects.select_for_update().filter(pk__in=lock_pks).order_by("pk"))
+            except DatabaseError:
+                return _database_failure_response()
             if len(locked) != len(lock_pks):
                 return _htmx_error_response(
                     "One of the devices no longer exists; it may have been deleted concurrently."
@@ -3404,8 +3416,11 @@ class MergeNetBoxDevicesView(
             donor = locked_by_pk[donor.pk]
 
             # Resolve the sync devices from the now-locked, current state.
-            winner_sync = get_librenms_sync_device(winner, server_key=server_key) or winner
-            donor_sync = get_librenms_sync_device(donor, server_key=server_key) or donor
+            try:
+                winner_sync = get_librenms_sync_device(winner, server_key=server_key) or winner
+                donor_sync = get_librenms_sync_device(donor, server_key=server_key) or donor
+            except DatabaseError:
+                return _database_failure_response()
             # Fail closed if a concurrent VC change added a member after we snapshotted lock_pks and
             # the resolved sync device wasn't among the locked rows — never write the link to an
             # unlocked row; the operator can retry.
@@ -3417,7 +3432,11 @@ class MergeNetBoxDevicesView(
             # scoped above, and the save block below writes their custom_field_data. Authorize them
             # too, or a grant covering only the selected pair mutates the link-holding sibling.
             sync_pks = {winner_sync.pk, donor_sync.pk}
-            if set(changeable.filter(pk__in=sync_pks).values_list("pk", flat=True)) != sync_pks:
+            try:
+                changeable_sync_pks = set(changeable.filter(pk__in=sync_pks).values_list("pk", flat=True))
+            except DatabaseError:
+                return _database_failure_response()
+            if changeable_sync_pks != sync_pks:
                 return _htmx_error_response("Winner or donor device not found")
             # Gate the link-holding sync devices, not merely the selected VC members. The merge
             # helpers reject legacy data either way; checking here preserves the actionable
@@ -3486,13 +3505,7 @@ class MergeNetBoxDevicesView(
                 transaction.set_rollback(True)
                 return _htmx_error_response(f"Cannot merge: {escape(str(exc))}")
             except DatabaseError:
-                logger.exception(
-                    "MergeNetBoxDevicesView: database failure preparing merge winner=%s donor=%s",
-                    winner.pk,
-                    donor.pk,
-                )
-                transaction.set_rollback(True)
-                return _htmx_error_response("Cannot merge because the database operation failed. Please retry.")
+                return _database_failure_response()
 
             # Persist only the fields we actually touched. Calling ``full_clean()`` here (or calling
             # ``_save_device`` without update_fields) would re-validate every field on the device —

--- a/netbox_librenms_plugin/views/imports/actions.py
+++ b/netbox_librenms_plugin/views/imports/actions.py
@@ -3027,6 +3027,414 @@ class AddAsOOBView(
             return None, "conflict"
 
 
+class PromoteToHostView(
+    LibreNMSPermissionMixin, NetBoxObjectPermissionMixin, LibreNMSAPIMixin, DeviceImportHelperMixin, View
+):
+    """
+    Promote an incoming LibreNMS host device to be the *primary* link of an existing
+    NetBox device whose current LibreNMS link is the OOB controller.
+
+    The existing NetBox device's current ``librenms_id.{server_key}.id`` is moved into
+    the ``oob`` slot (preserving its bare-int → dict-form transition), and the incoming
+    LibreNMS device id becomes the new host id.  No new NetBox device is created — this
+    is a reassignment, not an import.
+    """
+
+    def post(self, request, device_id):
+        if error := self.require_write_permission():
+            return error
+
+        from dcim.models import Device
+        from netbox_librenms_plugin.librenms_api import build_librenms_api
+
+        existing_device_id = request.POST.get("existing_device_id")
+        if not existing_device_id:
+            return _htmx_error_response("Missing existing_device_id")
+
+        post_server_key = (request.POST.get("server_key") or "").strip()
+        if post_server_key:
+            # Unknown/tampered server_key would otherwise raise → 500.
+            self._librenms_api = build_librenms_api(post_server_key)
+            if self._librenms_api is None:
+                return _htmx_error_response("Selected LibreNMS server is no longer configured.")
+
+        try:
+            existing_device = Device.objects.get(pk=int(existing_device_id))
+        except (Device.DoesNotExist, ValueError):
+            return _htmx_error_response("Existing device not found")
+
+        self.required_object_permissions = {"POST": [("change", Device)]}
+        if error := self.require_object_permissions("POST"):
+            return error
+
+        # Optional per-field overrides from the pre-promote pick modal.
+        # All three default to "keep current"; only applied when the POST
+        # carries an explicit non-empty value.
+        override_name = (request.POST.get("override_name") or "").strip() or None
+        override_dt_id = (request.POST.get("override_device_type_id") or "").strip() or None
+        override_platform_id = (request.POST.get("override_platform_id") or "").strip() or None
+
+        override_device_type = None
+        if override_dt_id:
+            from dcim.models import DeviceType
+
+            try:
+                override_device_type = DeviceType.objects.get(pk=int(override_dt_id))
+            except (DeviceType.DoesNotExist, ValueError, TypeError):
+                return _htmx_error_response("Invalid override_device_type_id")
+
+        override_platform = None
+        if override_platform_id:
+            from dcim.models import Platform
+
+            try:
+                override_platform = Platform.objects.get(pk=int(override_platform_id))
+            except (Platform.DoesNotExist, ValueError, TypeError):
+                return _htmx_error_response("Invalid override_platform_id")
+
+        libre_device, validation, selections = self.get_validated_device_with_selections(device_id, request)
+        if not libre_device:
+            return _htmx_error_response("LibreNMS device not found")
+
+        promote = validation.get("promote_to_host") if validation else None
+        if not promote:
+            return _htmx_error_response("Promotion is not applicable for this device")
+        validated_existing = validation.get("existing_device")
+        if validated_existing is None:
+            return _htmx_error_response("Missing validated conflict target for promotion")
+        if validated_existing.pk != existing_device.pk:
+            return _htmx_error_response("Device ID mismatch: existing_device_id does not match validation result")
+
+        new_host_id = libre_device.get("device_id")
+        if isinstance(new_host_id, bool):
+            return _htmx_error_response("Invalid or missing LibreNMS device_id")
+        try:
+            new_host_id = int(new_host_id)
+        except (TypeError, ValueError):
+            return _htmx_error_response("Invalid or missing LibreNMS device_id")
+        if new_host_id <= 0:
+            return _htmx_error_response("Invalid LibreNMS device_id")
+
+        existing_libre_id = promote.get("existing_libre_id")
+        try:
+            existing_libre_id = int(existing_libre_id)
+        except (TypeError, ValueError):
+            return _htmx_error_response("Invalid existing LibreNMS id in promotion data")
+        if existing_libre_id == new_host_id:
+            return _htmx_error_response("Existing link already points at this LibreNMS device")
+
+        oob_type = promote.get("existing_oob_type") or ""
+        if not oob_type:
+            return _htmx_error_response("Cannot determine OOB type for promotion")
+
+        from netbox_librenms_plugin.utils import set_librenms_device_id, set_librenms_oob
+
+        server_key = self.librenms_api.server_key
+
+        # Reject legacy bare-int librenms_id form (caller should migrate first).
+        stored_id = existing_device.custom_field_data.get("librenms_id")
+        _is_legacy = isinstance(stored_id, int) and not isinstance(stored_id, bool)
+        if not _is_legacy and isinstance(stored_id, str):
+            try:
+                int(stored_id)
+                _is_legacy = True
+            except (ValueError, TypeError):
+                pass
+        if _is_legacy:
+            return _htmx_error_response(
+                "Device has a legacy bare-integer librenms_id; use 'Convert mapping' to migrate first."
+            )
+
+        with transaction.atomic():
+            try:
+                existing_device = Device.objects.select_for_update().get(pk=existing_device.pk)
+            except Device.DoesNotExist:
+                return _htmx_error_response("Device no longer exists; it may have been deleted concurrently.")
+
+            from netbox_librenms_plugin.utils import (
+                AmbiguousLibreNMSIdError,
+                coerce_librenms_id,
+                find_by_librenms_id,
+                get_librenms_device_id,
+                get_librenms_oob,
+            )
+
+            current_host_id = get_librenms_device_id(existing_device, server_key=server_key, auto_save=False)
+            current_oob = get_librenms_oob(existing_device, server_key=server_key)
+            if coerce_librenms_id(current_host_id) != coerce_librenms_id(existing_libre_id):
+                return _htmx_error_response("LibreNMS host link changed concurrently; refresh and retry.")
+            if current_oob:
+                return _htmx_error_response(
+                    "OOB link already set; this device may have been promoted by a concurrent request."
+                )
+            # Another device may have claimed new_host_id since validation ran. Re-check
+            # inside the transaction and abort on a non-self conflict so we don't create a
+            # duplicate host mapping. find_by_librenms_id is an unlocked read, so this
+            # narrows — not closes — the window (no unique constraint exists on the cf).
+            try:
+                host_conflict = find_by_librenms_id(Device, new_host_id, server_key)
+            except AmbiguousLibreNMSIdError:
+                return _htmx_error_response(
+                    f"LibreNMS device #{new_host_id} is ambiguous — it matches more than one NetBox "
+                    "device. Resolve the duplicate assignment before promoting."
+                )
+            if host_conflict is not None and host_conflict.pk != existing_device.pk:
+                return _htmx_error_response(
+                    f"LibreNMS device #{new_host_id} is already linked to '{escape(host_conflict.name)}'; "
+                    "refresh and retry."
+                )
+
+            try:
+                # First, swap the host id to the incoming LibreNMS device id.
+                # set_librenms_device_id preserves any existing OOB sub-object.
+                set_librenms_device_id(
+                    existing_device,
+                    new_host_id,
+                    server_key=server_key,
+                )
+                # Then attach the previously-linked LibreNMS id as the OOB controller.
+                set_librenms_oob(
+                    existing_device,
+                    existing_libre_id,
+                    server_key,
+                    oob_type=oob_type,
+                )
+            except ValueError as exc:
+                return _htmx_error_response(f"Invalid promotion data: {escape(str(exc))}")
+
+            # Promotion re-points the LibreNMS host/OOB linkage only. NetBox
+            # requires primary_ip4/6 and oob_ip to be assigned to one of the
+            # device's interfaces, so those relationships are set from the
+            # interface-assigned IP-sync flow — not from auto-created global
+            # records here.
+            update_fields = ["custom_field_data"]
+
+            # Apply any explicit per-field overrides chosen in the pre-promote modal.
+            # Default behaviour (no overrides) keeps the existing device's name, type
+            # and platform — matching the original promote semantics.
+            if override_name and override_name != existing_device.name:
+                existing_device.name = override_name
+                update_fields.append("name")
+            if override_device_type and existing_device.device_type_id != override_device_type.pk:
+                existing_device.device_type = override_device_type
+                update_fields.append("device_type")
+            if override_platform and existing_device.platform_id != override_platform.pk:
+                existing_device.platform = override_platform
+                update_fields.append("platform")
+
+            if err := _save_device(existing_device, update_fields=update_fields, request=request):
+                return err
+
+        logger.info(
+            "Promoted LibreNMS host (id %d) to '%s' on server %s; demoted previous link (id %d, type %s) to OOB slot",
+            new_host_id,
+            existing_device.name,
+            server_key,
+            existing_libre_id,
+            oob_type,
+        )
+
+        cache_key = get_import_device_cache_key(device_id, server_key)
+        cache.delete(cache_key)
+
+        libre_device, validation, selections = self.get_validated_device_with_selections(device_id, request)
+        if not libre_device:
+            # Promotion already committed; a post-commit reload miss must not report failure.
+            return self.post_commit_refresh_fallback(
+                request, json.dumps({"validationRefresh": {"deviceId": device_id}})
+            )
+
+        response = self.render_device_row(request, libre_device, validation, selections)
+        # Keep the underlying validation modal open and re-fetch its content so
+        # the user can see the device's new link state (host id + OOB slot)
+        # without losing context. The JS handler in librenms_import.js fires a
+        # fresh GET to the validation URL using the row's existing details
+        # button.
+        response["HX-Trigger"] = json.dumps({"validationRefresh": {"deviceId": device_id}})
+        return response
+
+
+class MergeNetBoxDevicesView(
+    LibreNMSPermissionMixin, NetBoxObjectPermissionMixin, LibreNMSAPIMixin, DeviceImportHelperMixin, View
+):
+    """
+    Merge two existing NetBox devices that represent the same physical box.
+
+    The user (via radio buttons in the validation modal) picks which device is
+    the **winner** (kept) and which is the **donor** (absorbed). The donor's
+    LibreNMS link state under the active ``server_key`` is merged into the
+    winner; the donor's active link is then cleared and a ``_migrated_to``
+    marker is written.  Interfaces, cables and primary IPs are NOT moved —
+    those stay on the donor for the user to re-home incrementally via the
+    Stage-2b "Migrated to X" tab.
+    """
+
+    def post(self, request, device_id):
+        if error := self.require_write_permission():
+            return error
+
+        from dcim.models import Device
+        from netbox_librenms_plugin.librenms_api import build_librenms_api
+        from netbox_librenms_plugin.utils import (
+            mark_librenms_migrated,
+            merge_librenms_links,
+        )
+
+        post_server_key = (request.POST.get("server_key") or "").strip()
+        if post_server_key:
+            # Unknown/tampered server_key would otherwise raise → 500.
+            self._librenms_api = build_librenms_api(post_server_key)
+            if self._librenms_api is None:
+                return _htmx_error_response("Selected LibreNMS server is no longer configured.")
+
+        winner_pk_raw = request.POST.get("winner_pk")
+        if not winner_pk_raw:
+            return _htmx_error_response("Missing winner_pk")
+        try:
+            winner_pk = int(winner_pk_raw)
+        except (TypeError, ValueError):
+            return _htmx_error_response("Invalid winner_pk")
+
+        libre_device, validation, selections = self.get_validated_device_with_selections(device_id, request)
+        if not libre_device:
+            return _htmx_error_response("LibreNMS device not found")
+
+        merge_candidates = (validation or {}).get("merge_candidates") or {}
+        candidate_pks = {
+            (merge_candidates.get("host_named") or {}).get("pk"),
+            (merge_candidates.get("oob_named") or {}).get("pk"),
+        }
+        candidate_pks.discard(None)
+        # Derive the donor from the selected winner instead of trusting the client-posted
+        # donor_pk. The donor hidden field is kept in sync with the winner radio by inline JS;
+        # if that JS fails to run, the form would post winner_pk as its own donor (a no-op /
+        # self-merge) or a stale donor. The merge is always between this fixed pair of
+        # candidates, so the donor is unambiguously the *other* candidate — no client state
+        # needed. This also enforces that the winner is one of the two merge candidates.
+        if winner_pk not in candidate_pks or len(candidate_pks) != 2:
+            return _htmx_error_response("winner_pk does not match the validation result's merge candidates")
+        donor_pk = next(pk for pk in candidate_pks if pk != winner_pk)
+
+        try:
+            winner = Device.objects.get(pk=winner_pk)
+            donor = Device.objects.get(pk=donor_pk)
+        except Device.DoesNotExist:
+            return _htmx_error_response("Winner or donor device not found")
+
+        # Permission gate: user must be able to change BOTH devices.
+        self.required_object_permissions = {"POST": [("change", Device)]}
+        if error := self.require_object_permissions("POST"):
+            return error
+
+        # Reject legacy bare-int librenms_id form on either side. The merge
+        # helpers refuse to operate on legacy data to prevent silent migration.
+        for label, obj in (("winner", winner), ("donor", donor)):
+            stored = obj.custom_field_data.get("librenms_id")
+            is_legacy = isinstance(stored, int) and not isinstance(stored, bool)
+            if not is_legacy and isinstance(stored, str):
+                try:
+                    int(stored)
+                    is_legacy = True
+                except (ValueError, TypeError):
+                    pass
+            if is_legacy:
+                return _htmx_error_response(
+                    f"{label.capitalize()} device has a legacy bare-integer librenms_id; "
+                    "use 'Convert mapping' to migrate before merging."
+                )
+
+        server_key = self.librenms_api.server_key
+
+        with transaction.atomic():
+            # Lock both rows in deterministic pk order to avoid deadlocks.
+            locked = list(Device.objects.select_for_update().filter(pk__in=[winner_pk, donor_pk]).order_by("pk"))
+            if len(locked) != 2:
+                return _htmx_error_response(
+                    "One of the devices no longer exists; it may have been deleted concurrently."
+                )
+            locked_by_pk = {d.pk: d for d in locked}
+            winner = locked_by_pk[winner_pk]
+            donor = locked_by_pk[donor_pk]
+
+            try:
+                summary = merge_librenms_links(winner, donor, server_key=server_key)
+            except ValueError as exc:
+                return _htmx_error_response(f"Cannot merge: {escape(str(exc))}")
+
+            # Transfer OOB IP relationship if winner has none and donor has one — but
+            # only when the underlying IP already sits on a winner-owned interface.
+            # NetBox requires Device.oob_ip be assigned to one of that device's own
+            # interfaces, and this merge intentionally leaves interfaces on the donor.
+            # Since the persist below uses save(update_fields=...) which skips
+            # full_clean(), blindly moving oob_ip would silently leave the winner
+            # pointing at a donor interface. Leave it on the donor until the IP/interface
+            # is re-homed (via the migrate "move IP/interface" actions).
+            oob_ip_transferred = False
+            if donor.oob_ip_id and not winner.oob_ip_id:
+                oob_assigned = donor.oob_ip.assigned_object
+                if getattr(oob_assigned, "device_id", None) == winner.pk:
+                    # Capture before clearing the donor; set_device_ip_fk() re-checks the
+                    # address is on a winner interface (it is, per the guard above) and assigns
+                    # without saving — the batched donor-then-winner save below preserves the
+                    # release-before-claim ordering the UNIQUE oob_ip FK requires.
+                    transferred_oob_ip = donor.oob_ip
+                    set_device_ip_fk(winner, "oob_ip", transferred_oob_ip, save=False)
+                    set_device_ip_fk(donor, "oob_ip", None, save=False)
+                    oob_ip_transferred = True
+
+            # Clear donor's active link and stamp migration marker.
+            mark_librenms_migrated(donor, winner.pk, server_key=server_key)
+
+            # Persist only the fields we actually touched.  Calling
+            # ``full_clean()`` here (or relying on it via ``_save_device``)
+            # would re-validate every field on the device — which is
+            # undesirable when the rows hold pre-existing inconsistencies
+            # (e.g. ``face`` set without ``rack``) that are unrelated to
+            # this merge.  See issue surfaced during eve-ng-02 merge.
+            update_fields = ["custom_field_data"]
+            if oob_ip_transferred:
+                update_fields.append("oob_ip")
+            try:
+                # Persist the donor first. When an oob_ip is being transferred, the donor
+                # must release the OneToOne ``oob_ip`` (set to None) before the winner can
+                # claim it — saving the winner first would momentarily point two devices at
+                # the same IP and violate the unique constraint on ``Device.oob_ip``.
+                donor.save(update_fields=update_fields)
+                winner.save(update_fields=update_fields)
+            except Exception:  # pragma: no cover - defensive
+                logger.exception(
+                    "MergeNetBoxDevicesView: failed to persist merge winner=%s donor=%s",
+                    winner.pk,
+                    donor.pk,
+                )
+                transaction.set_rollback(True)
+                return _htmx_error_response("Unable to save the merge changes. Please try again.")
+
+        logger.info(
+            "Merged NetBox device '%s' (pk=%d) into '%s' (pk=%d) on server %s. Summary: %s; oob_ip_transferred=%s",
+            donor.name,
+            donor.pk,
+            winner.name,
+            winner.pk,
+            server_key,
+            summary,
+            oob_ip_transferred,
+        )
+
+        cache_key = get_import_device_cache_key(device_id, server_key)
+        cache.delete(cache_key)
+
+        libre_device, validation, selections = self.get_validated_device_with_selections(device_id, request)
+        if not libre_device:
+            # Merge already committed; a post-commit reload miss must not report failure
+            # (the donor is already absorbed — a retry would target stale/invalid state).
+            return self.post_commit_refresh_fallback(request, "closeModal")
+
+        response = self.render_device_row(request, libre_device, validation, selections)
+        response["HX-Trigger"] = "closeModal"
+        return response
+
+
 class SaveUserPrefView(LibreNMSPermissionMixin, View):
     """Save a user preference via POST. Used by JS toggle handlers."""
 

--- a/netbox_librenms_plugin/views/imports/actions.py
+++ b/netbox_librenms_plugin/views/imports/actions.py
@@ -3078,14 +3078,16 @@ class PromoteToHostView(
         if self.rebind_api_for_server(request.POST.get("server_key")) is None:
             return _htmx_error_response("Selected LibreNMS server is no longer configured.")
 
-        try:
-            existing_device = Device.objects.get(pk=int(existing_device_id))
-        except (Device.DoesNotExist, ValueError):
-            return _htmx_error_response("Existing device not found")
-
+        # Gate before the lookup (see DeviceConflictActionView.post).
         self.required_object_permissions = {"POST": [("change", Device)]}
         if error := self.require_object_permissions("POST"):
             return error
+
+        try:
+            # Scope by "change" so a constrained grant can't re-point another device's linkage.
+            existing_device = self.restricted_queryset(Device, "change").get(pk=int(existing_device_id))
+        except (Device.DoesNotExist, ValueError):
+            return _htmx_error_response("Existing device not found")
 
         # Optional per-field overrides from the pre-promote pick modal.
         # All three default to "keep current"; only applied when the POST
@@ -3344,16 +3346,19 @@ class MergeNetBoxDevicesView(
             return _htmx_error_response("winner_pk does not match the validation result's merge candidates")
         donor_pk = next(pk for pk in candidate_pks if pk != winner_pk)
 
-        try:
-            winner = Device.objects.get(pk=winner_pk)
-            donor = Device.objects.get(pk=donor_pk)
-        except Device.DoesNotExist:
-            return _htmx_error_response("Winner or donor device not found")
-
-        # Permission gate: user must be able to change BOTH devices.
+        # Permission gate: user must be able to change BOTH devices. Model-level first, then
+        # object-scoped: the gate below passes for a constrained grant, so both sides must be
+        # resolved through the restricted queryset or the merge could absorb an unseen device.
         self.required_object_permissions = {"POST": [("change", Device)]}
         if error := self.require_object_permissions("POST"):
             return error
+
+        changeable = self.restricted_queryset(Device, "change")
+        try:
+            winner = changeable.get(pk=winner_pk)
+            donor = changeable.get(pk=donor_pk)
+        except Device.DoesNotExist:
+            return _htmx_error_response("Winner or donor device not found")
 
         # Reject legacy bare-int librenms_id form on either side. The merge
         # helpers refuse to operate on legacy data to prevent silent migration.

--- a/netbox_librenms_plugin/views/imports/actions.py
+++ b/netbox_librenms_plugin/views/imports/actions.py
@@ -3358,25 +3358,22 @@ class MergeNetBoxDevicesView(
         # link state on the sync devices: writing it to a non-sync member would either split-brain a
         # VC that already has a linked member, or leave the donor's real link (on its sync sibling)
         # uncleared where every reader still resolves and finds it. For non-VC devices these resolve
-        # back to the same rows, so the common path is unchanged. Resolved unlocked then locked below
-        # (mirrors AddAsOOBView). The oob_ip transfer and the candidate-match check deliberately stay
-        # on the user-selected winner/donor: oob_ip is a per-device FK on those rows, not a VC link.
-        winner_sync = get_librenms_sync_device(winner, server_key=server_key) or winner
-        donor_sync = get_librenms_sync_device(donor, server_key=server_key) or donor
-        if winner_sync.pk == donor_sync.pk:
-            # Both candidates belong to the same virtual chassis (one sync device); merging its
-            # LibreNMS link into itself would read and write the same CF entry. Fail closed.
-            return _htmx_error_response(
-                "Winner and donor resolve to the same LibreNMS sync device "
-                "(they are members of the same virtual chassis); there is nothing to merge."
-            )
-
+        # back to the same rows, so the common path is unchanged. The oob_ip transfer and the
+        # candidate-match check deliberately stay on the user-selected winner/donor: oob_ip is a
+        # per-device FK on those rows, not a VC link.
         with transaction.atomic():
-            # Lock every distinct row we read or write, in deterministic pk order to avoid deadlocks:
-            # the selected winner/donor (oob_ip transfer + permission-gated saves) and their VC sync
-            # devices (LibreNMS link merge + migration marker). Deduped, so a non-VC merge locks the
-            # same two rows as before.
-            lock_pks = sorted({winner.pk, donor.pk, winner_sync.pk, donor_sync.pk})
+            # Lock the selected winner/donor AND every current member of their virtual chassis, in
+            # deterministic pk order to avoid deadlocks, BEFORE resolving the sync device:
+            # get_librenms_sync_device scans every VC member's librenms_id custom field, so resolving
+            # it from unlocked rows would let a concurrent VC edit (a member joining/leaving, or the
+            # id moving between members) shift the sync member to a row we never locked — splitting
+            # the link across the VC. Non-VC merges add no members, so they lock the same two rows.
+            lock_pks = {winner.pk, donor.pk}
+            for candidate in (winner, donor):
+                vc = getattr(candidate, "virtual_chassis", None)
+                if vc:
+                    lock_pks.update(vc.members.values_list("pk", flat=True))
+            lock_pks = sorted(lock_pks)
             locked = list(Device.objects.select_for_update().filter(pk__in=lock_pks).order_by("pk"))
             if len(locked) != len(lock_pks):
                 return _htmx_error_response(
@@ -3385,8 +3382,24 @@ class MergeNetBoxDevicesView(
             locked_by_pk = {d.pk: d for d in locked}
             winner = locked_by_pk[winner.pk]
             donor = locked_by_pk[donor.pk]
+
+            # Resolve the sync devices from the now-locked, current state.
+            winner_sync = get_librenms_sync_device(winner, server_key=server_key) or winner
+            donor_sync = get_librenms_sync_device(donor, server_key=server_key) or donor
+            # Fail closed if a concurrent VC change added a member after we snapshotted lock_pks and
+            # the resolved sync device wasn't among the locked rows — never write the link to an
+            # unlocked row; the operator can retry.
+            if winner_sync.pk not in locked_by_pk or donor_sync.pk not in locked_by_pk:
+                return _htmx_error_response("Virtual chassis membership changed during the merge; please retry.")
             winner_sync = locked_by_pk[winner_sync.pk]
             donor_sync = locked_by_pk[donor_sync.pk]
+            if winner_sync.pk == donor_sync.pk:
+                # Both candidates belong to the same virtual chassis (one sync device); merging its
+                # LibreNMS link into itself would read and write the same CF entry. Fail closed.
+                return _htmx_error_response(
+                    "Winner and donor resolve to the same LibreNMS sync device "
+                    "(they are members of the same virtual chassis); there is nothing to merge."
+                )
 
             # merge_librenms_links(), set_device_ip_fk() and mark_librenms_migrated() all raise
             # ValueError on corrupt link shapes or an ownership violation. Guard the whole group,

--- a/netbox_librenms_plugin/views/imports/actions.py
+++ b/netbox_librenms_plugin/views/imports/actions.py
@@ -1,5 +1,6 @@
 """HTMX endpoints and POST handlers for importing LibreNMS devices."""
 
+import hashlib
 import json
 import logging
 import re
@@ -254,8 +255,16 @@ def _acquire_serial_assignment_lock(serial: str) -> None:
 
     if not connection.in_atomic_block:
         raise RuntimeError("_acquire_serial_assignment_lock() requires an open transaction")
+    lock_key = int.from_bytes(
+        hashlib.blake2b(
+            f"netbox-librenms-plugin:device-serial:{serial}".encode(),
+            digest_size=8,
+        ).digest(),
+        byteorder="big",
+        signed=True,
+    )
     with connection.cursor() as cursor:
-        cursor.execute("SELECT pg_advisory_xact_lock(hashtext(%s))", [serial])
+        cursor.execute("SELECT pg_advisory_xact_lock(%s)", [lock_key])
 
 
 def _apply_conflict_checked_serial(device, incoming_serial: str) -> HttpResponse | None:
@@ -3185,6 +3194,10 @@ class PromoteToHostView(
             existing_device = locked.get(existing_device.pk)
             if existing_device is None:
                 return _htmx_error_response("Device no longer exists; it may have been deleted concurrently.")
+            if is_legacy_librenms_id(existing_device.custom_field_data.get("librenms_id")):
+                return _htmx_error_response(
+                    "Device has a legacy bare-integer librenms_id; use 'Convert mapping' to migrate first."
+                )
 
             current_host_id = get_librenms_device_id(existing_device, server_key=server_key, auto_save=False)
             current_oob = get_librenms_oob(existing_device, server_key=server_key)

--- a/netbox_librenms_plugin/views/imports/actions.py
+++ b/netbox_librenms_plugin/views/imports/actions.py
@@ -3166,10 +3166,11 @@ class PromoteToHostView(
                 )
             # Another device may have claimed new_host_id since validation ran. Re-check
             # inside the transaction and abort on a non-self conflict so we don't create a
-            # duplicate host mapping. find_by_librenms_id is an unlocked read, so this
-            # narrows — not closes — the window (no unique constraint exists on the cf).
+            # duplicate host mapping. select_for_update locks the competing owner row so a
+            # concurrent promote/attach of the same id serializes against it; best-effort like
+            # the serial guard (no unique constraint on the JSON cf to fully close the window).
             try:
-                host_conflict = find_by_librenms_id(Device, new_host_id, server_key)
+                host_conflict = find_by_librenms_id(Device, new_host_id, server_key, select_for_update=True)
             except AmbiguousLibreNMSIdError:
                 return _htmx_error_response(
                     f"LibreNMS device #{new_host_id} is ambiguous — it matches more than one NetBox "

--- a/netbox_librenms_plugin/views/imports/actions.py
+++ b/netbox_librenms_plugin/views/imports/actions.py
@@ -3412,6 +3412,12 @@ class MergeNetBoxDevicesView(
                 return _htmx_error_response("Virtual chassis membership changed during the merge; please retry.")
             winner_sync = locked_by_pk[winner_sync.pk]
             donor_sync = locked_by_pk[donor_sync.pk]
+            # The sync devices are DERIVED (a VC sibling of the selected winner/donor), not the pks
+            # scoped above, and the save block below writes their custom_field_data. Authorize them
+            # too, or a grant covering only the selected pair mutates the link-holding sibling.
+            sync_pks = {winner_sync.pk, donor_sync.pk}
+            if set(changeable.filter(pk__in=sync_pks).values_list("pk", flat=True)) != sync_pks:
+                return _htmx_error_response("Winner or donor device not found")
             if winner_sync.pk == donor_sync.pk:
                 # Both candidates belong to the same virtual chassis (one sync device); merging its
                 # LibreNMS link into itself would read and write the same CF entry. Fail closed.

--- a/netbox_librenms_plugin/views/imports/actions.py
+++ b/netbox_librenms_plugin/views/imports/actions.py
@@ -1082,9 +1082,12 @@ class BulkImportDevicesView(LibreNMSPermissionMixin, LibreNMSAPIMixin, View):
                 # page is HTMX, and without an htmx_toasts entry the user's background-import
                 # request silently blocks for the whole synchronous run with no explanation
                 # (only Django messages were queued, which the HTMX path never renders).
+                # Outcome-neutral wording: the per-row summary toasts below report the actual
+                # successes / failures / skips, so this banner must not claim every selected row
+                # was imported when the synchronous run may have failed or skipped some.
                 sync_fallback_msg = (
-                    f"Background job requested but no workers available. "
-                    f"Imported {total_import_count} devices synchronously."
+                    "Background job requested but no workers are available. "
+                    f"The request ran synchronously for {total_import_count} selected row(s)."
                 )
                 if not is_htmx:
                     messages.warning(

--- a/netbox_librenms_plugin/views/imports/actions.py
+++ b/netbox_librenms_plugin/views/imports/actions.py
@@ -3161,15 +3161,7 @@ class PromoteToHostView(
         server_key = self.librenms_api.server_key
 
         # Reject legacy bare-int librenms_id form (caller should migrate first).
-        stored_id = existing_device.custom_field_data.get("librenms_id")
-        _is_legacy = isinstance(stored_id, int) and not isinstance(stored_id, bool)
-        if not _is_legacy and isinstance(stored_id, str):
-            try:
-                int(stored_id)
-                _is_legacy = True
-            except (ValueError, TypeError):
-                pass
-        if _is_legacy:
+        if is_legacy_librenms_id(existing_device.custom_field_data.get("librenms_id")):
             return _htmx_error_response(
                 "Device has a legacy bare-integer librenms_id; use 'Convert mapping' to migrate first."
             )
@@ -3392,15 +3384,7 @@ class MergeNetBoxDevicesView(
         # Reject legacy bare-int librenms_id form on either side. The merge
         # helpers refuse to operate on legacy data to prevent silent migration.
         for label, obj in (("winner", winner), ("donor", donor)):
-            stored = obj.custom_field_data.get("librenms_id")
-            is_legacy = isinstance(stored, int) and not isinstance(stored, bool)
-            if not is_legacy and isinstance(stored, str):
-                try:
-                    int(stored)
-                    is_legacy = True
-                except (ValueError, TypeError):
-                    pass
-            if is_legacy:
+            if is_legacy_librenms_id(obj.custom_field_data.get("librenms_id")):
                 return _htmx_error_response(
                     f"{label.capitalize()} device has a legacy bare-integer librenms_id; "
                     "use 'Convert mapping' to migrate before merging."

--- a/netbox_librenms_plugin/views/imports/actions.py
+++ b/netbox_librenms_plugin/views/imports/actions.py
@@ -371,6 +371,33 @@ def _device_type_rack_fit_error(device) -> HttpResponse | None:
     return None
 
 
+def _rebind_api_for_posted_server(view, request) -> HttpResponse | None:
+    """
+    Rebind ``view._librenms_api`` to the POSTed ``server_key``, or return an HTMX error.
+
+    A blank/absent ``server_key`` leaves the session/default client in place. An
+    unknown/tampered key would otherwise raise the first time the API client is used
+    (turning the action into a 500), so build it eagerly here and surface the same
+    fragment error every POST action view uses.
+
+    Args:
+        view: The view whose ``_librenms_api`` is (re)bound on a posted key.
+        request: The current HTTP request (its POST body is read).
+
+    Returns:
+        HttpResponse: The error response to return verbatim when the posted key is
+            unknown, or ``None`` when the key is blank or successfully resolved.
+    """
+    from netbox_librenms_plugin.librenms_api import build_librenms_api
+
+    post_server_key = (request.POST.get("server_key") or "").strip()
+    if post_server_key:
+        view._librenms_api = build_librenms_api(post_server_key)
+        if view._librenms_api is None:
+            return _htmx_error_response("Selected LibreNMS server is no longer configured.")
+    return None
+
+
 def _save_device(device, update_fields: list[str] | None = None, request=None) -> HttpResponse | None:
     """
     Persist a Device row, returning an HttpResponse on failure or None on success.
@@ -3045,18 +3072,13 @@ class PromoteToHostView(
             return error
 
         from dcim.models import Device
-        from netbox_librenms_plugin.librenms_api import build_librenms_api
 
         existing_device_id = request.POST.get("existing_device_id")
         if not existing_device_id:
             return _htmx_error_response("Missing existing_device_id")
 
-        post_server_key = (request.POST.get("server_key") or "").strip()
-        if post_server_key:
-            # Unknown/tampered server_key would otherwise raise → 500.
-            self._librenms_api = build_librenms_api(post_server_key)
-            if self._librenms_api is None:
-                return _htmx_error_response("Selected LibreNMS server is no longer configured.")
+        if err := _rebind_api_for_posted_server(self, request):
+            return err
 
         try:
             existing_device = Device.objects.get(pk=int(existing_device_id))
@@ -3307,18 +3329,13 @@ class MergeNetBoxDevicesView(
             return error
 
         from dcim.models import Device
-        from netbox_librenms_plugin.librenms_api import build_librenms_api
         from netbox_librenms_plugin.utils import (
             mark_librenms_migrated,
             merge_librenms_links,
         )
 
-        post_server_key = (request.POST.get("server_key") or "").strip()
-        if post_server_key:
-            # Unknown/tampered server_key would otherwise raise → 500.
-            self._librenms_api = build_librenms_api(post_server_key)
-            if self._librenms_api is None:
-                return _htmx_error_response("Selected LibreNMS server is no longer configured.")
+        if err := _rebind_api_for_posted_server(self, request):
+            return err
 
         winner_pk_raw = request.POST.get("winner_pk")
         if not winner_pk_raw:

--- a/netbox_librenms_plugin/views/imports/actions.py
+++ b/netbox_librenms_plugin/views/imports/actions.py
@@ -3363,45 +3363,53 @@ class MergeNetBoxDevicesView(
             winner = locked_by_pk[winner_pk]
             donor = locked_by_pk[donor_pk]
 
+            # merge_librenms_links(), set_device_ip_fk() and mark_librenms_migrated() all raise
+            # ValueError on corrupt link shapes or an ownership violation. Guard the whole group,
+            # not just the first call: none of them persist anything (the save block is below), so
+            # a ValueError from the oob transfer or the migration marker must fail closed with a
+            # toast exactly like a merge_librenms_links() rejection — never bubble up as a 500.
             try:
                 summary = merge_librenms_links(winner, donor, server_key=server_key)
+
+                # Transfer OOB IP relationship if winner has none and donor has one — but
+                # only when the underlying IP already sits on a winner-owned interface.
+                # NetBox requires Device.oob_ip be assigned to one of that device's own
+                # interfaces, and this merge intentionally leaves interfaces on the donor.
+                # Since the persist below uses save(update_fields=...) which skips
+                # full_clean(), blindly moving oob_ip would silently leave the winner
+                # pointing at a donor interface. Leave it on the donor until the IP/interface
+                # is re-homed (via the migrate "move IP/interface" actions).
+                oob_ip_transferred = False
+                if donor.oob_ip_id and not winner.oob_ip_id:
+                    # Lock the IP row AND its owning interface before reading the assignment and
+                    # transferring. The Device-row lock above does NOT stabilize the interface's
+                    # device_id, so without these locks a concurrent interface move between the
+                    # check and commit could leave winner.oob_ip pointing at an interface no longer
+                    # on the winner — the invalid state set_device_ip_fk()'s contract requires the
+                    # caller to lock against, exactly as migrate._reconcile_donor_device_ip_fks does.
+                    from dcim.models import Interface
+                    from ipam.models import IPAddress
+
+                    locked_oob_ip = IPAddress.objects.select_for_update().filter(pk=donor.oob_ip_id).first()
+                    oob_assigned = locked_oob_ip.assigned_object if locked_oob_ip is not None else None
+                    if isinstance(oob_assigned, Interface):
+                        locked_iface = Interface.objects.select_for_update().filter(pk=oob_assigned.pk).first()
+                        if locked_iface is not None and locked_iface.device_id == winner.pk:
+                            # set_device_ip_fk() re-checks the address is on a winner interface
+                            # (verified above under lock) and assigns without saving — the batched
+                            # donor-then-winner save below preserves the release-before-claim
+                            # ordering the UNIQUE oob_ip FK requires.
+                            set_device_ip_fk(winner, "oob_ip", locked_oob_ip, save=False)
+                            set_device_ip_fk(donor, "oob_ip", None, save=False)
+                            oob_ip_transferred = True
+
+                # Clear donor's active link and stamp migration marker.
+                mark_librenms_migrated(donor, winner.pk, server_key=server_key)
             except ValueError as exc:
+                # Nothing was persisted yet, but locks were taken under this atomic block — roll
+                # back defensively before returning the fail-closed toast.
+                transaction.set_rollback(True)
                 return _htmx_error_response(f"Cannot merge: {escape(str(exc))}")
-
-            # Transfer OOB IP relationship if winner has none and donor has one — but
-            # only when the underlying IP already sits on a winner-owned interface.
-            # NetBox requires Device.oob_ip be assigned to one of that device's own
-            # interfaces, and this merge intentionally leaves interfaces on the donor.
-            # Since the persist below uses save(update_fields=...) which skips
-            # full_clean(), blindly moving oob_ip would silently leave the winner
-            # pointing at a donor interface. Leave it on the donor until the IP/interface
-            # is re-homed (via the migrate "move IP/interface" actions).
-            oob_ip_transferred = False
-            if donor.oob_ip_id and not winner.oob_ip_id:
-                # Lock the IP row AND its owning interface before reading the assignment and
-                # transferring. The Device-row lock above does NOT stabilize the interface's
-                # device_id, so without these locks a concurrent interface move between the
-                # check and commit could leave winner.oob_ip pointing at an interface no longer
-                # on the winner — the invalid state set_device_ip_fk()'s contract requires the
-                # caller to lock against, exactly as migrate._reconcile_donor_device_ip_fks does.
-                from dcim.models import Interface
-                from ipam.models import IPAddress
-
-                locked_oob_ip = IPAddress.objects.select_for_update().filter(pk=donor.oob_ip_id).first()
-                oob_assigned = locked_oob_ip.assigned_object if locked_oob_ip is not None else None
-                if isinstance(oob_assigned, Interface):
-                    locked_iface = Interface.objects.select_for_update().filter(pk=oob_assigned.pk).first()
-                    if locked_iface is not None and locked_iface.device_id == winner.pk:
-                        # set_device_ip_fk() re-checks the address is on a winner interface
-                        # (verified above under lock) and assigns without saving — the batched
-                        # donor-then-winner save below preserves the release-before-claim
-                        # ordering the UNIQUE oob_ip FK requires.
-                        set_device_ip_fk(winner, "oob_ip", locked_oob_ip, save=False)
-                        set_device_ip_fk(donor, "oob_ip", None, save=False)
-                        oob_ip_transferred = True
-
-            # Clear donor's active link and stamp migration marker.
-            mark_librenms_migrated(donor, winner.pk, server_key=server_key)
 
             # Persist only the fields we actually touched.  Calling
             # ``full_clean()`` here (or relying on it via ``_save_device``)

--- a/netbox_librenms_plugin/views/imports/actions.py
+++ b/netbox_librenms_plugin/views/imports/actions.py
@@ -3383,16 +3383,27 @@ class MergeNetBoxDevicesView(
             # is re-homed (via the migrate "move IP/interface" actions).
             oob_ip_transferred = False
             if donor.oob_ip_id and not winner.oob_ip_id:
-                oob_assigned = donor.oob_ip.assigned_object
-                if getattr(oob_assigned, "device_id", None) == winner.pk:
-                    # Capture before clearing the donor; set_device_ip_fk() re-checks the
-                    # address is on a winner interface (it is, per the guard above) and assigns
-                    # without saving — the batched donor-then-winner save below preserves the
-                    # release-before-claim ordering the UNIQUE oob_ip FK requires.
-                    transferred_oob_ip = donor.oob_ip
-                    set_device_ip_fk(winner, "oob_ip", transferred_oob_ip, save=False)
-                    set_device_ip_fk(donor, "oob_ip", None, save=False)
-                    oob_ip_transferred = True
+                # Lock the IP row AND its owning interface before reading the assignment and
+                # transferring. The Device-row lock above does NOT stabilize the interface's
+                # device_id, so without these locks a concurrent interface move between the
+                # check and commit could leave winner.oob_ip pointing at an interface no longer
+                # on the winner — the invalid state set_device_ip_fk()'s contract requires the
+                # caller to lock against, exactly as migrate._reconcile_donor_device_ip_fks does.
+                from dcim.models import Interface
+                from ipam.models import IPAddress
+
+                locked_oob_ip = IPAddress.objects.select_for_update().filter(pk=donor.oob_ip_id).first()
+                oob_assigned = locked_oob_ip.assigned_object if locked_oob_ip is not None else None
+                if isinstance(oob_assigned, Interface):
+                    locked_iface = Interface.objects.select_for_update().filter(pk=oob_assigned.pk).first()
+                    if locked_iface is not None and locked_iface.device_id == winner.pk:
+                        # set_device_ip_fk() re-checks the address is on a winner interface
+                        # (verified above under lock) and assigns without saving — the batched
+                        # donor-then-winner save below preserves the release-before-claim
+                        # ordering the UNIQUE oob_ip FK requires.
+                        set_device_ip_fk(winner, "oob_ip", locked_oob_ip, save=False)
+                        set_device_ip_fk(donor, "oob_ip", None, save=False)
+                        oob_ip_transferred = True
 
             # Clear donor's active link and stamp migration marker.
             mark_librenms_migrated(donor, winner.pk, server_key=server_key)

--- a/netbox_librenms_plugin/views/imports/actions.py
+++ b/netbox_librenms_plugin/views/imports/actions.py
@@ -86,7 +86,11 @@ def _attach_messages_oob(response, request):
     storage = messages.get_messages(request)
     if not list(storage):
         return response
-    storage.used = False
+    # ``get_messages`` returns a bare ``list`` (no ``.used``) when no message-storage
+    # middleware ran (e.g. RequestFactory requests); a real request always has a storage
+    # backend. Guard so re-marking the storage unconsumed can't AttributeError.
+    if hasattr(storage, "used"):
+        storage.used = False
     try:
         rendered = render_to_string("inc/messages.html", request=request)
     except Exception:  # pragma: no cover - defensive: don't break HTMX response on render error

--- a/netbox_librenms_plugin/views/imports/actions.py
+++ b/netbox_librenms_plugin/views/imports/actions.py
@@ -3352,16 +3352,41 @@ class MergeNetBoxDevicesView(
 
         server_key = self.librenms_api.server_key
 
+        # LibreNMS treats a Virtual Chassis as one logical device, so the host/OOB link lives on the
+        # single sync member (get_librenms_sync_device) — which may differ from the winner/donor the
+        # user selected when a candidate matched a NON-sync VC member by serial/hostname. Merge the
+        # link state on the sync devices: writing it to a non-sync member would either split-brain a
+        # VC that already has a linked member, or leave the donor's real link (on its sync sibling)
+        # uncleared where every reader still resolves and finds it. For non-VC devices these resolve
+        # back to the same rows, so the common path is unchanged. Resolved unlocked then locked below
+        # (mirrors AddAsOOBView). The oob_ip transfer and the candidate-match check deliberately stay
+        # on the user-selected winner/donor: oob_ip is a per-device FK on those rows, not a VC link.
+        winner_sync = get_librenms_sync_device(winner, server_key=server_key) or winner
+        donor_sync = get_librenms_sync_device(donor, server_key=server_key) or donor
+        if winner_sync.pk == donor_sync.pk:
+            # Both candidates belong to the same virtual chassis (one sync device); merging its
+            # LibreNMS link into itself would read and write the same CF entry. Fail closed.
+            return _htmx_error_response(
+                "Winner and donor resolve to the same LibreNMS sync device "
+                "(they are members of the same virtual chassis); there is nothing to merge."
+            )
+
         with transaction.atomic():
-            # Lock both rows in deterministic pk order to avoid deadlocks.
-            locked = list(Device.objects.select_for_update().filter(pk__in=[winner_pk, donor_pk]).order_by("pk"))
-            if len(locked) != 2:
+            # Lock every distinct row we read or write, in deterministic pk order to avoid deadlocks:
+            # the selected winner/donor (oob_ip transfer + permission-gated saves) and their VC sync
+            # devices (LibreNMS link merge + migration marker). Deduped, so a non-VC merge locks the
+            # same two rows as before.
+            lock_pks = sorted({winner.pk, donor.pk, winner_sync.pk, donor_sync.pk})
+            locked = list(Device.objects.select_for_update().filter(pk__in=lock_pks).order_by("pk"))
+            if len(locked) != len(lock_pks):
                 return _htmx_error_response(
                     "One of the devices no longer exists; it may have been deleted concurrently."
                 )
             locked_by_pk = {d.pk: d for d in locked}
-            winner = locked_by_pk[winner_pk]
-            donor = locked_by_pk[donor_pk]
+            winner = locked_by_pk[winner.pk]
+            donor = locked_by_pk[donor.pk]
+            winner_sync = locked_by_pk[winner_sync.pk]
+            donor_sync = locked_by_pk[donor_sync.pk]
 
             # merge_librenms_links(), set_device_ip_fk() and mark_librenms_migrated() all raise
             # ValueError on corrupt link shapes or an ownership violation. Guard the whole group,
@@ -3369,7 +3394,7 @@ class MergeNetBoxDevicesView(
             # a ValueError from the oob transfer or the migration marker must fail closed with a
             # toast exactly like a merge_librenms_links() rejection — never bubble up as a 500.
             try:
-                summary = merge_librenms_links(winner, donor, server_key=server_key)
+                summary = merge_librenms_links(winner_sync, donor_sync, server_key=server_key)
 
                 # Transfer OOB IP relationship if winner has none and donor has one — but
                 # only when the underlying IP already sits on a winner-owned interface.
@@ -3403,8 +3428,10 @@ class MergeNetBoxDevicesView(
                             set_device_ip_fk(donor, "oob_ip", None, save=False)
                             oob_ip_transferred = True
 
-                # Clear donor's active link and stamp migration marker.
-                mark_librenms_migrated(donor, winner.pk, server_key=server_key)
+                # Clear the donor sync device's active link and stamp the migration marker there —
+                # the marker is a sibling key of id/oob in the same librenms_id entry, so it must
+                # live wherever the link it supersedes lives (the sync device), not the raw member.
+                mark_librenms_migrated(donor_sync, winner_sync.pk, server_key=server_key)
             except ValueError as exc:
                 # Nothing was persisted yet, but locks were taken under this atomic block — roll
                 # back defensively before returning the fail-closed toast.
@@ -3417,16 +3444,40 @@ class MergeNetBoxDevicesView(
             # undesirable when the rows hold pre-existing inconsistencies
             # (e.g. ``face`` set without ``rack``) that are unrelated to
             # this merge.  See issue surfaced during eve-ng-02 merge.
-            update_fields = ["custom_field_data"]
+            # Persist only the fields we actually touched, per row. The LibreNMS link merge +
+            # migration marker land on the sync devices (custom_field_data); the oob_ip transfer
+            # lands on the selected winner/donor. When a selected device IS its own sync device
+            # (the non-VC common case) these collapse onto one row, saved once with both fields —
+            # never twice with different update_fields, which would drop one change.
+            fields_by_pk = {}
+
+            def _touch(dev, field):
+                fields_by_pk.setdefault(dev.pk, set()).add(field)
+
+            _touch(winner_sync, "custom_field_data")
+            _touch(donor_sync, "custom_field_data")
             if oob_ip_transferred:
-                update_fields.append("oob_ip")
+                _touch(winner, "oob_ip")
+                _touch(donor, "oob_ip")
+
+            # The donor side must release the OneToOne ``oob_ip`` (set to None) before the winner
+            # side claims it, or two devices momentarily point at the same IP and violate the unique
+            # constraint on ``Device.oob_ip``. The sync devices only carry custom_field_data (no
+            # unique field), so their order is free; save the donor group first and the selected
+            # winner last. A sync device can't cross-coincide with the other side's selected row
+            # (guaranteed by the winner_sync != donor_sync guard above), so grouping is unambiguous.
+            donor_extra = [donor_sync] if donor_sync.pk != donor.pk else []
+            winner_extra = [winner_sync] if winner_sync.pk != winner.pk else []
+            save_order = [donor, *donor_extra, *winner_extra, winner]
+            saved = set()
             try:
-                # Persist the donor first. When an oob_ip is being transferred, the donor
-                # must release the OneToOne ``oob_ip`` (set to None) before the winner can
-                # claim it — saving the winner first would momentarily point two devices at
-                # the same IP and violate the unique constraint on ``Device.oob_ip``.
-                donor.save(update_fields=update_fields)
-                winner.save(update_fields=update_fields)
+                for dev in save_order:
+                    if dev.pk in saved:
+                        continue
+                    saved.add(dev.pk)
+                    fields = fields_by_pk.get(dev.pk)
+                    if fields:
+                        dev.save(update_fields=sorted(fields))
             except Exception:  # pragma: no cover - defensive
                 logger.exception(
                     "MergeNetBoxDevicesView: failed to persist merge winner=%s donor=%s",

--- a/netbox_librenms_plugin/views/imports/actions.py
+++ b/netbox_librenms_plugin/views/imports/actions.py
@@ -3101,7 +3101,7 @@ class PromoteToHostView(
             from dcim.models import DeviceType
 
             try:
-                override_device_type = DeviceType.objects.get(pk=int(override_dt_id))
+                override_device_type = self.restricted_queryset(DeviceType, "view").get(pk=int(override_dt_id))
             except (DeviceType.DoesNotExist, ValueError, TypeError):
                 return _htmx_error_response("Invalid override_device_type_id")
 
@@ -3110,7 +3110,7 @@ class PromoteToHostView(
             from dcim.models import Platform
 
             try:
-                override_platform = Platform.objects.get(pk=int(override_platform_id))
+                override_platform = self.restricted_queryset(Platform, "view").get(pk=int(override_platform_id))
             except (Platform.DoesNotExist, ValueError, TypeError):
                 return _htmx_error_response("Invalid override_platform_id")
 
@@ -3336,12 +3336,9 @@ class MergeNetBoxDevicesView(
             (merge_candidates.get("oob_named") or {}).get("pk"),
         }
         candidate_pks.discard(None)
-        # Derive the donor from the selected winner instead of trusting the client-posted
-        # donor_pk. The donor hidden field is kept in sync with the winner radio by inline JS;
-        # if that JS fails to run, the form would post winner_pk as its own donor (a no-op /
-        # self-merge) or a stale donor. The merge is always between this fixed pair of
-        # candidates, so the donor is unambiguously the *other* candidate — no client state
-        # needed. This also enforces that the winner is one of the two merge candidates.
+        # Derive the donor from the selected winner. The merge is always between this fixed pair
+        # of candidates, so the donor is unambiguously the other candidate and no client-supplied
+        # donor state is needed. This also enforces that the winner is one of the two candidates.
         if winner_pk not in candidate_pks or len(candidate_pks) != 2:
             return _htmx_error_response("winner_pk does not match the validation result's merge candidates")
         donor_pk = next(pk for pk in candidate_pks if pk != winner_pk)
@@ -3359,15 +3356,6 @@ class MergeNetBoxDevicesView(
             donor = changeable.get(pk=donor_pk)
         except Device.DoesNotExist:
             return _htmx_error_response("Winner or donor device not found")
-
-        # Reject legacy bare-int librenms_id form on either side. The merge
-        # helpers refuse to operate on legacy data to prevent silent migration.
-        for label, obj in (("winner", winner), ("donor", donor)):
-            if is_legacy_librenms_id(obj.custom_field_data.get("librenms_id")):
-                return _htmx_error_response(
-                    f"{label.capitalize()} device has a legacy bare-integer librenms_id; "
-                    "use 'Convert mapping' to migrate before merging."
-                )
 
         server_key = self.librenms_api.server_key
 
@@ -3418,6 +3406,15 @@ class MergeNetBoxDevicesView(
             sync_pks = {winner_sync.pk, donor_sync.pk}
             if set(changeable.filter(pk__in=sync_pks).values_list("pk", flat=True)) != sync_pks:
                 return _htmx_error_response("Winner or donor device not found")
+            # Gate the link-holding sync devices, not merely the selected VC members. The merge
+            # helpers reject legacy data either way; checking here preserves the actionable
+            # convert-first message when the legacy link lives on a sibling.
+            for label, obj in (("winner", winner_sync), ("donor", donor_sync)):
+                if is_legacy_librenms_id(obj.custom_field_data.get("librenms_id")):
+                    return _htmx_error_response(
+                        f"{label.capitalize()} device has a legacy bare-integer librenms_id; "
+                        "use 'Convert mapping' to migrate before merging."
+                    )
             if winner_sync.pk == donor_sync.pk:
                 # Both candidates belong to the same virtual chassis (one sync device); merging its
                 # LibreNMS link into itself would read and write the same CF entry. Fail closed.

--- a/netbox_librenms_plugin/views/mixins.py
+++ b/netbox_librenms_plugin/views/mixins.py
@@ -501,6 +501,10 @@ class LibreNMSAPIMixin:
         migration controls and doesn't re-expose ordinary sync buttons. Routing all exits through
         this one chokepoint makes the spread impossible to forget on a new error/success branch.
 
+        ``build_migrated_context`` returns ``migrated_to_winner`` as a lazy proxy, so the
+        cable/module/VLAN partials (which render only the marker banner, never the winner) don't
+        pay the winner ``Device`` lookup on every HTMX refresh.
+
         Args:
             request: The current HTTP request.
             obj: The device/VM whose migration marker is resolved.

--- a/netbox_librenms_plugin/views/mixins.py
+++ b/netbox_librenms_plugin/views/mixins.py
@@ -143,8 +143,6 @@ def resolve_configured_server_key(server_key):
     Returns:
         str | None: *server_key* when it names a configured server, otherwise None.
     """
-    from netbox_librenms_plugin.librenms_api import LibreNMSAPI
-
     if not isinstance(server_key, str) or not server_key:
         return None
     return server_key if server_key in LibreNMSAPI.get_available_servers() else None

--- a/netbox_librenms_plugin/views/mixins.py
+++ b/netbox_librenms_plugin/views/mixins.py
@@ -145,7 +145,7 @@ def resolve_configured_server_key(server_key):
     """
     from netbox_librenms_plugin.librenms_api import LibreNMSAPI
 
-    if not server_key:
+    if not isinstance(server_key, str) or not server_key:
         return None
     return server_key if server_key in LibreNMSAPI.get_available_servers() else None
 

--- a/netbox_librenms_plugin/views/mixins.py
+++ b/netbox_librenms_plugin/views/mixins.py
@@ -555,10 +555,11 @@ class LibreNMSAPIMixin:
 
         # has_write_permission gates the migrated-donor "Move to winner" controls in the shared
         # inc/_migrate_move_button.html include. Inject it at this chokepoint so EVERY partial
-        # render exit (interface/IP success + error branches) carries it — a caller that omitted it
-        # silently collapsed every move button to the disabled read-only branch on an HTMX
-        # re-render, even for a user with change permission. A caller that sets it explicitly
-        # (modules_view renders directly, not through here) still wins via the context spread.
+        # render exit (interface/IP/cable/module/VLAN success + error branches) carries it — a
+        # caller that omitted it silently collapsed every move button to the disabled read-only
+        # branch on an HTMX re-render, even for a user with change permission. Callers therefore
+        # don't need to pass it themselves; the `**context` spread comes last only so that if one
+        # ever does set it explicitly, that value still wins (defensive — no caller relies on it).
         merged = {"has_write_permission": self.has_write_permission(), **context}
         return render(request, self.partial_template_name, {**merged, **build_migrated_context(obj, server_key)})
 

--- a/netbox_librenms_plugin/views/mixins.py
+++ b/netbox_librenms_plugin/views/mixins.py
@@ -128,6 +128,28 @@ def _safe_redirect_response(request):
     return redirect(app_root)
 
 
+def resolve_configured_server_key(server_key):
+    """
+    Return *server_key* iff it matches a currently-configured LibreNMS server, else None.
+
+    Centralises the "re-source the key from trusted config, never echo a raw/stale POST value"
+    allowlist shared by the sync-tab redirect (:func:`device_fields._sync_redirect`) and the
+    non-HTMX fallback URL builder (:func:`migrate._sync_tab_url`), so a stale or tampered
+    ``server_key`` is dropped by the same rule in both places. A blank/None key resolves to None.
+
+    Args:
+        server_key (str | None): The candidate server key (typically a raw POST value).
+
+    Returns:
+        str | None: *server_key* when it names a configured server, otherwise None.
+    """
+    from netbox_librenms_plugin.librenms_api import LibreNMSAPI
+
+    if not server_key:
+        return None
+    return server_key if server_key in LibreNMSAPI.get_available_servers() else None
+
+
 def redirect_with_server_key(request, url, server_key):
     """
     Redirect to *url*, appending a validated ``?server_key`` query param when one is given.
@@ -531,7 +553,14 @@ class LibreNMSAPIMixin:
         """
         from netbox_librenms_plugin.utils import build_migrated_context
 
-        return render(request, self.partial_template_name, {**context, **build_migrated_context(obj, server_key)})
+        # has_write_permission gates the migrated-donor "Move to winner" controls in the shared
+        # inc/_migrate_move_button.html include. Inject it at this chokepoint so EVERY partial
+        # render exit (interface/IP success + error branches) carries it — a caller that omitted it
+        # silently collapsed every move button to the disabled read-only branch on an HTMX
+        # re-render, even for a user with change permission. A caller that sets it explicitly
+        # (modules_view renders directly, not through here) still wins via the context spread.
+        merged = {"has_write_permission": self.has_write_permission(), **context}
+        return render(request, self.partial_template_name, {**merged, **build_migrated_context(obj, server_key)})
 
     def rebind_api_for_server(self, server_key):
         """

--- a/netbox_librenms_plugin/views/mixins.py
+++ b/netbox_librenms_plugin/views/mixins.py
@@ -637,11 +637,10 @@ class LibreNMSAPIMixin:
         # (no cached client + misconfigured default). Read the bound client's key directly
         # instead of going through the lazy ``librenms_api`` property, which would reconstruct
         # ``LibreNMSAPI()`` and can re-raise the very misconfiguration the rebind just avoided.
-        scoped = (
-            resolved
-            if resolved is not None
-            else (requested or getattr(getattr(self, "_librenms_api", None), "server_key", None))
-        )
+        # ``requested`` is necessarily blank on this branch (a non-blank ``requested`` with
+        # ``resolved is None`` already returned above), so the bound client's key is the only
+        # reachable fallback.
+        scoped = resolved if resolved is not None else getattr(getattr(self, "_librenms_api", None), "server_key", None)
         return scoped, False
 
     def get_server_info(self):

--- a/netbox_librenms_plugin/views/mixins.py
+++ b/netbox_librenms_plugin/views/mixins.py
@@ -59,12 +59,14 @@ def extract_cached_ports(cached, cache_key=None):
     return cached
 
 
-def _get_safe_redirect_url(request):
+def validated_referer(request):
     """
-    Return a validated redirect URL from the HTTP Referer header.
+    Return the request's ``Referer`` when it passes the open-redirect barrier, else None.
 
-    Validates the Referer against allowed hosts and schemes to prevent
-    open-redirect attacks. Falls back to the current request path or "/".
+    The single home for the CWE-601 Referer check (``url_has_allowed_host_and_scheme`` against the
+    current host/scheme) so every redirect helper that trusts the Referer — ``_get_safe_redirect_url``
+    here and ``migrate._safe_referer`` — validates it identically and can't drift. Callers own their
+    own fallback when this returns None.
     """
     referrer = request.META.get("HTTP_REFERER")
     if referrer and url_has_allowed_host_and_scheme(
@@ -72,6 +74,18 @@ def _get_safe_redirect_url(request):
         allowed_hosts={request.get_host()},
         require_https=request.is_secure(),
     ):
+        return referrer
+    return None
+
+
+def _get_safe_redirect_url(request):
+    """
+    Return a validated redirect URL from the HTTP Referer header.
+
+    Validates the Referer against allowed hosts and schemes to prevent
+    open-redirect attacks. Falls back to the current request path or "/".
+    """
+    if referrer := validated_referer(request):
         return referrer
     # No usable Referer. On a non-GET request, request.path is often a POST-only
     # action endpoint, so redirecting the browser there would 405 — fall back to a

--- a/netbox_librenms_plugin/views/mixins.py
+++ b/netbox_librenms_plugin/views/mixins.py
@@ -476,6 +476,22 @@ class LibreNMSAPIMixin:
         """
         return self.librenms_api.get_device_info(librenms_id, use_cache=False)
 
+    @property
+    def active_server_key(self):
+        """
+        The server key of the currently-bound API client, or ``"default"``.
+
+        Reads ``self._librenms_api.server_key`` WITHOUT going through the lazy
+        :attr:`librenms_api` property — used on rebind-failure render paths where the
+        rebind already returned None and constructing a fresh default client (which the
+        property would do, and which can raise on a misconfigured default) is exactly
+        what must be avoided. Falls back to ``"default"`` when no client is bound yet.
+
+        Returns:
+            str: The bound client's resolved server key, or ``"default"``.
+        """
+        return getattr(getattr(self, "_librenms_api", None), "server_key", None) or "default"
+
     def rebind_api_for_server(self, server_key):
         """
         Rebind ``self.librenms_api`` to the POST-scoped *server_key*.

--- a/netbox_librenms_plugin/views/mixins.py
+++ b/netbox_librenms_plugin/views/mixins.py
@@ -5,7 +5,7 @@ from django.contrib import messages
 from django.contrib.auth.mixins import PermissionRequiredMixin
 from django.core.cache import cache
 from django.http import HttpResponse, JsonResponse
-from django.shortcuts import get_object_or_404, redirect
+from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import get_script_prefix
 from django.utils.http import url_has_allowed_host_and_scheme
 from utilities.permissions import get_permission_for_model
@@ -491,6 +491,29 @@ class LibreNMSAPIMixin:
             str: The bound client's resolved server key, or ``"default"``.
         """
         return getattr(getattr(self, "_librenms_api", None), "server_key", None) or "default"
+
+    def render_sync_partial(self, request, obj, server_key, context):
+        """
+        Render the view's ``partial_template_name`` with migrated-context flags always merged in.
+
+        Every partial-render exit of the sync tab views needs the ``_migrated_to`` marker
+        context (``migrated_to_marker`` / ``migrated_to_winner``) so a migrated donor keeps its
+        migration controls and doesn't re-expose ordinary sync buttons. Routing all exits through
+        this one chokepoint makes the spread impossible to forget on a new error/success branch.
+
+        Args:
+            request: The current HTTP request.
+            obj: The device/VM whose migration marker is resolved.
+            server_key (str): The server key the marker is namespaced under (use
+                :attr:`active_server_key` on the rebind-failure path).
+            context (dict): The view-specific partial context (e.g. ``{"vlan_sync": ...}``).
+
+        Returns:
+            HttpResponse: The rendered partial.
+        """
+        from netbox_librenms_plugin.utils import build_migrated_context
+
+        return render(request, self.partial_template_name, {**context, **build_migrated_context(obj, server_key)})
 
     def rebind_api_for_server(self, server_key):
         """

--- a/netbox_librenms_plugin/views/mixins.py
+++ b/netbox_librenms_plugin/views/mixins.py
@@ -677,7 +677,11 @@ class LibreNMSAPIMixin:
                     "is_legacy": True,
                     "server_key": "default",
                 }
-        except (KeyError, AttributeError, ImportError):
+        except (KeyError, AttributeError, ImportError, ValueError):
+            # ValueError: reading self.librenms_api with no client bound reconstructs
+            # LibreNMSAPI(), which raises on a misconfigured default. That happens on the
+            # degraded render paths (stale ?server_key + broken default), where the header
+            # must show the configuration error rather than 500 the page.
             return {
                 "display_name": "Unknown Server",
                 "url": "Configuration error",

--- a/netbox_librenms_plugin/views/sync/device_fields.py
+++ b/netbox_librenms_plugin/views/sync/device_fields.py
@@ -32,6 +32,7 @@ from netbox_librenms_plugin.views.mixins import (
     LibreNMSPermissionMixin,
     NetBoxObjectPermissionMixin,
     redirect_with_server_key,
+    resolve_configured_server_key,
 )
 
 logger = logging.getLogger(__name__)
@@ -650,13 +651,11 @@ class CreateAndAssignPlatformView(LibreNMSPermissionMixin, NetBoxObjectPermissio
             HttpResponseRedirect: A redirect to the sync tab, with the validated
                 ``server_key`` query param when one matches a configured server.
         """
-        from netbox_librenms_plugin.librenms_api import LibreNMSAPI
-
         url = reverse("plugins:netbox_librenms_plugin:device_librenms_sync", kwargs={"pk": pk})
         requested = (request.POST.get("server_key") or "").strip() or (fallback_server_key or "").strip()
         # Re-source the matched key from the trusted config rather than echoing the raw request
         # value; the shared helper then gates the redirect on url_has_allowed_host_and_scheme.
-        server_key = next((key for key in LibreNMSAPI.get_available_servers() if key == requested), None)
+        server_key = resolve_configured_server_key(requested)
         return redirect_with_server_key(request, url, server_key)
 
 
@@ -864,8 +863,6 @@ class ConvertLegacyLibreNMSIdView(LibreNMSPermissionMixin, NetBoxObjectPermissio
         return model, get_object_or_404(model, pk=pk)
 
     def _sync_url(self, object_type, pk):
-        from netbox_librenms_plugin.librenms_api import LibreNMSAPI
-
         name = "vm_librenms_sync" if object_type == "vm" else "device_librenms_sync"
         url = reverse(f"plugins:netbox_librenms_plugin:{name}", kwargs={"pk": pk})
         # Propagate the active multi-server server_key so redirects land on the server the user was
@@ -881,9 +878,7 @@ class ConvertLegacyLibreNMSIdView(LibreNMSPermissionMixin, NetBoxObjectPermissio
         # Re-source the matched key from the trusted config rather than echoing the raw request
         # value. A stale/unconfigured POST key (server removed since the page loaded, or tampered)
         # resolves to None here — so it must NOT short-circuit the fallback below.
-        server_key = (
-            next((key for key in LibreNMSAPI.get_available_servers() if key == requested), None) if requested else None
-        )
+        server_key = resolve_configured_server_key(requested)
         if not server_key:
             # POST omitted server_key OR sent an unconfigured one — fall back to the active API
             # server the action ran against so a non-default-server user isn't dropped onto the
@@ -894,11 +889,7 @@ class ConvertLegacyLibreNMSIdView(LibreNMSPermissionMixin, NetBoxObjectPermissio
             # silently resolve to a different first-configured server → wrong tab).
             bound = getattr(self, "_librenms_api", None)
             fallback = (getattr(bound, "server_key", "") or "").strip() if bound is not None else ""
-            server_key = (
-                next((key for key in LibreNMSAPI.get_available_servers() if key == fallback), None)
-                if fallback
-                else None
-            )
+            server_key = resolve_configured_server_key(fallback)
         return redirect_with_server_key(request, url, server_key)
 
     def post(self, request, pk):

--- a/netbox_librenms_plugin/views/sync/migrate.py
+++ b/netbox_librenms_plugin/views/sync/migrate.py
@@ -38,16 +38,19 @@ logger = logging.getLogger(__name__)
 
 def _resolve_winner_for_donor(donor, server_key="default"):
     """
-    Return ``(winner, marker)`` for *donor*.
-
-    - ``(None, None)`` when no ``_migrated_to`` marker is present.
-    - ``(None, marker)`` when the marker exists but the winner device has
-      been deleted, the ``device_id`` in the marker is invalid/unparseable, or
-      the marker points back at the donor itself (so callers can distinguish
-      "no marker" from "stale marker").
-    - ``(winner, marker)`` when the marker is valid and the winner exists.
+    Resolve the migration winner device recorded on a donor.
 
     ``marker`` is the dict written by :func:`mark_librenms_migrated`.
+
+    Args:
+        donor: The donor device whose ``_migrated_to`` marker is read.
+        server_key (str): The LibreNMS server key the marker is namespaced under.
+
+    Returns:
+        tuple: ``(winner, marker)`` when the marker is valid and the winner exists;
+            ``(None, None)`` when no marker is present; ``(None, marker)`` when the
+            marker is stale (winner deleted, unparseable ``device_id``, or
+            self-pointing) so callers can distinguish "no marker" from "stale marker".
     """
     marker = get_migrated_to_marker(donor, server_key)
     if not marker:
@@ -74,14 +77,24 @@ def _resolve_winner_for_donor(donor, server_key="default"):
 
 
 def _server_key_from_request(request, default_factory=None):
-    """Extract the LibreNMS server key from the POST body (form field).
+    """
+    Extract the LibreNMS server key from the POST body (form field).
 
     Pass ``default_factory=lambda: self.librenms_api.server_key`` from views that
-    have API access so the fallback matches the active server's namespace rather
-    than the literal ``"default"``. The factory is a callable (not the resolved
-    value) so the API — and the DB lookup it performs — is only touched when the
-    POST body omits ``server_key``; the common path where the form supplies the
-    key never instantiates the API.
+    have API access so the fallback matches the active server's namespace rather than
+    the literal ``"default"``. The factory is a callable (not the resolved value) so
+    the API — and the DB lookup it performs — is only touched when the POST body omits
+    ``server_key``; the common path where the form supplies the key never instantiates
+    the API.
+
+    Args:
+        request: The current HTTP request (its POST body is read).
+        default_factory: Optional callable returning the fallback server key when the
+            POST body omits ``server_key``.
+
+    Returns:
+        str: The resolved server key, or ``"default"`` when neither the POST body nor
+            the factory supplies one.
     """
     sk = request.POST.get("server_key")
     if isinstance(sk, str) and sk:
@@ -94,12 +107,22 @@ def _server_key_from_request(request, default_factory=None):
 
 
 def _sync_tab_url(device_pk, tab, server_key):
-    """Build the device's LibreNMS sync URL for *tab*, preserving *server_key*.
+    """
+    Build the device's LibreNMS sync URL for a tab, preserving server_key.
 
-    Used as the non-HTMX fallback target when a plain POST carries no usable
-    Referer: without this the redirect would drop the active sync tab and server
-    context, bouncing the user to the bare app root instead of the donor's
-    "Migrated to ..." view they acted from.
+    Used as the non-HTMX fallback target when a plain POST carries no usable Referer:
+    without this the redirect would drop the active sync tab and server context,
+    bouncing the user to the bare app root instead of the donor's "Migrated to ..."
+    view they acted from.
+
+    Args:
+        device_pk: The device primary key the sync URL is built for.
+        tab (str): The sync tab to land on.
+        server_key (str): The active server key; appended only when it matches a
+            configured server (a stale/tampered key is dropped).
+
+    Returns:
+        str: The sync URL with ``tab`` (and a validated ``server_key``) query params.
     """
     url = f"{reverse('plugins:netbox_librenms_plugin:device_librenms_sync', args=[device_pk])}?tab={tab}"
     if server_key:
@@ -115,17 +138,21 @@ def _sync_tab_url(device_pk, tab, server_key):
 
 def _safe_referer(request, fallback=None):
     """
-    Return the request's ``Referer`` only when it points back at this
-    site, otherwise *fallback* (or the app mount path).
+    Return the request's validated ``Referer``, or a safe fallback.
 
-    ``Referer`` is a client-controlled header, so it must be validated
-    against the current host before being used as a redirect target —
-    trusting it blindly is an open-redirect vector.
+    ``Referer`` is a client-controlled header, so it must be validated against the
+    current host before being used as a redirect target — trusting it blindly is an
+    open-redirect vector.
 
-    *fallback* is an internal, server-built URL (see :func:`_sync_tab_url`); it is
-    used as-is so a missing Referer still lands on the right sync tab/server. When
-    no fallback is supplied, fall back to the app mount path (not literal ``"/"``)
-    so prefixed deployments land on the NetBox app root rather than the site root.
+    Args:
+        request: The current HTTP request whose ``Referer`` is validated.
+        fallback: An internal, server-built URL (see :func:`_sync_tab_url`) used as-is
+            when the Referer is missing/untrusted. When None, the app mount path is
+            used (not literal ``"/"``) so prefixed deployments land on the NetBox app
+            root rather than the site root.
+
+    Returns:
+        str: The validated Referer, or *fallback* / the app mount path.
     """
     referer = request.META.get("HTTP_REFERER")
     if referer and url_has_allowed_host_and_scheme(
@@ -139,12 +166,23 @@ def _safe_referer(request, fallback=None):
 
 def _hx_response(request, message, level=messages.SUCCESS, *, status=200, fallback_url=None):
     """
-    Common HTMX response: queue a Django messages flash and emit the
-    ``HX-Refresh`` header so the sync page re-renders with the row gone.
+    Build the common HTMX (or redirect) response after a successful move.
 
-    For non-HTMX requests, queue the message and redirect to the validated
-    Referer, falling back to *fallback_url* (the donor's sync tab) so the
-    server/tab context survives a missing Referer.
+    Queues a Django messages flash and emits the ``HX-Refresh`` header so the sync
+    page re-renders with the row gone. For non-HTMX requests, queues the message and
+    redirects to the validated Referer, falling back to *fallback_url* (the donor's
+    sync tab) so the server/tab context survives a missing Referer.
+
+    Args:
+        request: The current HTTP request.
+        message (str): The flash message to queue.
+        level: The Django messages level (default ``messages.SUCCESS``).
+        status (int): The HTTP status for the HTMX response.
+        fallback_url: The non-HTMX redirect fallback (the donor's sync tab).
+
+    Returns:
+        HttpResponse: An ``HX-Refresh`` response for HTMX requests, or a redirect to
+            the validated Referer / fallback otherwise.
     """
     messages.add_message(request, level, message)
     if request.headers.get("HX-Request"):
@@ -153,19 +191,29 @@ def _hx_response(request, message, level=messages.SUCCESS, *, status=200, fallba
 
 
 def _reconcile_donor_device_ip_fks(donor, winner):
-    """Keep the donor valid after a move re-homes an interface/IP onto the winner.
+    """
+    Keep the donor valid after a move re-homes an interface/IP onto the winner.
 
-    NetBox requires ``Device.primary_ip4``/``primary_ip6``/``oob_ip`` to reference an address
-    assigned to one of that device's *own* interfaces. Moving an interface (with its addresses)
-    or an IP to the winner can leave one of those donor FKs pointing at an address now living on
-    a winner-owned interface — an invalid state that surfaces the next time the donor is
-    full_clean()'d. For each such dangling FK, transfer the designation to the winner when its
-    slot is free, otherwise clear it on the donor. Only the touched FK column is saved
-    (``update_fields``) so we don't trip ``full_clean()`` on pre-existing unrelated
-    inconsistencies, mirroring :class:`TransferDeviceIPView`.
+    NetBox requires ``Device.primary_ip4``/``primary_ip6``/``oob_ip`` to reference an
+    address assigned to one of that device's *own* interfaces. Moving an interface
+    (with its addresses) or an IP to the winner can leave one of those donor FKs
+    pointing at an address now living on a winner-owned interface — an invalid state
+    that surfaces the next time the donor is full_clean()'d. For each such dangling FK,
+    transfer the designation to the winner when its slot is free, otherwise clear it on
+    the donor. Only the touched FK column is saved (``update_fields``) so we don't trip
+    ``full_clean()`` on pre-existing unrelated inconsistencies, mirroring
+    :class:`TransferDeviceIPView`.
 
-    Must run inside the caller's ``transaction.atomic()`` with both devices already locked.
-    Returns human-readable notes describing what was reconciled (for the response message).
+    Must run inside the caller's ``transaction.atomic()`` with both devices already
+    locked.
+
+    Args:
+        donor: The donor device whose dangling IP FKs are reconciled.
+        winner: The device that received the moved interface/IP.
+
+    Returns:
+        list: Human-readable notes describing what was reconciled (for the response
+            message).
     """
     notes = []
     for field, human in (
@@ -224,8 +272,14 @@ class _BaseMoveToWinnerView(LibreNMSAPIMixin, LibreNMSPermissionMixin, NetBoxObj
 
     def _gate(self, request):
         """
-        Plugin-write + object-perm gate.  Returns a response on failure
-        (which the caller must return verbatim) or ``None`` on success.
+        Apply the plugin-write + object-perm gate.
+
+        Args:
+            request: The current HTTP request being authorized.
+
+        Returns:
+            A response on failure (which the caller must return verbatim), or None on
+            success.
         """
         resp = self.require_all_permissions("POST")
         if resp is not None:
@@ -236,15 +290,20 @@ class _BaseMoveToWinnerView(LibreNMSAPIMixin, LibreNMSPermissionMixin, NetBoxObj
         """
         Return an error response.
 
-        For HTMX requests: returns HTTP 200 with an out-of-band swap into
-        ``#django-messages`` so the toast renders through NetBox's Bootstrap
-        pipeline.  ``HX-Reswap: none`` prevents the primary swap target from
-        being overwritten.  The ``status`` parameter is not used for HTMX
-        responses — errors are always signalled via the OOB toast, not the
-        status code.
+        For HTMX requests this returns HTTP 200 with an out-of-band swap into
+        ``#django-messages`` so the toast renders through NetBox's Bootstrap pipeline;
+        ``HX-Reswap: none`` prevents the primary swap target from being overwritten.
+        For non-HTMX requests it adds a Django error message and redirects to the
+        validated Referer or the app mount path.
 
-        For non-HTMX requests: adds a Django error message and redirects to
-        the validated Referer or '/'.
+        Args:
+            request: The current HTTP request.
+            msg (str): The error message to surface.
+            status (int): The HTTP status for non-HTMX responses; ignored for HTMX
+                responses, where errors are always signalled via the OOB toast.
+
+        Returns:
+            HttpResponse: The OOB-toast response (HTMX) or a redirect (non-HTMX).
         """
         if request.headers.get("HX-Request"):
             toast_html = format_html(

--- a/netbox_librenms_plugin/views/sync/migrate.py
+++ b/netbox_librenms_plugin/views/sync/migrate.py
@@ -26,7 +26,7 @@ from django.utils.http import url_has_allowed_host_and_scheme
 from django.views import View
 from ipam.models import IPAddress
 
-from netbox_librenms_plugin.utils import get_migrated_to_marker, set_device_ip_fk
+from netbox_librenms_plugin.utils import DEVICE_IP_FK_FIELDS, get_migrated_to_marker, set_device_ip_fk
 from netbox_librenms_plugin.views.mixins import (
     LibreNMSAPIMixin,
     LibreNMSPermissionMixin,
@@ -34,6 +34,27 @@ from netbox_librenms_plugin.views.mixins import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+def _parse_marker_winner_pk(device_id):
+    """
+    Parse a ``_migrated_to`` marker's ``device_id`` to a positive int pk, or None if invalid.
+
+    bool is rejected (it subclasses int, so ``int(True) == 1`` would misroute a move), and only a
+    real int or a plain digit string is accepted (``int()`` would truncate ``1.9`` / ``Decimal('1.9')``
+    to a valid-looking but wrong pk). A non-positive result is rejected too — it can never be a real
+    Device row. Shared by :func:`_resolve_winner_for_donor` and :func:`_winner_unavailable_reason`
+    so the two can't drift on what counts as a parseable winner id.
+    """
+    if isinstance(device_id, bool):
+        return None
+    if not (isinstance(device_id, int) or (isinstance(device_id, str) and device_id.isdecimal())):
+        return None
+    try:
+        pk = int(device_id)
+    except (TypeError, ValueError):
+        return None
+    return pk if pk > 0 else None
 
 
 def _resolve_winner_for_donor(donor, server_key="default"):
@@ -57,19 +78,8 @@ def _resolve_winner_for_donor(donor, server_key="default"):
     marker = get_migrated_to_marker(donor, server_key)
     if not marker:
         return None, None
-    device_id = marker.get("device_id")
-    # Reject bools explicitly: bool is a subclass of int, so int(True) == 1 would
-    # otherwise resolve Device(pk=1) and misroute a move operation. A corrupt marker
-    # like {"device_id": true} must fail closed as a stale/invalid marker.
-    if isinstance(device_id, bool):
-        return None, marker
-    # int() truncates numeric-like values (1.9, Decimal("1.9")) to a valid-looking pk, which
-    # would resolve the WRONG winner. Accept only a real int or a plain digit string.
-    if not (isinstance(device_id, int) or (isinstance(device_id, str) and device_id.isdecimal())):
-        return None, marker
-    try:
-        winner_pk = int(device_id)
-    except (TypeError, ValueError):
+    winner_pk = _parse_marker_winner_pk(marker.get("device_id"))
+    if winner_pk is None:
         return None, marker
     winner = Device.objects.filter(pk=winner_pk).first()
     if winner is None:
@@ -94,21 +104,10 @@ def _winner_unavailable_reason(donor, marker):
         str: ``"deleted"`` (well-formed positive id, winner row gone) or ``"corrupt"``
             (bool/unparseable/non-positive ``device_id``, or self-pointing).
     """
-    device_id = marker.get("device_id")
-    if isinstance(device_id, bool):
-        return "corrupt"
-    # Mirror _resolve_winner_for_donor: a numeric-like value int() would truncate (1.9,
-    # Decimal("1.9")) is a corrupt marker, not a deleted winner.
-    if not (isinstance(device_id, int) or (isinstance(device_id, str) and device_id.isdecimal())):
-        return "corrupt"
-    try:
-        winner_pk = int(device_id)
-    except (TypeError, ValueError):
-        return "corrupt"
-    # A non-positive pk is never a real Device row, so int() succeeding doesn't make it a
-    # "deleted winner" — it's a corrupt marker. Classify it as such so recovery isn't sent
-    # chasing a device that never existed.
-    if winner_pk <= 0 or winner_pk == donor.pk:
+    # A parseable positive pk (shared parser rejects bool/numeric-like/non-positive) that isn't
+    # the donor itself means the winner row was deleted; anything else is a corrupt marker.
+    winner_pk = _parse_marker_winner_pk(marker.get("device_id"))
+    if winner_pk is None or winner_pk == donor.pk:
         return "corrupt"
     return "deleted"
 
@@ -264,11 +263,12 @@ def _reconcile_donor_device_ip_fks(donor, winner):
             message).
     """
     notes = []
-    for field, human in (
-        ("primary_ip4", "primary IPv4"),
-        ("primary_ip6", "primary IPv6"),
-        ("oob_ip", "OOB IP"),
-    ):
+    # Drive the loop off utils.DEVICE_IP_FK_FIELDS — the canonical list set_device_ip_fk()
+    # validates against — so a fourth device IP FK added there is reconciled here too instead of
+    # being silently skipped by a stale hardcoded copy. The labels are display-only.
+    _human_labels = {"primary_ip4": "primary IPv4", "primary_ip6": "primary IPv6", "oob_ip": "OOB IP"}
+    for field in DEVICE_IP_FK_FIELDS:
+        human = _human_labels.get(field, field)
         donor_ip_id = getattr(donor, f"{field}_id", None)
         # Real FK columns are plain ints; the isinstance guard also makes this a clean no-op
         # against the mock-based unit tests (a MagicMock id is not an int).

--- a/netbox_librenms_plugin/views/sync/migrate.py
+++ b/netbox_librenms_plugin/views/sync/migrate.py
@@ -144,8 +144,12 @@ def _server_key_from_request(request, default_factory=None):
             the factory supplies one.
     """
     sk = request.POST.get("server_key")
-    if isinstance(sk, str) and sk:
-        return sk
+    if isinstance(sk, str):
+        # Strip whitespace so a padded-but-valid key (" prod ") resolves instead of breaking
+        # migrated-marker lookup / server-scoped redirects; a blank/whitespace key falls through.
+        sk = sk.strip()
+        if sk:
+            return sk
     if default_factory is not None:
         resolved = default_factory()
         if isinstance(resolved, str) and resolved:

--- a/netbox_librenms_plugin/views/sync/migrate.py
+++ b/netbox_librenms_plugin/views/sync/migrate.py
@@ -14,10 +14,12 @@ appropriate NetBox model permission on the object being moved.
 import logging
 from urllib.parse import quote_plus
 
-from dcim.models import Device, Interface
+from dcim.models import CableTermination, Device, Interface
 from django.contrib import messages
+from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ValidationError
 from django.db import IntegrityError, transaction
+from django.db.models import Q
 from django.http import HttpResponse
 from django.shortcuts import get_object_or_404, redirect
 from django.urls import get_script_prefix, reverse
@@ -420,17 +422,64 @@ class _BaseMoveToWinnerView(LibreNMSAPIMixin, LibreNMSPermissionMixin, NetBoxObj
         return donor, winner, None
 
 
+def _refresh_cable_termination_caches(interface):
+    """
+    Re-save the interface's cable terminations after a device move.
+
+    ``CableTermination`` denormalizes ``_device``/``_rack``/``_location``/``_site``
+    for cable-list filtering, and recomputes them only inside its own ``save()``
+    (``cache_related_objects()``) — nothing tracks an Interface changing device
+    (the same upstream gap as netbox#9788 for device site moves). Without this,
+    the moved interface's cables keep filtering under the DONOR's cable lists.
+    """
+    ct_type = ContentType.objects.get_for_model(Interface)
+    for termination in CableTermination.objects.filter(termination_type=ct_type, termination_id=interface.pk):
+        termination.save()
+
+
+def _donor_side_dependents(interface, donor):
+    """
+    Collect (and lock) donor interfaces that reference *interface* transitively.
+
+    Interfaces left on the donor whose ``lag``/``parent``/``bridge`` points at a
+    moved row would persist as cross-device relationships NetBox itself refuses
+    to create — surfacing only as a validation error on their NEXT save. The
+    move therefore carries the whole family. BFS order (level by level) so a
+    parent is always moved before its own dependents ``full_clean()``.
+    """
+    dependents = []
+    seen = {interface.pk}
+    frontier = [interface]
+    while frontier:
+        layer = list(
+            Interface.objects.select_for_update()
+            .filter(device=donor)
+            .filter(Q(lag__in=frontier) | Q(parent__in=frontier) | Q(bridge__in=frontier))
+            .exclude(pk__in=seen)
+            .order_by("pk")
+        )
+        seen.update(dep.pk for dep in layer)
+        dependents.extend(layer)
+        frontier = layer
+    return dependents
+
+
 class MoveInterfaceToWinnerView(_BaseMoveToWinnerView):
     """
     Reassign ``Interface.device`` from donor to winner.
 
-    Cables, IP-address attachments, MAC objects, and VLAN tag config all
-    point at the Interface row by FK, so they follow the move
-    automatically.
+    IP-address attachments, MAC objects, and VLAN tag config all point at
+    the Interface row by FK, so they follow the move automatically; cable
+    terminations follow by FK too, but their denormalized device/rack/
+    location/site cache columns are explicitly refreshed (see
+    :func:`_refresh_cable_termination_caches`). Donor-side interfaces whose
+    ``lag``/``parent``/``bridge`` points at the moved row are carried along
+    in the same transaction so no cross-device relationship is ever left
+    behind.
 
     Fails (toast + 409) when the winner already has an interface with the
-    same name — the user must rename or delete the colliding interface
-    on the winner first.
+    same name as the moved row or any carried dependent — the user must
+    rename or delete the colliding interface on the winner first.
     """
 
     # Requires change Device too: on success the move calls
@@ -490,6 +539,23 @@ class MoveInterfaceToWinnerView(_BaseMoveToWinnerView):
                     "Rename or remove the existing interface first.",
                     status=409,
                 )
+            # Carry the moved row's donor-side family (lag members, children, bridged
+            # peers) in the same transaction. Pre-check ALL their names on the winner
+            # before anything is saved, so the family either moves whole or not at all.
+            dependents = _donor_side_dependents(interface, donor)
+            colliding = sorted(
+                Interface.objects.filter(device=winner, name__in=[dep.name for dep in dependents]).values_list(
+                    "name", flat=True
+                )
+            )
+            if colliding:
+                return self._fail(
+                    request,
+                    f"Winner device '{winner.name}' already has interface(s) named "
+                    f"{', '.join(colliding)}. They are attached to '{interface.name}' and must move "
+                    "with it — rename or remove the colliding interface(s) first.",
+                    status=409,
+                )
             # Move via full_clean()+save(), not a bare .update(): a plain column update
             # bypasses Interface.clean(), which is exactly what guards against the moved
             # interface keeping a parent/lag/bridge that still lives on the donor (a
@@ -545,6 +611,38 @@ class MoveInterfaceToWinnerView(_BaseMoveToWinnerView):
                     status=409,
                 )
 
+            # Carry the donor-side family collected (and locked) above. BFS order
+            # guarantees each dependent's lag/parent/bridge target has already moved,
+            # so full_clean()'s cross-device checks pass for real.
+            for dep in dependents:
+                dep.device = winner
+                dep._original_device = winner.pk  # same ComponentModel re-seed as above
+                try:
+                    dep.full_clean()
+                    dep.save()
+                except (ValidationError, IntegrityError) as exc:
+                    # The master already saved in this transaction; a plain return would
+                    # COMMIT the half-moved family, so roll the whole move back explicitly
+                    # (IntegrityError poisons the transaction anyway; ValidationError doesn't).
+                    transaction.set_rollback(True)
+                    logger.warning(
+                        "Family move failed for attached interface pk=%s (master pk=%s): %s",
+                        dep.pk,
+                        interface.pk,
+                        exc,
+                    )
+                    return self._fail(
+                        request,
+                        f"Cannot move attached interface '{dep.name}' with '{interface.name}'; "
+                        "the whole move was rolled back.",
+                        status=409,
+                    )
+
+            # Refresh the denormalized cable-list cache columns for every moved row.
+            _refresh_cable_termination_caches(interface)
+            for dep in dependents:
+                _refresh_cable_termination_caches(dep)
+
             # The moved interface may carry an address the donor still points at via
             # primary_ip4/primary_ip6/oob_ip; reconcile those device FKs so the donor isn't
             # left referencing an address now on a winner-owned interface.
@@ -558,6 +656,11 @@ class MoveInterfaceToWinnerView(_BaseMoveToWinnerView):
                 return self._fail(request, f"Cannot reconcile donor IP assignments: {exc}", status=409)
 
         message = f"Moved interface '{interface.name}' to {winner.name}."
+        if dependents:
+            message = (
+                f"Moved interface '{interface.name}' and {len(dependents)} attached "
+                f"interface(s) ({', '.join(dep.name for dep in dependents)}) to {winner.name}."
+            )
         if notes:
             message += " " + "; ".join(notes) + "."
         return _hx_response(request, message, fallback_url=self._fallback_url)

--- a/netbox_librenms_plugin/views/sync/migrate.py
+++ b/netbox_librenms_plugin/views/sync/migrate.py
@@ -103,7 +103,13 @@ def _sync_tab_url(device_pk, tab, server_key):
     """
     url = f"{reverse('plugins:netbox_librenms_plugin:device_librenms_sync', args=[device_pk])}?tab={tab}"
     if server_key:
-        url += f"&server_key={quote_plus(server_key)}"
+        # Re-source the key from the trusted config rather than reflecting the raw POST value:
+        # only append it when it matches a configured server (a stale/tampered key resolves to
+        # nothing and is dropped). Mirrors device_fields._sync_redirect's allowlist guard.
+        from netbox_librenms_plugin.librenms_api import LibreNMSAPI
+
+        if server_key in LibreNMSAPI.get_available_servers():
+            url += f"&server_key={quote_plus(server_key)}"
     return url
 
 

--- a/netbox_librenms_plugin/views/sync/migrate.py
+++ b/netbox_librenms_plugin/views/sync/migrate.py
@@ -392,6 +392,20 @@ class _BaseMoveToWinnerView(LibreNMSAPIMixin, LibreNMSPermissionMixin, NetBoxObj
             return None, self._fail(request, "Donor device is not marked as migrated.", status=409)
         if winner is None:
             return None, _fail_winner_unavailable(self, request, donor, marker)
+        # Both device rows are DERIVED — the donor from the moved interface/IP, the winner from the
+        # donor's marker — and every move writes device-level IP FKs on both. The model-level gate
+        # can't see them, so authorize each against the restricted change queryset before any write.
+        device_pks = {donor.pk, winner.pk}
+        authorized = set(
+            self.restricted_queryset(Device, "change").filter(pk__in=device_pks).values_list("pk", flat=True)
+        )
+        if authorized != device_pks:
+            return None, self._fail(
+                request,
+                "You do not have permission to change every device this move touches "
+                "(the donor and its migration winner).",
+                status=403,
+            )
         return winner, None
 
     def _lock_donor_winner_and_reverify(self, request, donor, winner, server_key):
@@ -553,6 +567,22 @@ class MoveInterfaceToWinnerView(_BaseMoveToWinnerView):
             # peers) in the same transaction. Pre-check ALL their names on the winner
             # before anything is saved, so the family either moves whole or not at all.
             dependents = _donor_side_dependents(interface, donor)
+            # The family is DERIVED from the moved row, not the scoped pk, and every member is
+            # saved below. The move is all-or-nothing, so refuse unless the grant covers all of it.
+            if dependents:
+                dependent_pks = {dep.pk for dep in dependents}
+                authorized = set(
+                    self.restricted_queryset(Interface, "change")
+                    .filter(pk__in=dependent_pks)
+                    .values_list("pk", flat=True)
+                )
+                if authorized != dependent_pks:
+                    return self._fail(
+                        request,
+                        f"Interface '{interface.name}' has attached interface(s) that must move with "
+                        "it, and you do not have permission to change all of them.",
+                        status=403,
+                    )
             colliding = sorted(
                 Interface.objects.filter(device=winner, name__in=[dep.name for dep in dependents]).values_list(
                     "name", flat=True

--- a/netbox_librenms_plugin/views/sync/migrate.py
+++ b/netbox_librenms_plugin/views/sync/migrate.py
@@ -21,7 +21,7 @@ from django.core.exceptions import ValidationError
 from django.db import IntegrityError, transaction
 from django.db.models import Q
 from django.http import HttpResponse
-from django.shortcuts import get_object_or_404, redirect
+from django.shortcuts import redirect
 from django.urls import get_script_prefix, reverse
 from django.views import View
 from ipam.models import IPAddress
@@ -501,7 +501,9 @@ class MoveInterfaceToWinnerView(_BaseMoveToWinnerView):
         if gate is not None:
             return gate
 
-        interface = get_object_or_404(Interface, pk=pk)
+        # Object-scoped: the gate above is model-level only, so a constrained change_interface
+        # grant would otherwise move an interface it cannot see.
+        interface = self.restrict_object_or_404(Interface, "change", pk=pk)
         donor = interface.device
         if donor is None:
             return self._fail(request, "Interface has no device.")
@@ -700,7 +702,8 @@ class MoveIPAddressToWinnerView(_BaseMoveToWinnerView):
         if gate is not None:
             return gate
 
-        ip = get_object_or_404(IPAddress, pk=pk)
+        # Object-scoped — see MoveInterfaceToWinnerView.post.
+        ip = self.restrict_object_or_404(IPAddress, "change", pk=pk)
         assigned = ip.assigned_object
         if not isinstance(assigned, Interface):
             return self._fail(
@@ -806,7 +809,8 @@ class TransferDeviceIPView(_BaseMoveToWinnerView):
             return self._fail(request, f"Unknown ip_kind '{ip_kind}'.")
         human = DEVICE_IP_FK_LABELS[field]
 
-        donor = get_object_or_404(Device, pk=pk)
+        # Object-scoped — see MoveInterfaceToWinnerView.post.
+        donor = self.restrict_object_or_404(Device, "change", pk=pk)
         # Fall back to active_server_key (never builds LibreNMSAPI) so a misconfigured default
         # server can't 500 a move that only needs the marker's server namespace, not the live API.
         server_key = _server_key_from_request(request, default_factory=lambda: self.active_server_key)

--- a/netbox_librenms_plugin/views/sync/migrate.py
+++ b/netbox_librenms_plugin/views/sync/migrate.py
@@ -19,14 +19,19 @@ from django.contrib import messages
 from django.core.exceptions import ValidationError
 from django.db import IntegrityError, transaction
 from django.http import HttpResponse
-from django.utils.html import format_html
 from django.shortcuts import get_object_or_404, redirect
 from django.urls import get_script_prefix, reverse
 from django.utils.http import url_has_allowed_host_and_scheme
 from django.views import View
 from ipam.models import IPAddress
 
-from netbox_librenms_plugin.utils import DEVICE_IP_FK_FIELDS, get_migrated_to_marker, set_device_ip_fk
+from netbox_librenms_plugin.utils import (
+    DEVICE_IP_FK_FIELDS,
+    DEVICE_IP_FK_LABELS,
+    get_migrated_to_marker,
+    set_device_ip_fk,
+)
+from netbox_librenms_plugin.views.imports.actions import _htmx_error_response
 from netbox_librenms_plugin.views.mixins import (
     LibreNMSAPIMixin,
     LibreNMSPermissionMixin,
@@ -270,9 +275,8 @@ def _reconcile_donor_device_ip_fks(donor, winner):
     # Drive the loop off utils.DEVICE_IP_FK_FIELDS — the canonical list set_device_ip_fk()
     # validates against — so a fourth device IP FK added there is reconciled here too instead of
     # being silently skipped by a stale hardcoded copy. The labels are display-only.
-    _human_labels = {"primary_ip4": "primary IPv4", "primary_ip6": "primary IPv6", "oob_ip": "OOB IP"}
     for field in DEVICE_IP_FK_FIELDS:
-        human = _human_labels.get(field, field)
+        human = DEVICE_IP_FK_LABELS.get(field, field)
         donor_ip_id = getattr(donor, f"{field}_id", None)
         # Real FK columns are plain ints; the isinstance guard also makes this a clean no-op
         # against the mock-based unit tests (a MagicMock id is not an int).
@@ -358,24 +362,9 @@ class _BaseMoveToWinnerView(LibreNMSAPIMixin, LibreNMSPermissionMixin, NetBoxObj
             HttpResponse: The OOB-toast response (HTMX) or a redirect (non-HTMX).
         """
         if request.headers.get("HX-Request"):
-            toast_html = format_html(
-                '<div id="django-messages"'
-                ' class="toast-container position-fixed bottom-0 end-0 p-3"'
-                ' hx-swap-oob="true">'
-                '<div class="toast toast-dark border-0 shadow-sm" role="alert"'
-                ' aria-live="assertive" aria-atomic="true" data-bs-delay="12000">'
-                '<div class="toast-header text-bg-danger">'
-                '<i class="mdi mdi-alert-circle me-1"></i>Error'
-                '<button type="button" class="btn-close me-0 m-auto"'
-                ' data-bs-dismiss="toast" aria-label="Close"></button>'
-                "</div>"
-                '<div class="toast-body">{}</div>'
-                "</div></div>",
-                msg,
-            )
-            resp = HttpResponse(toast_html, content_type="text/html")
-            resp["HX-Reswap"] = "none"
-            return resp
+            # Reuse the shared OOB-toast builder (same #django-messages container, toast classes and
+            # HX-Reswap:none) so move-to-winner error toasts can't drift from the import flow's markup.
+            return _htmx_error_response(msg)
         messages.error(request, msg)
         return redirect(_safe_referer(request, self._fallback_url))
 
@@ -664,20 +653,19 @@ class TransferDeviceIPView(_BaseMoveToWinnerView):
 
     required_object_permissions = {"POST": [("change", Device)]}
 
-    _FIELD_MAP = {
-        "primary4": ("primary_ip4", "primary IPv4"),
-        "primary6": ("primary_ip6", "primary IPv6"),
-        "oob": ("oob_ip", "OOB IP"),
-    }
+    # URL ``ip_kind`` kwarg → device IP FK field name; the human label comes from the single
+    # utils.DEVICE_IP_FK_LABELS map so it can't drift from the reconcile-notes wording.
+    _IP_KIND_TO_FIELD = {"primary4": "primary_ip4", "primary6": "primary_ip6", "oob": "oob_ip"}
 
     def post(self, request, pk, ip_kind):
         gate = self._gate(request)
         if gate is not None:
             return gate
 
-        if ip_kind not in self._FIELD_MAP:
+        field = self._IP_KIND_TO_FIELD.get(ip_kind)
+        if field is None:
             return self._fail(request, f"Unknown ip_kind '{ip_kind}'.")
-        field, human = self._FIELD_MAP[ip_kind]
+        human = DEVICE_IP_FK_LABELS[field]
 
         donor = get_object_or_404(Device, pk=pk)
         # Fall back to active_server_key (never builds LibreNMSAPI) so a misconfigured default

--- a/netbox_librenms_plugin/views/sync/migrate.py
+++ b/netbox_librenms_plugin/views/sync/migrate.py
@@ -1,0 +1,629 @@
+"""
+Stage 2b: per-row "Move to winner" actions on a donor device whose
+``librenms_id[server_key]`` carries a ``_migrated_to`` marker.
+
+Each view validates the marker, looks up the winner Device, runs an
+atomic move under ``select_for_update`` ordering by primary key (to avoid
+cross-merge deadlocks), and returns either an HTMX-friendly partial
+response or a plain redirect.
+
+Permissions: each view requires plugin write permission AND the
+appropriate NetBox model permission on the object being moved.
+"""
+
+import logging
+from urllib.parse import quote_plus
+
+from dcim.models import Device, Interface
+from django.contrib import messages
+from django.core.exceptions import ValidationError
+from django.db import IntegrityError, transaction
+from django.http import HttpResponse
+from django.utils.html import format_html
+from django.shortcuts import get_object_or_404, redirect
+from django.urls import get_script_prefix, reverse
+from django.utils.http import url_has_allowed_host_and_scheme
+from django.views import View
+from ipam.models import IPAddress
+
+from netbox_librenms_plugin.utils import get_migrated_to_marker, set_device_ip_fk
+from netbox_librenms_plugin.views.mixins import (
+    LibreNMSAPIMixin,
+    LibreNMSPermissionMixin,
+    NetBoxObjectPermissionMixin,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def _resolve_winner_for_donor(donor, server_key="default"):
+    """
+    Return ``(winner, marker)`` for *donor*.
+
+    - ``(None, None)`` when no ``_migrated_to`` marker is present.
+    - ``(None, marker)`` when the marker exists but the winner device has
+      been deleted, the ``device_id`` in the marker is invalid/unparseable, or
+      the marker points back at the donor itself (so callers can distinguish
+      "no marker" from "stale marker").
+    - ``(winner, marker)`` when the marker is valid and the winner exists.
+
+    ``marker`` is the dict written by :func:`mark_librenms_migrated`.
+    """
+    marker = get_migrated_to_marker(donor, server_key)
+    if not marker:
+        return None, None
+    device_id = marker.get("device_id")
+    # Reject bools explicitly: bool is a subclass of int, so int(True) == 1 would
+    # otherwise resolve Device(pk=1) and misroute a move operation. A corrupt marker
+    # like {"device_id": true} must fail closed as a stale/invalid marker.
+    if isinstance(device_id, bool):
+        return None, marker
+    try:
+        winner_pk = int(device_id)
+    except (TypeError, ValueError):
+        return None, marker
+    winner = Device.objects.filter(pk=winner_pk).first()
+    if winner is None:
+        return None, marker
+    # A self-pointing marker (winner == donor) is corrupt: it would make the move
+    # operate on the same Device as both donor and winner (e.g. reconciling a device's
+    # IP FKs against itself). Fail closed as a stale marker rather than resolve it.
+    if winner.pk == donor.pk:
+        return None, marker
+    return winner, marker
+
+
+def _server_key_from_request(request, default_factory=None):
+    """Extract the LibreNMS server key from the POST body (form field).
+
+    Pass ``default_factory=lambda: self.librenms_api.server_key`` from views that
+    have API access so the fallback matches the active server's namespace rather
+    than the literal ``"default"``. The factory is a callable (not the resolved
+    value) so the API — and the DB lookup it performs — is only touched when the
+    POST body omits ``server_key``; the common path where the form supplies the
+    key never instantiates the API.
+    """
+    sk = request.POST.get("server_key")
+    if isinstance(sk, str) and sk:
+        return sk
+    if default_factory is not None:
+        resolved = default_factory()
+        if isinstance(resolved, str) and resolved:
+            return resolved
+    return "default"
+
+
+def _sync_tab_url(device_pk, tab, server_key):
+    """Build the device's LibreNMS sync URL for *tab*, preserving *server_key*.
+
+    Used as the non-HTMX fallback target when a plain POST carries no usable
+    Referer: without this the redirect would drop the active sync tab and server
+    context, bouncing the user to the bare app root instead of the donor's
+    "Migrated to ..." view they acted from.
+    """
+    url = f"{reverse('plugins:netbox_librenms_plugin:device_librenms_sync', args=[device_pk])}?tab={tab}"
+    if server_key:
+        url += f"&server_key={quote_plus(server_key)}"
+    return url
+
+
+def _safe_referer(request, fallback=None):
+    """
+    Return the request's ``Referer`` only when it points back at this
+    site, otherwise *fallback* (or the app mount path).
+
+    ``Referer`` is a client-controlled header, so it must be validated
+    against the current host before being used as a redirect target —
+    trusting it blindly is an open-redirect vector.
+
+    *fallback* is an internal, server-built URL (see :func:`_sync_tab_url`); it is
+    used as-is so a missing Referer still lands on the right sync tab/server. When
+    no fallback is supplied, fall back to the app mount path (not literal ``"/"``)
+    so prefixed deployments land on the NetBox app root rather than the site root.
+    """
+    referer = request.META.get("HTTP_REFERER")
+    if referer and url_has_allowed_host_and_scheme(
+        referer,
+        allowed_hosts={request.get_host()},
+        require_https=request.is_secure(),
+    ):
+        return referer
+    return fallback or get_script_prefix()
+
+
+def _hx_response(request, message, level=messages.SUCCESS, *, status=200, fallback_url=None):
+    """
+    Common HTMX response: queue a Django messages flash and emit the
+    ``HX-Refresh`` header so the sync page re-renders with the row gone.
+
+    For non-HTMX requests, queue the message and redirect to the validated
+    Referer, falling back to *fallback_url* (the donor's sync tab) so the
+    server/tab context survives a missing Referer.
+    """
+    messages.add_message(request, level, message)
+    if request.headers.get("HX-Request"):
+        return HttpResponse(status=status, headers={"HX-Refresh": "true"})
+    return redirect(_safe_referer(request, fallback_url))
+
+
+def _reconcile_donor_device_ip_fks(donor, winner):
+    """Keep the donor valid after a move re-homes an interface/IP onto the winner.
+
+    NetBox requires ``Device.primary_ip4``/``primary_ip6``/``oob_ip`` to reference an address
+    assigned to one of that device's *own* interfaces. Moving an interface (with its addresses)
+    or an IP to the winner can leave one of those donor FKs pointing at an address now living on
+    a winner-owned interface — an invalid state that surfaces the next time the donor is
+    full_clean()'d. For each such dangling FK, transfer the designation to the winner when its
+    slot is free, otherwise clear it on the donor. Only the touched FK column is saved
+    (``update_fields``) so we don't trip ``full_clean()`` on pre-existing unrelated
+    inconsistencies, mirroring :class:`TransferDeviceIPView`.
+
+    Must run inside the caller's ``transaction.atomic()`` with both devices already locked.
+    Returns human-readable notes describing what was reconciled (for the response message).
+    """
+    notes = []
+    for field, human in (
+        ("primary_ip4", "primary IPv4"),
+        ("primary_ip6", "primary IPv6"),
+        ("oob_ip", "OOB IP"),
+    ):
+        donor_ip_id = getattr(donor, f"{field}_id", None)
+        # Real FK columns are plain ints; the isinstance guard also makes this a clean no-op
+        # against the mock-based unit tests (a MagicMock id is not an int).
+        if not isinstance(donor_ip_id, int) or isinstance(donor_ip_id, bool):
+            continue
+        # Lock the address row before reading its assignment so a concurrent reassignment can't
+        # change assigned_object between this check and the FK save.
+        ip = IPAddress.objects.select_for_update().filter(pk=donor_ip_id).first()
+        if ip is None:
+            continue
+        assigned = ip.assigned_object
+        # Only reconcile when the address now sits on a winner-owned interface (the move just
+        # detached it from the donor). A non-Interface assignment (e.g. a VMInterface) has no
+        # device_id and is left untouched.
+        if not isinstance(assigned, Interface):
+            continue
+        # Locking the IPAddress row alone doesn't stabilize the owning interface's device_id:
+        # this helper also reconciles pre-existing dangling FKs, so a concurrent interface move
+        # could flip device_id between this check and winner.save(). Lock the owning Interface
+        # and re-read device_id from the locked row so the winner can't end up owning an address
+        # that has since moved away.
+        locked_iface = Interface.objects.select_for_update().filter(pk=assigned.pk).first()
+        if locked_iface is None or locked_iface.device_id != winner.pk:
+            continue
+        if getattr(winner, f"{field}_id", None) is None:
+            # device.primary_ip4/6 / oob_ip are UNIQUE per address, so the donor must release the
+            # FK *before* the winner claims it — saving the winner first while the donor still
+            # holds the same address violates the unique constraint. set_device_ip_fk() enforces
+            # the "address must live on the target device's own interface" invariant the
+            # update_fields save would otherwise skip (the locked-row check above is the lock-
+            # stabilized first line; the helper is the shared backstop).
+            set_device_ip_fk(donor, field, None)
+            set_device_ip_fk(winner, field, ip)
+            notes.append(f"transferred donor {human} to {winner.name}")
+        else:
+            set_device_ip_fk(donor, field, None)
+            notes.append(f"cleared donor {human} (winner already had a {human})")
+    return notes
+
+
+class _BaseMoveToWinnerView(LibreNMSAPIMixin, LibreNMSPermissionMixin, NetBoxObjectPermissionMixin, View):
+    """Shared plumbing for the per-resource move endpoints."""
+
+    # Per-request, server-built non-HTMX redirect fallback (donor sync tab +
+    # server_key). Set by each post() once the donor device and server_key are
+    # known; until then it stays None and _fail/_hx_response fall back to the app
+    # mount path (there is no donor device to redirect to yet).
+    _fallback_url = None
+
+    def _gate(self, request):
+        """
+        Plugin-write + object-perm gate.  Returns a response on failure
+        (which the caller must return verbatim) or ``None`` on success.
+        """
+        resp = self.require_all_permissions("POST")
+        if resp is not None:
+            return resp
+        return None
+
+    def _fail(self, request, msg, *, status=400):
+        """
+        Return an error response.
+
+        For HTMX requests: returns HTTP 200 with an out-of-band swap into
+        ``#django-messages`` so the toast renders through NetBox's Bootstrap
+        pipeline.  ``HX-Reswap: none`` prevents the primary swap target from
+        being overwritten.  The ``status`` parameter is not used for HTMX
+        responses — errors are always signalled via the OOB toast, not the
+        status code.
+
+        For non-HTMX requests: adds a Django error message and redirects to
+        the validated Referer or '/'.
+        """
+        if request.headers.get("HX-Request"):
+            toast_html = format_html(
+                '<div id="django-messages"'
+                ' class="toast-container position-fixed bottom-0 end-0 p-3"'
+                ' hx-swap-oob="true">'
+                '<div class="toast toast-dark border-0 shadow-sm" role="alert"'
+                ' aria-live="assertive" aria-atomic="true" data-bs-delay="12000">'
+                '<div class="toast-header text-bg-danger">'
+                '<i class="mdi mdi-alert-circle me-1"></i>Error'
+                '<button type="button" class="btn-close me-0 m-auto"'
+                ' data-bs-dismiss="toast" aria-label="Close"></button>'
+                "</div>"
+                '<div class="toast-body">{}</div>'
+                "</div></div>",
+                msg,
+            )
+            resp = HttpResponse(toast_html, content_type="text/html")
+            resp["HX-Reswap"] = "none"
+            return resp
+        messages.error(request, msg)
+        return redirect(_safe_referer(request, self._fallback_url))
+
+
+class MoveInterfaceToWinnerView(_BaseMoveToWinnerView):
+    """
+    Reassign ``Interface.device`` from donor to winner.
+
+    Cables, IP-address attachments, MAC objects, and VLAN tag config all
+    point at the Interface row by FK, so they follow the move
+    automatically.
+
+    Fails (toast + 409) when the winner already has an interface with the
+    same name — the user must rename or delete the colliding interface
+    on the winner first.
+    """
+
+    # Requires change Device too: on success the move calls
+    # _reconcile_donor_device_ip_fks(), which writes device-level FKs
+    # (winner/donor primary_ip4/primary_ip6/oob_ip). NetBoxObjectPermissionMixin is
+    # model-level only, so Device must be in the declared boundary.
+    required_object_permissions = {"POST": [("change", Interface), ("change", Device)]}
+
+    def post(self, request, pk):
+        gate = self._gate(request)
+        if gate is not None:
+            return gate
+
+        interface = get_object_or_404(Interface, pk=pk)
+        donor = interface.device
+        if donor is None:
+            return self._fail(request, "Interface has no device.")
+
+        server_key = _server_key_from_request(request, default_factory=lambda: self.librenms_api.server_key)
+        self._fallback_url = _sync_tab_url(donor.pk, "interfaces", server_key)
+        winner, marker = _resolve_winner_for_donor(donor, server_key)
+        if marker is None:
+            return self._fail(request, "Donor device is not marked as migrated.", status=409)
+        if winner is None:
+            return self._fail(request, "Winner device no longer exists.", status=410)
+
+        # Quick pre-check before acquiring the lock (avoids round-trip in the
+        # obvious already-taken case).  The check is repeated under the lock
+        # below to close the TOCTOU window.
+        if Interface.objects.filter(device=winner, name=interface.name).exists():
+            return self._fail(
+                request,
+                f"Winner device '{winner.name}' already has an interface named '{interface.name}'. "
+                "Rename or remove the existing interface first.",
+                status=409,
+            )
+
+        with transaction.atomic():
+            # Lock both devices in pk order to avoid cross-merge deadlocks.
+            ordered = sorted({donor.pk, winner.pk})
+            locked = {d.pk: d for d in Device.objects.select_for_update().filter(pk__in=ordered).order_by("pk")}
+            donor = locked.get(donor.pk)
+            winner = locked.get(winner.pk)
+            if donor is None or winner is None:
+                return self._fail(request, "Device was deleted concurrently.", status=410)
+            # Re-verify the migration marker under the lock: a concurrent request
+            # could have cleared or repointed _migrated_to between the unlocked
+            # resolve above and acquiring these row locks, which would otherwise
+            # move the interface to the wrong (stale) winner.
+            relocked_winner, relocked_marker = _resolve_winner_for_donor(donor, server_key)
+            if relocked_marker is None or relocked_winner is None or relocked_winner.pk != winner.pk:
+                return self._fail(request, "Donor migration changed concurrently; refresh and retry.", status=409)
+            # Lock the donor interface row and re-read it under the lock. A
+            # concurrent rename would otherwise let a stale name slip past the
+            # collision check below while the row is still moved by pk.
+            interface = Interface.objects.select_for_update().filter(pk=interface.pk, device=donor).first()
+            if interface is None:
+                return self._fail(
+                    request,
+                    f"Interface is no longer attached to '{donor.name}'.",
+                    status=409,
+                )
+            # Re-check the collision under the lock, using the locked name.
+            if Interface.objects.filter(device=winner, name=interface.name).exists():
+                return self._fail(
+                    request,
+                    f"Winner device '{winner.name}' already has an interface named '{interface.name}'. "
+                    "Rename or remove the existing interface first.",
+                    status=409,
+                )
+            # Move via full_clean()+save(), not a bare .update(): a plain column update
+            # bypasses Interface.clean(), which is exactly what guards against the moved
+            # interface keeping a parent/lag/bridge that still lives on the donor (a
+            # cross-device link NetBox forbids). Surface that as a 409 so the user unlinks
+            # the relationship first rather than silently creating an invalid interface.
+            #
+            # NetBox's ComponentModel.clean() also hard-blocks ANY device change on an
+            # existing component ("Components cannot be moved to a different device"), keyed
+            # on the device_id cached into self._original_device at load time. That blanket
+            # block is precisely the operation this view exists to perform, so re-seed the
+            # cached original to the new device to defeat ONLY that one check — every other
+            # validation in clean() (the cross-device parent/lag/bridge checks above, name
+            # uniqueness, …) still runs, and save() still refreshes the denormalized
+            # _site/_location/_rack columns. A bare .update(device=...) would skip all of
+            # that (stale denormalized location + no relationship validation).
+            interface.device = winner
+            interface._original_device = winner.pk
+            try:
+                interface.full_clean()
+            except ValidationError as exc:
+                detail = (
+                    "; ".join(f"{field}: {' '.join(str(m) for m in msgs)}" for field, msgs in exc.message_dict.items())
+                    if hasattr(exc, "message_dict")
+                    else str(exc)
+                )
+                return self._fail(
+                    request,
+                    f"Cannot move interface '{interface.name}' to '{winner.name}': {detail}",
+                    status=409,
+                )
+            try:
+                interface.save()
+            except IntegrityError:
+                # A concurrent rename/create on the winner side can still trip a DB unique
+                # constraint between our name re-check and this save. Surface it as the same
+                # 409 the collision check uses rather than letting it bubble up as a 500.
+                logger.warning(
+                    "IntegrityError moving interface pk=%s to winner pk=%s (concurrent winner-side change)",
+                    interface.pk,
+                    winner.pk,
+                )
+                return self._fail(
+                    request,
+                    f"Winner device '{winner.name}' already has an interface named '{interface.name}'. "
+                    "Rename or remove the existing interface first.",
+                    status=409,
+                )
+
+            # The moved interface may carry an address the donor still points at via
+            # primary_ip4/primary_ip6/oob_ip; reconcile those device FKs so the donor isn't
+            # left referencing an address now on a winner-owned interface.
+            notes = _reconcile_donor_device_ip_fks(donor, winner)
+
+        message = f"Moved interface '{interface.name}' to {winner.name}."
+        if notes:
+            message += " " + "; ".join(notes) + "."
+        return _hx_response(request, message, fallback_url=self._fallback_url)
+
+
+class MoveIPAddressToWinnerView(_BaseMoveToWinnerView):
+    """
+    Reassign ``IPAddress.assigned_object`` from a donor-owned target to
+    the winner's equivalent.
+
+    Behaviour by current assignment:
+
+    * Assigned to a donor :class:`Interface` whose name exists on the
+      winner → reassign to the winner's same-name interface.
+    * Assigned to a donor :class:`Interface` whose name does *not* exist
+      on the winner → fail (user must move the interface first).
+    * Unassigned IP picked from the donor's sync page → fail (no donor
+      relationship to migrate).
+    """
+
+    # Requires change Device too: on success the move calls
+    # _reconcile_donor_device_ip_fks(), which writes device-level FKs
+    # (winner/donor primary_ip4/primary_ip6/oob_ip). NetBoxObjectPermissionMixin is
+    # model-level only, so Device must be in the declared boundary.
+    required_object_permissions = {"POST": [("change", IPAddress), ("change", Device)]}
+
+    def post(self, request, pk):
+        gate = self._gate(request)
+        if gate is not None:
+            return gate
+
+        ip = get_object_or_404(IPAddress, pk=pk)
+        assigned = ip.assigned_object
+        if not isinstance(assigned, Interface):
+            return self._fail(
+                request,
+                "IP is not assigned to a donor interface; nothing to migrate.",
+                status=409,
+            )
+        donor = assigned.device
+        if donor is None:
+            return self._fail(request, "IP's interface has no device.", status=409)
+
+        server_key = _server_key_from_request(request, default_factory=lambda: self.librenms_api.server_key)
+        self._fallback_url = _sync_tab_url(donor.pk, "ipaddresses", server_key)
+        winner, marker = _resolve_winner_for_donor(donor, server_key)
+        if marker is None:
+            return self._fail(request, "Donor device is not marked as migrated.", status=409)
+        if winner is None:
+            return self._fail(request, "Winner device no longer exists.", status=410)
+
+        # Quick pre-check before acquiring the lock.  Repeated under lock below.
+        if not Interface.objects.filter(device=winner, name=assigned.name).exists():
+            return self._fail(
+                request,
+                f"Winner '{winner.name}' has no interface named '{assigned.name}'. "
+                "Move the interface first, then retry.",
+                status=409,
+            )
+
+        with transaction.atomic():
+            ordered = sorted({donor.pk, winner.pk})
+            locked = {d.pk: d for d in Device.objects.select_for_update().filter(pk__in=ordered).order_by("pk")}
+            donor = locked.get(donor.pk)
+            winner = locked.get(winner.pk)
+            if donor is None or winner is None:
+                return self._fail(request, "Device was deleted concurrently.", status=410)
+            # Re-verify the migration marker under the lock (it could have been
+            # cleared or repointed since the unlocked resolve above).
+            relocked_winner, relocked_marker = _resolve_winner_for_donor(donor, server_key)
+            if relocked_marker is None or relocked_winner is None or relocked_winner.pk != winner.pk:
+                return self._fail(request, "Donor migration changed concurrently; refresh and retry.", status=409)
+            ip = IPAddress.objects.select_for_update().filter(pk=ip.pk).first()
+            if ip is None:
+                return self._fail(request, "IP address no longer exists.", status=410)
+            assigned = ip.assigned_object
+            if not isinstance(assigned, Interface) or assigned.device_id != donor.pk:
+                return self._fail(request, "IP is no longer assigned to the donor interface.", status=409)
+            # Lock the donor interface row too and re-read it: its name is used
+            # below to find the winner-side interface, so a concurrent rename
+            # would otherwise send the IP to the wrong interface (TOCTOU).
+            assigned = Interface.objects.select_for_update().filter(pk=assigned.pk, device=donor).first()
+            if assigned is None:
+                return self._fail(request, "IP is no longer assigned to the donor interface.", status=409)
+            # Re-fetch the winner interface under the lock to close the TOCTOU window.
+            winner_iface = Interface.objects.select_for_update().filter(device=winner, name=assigned.name).first()
+            if winner_iface is None:
+                return self._fail(
+                    request,
+                    f"Winner '{winner.name}' has no interface named '{assigned.name}'. "
+                    "Move the interface first, then retry.",
+                    status=409,
+                )
+            ip.assigned_object = winner_iface
+            ip.save(update_fields=["assigned_object_type", "assigned_object_id"])
+
+            # The moved address may itself be the donor's primary_ip4/primary_ip6/oob_ip;
+            # reconcile those device FKs so the donor isn't left referencing an address now on a
+            # winner-owned interface.
+            notes = _reconcile_donor_device_ip_fks(donor, winner)
+
+        message = f"Moved IP {ip.address} to {winner.name} interface '{winner_iface.name}'."
+        if notes:
+            message += " " + "; ".join(notes) + "."
+        return _hx_response(request, message, fallback_url=self._fallback_url)
+
+
+class TransferDeviceIPView(_BaseMoveToWinnerView):
+    """
+    One-shot transfer of a donor's primary IPv4/v6 or OOB IP to the
+    winner.
+
+    Triggered with URL kwarg ``ip_kind`` ∈ ``{"primary4", "primary6",
+    "oob"}``.  Refuses to overwrite a value already set on the winner —
+    the user must clear it on the winner first.
+
+    The IPAddress object itself is *not* moved off its current
+    ``assigned_object`` (an interface) — only the ``Device.primary_ip4``
+    / ``primary_ip6`` / ``oob_ip`` foreign key on the winner is set, and
+    the donor's foreign key is cleared.
+    """
+
+    required_object_permissions = {"POST": [("change", Device)]}
+
+    _FIELD_MAP = {
+        "primary4": ("primary_ip4", "primary IPv4"),
+        "primary6": ("primary_ip6", "primary IPv6"),
+        "oob": ("oob_ip", "OOB IP"),
+    }
+
+    def post(self, request, pk, ip_kind):
+        gate = self._gate(request)
+        if gate is not None:
+            return gate
+
+        if ip_kind not in self._FIELD_MAP:
+            return self._fail(request, f"Unknown ip_kind '{ip_kind}'.")
+        field, human = self._FIELD_MAP[ip_kind]
+
+        donor = get_object_or_404(Device, pk=pk)
+        server_key = _server_key_from_request(request, default_factory=lambda: self.librenms_api.server_key)
+        self._fallback_url = _sync_tab_url(donor.pk, "ipaddresses", server_key)
+        winner, marker = _resolve_winner_for_donor(donor, server_key)
+        if marker is None:
+            return self._fail(request, "Donor device is not marked as migrated.", status=409)
+        if winner is None:
+            return self._fail(request, "Winner device no longer exists.", status=410)
+
+        donor_ip = getattr(donor, field, None)
+        if donor_ip is None:
+            return self._fail(request, f"Donor has no {human} to transfer.", status=409)
+        # Quick pre-check before acquiring the lock.  Repeated under lock below.
+        if getattr(winner, field, None) is not None:
+            return self._fail(
+                request,
+                f"Winner '{winner.name}' already has a {human}. Clear it on the winner first.",
+                status=409,
+            )
+
+        with transaction.atomic():
+            ordered = sorted({donor.pk, winner.pk})
+            locked = {d.pk: d for d in Device.objects.select_for_update().filter(pk__in=ordered).order_by("pk")}
+            donor = locked.get(donor.pk)
+            winner = locked.get(winner.pk)
+            if donor is None or winner is None:
+                return self._fail(request, "Device was deleted concurrently.", status=410)
+            # Re-verify the migration marker under the lock (it could have been
+            # cleared or repointed since the unlocked resolve above).
+            relocked_winner, relocked_marker = _resolve_winner_for_donor(donor, server_key)
+            if relocked_marker is None or relocked_winner is None or relocked_winner.pk != winner.pk:
+                return self._fail(request, "Donor migration changed concurrently; refresh and retry.", status=409)
+            # Re-check under the lock so concurrent transfers don't race.
+            donor_ip = getattr(donor, field, None)
+            if donor_ip is None:
+                return self._fail(request, f"Donor has no {human} to transfer.", status=409)
+            # Lock the IPAddress row itself before validating its assignment below: the
+            # device FKs are locked but the address is not, so a concurrent reassignment
+            # could otherwise change assigned_object between this check and the FK update,
+            # leaving winner.primary_ip*/oob_ip pointing at an address it no longer owns.
+            donor_ip = IPAddress.objects.select_for_update().filter(pk=donor_ip.pk).first()
+            if donor_ip is None:
+                return self._fail(request, f"Donor's {human} no longer exists.", status=410)
+            if getattr(winner, field, None) is not None:
+                return self._fail(
+                    request,
+                    f"Winner '{winner.name}' already has a {human}. Clear it on the winner first.",
+                    status=409,
+                )
+            # The save below uses update_fields (skips full_clean), so nothing else
+            # validates that the address belongs to the winner. NetBox requires
+            # primary_ip/oob_ip be assigned to one of the device's OWN interfaces, so
+            # refuse to point the winner at an address still attached to the donor —
+            # the interface/IP must be moved to the winner first (MoveIPAddressToWinnerView).
+            #
+            # Locking the IPAddress only pins which interface it points at, not that
+            # interface's device_id. Re-lock the owning interface so a concurrent move
+            # can't change its device after this check but before the FK saves, which
+            # would leave winner.primary_ip*/oob_ip on an interface it no longer owns.
+            assigned = getattr(donor_ip, "assigned_object", None)
+            # Only re-lock when the assignment really is a dcim Interface. GenericForeignKey
+            # pks aren't unique across models, so filtering Interface by a non-Interface pk
+            # (e.g. a VMInterface) could lock an unrelated Interface and let the device_id
+            # check validate the wrong row. A non-Interface assignment fails closed (None).
+            if isinstance(assigned, Interface):
+                # Lock the owning interface row (this transfer is device-scoped).
+                assigned = Interface.objects.select_for_update().filter(pk=assigned.pk).first()
+            else:
+                assigned = None
+            if getattr(assigned, "device_id", None) != winner.pk:
+                return self._fail(
+                    request,
+                    f"{human} ({donor_ip}) is still attached to '{donor.name}'. "
+                    f"Move its interface/IP to '{winner.name}' first.",
+                    status=409,
+                )
+            # set_device_ip_fk() saves only the touched FK column (skips full_clean(), so a
+            # pre-existing inconsistency like ``face`` without ``rack`` can't block the merge)
+            # while enforcing the "address must live on the winner's own interface" invariant
+            # the bare update_fields save would skip. device.primary_ip4/6 / oob_ip are UNIQUE
+            # per address, so the donor must release the FK (saved first, below) BEFORE the
+            # winner claims it — the reverse order trips the unique constraint.
+            set_device_ip_fk(donor, field, None)
+            set_device_ip_fk(winner, field, donor_ip)
+
+        return _hx_response(
+            request,
+            f"Transferred {human} ({donor_ip}) to {winner.name}.",
+            fallback_url=self._fallback_url,
+        )

--- a/netbox_librenms_plugin/views/sync/migrate.py
+++ b/netbox_librenms_plugin/views/sync/migrate.py
@@ -409,7 +409,9 @@ class MoveInterfaceToWinnerView(_BaseMoveToWinnerView):
         if donor is None:
             return self._fail(request, "Interface has no device.")
 
-        server_key = _server_key_from_request(request, default_factory=lambda: self.librenms_api.server_key)
+        # Fall back to active_server_key (never builds LibreNMSAPI) so a misconfigured default
+        # server can't 500 a move that only needs the marker's server namespace, not the live API.
+        server_key = _server_key_from_request(request, default_factory=lambda: self.active_server_key)
         self._fallback_url = _sync_tab_url(donor.pk, "interfaces", server_key)
         winner, marker = _resolve_winner_for_donor(donor, server_key)
         if marker is None:
@@ -572,7 +574,9 @@ class MoveIPAddressToWinnerView(_BaseMoveToWinnerView):
         if donor is None:
             return self._fail(request, "IP's interface has no device.", status=409)
 
-        server_key = _server_key_from_request(request, default_factory=lambda: self.librenms_api.server_key)
+        # Fall back to active_server_key (never builds LibreNMSAPI) so a misconfigured default
+        # server can't 500 a move that only needs the marker's server namespace, not the live API.
+        server_key = _server_key_from_request(request, default_factory=lambda: self.active_server_key)
         self._fallback_url = _sync_tab_url(donor.pk, "ipaddresses", server_key)
         winner, marker = _resolve_winner_for_donor(donor, server_key)
         if marker is None:
@@ -676,7 +680,9 @@ class TransferDeviceIPView(_BaseMoveToWinnerView):
         field, human = self._FIELD_MAP[ip_kind]
 
         donor = get_object_or_404(Device, pk=pk)
-        server_key = _server_key_from_request(request, default_factory=lambda: self.librenms_api.server_key)
+        # Fall back to active_server_key (never builds LibreNMSAPI) so a misconfigured default
+        # server can't 500 a move that only needs the marker's server namespace, not the live API.
+        server_key = _server_key_from_request(request, default_factory=lambda: self.active_server_key)
         self._fallback_url = _sync_tab_url(donor.pk, "ipaddresses", server_key)
         winner, marker = _resolve_winner_for_donor(donor, server_key)
         if marker is None:

--- a/netbox_librenms_plugin/views/sync/migrate.py
+++ b/netbox_librenms_plugin/views/sync/migrate.py
@@ -21,7 +21,6 @@ from django.db import IntegrityError, transaction
 from django.http import HttpResponse
 from django.shortcuts import get_object_or_404, redirect
 from django.urls import get_script_prefix, reverse
-from django.utils.http import url_has_allowed_host_and_scheme
 from django.views import View
 from ipam.models import IPAddress
 
@@ -36,6 +35,7 @@ from netbox_librenms_plugin.views.mixins import (
     LibreNMSAPIMixin,
     LibreNMSPermissionMixin,
     NetBoxObjectPermissionMixin,
+    validated_referer,
 )
 
 logger = logging.getLogger(__name__)
@@ -210,12 +210,9 @@ def _safe_referer(request, fallback=None):
     Returns:
         str: The validated Referer, or *fallback* / the app mount path.
     """
-    referer = request.META.get("HTTP_REFERER")
-    if referer and url_has_allowed_host_and_scheme(
-        referer,
-        allowed_hosts={request.get_host()},
-        require_https=request.is_secure(),
-    ):
+    # Delegate the CWE-601 Referer check to the shared barrier so this and _get_safe_redirect_url
+    # can't drift; this endpoint keeps its own fallback (a server-built sync-tab URL, else prefix).
+    if referer := validated_referer(request):
         return referer
     return fallback or get_script_prefix()
 

--- a/netbox_librenms_plugin/views/sync/migrate.py
+++ b/netbox_librenms_plugin/views/sync/migrate.py
@@ -87,8 +87,8 @@ def _winner_unavailable_reason(donor, marker):
     is a corrupt marker. Mirrors the staleness checks in :func:`_resolve_winner_for_donor`.
 
     Returns:
-        str: ``"deleted"`` (well-formed id, winner row gone) or ``"corrupt"``
-            (bool/unparseable ``device_id``, or self-pointing).
+        str: ``"deleted"`` (well-formed positive id, winner row gone) or ``"corrupt"``
+            (bool/unparseable/non-positive ``device_id``, or self-pointing).
     """
     device_id = marker.get("device_id")
     if isinstance(device_id, bool):
@@ -97,7 +97,10 @@ def _winner_unavailable_reason(donor, marker):
         winner_pk = int(device_id)
     except (TypeError, ValueError):
         return "corrupt"
-    if winner_pk == donor.pk:
+    # A non-positive pk is never a real Device row, so int() succeeding doesn't make it a
+    # "deleted winner" — it's a corrupt marker. Classify it as such so recovery isn't sent
+    # chasing a device that never existed.
+    if winner_pk <= 0 or winner_pk == donor.pk:
         return "corrupt"
     return "deleted"
 

--- a/netbox_librenms_plugin/views/sync/migrate.py
+++ b/netbox_librenms_plugin/views/sync/migrate.py
@@ -51,6 +51,8 @@ def _resolve_winner_for_donor(donor, server_key="default"):
             ``(None, None)`` when no marker is present; ``(None, marker)`` when the
             marker is stale (winner deleted, unparseable ``device_id``, or
             self-pointing) so callers can distinguish "no marker" from "stale marker".
+            Use :func:`_winner_unavailable_reason` to tell a deleted winner from a
+            corrupt marker.
     """
     marker = get_migrated_to_marker(donor, server_key)
     if not marker:
@@ -74,6 +76,41 @@ def _resolve_winner_for_donor(donor, server_key="default"):
     if winner.pk == donor.pk:
         return None, marker
     return winner, marker
+
+
+def _winner_unavailable_reason(donor, marker):
+    """
+    Classify a present ``_migrated_to`` marker that resolved to no winner.
+
+    Called only on the ``(None, marker)`` path of :func:`_resolve_winner_for_donor`, so a
+    well-formed, non-self ``device_id`` here means the winner row was deleted; anything else
+    is a corrupt marker. Mirrors the staleness checks in :func:`_resolve_winner_for_donor`.
+
+    Returns:
+        str: ``"deleted"`` (well-formed id, winner row gone) or ``"corrupt"``
+            (bool/unparseable ``device_id``, or self-pointing).
+    """
+    device_id = marker.get("device_id")
+    if isinstance(device_id, bool):
+        return "corrupt"
+    try:
+        winner_pk = int(device_id)
+    except (TypeError, ValueError):
+        return "corrupt"
+    if winner_pk == donor.pk:
+        return "corrupt"
+    return "deleted"
+
+
+def _fail_winner_unavailable(view, request, donor, marker):
+    """Render the right error for a present-but-unresolvable migration marker."""
+    if _winner_unavailable_reason(donor, marker) == "corrupt":
+        return view._fail(
+            request,
+            "Donor migration marker is stale or corrupt; clear it and re-run the migration.",
+            status=409,
+        )
+    return view._fail(request, "Winner device no longer exists.", status=410)
 
 
 def _server_key_from_request(request, default_factory=None):
@@ -363,7 +400,7 @@ class MoveInterfaceToWinnerView(_BaseMoveToWinnerView):
         if marker is None:
             return self._fail(request, "Donor device is not marked as migrated.", status=409)
         if winner is None:
-            return self._fail(request, "Winner device no longer exists.", status=410)
+            return _fail_winner_unavailable(self, request, donor, marker)
 
         # Quick pre-check before acquiring the lock (avoids round-trip in the
         # obvious already-taken case).  The check is repeated under the lock
@@ -512,7 +549,7 @@ class MoveIPAddressToWinnerView(_BaseMoveToWinnerView):
         if marker is None:
             return self._fail(request, "Donor device is not marked as migrated.", status=409)
         if winner is None:
-            return self._fail(request, "Winner device no longer exists.", status=410)
+            return _fail_winner_unavailable(self, request, donor, marker)
 
         # Quick pre-check before acquiring the lock.  Repeated under lock below.
         if not Interface.objects.filter(device=winner, name=assigned.name).exists():
@@ -609,7 +646,7 @@ class TransferDeviceIPView(_BaseMoveToWinnerView):
         if marker is None:
             return self._fail(request, "Donor device is not marked as migrated.", status=409)
         if winner is None:
-            return self._fail(request, "Winner device no longer exists.", status=410)
+            return _fail_winner_unavailable(self, request, donor, marker)
 
         donor_ip = getattr(donor, field, None)
         if donor_ip is None:

--- a/netbox_librenms_plugin/views/sync/migrate.py
+++ b/netbox_librenms_plugin/views/sync/migrate.py
@@ -477,6 +477,13 @@ class MoveInterfaceToWinnerView(_BaseMoveToWinnerView):
             # _site/_location/_rack columns. A bare .update(device=...) would skip all of
             # that (stale denormalized location + no relationship validation).
             interface.device = winner
+            # Coupling to a private NetBox internal: ComponentModel seeds
+            # _original_device from device_id in __init__ and clean() raises
+            # "Components cannot be moved to a different device" when it differs
+            # (dcim/models/device_components.py — ComponentModel.__init__ /
+            # ComponentModel.clean). If a NetBox upgrade renames or drops this
+            # attribute, the move below will silently stop working or 500 — treat
+            # any change to that attribute as a breaking change in upgrade notes.
             interface._original_device = winner.pk
             try:
                 interface.full_clean()

--- a/netbox_librenms_plugin/views/sync/migrate.py
+++ b/netbox_librenms_plugin/views/sync/migrate.py
@@ -365,6 +365,64 @@ class _BaseMoveToWinnerView(LibreNMSAPIMixin, LibreNMSPermissionMixin, NetBoxObj
         messages.error(request, msg)
         return redirect(_safe_referer(request, self._fallback_url))
 
+    def _resolve_winner_or_fail(self, request, donor, server_key):
+        """
+        Resolve the migration winner for *donor*, or return an early failure response.
+
+        Returns ``(winner, None)`` when the donor is marked migrated and its winner resolves;
+        otherwise ``(None, error_response)`` — the caller returns the response verbatim. Shared by
+        the three move endpoints so the "not marked" / winner-unavailable branches can't drift.
+
+        Args:
+            request: The current HTTP request.
+            donor: The donor device whose migration marker is resolved.
+            server_key (str): The LibreNMS server key the marker is namespaced under.
+
+        Returns:
+            tuple: ``(winner, None)`` on success, or ``(None, error_response)`` on failure.
+        """
+        winner, marker = _resolve_winner_for_donor(donor, server_key)
+        if marker is None:
+            return None, self._fail(request, "Donor device is not marked as migrated.", status=409)
+        if winner is None:
+            return None, _fail_winner_unavailable(self, request, donor, marker)
+        return winner, None
+
+    def _lock_donor_winner_and_reverify(self, request, donor, winner, server_key):
+        """
+        Lock donor+winner by pk order and re-verify the migration marker under the lock.
+
+        Must be called inside a ``transaction.atomic()`` block. Locks both devices in pk order
+        (deadlock-safe), then re-resolves the winner under the lock so a concurrent request that
+        cleared or repointed ``_migrated_to`` between the unlocked resolve and acquiring these row
+        locks can't move the resource to a stale winner (TOCTOU). Shared by the three move endpoints
+        so this concurrency guard lives in one place.
+
+        Args:
+            request: The current HTTP request.
+            donor: The donor device (re-read under the lock).
+            winner: The winner device resolved before the lock (re-verified under it).
+            server_key (str): The LibreNMS server key the marker is namespaced under.
+
+        Returns:
+            tuple: ``(locked_donor, locked_winner, None)`` on success, or ``(None, None,
+                error_response)`` when a device was deleted or the marker changed concurrently.
+        """
+        ordered = sorted({donor.pk, winner.pk})
+        locked = {d.pk: d for d in Device.objects.select_for_update().filter(pk__in=ordered).order_by("pk")}
+        donor = locked.get(donor.pk)
+        winner = locked.get(winner.pk)
+        if donor is None or winner is None:
+            return None, None, self._fail(request, "Device was deleted concurrently.", status=410)
+        relocked_winner, relocked_marker = _resolve_winner_for_donor(donor, server_key)
+        if relocked_marker is None or relocked_winner is None or relocked_winner.pk != winner.pk:
+            return (
+                None,
+                None,
+                self._fail(request, "Donor migration changed concurrently; refresh and retry.", status=409),
+            )
+        return donor, winner, None
+
 
 class MoveInterfaceToWinnerView(_BaseMoveToWinnerView):
     """
@@ -399,11 +457,9 @@ class MoveInterfaceToWinnerView(_BaseMoveToWinnerView):
         # server can't 500 a move that only needs the marker's server namespace, not the live API.
         server_key = _server_key_from_request(request, default_factory=lambda: self.active_server_key)
         self._fallback_url = _sync_tab_url(donor.pk, "interfaces", server_key)
-        winner, marker = _resolve_winner_for_donor(donor, server_key)
-        if marker is None:
-            return self._fail(request, "Donor device is not marked as migrated.", status=409)
-        if winner is None:
-            return _fail_winner_unavailable(self, request, donor, marker)
+        winner, err = self._resolve_winner_or_fail(request, donor, server_key)
+        if err is not None:
+            return err
 
         # Quick pre-check before acquiring the lock (avoids round-trip in the
         # obvious already-taken case).  The check is repeated under the lock
@@ -417,20 +473,9 @@ class MoveInterfaceToWinnerView(_BaseMoveToWinnerView):
             )
 
         with transaction.atomic():
-            # Lock both devices in pk order to avoid cross-merge deadlocks.
-            ordered = sorted({donor.pk, winner.pk})
-            locked = {d.pk: d for d in Device.objects.select_for_update().filter(pk__in=ordered).order_by("pk")}
-            donor = locked.get(donor.pk)
-            winner = locked.get(winner.pk)
-            if donor is None or winner is None:
-                return self._fail(request, "Device was deleted concurrently.", status=410)
-            # Re-verify the migration marker under the lock: a concurrent request
-            # could have cleared or repointed _migrated_to between the unlocked
-            # resolve above and acquiring these row locks, which would otherwise
-            # move the interface to the wrong (stale) winner.
-            relocked_winner, relocked_marker = _resolve_winner_for_donor(donor, server_key)
-            if relocked_marker is None or relocked_winner is None or relocked_winner.pk != winner.pk:
-                return self._fail(request, "Donor migration changed concurrently; refresh and retry.", status=409)
+            donor, winner, err = self._lock_donor_winner_and_reverify(request, donor, winner, server_key)
+            if err is not None:
+                return err
             # Lock the donor interface row and re-read it under the lock. A
             # concurrent rename would otherwise let a stale name slip past the
             # collision check below while the row is still moved by pk.
@@ -564,11 +609,9 @@ class MoveIPAddressToWinnerView(_BaseMoveToWinnerView):
         # server can't 500 a move that only needs the marker's server namespace, not the live API.
         server_key = _server_key_from_request(request, default_factory=lambda: self.active_server_key)
         self._fallback_url = _sync_tab_url(donor.pk, "ipaddresses", server_key)
-        winner, marker = _resolve_winner_for_donor(donor, server_key)
-        if marker is None:
-            return self._fail(request, "Donor device is not marked as migrated.", status=409)
-        if winner is None:
-            return _fail_winner_unavailable(self, request, donor, marker)
+        winner, err = self._resolve_winner_or_fail(request, donor, server_key)
+        if err is not None:
+            return err
 
         # Quick pre-check before acquiring the lock.  Repeated under lock below.
         if not Interface.objects.filter(device=winner, name=assigned.name).exists():
@@ -580,17 +623,9 @@ class MoveIPAddressToWinnerView(_BaseMoveToWinnerView):
             )
 
         with transaction.atomic():
-            ordered = sorted({donor.pk, winner.pk})
-            locked = {d.pk: d for d in Device.objects.select_for_update().filter(pk__in=ordered).order_by("pk")}
-            donor = locked.get(donor.pk)
-            winner = locked.get(winner.pk)
-            if donor is None or winner is None:
-                return self._fail(request, "Device was deleted concurrently.", status=410)
-            # Re-verify the migration marker under the lock (it could have been
-            # cleared or repointed since the unlocked resolve above).
-            relocked_winner, relocked_marker = _resolve_winner_for_donor(donor, server_key)
-            if relocked_marker is None or relocked_winner is None or relocked_winner.pk != winner.pk:
-                return self._fail(request, "Donor migration changed concurrently; refresh and retry.", status=409)
+            donor, winner, err = self._lock_donor_winner_and_reverify(request, donor, winner, server_key)
+            if err is not None:
+                return err
             ip = IPAddress.objects.select_for_update().filter(pk=ip.pk).first()
             if ip is None:
                 return self._fail(request, "IP address no longer exists.", status=410)
@@ -669,11 +704,9 @@ class TransferDeviceIPView(_BaseMoveToWinnerView):
         # server can't 500 a move that only needs the marker's server namespace, not the live API.
         server_key = _server_key_from_request(request, default_factory=lambda: self.active_server_key)
         self._fallback_url = _sync_tab_url(donor.pk, "ipaddresses", server_key)
-        winner, marker = _resolve_winner_for_donor(donor, server_key)
-        if marker is None:
-            return self._fail(request, "Donor device is not marked as migrated.", status=409)
-        if winner is None:
-            return _fail_winner_unavailable(self, request, donor, marker)
+        winner, err = self._resolve_winner_or_fail(request, donor, server_key)
+        if err is not None:
+            return err
 
         donor_ip = getattr(donor, field, None)
         if donor_ip is None:
@@ -687,17 +720,9 @@ class TransferDeviceIPView(_BaseMoveToWinnerView):
             )
 
         with transaction.atomic():
-            ordered = sorted({donor.pk, winner.pk})
-            locked = {d.pk: d for d in Device.objects.select_for_update().filter(pk__in=ordered).order_by("pk")}
-            donor = locked.get(donor.pk)
-            winner = locked.get(winner.pk)
-            if donor is None or winner is None:
-                return self._fail(request, "Device was deleted concurrently.", status=410)
-            # Re-verify the migration marker under the lock (it could have been
-            # cleared or repointed since the unlocked resolve above).
-            relocked_winner, relocked_marker = _resolve_winner_for_donor(donor, server_key)
-            if relocked_marker is None or relocked_winner is None or relocked_winner.pk != winner.pk:
-                return self._fail(request, "Donor migration changed concurrently; refresh and retry.", status=409)
+            donor, winner, err = self._lock_donor_winner_and_reverify(request, donor, winner, server_key)
+            if err is not None:
+                return err
             # Re-check under the lock so concurrent transfers don't race.
             donor_ip = getattr(donor, field, None)
             if donor_ip is None:

--- a/netbox_librenms_plugin/views/sync/migrate.py
+++ b/netbox_librenms_plugin/views/sync/migrate.py
@@ -63,6 +63,10 @@ def _resolve_winner_for_donor(donor, server_key="default"):
     # like {"device_id": true} must fail closed as a stale/invalid marker.
     if isinstance(device_id, bool):
         return None, marker
+    # int() truncates numeric-like values (1.9, Decimal("1.9")) to a valid-looking pk, which
+    # would resolve the WRONG winner. Accept only a real int or a plain digit string.
+    if not (isinstance(device_id, int) or (isinstance(device_id, str) and device_id.isdecimal())):
+        return None, marker
     try:
         winner_pk = int(device_id)
     except (TypeError, ValueError):
@@ -92,6 +96,10 @@ def _winner_unavailable_reason(donor, marker):
     """
     device_id = marker.get("device_id")
     if isinstance(device_id, bool):
+        return "corrupt"
+    # Mirror _resolve_winner_for_donor: a numeric-like value int() would truncate (1.9,
+    # Decimal("1.9")) is a corrupt marker, not a deleted winner.
+    if not (isinstance(device_id, int) or (isinstance(device_id, str) and device_id.isdecimal())):
         return "corrupt"
     try:
         winner_pk = int(device_id)

--- a/netbox_librenms_plugin/views/sync/migrate.py
+++ b/netbox_librenms_plugin/views/sync/migrate.py
@@ -636,6 +636,9 @@ class MoveInterfaceToWinnerView(_BaseMoveToWinnerView):
             try:
                 interface.save()
             except IntegrityError:
+                # IntegrityError already marks this atomic block rollback-only; keep the
+                # rollback explicit here to match the non-database failure handlers below.
+                transaction.set_rollback(True)
                 # A concurrent rename/create on the winner side can still trip a DB unique
                 # constraint between our name re-check and this save. Surface it as the same
                 # 409 the collision check uses rather than letting it bubble up as a 500.

--- a/netbox_librenms_plugin/views/sync/migrate.py
+++ b/netbox_librenms_plugin/views/sync/migrate.py
@@ -27,6 +27,7 @@ from ipam.models import IPAddress
 from netbox_librenms_plugin.utils import (
     DEVICE_IP_FK_FIELDS,
     DEVICE_IP_FK_LABELS,
+    coerce_librenms_id,
     get_migrated_to_marker,
     set_device_ip_fk,
 )
@@ -35,6 +36,7 @@ from netbox_librenms_plugin.views.mixins import (
     LibreNMSAPIMixin,
     LibreNMSPermissionMixin,
     NetBoxObjectPermissionMixin,
+    resolve_configured_server_key,
     validated_referer,
 )
 
@@ -45,21 +47,17 @@ def _parse_marker_winner_pk(device_id):
     """
     Parse a ``_migrated_to`` marker's ``device_id`` to a positive int pk, or None if invalid.
 
-    bool is rejected (it subclasses int, so ``int(True) == 1`` would misroute a move), and only a
-    real int or a plain digit string is accepted (``int()`` would truncate ``1.9`` / ``Decimal('1.9')``
-    to a valid-looking but wrong pk). A non-positive result is rejected too — it can never be a real
-    Device row. Shared by :func:`_resolve_winner_for_donor` and :func:`_winner_unavailable_reason`
-    so the two can't drift on what counts as a parseable winner id.
+    A marker id from a tampered/legacy source may arrive as a string: accept ONLY a plain digit
+    string (``str.isdecimal()``) so whitespace/sign/decimal forms (``" 5 "``, ``"+5"``, ``"1.9"``)
+    fail closed — deliberately stricter than the raw ``int()`` :func:`~netbox_librenms_plugin.utils.
+    coerce_librenms_id` applies to LibreNMS ids. The int/positive-value coercion itself is delegated
+    to ``coerce_librenms_id`` (bool rejected, positive int only) so that rule lives in one place and
+    can't drift from the rest of the plugin's id handling. Shared by :func:`_resolve_winner_for_donor`
+    and :func:`_winner_unavailable_reason` so the two can't disagree on a parseable winner id.
     """
-    if isinstance(device_id, bool):
+    if isinstance(device_id, str) and not device_id.isdecimal():
         return None
-    if not (isinstance(device_id, int) or (isinstance(device_id, str) and device_id.isdecimal())):
-        return None
-    try:
-        pk = int(device_id)
-    except (TypeError, ValueError):
-        return None
-    return pk if pk > 0 else None
+    return coerce_librenms_id(device_id)
 
 
 def _resolve_winner_for_donor(donor, server_key="default"):
@@ -181,14 +179,12 @@ def _sync_tab_url(device_pk, tab, server_key):
         str: The sync URL with ``tab`` (and a validated ``server_key``) query params.
     """
     url = f"{reverse('plugins:netbox_librenms_plugin:device_librenms_sync', args=[device_pk])}?tab={tab}"
-    if server_key:
-        # Re-source the key from the trusted config rather than reflecting the raw POST value:
-        # only append it when it matches a configured server (a stale/tampered key resolves to
-        # nothing and is dropped). Mirrors device_fields._sync_redirect's allowlist guard.
-        from netbox_librenms_plugin.librenms_api import LibreNMSAPI
-
-        if server_key in LibreNMSAPI.get_available_servers():
-            url += f"&server_key={quote_plus(server_key)}"
+    # Re-source the key from the trusted config rather than reflecting the raw POST value: append it
+    # only when it matches a configured server (a stale/tampered key resolves to None and is dropped).
+    # The allowlist policy is shared with device_fields._sync_redirect via resolve_configured_server_key.
+    configured_key = resolve_configured_server_key(server_key)
+    if configured_key:
+        url += f"&server_key={quote_plus(configured_key)}"
     return url
 
 

--- a/netbox_librenms_plugin/views/sync/migrate.py
+++ b/netbox_librenms_plugin/views/sync/migrate.py
@@ -296,6 +296,14 @@ def _reconcile_donor_device_ip_fks(donor, winner):
         locked_iface = Interface.objects.select_for_update().filter(pk=assigned.pk).first()
         if locked_iface is None or locked_iface.device_id != winner.pk:
             continue
+        # Refresh the cached GenericForeignKey on `ip` to the freshly locked interface:
+        # set_device_ip_fk()'s internal ownership check re-reads ip.assigned_object, and the
+        # GFK cache still holds the pre-lock snapshot (the FK id fields never changed, so
+        # Django won't re-query). A move ONTO the winner landing between the read above and
+        # the lock would otherwise pass the locked-row gate here and then be spuriously
+        # rejected against the stale device_id — the freshen-after-lock pattern
+        # TransferDeviceIPView already uses.
+        ip.assigned_object = locked_iface
         if getattr(winner, f"{field}_id", None) is None:
             # device.primary_ip4/6 / oob_ip are UNIQUE per address, so the donor must release the
             # FK *before* the winner claims it — saving the winner first while the donor still

--- a/netbox_librenms_plugin/views/sync/migrate.py
+++ b/netbox_librenms_plugin/views/sync/migrate.py
@@ -508,7 +508,14 @@ class MoveInterfaceToWinnerView(_BaseMoveToWinnerView):
             # The moved interface may carry an address the donor still points at via
             # primary_ip4/primary_ip6/oob_ip; reconcile those device FKs so the donor isn't
             # left referencing an address now on a winner-owned interface.
-            notes = _reconcile_donor_device_ip_fks(donor, winner)
+            try:
+                notes = _reconcile_donor_device_ip_fks(donor, winner)
+            except ValueError as exc:
+                # A corrupt donor IP FK (e.g. a primary_ip4 referencing an IPv6 address) makes
+                # set_device_ip_fk() refuse the transfer. Fail closed — roll back the whole move
+                # rather than 500ing or leaving the donor with a dangling FK NetBox rejects.
+                transaction.set_rollback(True)
+                return self._fail(request, f"Cannot reconcile donor IP assignments: {exc}", status=409)
 
         message = f"Moved interface '{interface.name}' to {winner.name}."
         if notes:
@@ -610,7 +617,14 @@ class MoveIPAddressToWinnerView(_BaseMoveToWinnerView):
             # The moved address may itself be the donor's primary_ip4/primary_ip6/oob_ip;
             # reconcile those device FKs so the donor isn't left referencing an address now on a
             # winner-owned interface.
-            notes = _reconcile_donor_device_ip_fks(donor, winner)
+            try:
+                notes = _reconcile_donor_device_ip_fks(donor, winner)
+            except ValueError as exc:
+                # A corrupt donor IP FK (e.g. a primary_ip4 referencing an IPv6 address) makes
+                # set_device_ip_fk() refuse the transfer. Fail closed — roll back the whole move
+                # rather than 500ing or leaving the donor with a dangling FK NetBox rejects.
+                transaction.set_rollback(True)
+                return self._fail(request, f"Cannot reconcile donor IP assignments: {exc}", status=409)
 
         message = f"Moved IP {ip.address} to {winner.name} interface '{winner_iface.name}'."
         if notes:
@@ -732,8 +746,15 @@ class TransferDeviceIPView(_BaseMoveToWinnerView):
             # the bare update_fields save would skip. device.primary_ip4/6 / oob_ip are UNIQUE
             # per address, so the donor must release the FK (saved first, below) BEFORE the
             # winner claims it — the reverse order trips the unique constraint.
-            set_device_ip_fk(donor, field, None)
-            set_device_ip_fk(winner, field, donor_ip)
+            try:
+                set_device_ip_fk(donor, field, None)
+                set_device_ip_fk(winner, field, donor_ip)
+            except ValueError as exc:
+                # A corrupt donor FK (e.g. a primary_ip4 referencing an IPv6 address) makes
+                # set_device_ip_fk() refuse the claim. Roll back the donor release rather than
+                # 500ing or leaving the donor's FK cleared with the winner's left unset.
+                transaction.set_rollback(True)
+                return self._fail(request, f"Cannot transfer {human}: {exc}", status=409)
 
         return _hx_response(
             request,

--- a/netbox_librenms_plugin/views/sync/modules.py
+++ b/netbox_librenms_plugin/views/sync/modules.py
@@ -1440,7 +1440,7 @@ class UpdateModuleInterfaceView(
             module_id = int(request.POST.get("module_id"))
         except (TypeError, ValueError):
             messages.error(request, "Missing or invalid module ID.")
-            return _modules_redirect_response(request, sync_url)
+            return _modules_redirect_response(request, sync_url, server_key)
 
         module = get_object_or_404(Module, pk=module_id, device=target_device)
 
@@ -1534,7 +1534,7 @@ class UpdateModuleInterfaceView(
                 f"Could not update interface association: {bind_result.get('reason', 'unknown reason')}",
             )
 
-        return _modules_redirect_response(request, sync_url)
+        return _modules_redirect_response(request, sync_url, server_key)
 
 
 class ModuleMismatchPreviewView(

--- a/netbox_librenms_plugin/views/sync/modules.py
+++ b/netbox_librenms_plugin/views/sync/modules.py
@@ -1523,11 +1523,7 @@ class UpdateModuleInterfaceView(
             messages.error(request, "No LibreNMS interface identity is available for this row.")
         elif bind_result.get("status") == "bound":
             location = f"{module.module_type.model} in {module.module_bay.name}"
-            # Only announce an update that actually changed something: a no-op rebind returns
-            # changed=False (nothing written). Gate on changed (or an adoption tally) so a no-op
-            # click doesn't tell the user an interface was updated when it wasn't.
-            if bind_result.get("changed") or bind_result.get("adopted_count"):
-                messages.success(request, _module_interface_update_message(bind_result, location))
+            messages.success(request, _module_interface_update_message(bind_result, location))
         else:
             messages.warning(
                 request,

--- a/netbox_librenms_plugin/views/sync/modules.py
+++ b/netbox_librenms_plugin/views/sync/modules.py
@@ -318,6 +318,11 @@ def _module_interface_update_message(bind_result, location):
         )
     if adopted_count:
         return f"Updated interfaces for {location}: adopted {adopted_count} existing standalone interface(s)."
+    if not interface_name:
+        # Pure-adoption path (bind_item is None) where a concurrent/duplicate request already
+        # adopted the interfaces, so adopted_count is 0 too: neither branch above fired. Without
+        # this guard the fall-through renders "Updated interface None for ..." to the user.
+        return f"No interface changes were needed for {location}."
     return f"Updated interface {interface_name} for {location}."
 
 

--- a/netbox_librenms_plugin/views/sync/modules.py
+++ b/netbox_librenms_plugin/views/sync/modules.py
@@ -311,6 +311,8 @@ def _module_interface_update_message(bind_result, location):
     """
     interface_name = bind_result.get("interface")
     adopted_count = bind_result.get("adopted_count") or 0
+    if bind_result.get("changed") is False and not adopted_count:
+        return f"No interface changes were needed for {location}."
     if interface_name and adopted_count:
         return (
             f"Updated interface {interface_name} for {location} and "


### PR DESCRIPTION
## Summary
**Stacked on #324 — review only the delta over.**

Device merge / move-to-winner migration. When two NetBox devices represent one physical box (e.g. a host and its separately-imported OOB controller), pick a winner and move the donor's interfaces, IP addresses and cables onto it, then mark the donor migrated. A migrated donor's sync controls are suppressed so it isn't re-synced.

## Motivation / Problem
Feature. Consolidate duplicate NetBox devices found during import without losing interfaces/IPs/cables.

## Scope of Change
- Sync/Import logic
- NetBox models / ORM
- Web UI / templates
- Tests

## How Was This Tested?
- Unit tests: yes — winner/donor resolution, FK transfer (IP unique-constraint ordering), migrated-marker handling, donor-sync suppression; real Device/Interface/IP rows.
- Manual testing: yes — merge a host + OOB controller, verify FKs moved and donor marked migrated.

## Risk Assessment
Moves FKs between existing devices; gated behind explicit user action. No automatic merges.

## Backwards Compatibility
- No breaking changes