### PR TITLE
feat: bulk import - followup for OOB/Sync

### DIFF
--- a/netbox_librenms_plugin/import_utils/__init__.py
+++ b/netbox_librenms_plugin/import_utils/__init__.py
@@ -33,6 +33,7 @@ from .device_operations import (  # noqa: F401
     import_single_device,
     validate_device_for_import,
 )
+from .collisions import detect_bulk_collisions  # noqa: F401
 from .filters import (  # noqa: F401
     _apply_client_filters,
     get_device_count_for_filters,

--- a/netbox_librenms_plugin/import_utils/__init__.py
+++ b/netbox_librenms_plugin/import_utils/__init__.py
@@ -15,8 +15,10 @@ The F401 suppressions prevent linters from flagging them as unused.
 """
 
 from .bulk_import import (  # noqa: F401
+    BulkPrecheckOutcome,
     bulk_import_devices,
     bulk_import_devices_shared,
+    classify_bulk_precheck,
     detect_collisions_for_device_ids,
     process_device_filters,
 )

--- a/netbox_librenms_plugin/import_utils/__init__.py
+++ b/netbox_librenms_plugin/import_utils/__init__.py
@@ -42,7 +42,7 @@ from .filters import (  # noqa: F401
     get_device_count_for_filters,
     get_librenms_devices_for_import,
 )
-from .permissions import check_user_permissions, require_permissions  # noqa: F401
+from .permissions import check_user_permissions, require_permissions, required_import_permissions  # noqa: F401
 from .virtual_chassis import (  # noqa: F401
     _clone_virtual_chassis_data,
     _generate_vc_member_name,

--- a/netbox_librenms_plugin/import_utils/__init__.py
+++ b/netbox_librenms_plugin/import_utils/__init__.py
@@ -17,6 +17,7 @@ The F401 suppressions prevent linters from flagging them as unused.
 from .bulk_import import (  # noqa: F401
     bulk_import_devices,
     bulk_import_devices_shared,
+    detect_collisions_for_device_ids,
     process_device_filters,
 )
 from .cache import (  # noqa: F401

--- a/netbox_librenms_plugin/import_utils/bulk_import.py
+++ b/netbox_librenms_plugin/import_utils/bulk_import.py
@@ -88,7 +88,7 @@ def _is_job_cancelled(job) -> bool:
 
 
 def detect_collisions_for_device_ids(
-    device_ids, api, libre_devices_cache=None, sync_options=None
+    device_ids, api, libre_devices_cache=None, sync_options=None, job=None
 ) -> tuple[list[dict], list]:
     """
     Detect same-NetBox-device collisions for a batch of LibreNMS device ids.
@@ -109,14 +109,18 @@ def detect_collisions_for_device_ids(
             ``get_device_info`` is called only for ids missing from the cache).
         libre_devices_cache: Optional ``{device_id: libre_device}`` pre-fetched data.
         sync_options: Optional sync options (``use_sysname`` / ``strip_domain``).
+        job: Optional background-job context. When set, cancellation is polled the same
+            way the import loops poll it (first id, then every 5th); a cancelled job stops
+            the scan instead of finishing a large cache-miss batch's API calls.
 
     Returns:
         tuple[list[dict], list]: ``(collisions, unresolved_ids)`` — the collision groups from
             :func:`detect_bulk_collisions` (empty when the batch is clean), and the device ids
             that could NOT be validated (``get_device_info`` failed and they weren't in the
-            cache). Those ids were not collision-checked, so the caller must fail closed on them
-            rather than import them unchecked — a transient miss could otherwise slip a colliding
-            row through on a retry.
+            cache), plus — on a mid-scan cancellation — every id not yet scanned. Those ids
+            were not collision-checked, so the caller must fail closed on them rather than
+            import them unchecked — a transient miss could otherwise slip a colliding row
+            through on a retry.
     """
     use_sysname = (sync_options or {}).get("use_sysname", True)
     strip_domain = (sync_options or {}).get("strip_domain", False)
@@ -126,7 +130,18 @@ def detect_collisions_for_device_ids(
     cache = libre_devices_cache if libre_devices_cache is not None else {}
     devices = []
     unresolved_ids = []
-    for device_id in device_ids:
+    device_ids = list(device_ids)
+    for idx, device_id in enumerate(device_ids, start=1):
+        # Same cancellation cadence as the import loops below (first id, then every 5th):
+        # a large batch with many cache misses is one LibreNMS call per id, so a cancelled
+        # job must not sit through the whole scan. The unscanned remainder goes to
+        # unresolved_ids — those ids were NOT collision-checked, and the caller's existing
+        # unresolved gate already fails closed on them, so nothing imports unchecked.
+        if job and (idx == 1 or idx % 5 == 0) and _is_job_cancelled(job):
+            if getattr(job, "logger", None):
+                job.logger.warning(f"Collision pre-check stopped by cancellation at id {idx} of {len(device_ids)}")
+            unresolved_ids.extend(device_ids[idx - 1 :])
+            break
         libre_device = cache.get(device_id)
         if libre_device is None:
             success, libre_device = api.get_device_info(device_id)

--- a/netbox_librenms_plugin/import_utils/bulk_import.py
+++ b/netbox_librenms_plugin/import_utils/bulk_import.py
@@ -152,7 +152,7 @@ def detect_collisions_for_device_ids(
         libre_device = cache.get(device_id)
         if libre_device is None:
             success, libre_device = api.get_device_info(device_id)
-            if not success or not libre_device:
+            if not success or not isinstance(libre_device, dict):
                 # Couldn't fetch device info → can't collision-check this id. Record it so the
                 # caller blocks it instead of importing it unchecked (fail closed).
                 unresolved_ids.append(device_id)
@@ -162,6 +162,15 @@ def detect_collisions_for_device_ids(
             # same device from LibreNMS. Without this, the collision pre-check doubles the API
             # round-trips for any id the caller didn't already pre-populate.
             cache[device_id] = libre_device
+        # Fail closed on a bad cached payload too: a negatively-cached lookup (an empty dict or a
+        # row whose device_id doesn't match the requested id — e.g. a stale/mis-keyed cache entry)
+        # would otherwise reach validation as a brand-new device and make the collision gate report
+        # a clean scan for an id it never actually verified.
+        requested_id = coerce_librenms_id(device_id)
+        cached_id = coerce_librenms_id(libre_device.get("device_id")) if isinstance(libre_device, dict) else None
+        if requested_id is None or cached_id != requested_id:
+            unresolved_ids.append(device_id)
+            continue
         validation = validate_device_for_import(
             # DB-only collision pre-check: don't hand the validator an API client (it would let
             # API-backed validation paths run even with the cache supplied + include_vc_detection

--- a/netbox_librenms_plugin/import_utils/bulk_import.py
+++ b/netbox_librenms_plugin/import_utils/bulk_import.py
@@ -152,7 +152,18 @@ def detect_collisions_for_device_ids(
         libre_device = cache.get(device_id)
         just_fetched = False
         if libre_device is None:
-            success, libre_device = api.get_device_info(device_id)
+            try:
+                success, libre_device = api.get_device_info(device_id)
+            except Exception as exc:
+                # get_device_info can RAISE rather than return (False, None) — e.g. a cache-backend
+                # outage, since its cache.get() runs before its own try. An unhandled raise here would
+                # crash the whole gate/batch, but the gate's contract is to fail CLOSED per row, so
+                # treat an exception like a fetch miss: record the id unresolved and let the caller
+                # block it instead of importing it unchecked.
+                if getattr(job, "logger", None):
+                    job.logger.warning(f"Collision pre-check couldn't fetch device {device_id}: {exc}")
+                unresolved_ids.append(device_id)
+                continue
             if not success or not isinstance(libre_device, dict):
                 # Couldn't fetch device info → can't collision-check this id. Record it so the
                 # caller blocks it instead of importing it unchecked (fail closed).
@@ -385,9 +396,19 @@ def bulk_import_devices_shared(
             break
 
         try:
-            # Use cached device data if available to avoid redundant API calls
-            if libre_devices_cache and device_id in libre_devices_cache:
-                libre_device = libre_devices_cache[device_id]
+            # Use cached device data if available to avoid redundant API calls — but only when the
+            # cached row's OWN device_id doesn't contradict the requested id. A mis-keyed/stale cache
+            # entry (another device's row stored under this id) would otherwise be imported AS this
+            # device. detect_collisions_for_device_ids verifies this too, but its callers skip the
+            # pre-check for single-row imports, so re-check at the point of use; a contradiction falls
+            # through to a live fetch below. (A real LibreNMS row always carries device_id; a cached
+            # row lacking it can't be verified and is left trusted.)
+            cached_row = libre_devices_cache.get(device_id) if libre_devices_cache else None
+            cached_row_id = cached_row.get("device_id") if isinstance(cached_row, dict) else None
+            if cached_row is not None and (
+                cached_row_id is None or coerce_librenms_id(cached_row_id) == coerce_librenms_id(device_id)
+            ):
+                libre_device = cached_row
                 success = True
             else:
                 # Import decisions (DeviceType match, serial-conflict, hostname) must run against

--- a/netbox_librenms_plugin/import_utils/bulk_import.py
+++ b/netbox_librenms_plugin/import_utils/bulk_import.py
@@ -414,29 +414,33 @@ def _refresh_librenms_linkage(validation: dict, device, libre_device: dict, serv
     """
     link = _describe_existing_librenms_link(device, server_key)
     validation["existing_librenms_link"] = link
-    # Only re-classify librenms-id-based matches; leave serial/hostname/primary_ip
-    # match types untouched.
+
+    scanned_id = coerce_librenms_id((libre_device or {}).get("device_id"))
+    oob = get_librenms_oob(device, server_key=server_key)
+    oob_id = coerce_librenms_id(oob.get("id")) if oob else None
+
+    # Promote to a *current* librenms-id / OOB link first, regardless of the cached match type.
+    # A row cached as a serial/hostname conflict may since have gained the matching host/OOB
+    # librenms_id in NetBox; it should render as the link, not the stale conflict, instead of
+    # waiting for the cache to expire.
+    if scanned_id is not None and oob_id is not None and oob_id == scanned_id:
+        validation["existing_match_type"] = "librenms_oob"
+        return
+    if scanned_id is not None and link["host_id"] is not None and link["host_id"] == scanned_id:
+        validation["existing_match_type"] = "librenms_id"
+        return
+
+    # No current id/OOB link matches the scanned device. Only clear a *prior* librenms-id/OOB
+    # match here — leave serial/hostname/primary_ip match types untouched (evaluated elsewhere).
     if validation.get("existing_match_type") in ("librenms_id", "librenms_oob"):
-        scanned_id = coerce_librenms_id((libre_device or {}).get("device_id"))
         if scanned_id is None:
-            # The current scan didn't return a usable device_id (libre_device omitted or
-            # malformed). A missing scanned id is NOT proof the link disappeared — only drop
-            # the cached match when the DB linkage itself is gone; otherwise leave the prior
-            # match type until there's a real id to compare against.
+            # A missing scanned id (libre_device omitted/malformed) is NOT proof the link
+            # disappeared — only drop the cached match when the DB linkage itself is gone.
             if link["host_id"] is None and link["oob_id"] is None:
                 validation["existing_match_type"] = None
             return
-        oob = get_librenms_oob(device, server_key=server_key)
-        oob_id = coerce_librenms_id(oob.get("id")) if oob else None
-        if scanned_id is not None and oob_id is not None and oob_id == scanned_id:
-            validation["existing_match_type"] = "librenms_oob"
-        elif scanned_id is not None and link["host_id"] is not None and link["host_id"] == scanned_id:
-            # Host id still matches the scanned device — a genuine host-side link.
-            validation["existing_match_type"] = "librenms_id"
-        else:
-            # Linkage changed since caching: neither the host id nor the OOB id matches
-            # the scanned device anymore, so don't keep a stale librenms_id badge.
-            validation["existing_match_type"] = None
+        # scanned id present but neither the host id nor the OOB id matches it anymore.
+        validation["existing_match_type"] = None
 
 
 def _clear_existing_match_derived_fields(validation: dict) -> None:

--- a/netbox_librenms_plugin/import_utils/bulk_import.py
+++ b/netbox_librenms_plugin/import_utils/bulk_import.py
@@ -24,6 +24,7 @@ from ..utils import (
 from .cache import get_cache_metadata_key, get_import_device_cache_key, get_validated_device_cache_key
 from .collisions import detect_bulk_collisions
 from .device_operations import (
+    VALIDATION_ERROR_ISSUE_PREFIX,
     _describe_existing_librenms_link,
     import_single_device,
     resolve_device_by_host_ip,
@@ -143,12 +144,13 @@ def detect_collisions_for_device_ids(
             server_key=api.server_key,
             include_vc_detection=False,
         )
-        if any(str(issue).startswith("Validation error:") for issue in validation.get("issues", [])):
+        if any(str(issue).startswith(VALIDATION_ERROR_ISSUE_PREFIX) for issue in validation.get("issues", [])):
             # validate_device_for_import() caught an exception and returned only a partial result
-            # (its except branch appends a "Validation error: ..." issue). The collision-relevant
+            # (its except branch appends a VALIDATION_ERROR_ISSUE_PREFIX issue). The collision-relevant
             # match fields may be missing, so this id was NOT reliably collision-checked. Fail
             # closed: record it as unresolved rather than collision-check it on incomplete data
-            # (mirrors the get_device_info miss above).
+            # (mirrors the get_device_info miss above). The prefix is a shared constant so this
+            # guard can't silently drift from the producer's wording.
             unresolved_ids.append(device_id)
             continue
         devices.append(

--- a/netbox_librenms_plugin/import_utils/bulk_import.py
+++ b/netbox_librenms_plugin/import_utils/bulk_import.py
@@ -86,7 +86,9 @@ def _is_job_cancelled(job) -> bool:
         return False
 
 
-def detect_collisions_for_device_ids(device_ids, api, libre_devices_cache=None, sync_options=None) -> list[dict]:
+def detect_collisions_for_device_ids(
+    device_ids, api, libre_devices_cache=None, sync_options=None
+) -> tuple[list[dict], list]:
     """
     Detect same-NetBox-device collisions for a batch of LibreNMS device ids.
 
@@ -141,6 +143,14 @@ def detect_collisions_for_device_ids(device_ids, api, libre_devices_cache=None, 
             server_key=api.server_key,
             include_vc_detection=False,
         )
+        if any(str(issue).startswith("Validation error:") for issue in validation.get("issues", [])):
+            # validate_device_for_import() caught an exception and returned only a partial result
+            # (its except branch appends a "Validation error: ..." issue). The collision-relevant
+            # match fields may be missing, so this id was NOT reliably collision-checked. Fail
+            # closed: record it as unresolved rather than collision-check it on incomplete data
+            # (mirrors the get_device_info miss above).
+            unresolved_ids.append(device_id)
+            continue
         devices.append(
             {
                 "device_id": device_id,

--- a/netbox_librenms_plugin/import_utils/bulk_import.py
+++ b/netbox_librenms_plugin/import_utils/bulk_import.py
@@ -153,15 +153,17 @@ def detect_collisions_for_device_ids(
         just_fetched = False
         if libre_device is None:
             try:
-                success, libre_device = api.get_device_info(device_id)
+                # The verified row is written into the shared import cache below, so bypass the
+                # short-lived API snapshot just like the downstream import's own live read.
+                success, libre_device = api.get_device_info(device_id, use_cache=False)
             except Exception as exc:
-                # get_device_info can RAISE rather than return (False, None) — e.g. a cache-backend
-                # outage, since its cache.get() runs before its own try. An unhandled raise here would
-                # crash the whole gate/batch, but the gate's contract is to fail CLOSED per row, so
-                # treat an exception like a fetch miss: record the id unresolved and let the caller
-                # block it instead of importing it unchecked.
+                # get_device_info can raise rather than return (False, None), for example on an
+                # unexpected transport/backend failure. The gate's contract is to fail closed per
+                # row, so treat an exception like a fetch miss instead of crashing the whole batch.
                 if getattr(job, "logger", None):
                     job.logger.warning(f"Collision pre-check couldn't fetch device {device_id}: {exc}")
+                else:
+                    logger.warning("Collision pre-check couldn't fetch device %s: %s", device_id, exc)
                 unresolved_ids.append(device_id)
                 continue
             if not success or not isinstance(libre_device, dict):

--- a/netbox_librenms_plugin/import_utils/bulk_import.py
+++ b/netbox_librenms_plugin/import_utils/bulk_import.py
@@ -22,6 +22,7 @@ from ..utils import (
     find_by_librenms_id,
     normalize_serial,
     preload_normalization_rules,
+    row_identity_matches,
 )
 from .cache import get_cache_metadata_key, get_import_device_cache_key, get_validated_device_cache_key
 from .collisions import detect_bulk_collisions
@@ -177,9 +178,7 @@ def detect_collisions_for_device_ids(
         # row whose device_id doesn't match the requested id — e.g. a stale/mis-keyed cache entry)
         # would otherwise reach validation as a brand-new device and make the collision gate report
         # a clean scan for an id it never actually verified.
-        requested_id = coerce_librenms_id(device_id)
-        cached_id = coerce_librenms_id(libre_device.get("device_id")) if isinstance(libre_device, dict) else None
-        if requested_id is None or cached_id != requested_id:
+        if not row_identity_matches(libre_device, device_id):
             unresolved_ids.append(device_id)
             continue
         if just_fetched:
@@ -410,6 +409,11 @@ def bulk_import_devices_shared(
                 # live LibreNMS data: bypass the short device-info read cache so a value the user
                 # just corrected in LibreNMS isn't read back stale within the cache window.
                 success, libre_device = api.get_device_info(device_id, use_cache=False)
+                # Same fail-closed identity rule as the collision pre-check (row_identity_matches):
+                # a payload that isn't a dict carrying the requested device_id must be neither
+                # imported nor written into the shared cache — treat it as a failed retrieval.
+                if success and not row_identity_matches(libre_device, device_id):
+                    success, libre_device = False, None
                 # Backfill the shared cache so the synchronous import's post-import row re-render
                 # (which reads the same dict via fetch_device_with_cache) doesn't issue a second
                 # LibreNMS round-trip per device on a cold cache. The background path passes a

--- a/netbox_librenms_plugin/import_utils/bulk_import.py
+++ b/netbox_librenms_plugin/import_utils/bulk_import.py
@@ -133,7 +133,7 @@ def detect_collisions_for_device_ids(
     # Reuse the caller's dict object (mutate it in place) rather than `or {}`, which would swap in a
     # throwaway dict when the caller passes an empty one — the write-back below must be visible to
     # the caller so the downstream import reuses it.
-    cache = libre_devices_cache if libre_devices_cache is not None else {}
+    devices_cache = libre_devices_cache if libre_devices_cache is not None else {}
     vm_id_set = set(vm_device_ids or ())
     devices = []
     unresolved_ids = []
@@ -149,7 +149,7 @@ def detect_collisions_for_device_ids(
                 job.logger.warning(f"Collision pre-check stopped by cancellation at id {idx} of {len(device_ids)}")
             unresolved_ids.extend(device_ids[idx - 1 :])
             break
-        libre_device = cache.get(device_id)
+        libre_device = devices_cache.get(device_id)
         just_fetched = False
         if libre_device is None:
             try:
@@ -187,7 +187,7 @@ def detect_collisions_for_device_ids(
             # mis-keyed payload from poisoning the shared cache for any other consumer that reads it
             # (e.g. a same-batch retry that hits the cache instead of re-fetching), even though this
             # id is (correctly) recorded unresolved above.
-            cache[device_id] = libre_device
+            devices_cache[device_id] = libre_device
         validation = validate_device_for_import(
             # DB-only collision pre-check: don't hand the validator an API client (it would let
             # API-backed validation paths run even with the cache supplied + include_vc_detection

--- a/netbox_librenms_plugin/import_utils/bulk_import.py
+++ b/netbox_librenms_plugin/import_utils/bulk_import.py
@@ -88,7 +88,7 @@ def _is_job_cancelled(job) -> bool:
 
 
 def detect_collisions_for_device_ids(
-    device_ids, api, libre_devices_cache=None, sync_options=None, job=None
+    device_ids, api, libre_devices_cache=None, sync_options=None, job=None, vm_device_ids=None
 ) -> tuple[list[dict], list]:
     """
     Detect same-NetBox-device collisions for a batch of LibreNMS device ids.
@@ -112,6 +112,11 @@ def detect_collisions_for_device_ids(
         job: Optional background-job context. When set, cancellation is polled the same
             way the import loops poll it (first id, then every 5th); a cancelled job stops
             the scan instead of finishing a large cache-miss batch's API calls.
+        vm_device_ids: Optional collection of the batch's VM-selected LibreNMS ids. Each row
+            is validated in its ACTUAL import mode: a VM row validated as a Device would run
+            the Device-only serial/IP matching that ``bulk_import_vms`` intentionally skips,
+            and could fabricate a collision (blocking a valid batch) against a Device it
+            will never touch.
 
     Returns:
         tuple[list[dict], list]: ``(collisions, unresolved_ids)`` — the collision groups from
@@ -128,6 +133,7 @@ def detect_collisions_for_device_ids(
     # throwaway dict when the caller passes an empty one — the write-back below must be visible to
     # the caller so the downstream import reuses it.
     cache = libre_devices_cache if libre_devices_cache is not None else {}
+    vm_id_set = set(vm_device_ids or ())
     devices = []
     unresolved_ids = []
     device_ids = list(device_ids)
@@ -162,6 +168,10 @@ def detect_collisions_for_device_ids(
             # used for VC/chassis enrichment, all of which is guarded on `api` being truthy.
             libre_device,
             api=None,
+            # Validate in the row's ACTUAL import mode: VM rows skip the Device-only
+            # serial/IP matching exactly like bulk_import_vms will, so a coincidental
+            # serial can't fabricate a collision against a Device the row never touches.
+            import_as_vm=device_id in vm_id_set,
             use_sysname=use_sysname,
             strip_domain=strip_domain,
             server_key=api.server_key,

--- a/netbox_librenms_plugin/import_utils/bulk_import.py
+++ b/netbox_librenms_plugin/import_utils/bulk_import.py
@@ -360,13 +360,10 @@ def bulk_import_devices_shared(
     if user is None and job is not None:
         user = getattr(job.job, "user", None)
 
-    # Check permissions at start of bulk operation — device and VM add perms are
-    # required because any device may be flagged as import_as_vm during validation.
     # change_device is needed for VC master/member updates.
     required_perms = [
         "dcim.add_device",
         "dcim.change_device",
-        "virtualization.add_virtualmachine",
     ]
     require_permissions(user, required_perms, "import devices")
 
@@ -445,6 +442,20 @@ def bulk_import_devices_shared(
                 include_vc_detection=True,
                 preloaded_device_type_rules=device_type_norm_rules,
             )
+
+            if validation.get("import_as_vm"):
+                has_vm_perm, _ = check_user_permissions(user, ["virtualization.add_virtualmachine"])
+                if not has_vm_perm:
+                    error_msg = (
+                        f"Cannot import device row {device_id} as a VM: "
+                        "missing permission virtualization.add_virtualmachine"
+                    )
+                    failed_list.append({"device_id": device_id, "error": error_msg})
+                    if job and job.logger:
+                        job.logger.error(error_msg)
+                    else:
+                        logger.error(error_msg)
+                    continue
 
             vc_data = validation.get("virtual_chassis", {})
             if vc_data.get("is_stack", False):

--- a/netbox_librenms_plugin/import_utils/bulk_import.py
+++ b/netbox_librenms_plugin/import_utils/bulk_import.py
@@ -120,7 +120,10 @@ def detect_collisions_for_device_ids(
     """
     use_sysname = (sync_options or {}).get("use_sysname", True)
     strip_domain = (sync_options or {}).get("strip_domain", False)
-    cache = libre_devices_cache or {}
+    # Reuse the caller's dict object (mutate it in place) rather than `or {}`, which would swap in a
+    # throwaway dict when the caller passes an empty one — the write-back below must be visible to
+    # the caller so the downstream import reuses it.
+    cache = libre_devices_cache if libre_devices_cache is not None else {}
     devices = []
     unresolved_ids = []
     for device_id in device_ids:
@@ -132,6 +135,11 @@ def detect_collisions_for_device_ids(
                 # caller blocks it instead of importing it unchecked (fail closed).
                 unresolved_ids.append(device_id)
                 continue
+            # Persist the freshly fetched row into the shared cache so the downstream import
+            # (bulk_import_devices_shared / bulk_import_vms) reuses it instead of re-fetching the
+            # same device from LibreNMS. Without this, the collision pre-check doubles the API
+            # round-trips for any id the caller didn't already pre-populate.
+            cache[device_id] = libre_device
         validation = validate_device_for_import(
             # DB-only collision pre-check: don't hand the validator an API client (it would let
             # API-backed validation paths run even with the cache supplied + include_vc_detection

--- a/netbox_librenms_plugin/import_utils/bulk_import.py
+++ b/netbox_librenms_plugin/import_utils/bulk_import.py
@@ -248,7 +248,7 @@ class BulkPrecheckOutcome:
         collisions: The collision groups (for the HTMX modal / job log).
         block_message: Shared collision-block copy (``""`` when not blocked).
         skipped_ids: Unresolved ids to skip (import the rest).
-        skip_message: Shared copy naming the skipped rows (``""`` when none).
+        skip_message: Shared copy naming skipped rows in an unblocked batch (``""`` otherwise).
         importable_device_ids: ``device_ids`` minus ``skipped_ids``.
         importable_vm_imports: ``vm_imports`` minus ``skipped_ids``.
     """
@@ -284,7 +284,7 @@ def classify_bulk_precheck(collisions, unresolved, device_ids, vm_imports) -> Bu
     importable_vm_imports = {d: v for d, v in vm_imports.items() if d not in unresolved_set}
 
     skip_message = ""
-    if unresolved:
+    if unresolved and not collisions:
         ids = ", ".join(str(d) for d in unresolved)
         skip_message = (
             f"Skipped {len(unresolved)} selected row(s) (id(s): {ids}): their LibreNMS device info "

--- a/netbox_librenms_plugin/import_utils/bulk_import.py
+++ b/netbox_librenms_plugin/import_utils/bulk_import.py
@@ -17,6 +17,7 @@ from ..import_validation_helpers import (
 from ..librenms_api import LibreNMSAPI
 from ..utils import (
     AmbiguousLibreNMSIdError,
+    cached_row_matches,
     coerce_librenms_id,
     find_by_librenms_id,
     normalize_serial,
@@ -396,17 +397,12 @@ def bulk_import_devices_shared(
 
         try:
             # Use cached device data if available to avoid redundant API calls — but only when the
-            # cached row's OWN device_id doesn't contradict the requested id. A mis-keyed/stale cache
-            # entry (another device's row stored under this id) would otherwise be imported AS this
-            # device. detect_collisions_for_device_ids verifies this too, but its callers skip the
-            # pre-check for single-row imports, so re-check at the point of use; a contradiction falls
-            # through to a live fetch below. (A real LibreNMS row always carries device_id; a cached
-            # row lacking it can't be verified and is left trusted.)
+            # cached row's OWN device_id doesn't contradict the requested id (cached_row_matches).
+            # detect_collisions_for_device_ids verifies this too, but its callers skip the pre-check
+            # for single-row imports, so re-check at the point of use; a contradiction falls through
+            # to a live fetch below.
             cached_row = libre_devices_cache.get(device_id) if libre_devices_cache else None
-            cached_row_id = cached_row.get("device_id") if isinstance(cached_row, dict) else None
-            if cached_row is not None and (
-                cached_row_id is None or coerce_librenms_id(cached_row_id) == coerce_librenms_id(device_id)
-            ):
+            if cached_row_matches(cached_row, device_id):
                 libre_device = cached_row
                 success = True
             else:

--- a/netbox_librenms_plugin/import_utils/bulk_import.py
+++ b/netbox_librenms_plugin/import_utils/bulk_import.py
@@ -150,6 +150,7 @@ def detect_collisions_for_device_ids(
             unresolved_ids.extend(device_ids[idx - 1 :])
             break
         libre_device = cache.get(device_id)
+        just_fetched = False
         if libre_device is None:
             success, libre_device = api.get_device_info(device_id)
             if not success or not isinstance(libre_device, dict):
@@ -157,11 +158,7 @@ def detect_collisions_for_device_ids(
                 # caller blocks it instead of importing it unchecked (fail closed).
                 unresolved_ids.append(device_id)
                 continue
-            # Persist the freshly fetched row into the shared cache so the downstream import
-            # (bulk_import_devices_shared / bulk_import_vms) reuses it instead of re-fetching the
-            # same device from LibreNMS. Without this, the collision pre-check doubles the API
-            # round-trips for any id the caller didn't already pre-populate.
-            cache[device_id] = libre_device
+            just_fetched = True
         # Fail closed on a bad cached payload too: a negatively-cached lookup (an empty dict or a
         # row whose device_id doesn't match the requested id — e.g. a stale/mis-keyed cache entry)
         # would otherwise reach validation as a brand-new device and make the collision gate report
@@ -171,6 +168,15 @@ def detect_collisions_for_device_ids(
         if requested_id is None or cached_id != requested_id:
             unresolved_ids.append(device_id)
             continue
+        if just_fetched:
+            # Persist the freshly fetched row into the shared cache — but only now that its
+            # device_id is verified to match the requested id — so the downstream import
+            # (bulk_import_devices_shared / bulk_import_vms) reuses it instead of re-fetching the
+            # same device from LibreNMS. Deferring the write until past the mismatch check keeps a
+            # mis-keyed payload from poisoning the shared cache for any other consumer that reads it
+            # (e.g. a same-batch retry that hits the cache instead of re-fetching), even though this
+            # id is (correctly) recorded unresolved above.
+            cache[device_id] = libre_device
         validation = validate_device_for_import(
             # DB-only collision pre-check: don't hand the validator an API client (it would let
             # API-backed validation paths run even with the cache supplied + include_vc_detection

--- a/netbox_librenms_plugin/import_utils/bulk_import.py
+++ b/netbox_librenms_plugin/import_utils/bulk_import.py
@@ -108,22 +108,34 @@ def detect_collisions_for_device_ids(device_ids, api, libre_devices_cache=None, 
         sync_options: Optional sync options (``use_sysname`` / ``strip_domain``).
 
     Returns:
-        list[dict]: Collision groups as produced by :func:`detect_bulk_collisions`
-            (empty when the batch is clean).
+        tuple[list[dict], list]: ``(collisions, unresolved_ids)`` — the collision groups from
+            :func:`detect_bulk_collisions` (empty when the batch is clean), and the device ids
+            that could NOT be validated (``get_device_info`` failed and they weren't in the
+            cache). Those ids were not collision-checked, so the caller must fail closed on them
+            rather than import them unchecked — a transient miss could otherwise slip a colliding
+            row through on a retry.
     """
     use_sysname = (sync_options or {}).get("use_sysname", True)
     strip_domain = (sync_options or {}).get("strip_domain", False)
     cache = libre_devices_cache or {}
     devices = []
+    unresolved_ids = []
     for device_id in device_ids:
         libre_device = cache.get(device_id)
         if libre_device is None:
             success, libre_device = api.get_device_info(device_id)
             if not success or not libre_device:
+                # Couldn't fetch device info → can't collision-check this id. Record it so the
+                # caller blocks it instead of importing it unchecked (fail closed).
+                unresolved_ids.append(device_id)
                 continue
         validation = validate_device_for_import(
+            # DB-only collision pre-check: don't hand the validator an API client (it would let
+            # API-backed validation paths run even with the cache supplied + include_vc_detection
+            # False). The collision-relevant match fields are resolved from the DB; api is only
+            # used for VC/chassis enrichment, all of which is guarded on `api` being truthy.
             libre_device,
-            api=api,
+            api=None,
             use_sysname=use_sysname,
             strip_domain=strip_domain,
             server_key=api.server_key,
@@ -136,7 +148,7 @@ def detect_collisions_for_device_ids(device_ids, api, libre_devices_cache=None, 
                 "validation": validation,
             }
         )
-    return detect_bulk_collisions(devices)
+    return detect_bulk_collisions(devices), unresolved_ids
 
 
 def bulk_import_devices_shared(

--- a/netbox_librenms_plugin/import_utils/bulk_import.py
+++ b/netbox_librenms_plugin/import_utils/bulk_import.py
@@ -18,11 +18,11 @@ from ..utils import (
     AmbiguousLibreNMSIdError,
     coerce_librenms_id,
     find_by_librenms_id,
-    get_librenms_oob,
     normalize_serial,
     preload_normalization_rules,
 )
 from .cache import get_cache_metadata_key, get_import_device_cache_key, get_validated_device_cache_key
+from .collisions import detect_bulk_collisions
 from .device_operations import (
     _describe_existing_librenms_link,
     import_single_device,
@@ -84,6 +84,59 @@ def _is_job_cancelled(job) -> bool:
     except Exception:
         logger.warning("Unexpected error checking RQ job cancellation state", exc_info=True)
         return False
+
+
+def detect_collisions_for_device_ids(device_ids, api, libre_devices_cache=None, sync_options=None) -> list[dict]:
+    """
+    Detect same-NetBox-device collisions for a batch of LibreNMS device ids.
+
+    Validates each device just enough to read the collision-relevant match fields
+    (``include_vc_detection=False`` — DB-only, no VC API call), then groups rows that
+    target the same NetBox device. Reuses ``libre_devices_cache`` so it adds no LibreNMS
+    API calls when the caller already pre-fetched device data.
+
+    This enforces the bulk-confirm collision block on the import paths that do NOT pass
+    through the confirm modal — the direct ``BulkImportDevicesView`` POST and the
+    background ``ImportDevicesJob`` — so a colliding batch can't be imported by bypassing
+    the preview.
+
+    Args:
+        device_ids: LibreNMS device ids about to be imported.
+        api: A LibreNMS API client (only ``server_key`` and ``get_device_info`` are used;
+            ``get_device_info`` is called only for ids missing from the cache).
+        libre_devices_cache: Optional ``{device_id: libre_device}`` pre-fetched data.
+        sync_options: Optional sync options (``use_sysname`` / ``strip_domain``).
+
+    Returns:
+        list[dict]: Collision groups as produced by :func:`detect_bulk_collisions`
+            (empty when the batch is clean).
+    """
+    use_sysname = (sync_options or {}).get("use_sysname", True)
+    strip_domain = (sync_options or {}).get("strip_domain", False)
+    cache = libre_devices_cache or {}
+    devices = []
+    for device_id in device_ids:
+        libre_device = cache.get(device_id)
+        if libre_device is None:
+            success, libre_device = api.get_device_info(device_id)
+            if not success or not libre_device:
+                continue
+        validation = validate_device_for_import(
+            libre_device,
+            api=api,
+            use_sysname=use_sysname,
+            strip_domain=strip_domain,
+            server_key=api.server_key,
+            include_vc_detection=False,
+        )
+        devices.append(
+            {
+                "device_id": device_id,
+                "device_name": validation.get("resolved_name") or f"device-{device_id}",
+                "validation": validation,
+            }
+        )
+    return detect_bulk_collisions(devices)
 
 
 def bulk_import_devices_shared(
@@ -416,8 +469,9 @@ def _refresh_librenms_linkage(validation: dict, device, libre_device: dict, serv
     validation["existing_librenms_link"] = link
 
     scanned_id = coerce_librenms_id((libre_device or {}).get("device_id"))
-    oob = get_librenms_oob(device, server_key=server_key)
-    oob_id = coerce_librenms_id(oob.get("id")) if oob else None
+    # _describe_existing_librenms_link already read the OOB sub-object via get_librenms_oob and
+    # exposes the coerced positive-int id as link["oob_id"]; reuse it instead of re-reading.
+    oob_id = link["oob_id"]
 
     # Promote to a *current* librenms-id / OOB link first, regardless of the cached match type.
     # A row cached as a serial/hostname conflict may since have gained the matching host/OOB
@@ -564,6 +618,19 @@ def _refresh_existing_device(validation: dict, libre_device: dict = None, server
                 # is reflected in the badge (DB-only; no LibreNMS API call).
                 prior_match = validation.get("existing_match_type")
                 _refresh_librenms_linkage(validation, refreshed, libre_device, server_key)
+                if prior_match not in ("librenms_id", "librenms_oob") and validation.get("existing_match_type") in (
+                    "librenms_id",
+                    "librenms_oob",
+                ):
+                    # _refresh_librenms_linkage just PROMOTED a row cached under a non-link match
+                    # (serial/hostname/primary_ip) to a current librenms_id/OOB link. The
+                    # serial/merge/oob/promote actions derived for that old match are now stale and
+                    # would render a destructive "Merge two NetBox devices" form (the template
+                    # checks serial_action == "merge_netbox_devices" before the match_type chain)
+                    # or a misleading "Add as OOB" badge (device_status keys that on serial_action,
+                    # independent of match_type) on a row that is actually host/OOB-linked. Drop
+                    # them; a row already cached as a link type keeps its link-derived fields.
+                    _clear_existing_match_derived_fields(validation)
                 if prior_match in ("librenms_id", "librenms_oob") and validation.get("existing_match_type") is None:
                     # The librenms-id/OOB link that made this the cached match is gone
                     # (removed/repointed in NetBox since caching). Treat it like a vanished

--- a/netbox_librenms_plugin/import_utils/bulk_import.py
+++ b/netbox_librenms_plugin/import_utils/bulk_import.py
@@ -2,6 +2,7 @@
 
 import hashlib
 import logging
+from dataclasses import dataclass
 from typing import List
 
 from django.core.cache import cache
@@ -194,6 +195,93 @@ def detect_collisions_for_device_ids(
             }
         )
     return detect_bulk_collisions(devices), unresolved_ids
+
+
+@dataclass
+class BulkPrecheckOutcome:
+    """
+    Shared decision derived from a :func:`detect_collisions_for_device_ids` result.
+
+    Consumed by BOTH non-modal import callers — the synchronous ``BulkImportDevicesView`` and the
+    async ``ImportDevicesJob`` — so their block/skip semantics and user-facing wording can't drift
+    (they previously re-implemented the branching inline, and the copy had already diverged:
+    "Import blocked" vs "Bulk import blocked").
+
+    Semantics:
+        * ``blocked`` (genuine collisions): two LibreNMS rows resolve to the same NetBox object,
+          which can't be auto-resolved — the WHOLE batch is blocked and nothing imports.
+        * ``skipped_ids`` (unresolved rows): a row whose LibreNMS info couldn't be fetched/validated
+          to collision-check it. These are SKIPPED, not a whole-batch block — a transient miss on
+          one row no longer drops the entire import — but they are NOT imported either (importing an
+          un-collision-checked row could bypass the collision guard). The rest import normally.
+
+    Attributes:
+        blocked: True when genuine collisions exist → import nothing.
+        collisions: The collision groups (for the HTMX modal / job log).
+        block_message: Shared collision-block copy (``""`` when not blocked).
+        skipped_ids: Unresolved ids to skip (import the rest).
+        skip_message: Shared copy naming the skipped rows (``""`` when none).
+        importable_device_ids: ``device_ids`` minus ``skipped_ids``.
+        importable_vm_imports: ``vm_imports`` minus ``skipped_ids``.
+    """
+
+    blocked: bool
+    collisions: list
+    block_message: str
+    skipped_ids: list
+    skip_message: str
+    importable_device_ids: list
+    importable_vm_imports: dict
+
+
+def classify_bulk_precheck(collisions, unresolved, device_ids, vm_imports) -> BulkPrecheckOutcome:
+    """
+    Turn a ``(collisions, unresolved)`` pre-check result into the shared import decision.
+
+    See :class:`BulkPrecheckOutcome` for the block-vs-skip semantics. Genuine collisions block the
+    whole batch; unresolved rows are excluded from the importable sets and surfaced via
+    ``skip_message`` while the rest import. Both callers apply this identically.
+
+    Args:
+        collisions: Collision groups from :func:`detect_bulk_collisions`.
+        unresolved: Ids that couldn't be collision-checked (fetch/validation miss).
+        device_ids: The batch's device-import ids.
+        vm_imports: The batch's VM imports mapping (``{device_id: manual_mappings}``).
+
+    Returns:
+        BulkPrecheckOutcome: The shared block/skip decision.
+    """
+    unresolved_set = set(unresolved)
+    importable_device_ids = [d for d in device_ids if d not in unresolved_set]
+    importable_vm_imports = {d: v for d, v in vm_imports.items() if d not in unresolved_set}
+
+    skip_message = ""
+    if unresolved:
+        ids = ", ".join(str(d) for d in unresolved)
+        skip_message = (
+            f"Skipped {len(unresolved)} selected row(s) (id(s): {ids}): their LibreNMS device info "
+            f"couldn't be fetched to verify collisions, so they were not imported. The remaining "
+            f"rows were imported; retry those rows individually."
+        )
+
+    block_message = ""
+    if collisions:
+        pks = ", ".join(str(group["nb_device_pk"]) for group in collisions)
+        block_message = (
+            f"Bulk import blocked: {len(collisions)} NetBox object collision(s) in this batch "
+            f"(pk(s): {pks}). Two or more selected LibreNMS devices resolve to the same NetBox "
+            f"object; resolve each individually, or deselect the duplicates."
+        )
+
+    return BulkPrecheckOutcome(
+        blocked=bool(collisions),
+        collisions=collisions,
+        block_message=block_message,
+        skipped_ids=list(unresolved),
+        skip_message=skip_message,
+        importable_device_ids=importable_device_ids,
+        importable_vm_imports=importable_vm_imports,
+    )
 
 
 def bulk_import_devices_shared(

--- a/netbox_librenms_plugin/import_utils/collisions.py
+++ b/netbox_librenms_plugin/import_utils/collisions.py
@@ -1,0 +1,175 @@
+"""
+Bulk-import collision detection.
+
+When a user selects multiple LibreNMS devices for bulk import, two or more
+rows in the same batch may resolve to the *same* NetBox device — for
+example, one row would be linked as the host and another as the OOB
+controller, or two rows both want to promote to the same existing host.
+Importing all of them blindly would race for the same custom-field slot
+and produce inconsistent state.
+
+`detect_bulk_collisions` walks the per-row validation results and groups
+rows that target the same NetBox device pk so the bulk-confirm view can
+block the import and let the user adjust their selection.
+"""
+
+from __future__ import annotations
+
+
+def _candidate_pks_for_row(validation: dict) -> list[tuple[int, str, str, str]]:
+    """Return [(nb_device_pk, nb_device_name, role, model_name)] candidates for a single row.
+
+    ``role`` is a short human-readable label describing how this LibreNMS
+    row would touch the NetBox device:
+
+    * ``"host"`` — the device is the existing NetBox device this row would
+      update / link to (``existing_device``).
+    * ``"oob"`` — this LibreNMS row would be installed as the OOB
+      controller of the NetBox device (``oob_candidate.device``).
+    * ``"merge_host_named"`` / ``"merge_oob_named"`` — the row would feed
+      a Stage-2 merge of two NetBox devices.
+    * ``"promote_target"`` — the row should be promoted to host of an
+      existing NetBox device that currently only has an OOB link
+      (``promote_to_host``).
+
+    ``model_name`` is the Python class name of the NetBox object
+    (e.g. ``"Device"``, ``"VirtualMachine"``) so that two objects of
+    different types that happen to share the same pk are not grouped as
+    collisions.
+
+    Duplicate ``(pk, role, model_name)`` tuples are de-duplicated; a
+    single row may legitimately surface the same pk under different roles.
+    """
+    candidates: list[tuple[int, str, str, str]] = []
+    seen: set[tuple[int, str, str]] = set()
+
+    def _add(pk, name, role, model_name="Device"):
+        try:
+            pk_int = int(pk)
+        except (TypeError, ValueError):
+            return
+        key = (pk_int, role, model_name)
+        if key in seen:
+            return
+        seen.add(key)
+        candidates.append((pk_int, str(name or f"device-{pk_int}"), role, model_name))
+
+    existing = validation.get("existing_device")
+    if existing is not None and getattr(existing, "pk", None) is not None:
+        _add(existing.pk, getattr(existing, "name", None), "host", type(existing).__name__)
+
+    oob_candidate = validation.get("oob_candidate") or {}
+    oob_device = oob_candidate.get("device") if isinstance(oob_candidate, dict) else None
+    if oob_device is not None and getattr(oob_device, "pk", None) is not None:
+        _add(oob_device.pk, getattr(oob_device, "name", None), "oob", type(oob_device).__name__)
+
+    merge = validation.get("merge_candidates") or {}
+    if isinstance(merge, dict):
+        for slot, role in (("host_named", "merge_host_named"), ("oob_named", "merge_oob_named")):
+            entry = merge.get(slot) or {}
+            pk = entry.get("pk") if isinstance(entry, dict) else None
+            name = entry.get("name") if isinstance(entry, dict) else None
+            if pk is not None:
+                _add(pk, name, role)
+
+    promote = validation.get("promote_to_host") or {}
+    if isinstance(promote, dict):
+        target = promote.get("existing_device")
+        if target is not None and getattr(target, "pk", None) is not None:
+            _add(target.pk, getattr(target, "name", None), "promote_target", type(target).__name__)
+
+    return candidates
+
+
+def detect_bulk_collisions(devices: list[dict] | None) -> list[dict]:
+    """Find groups of LibreNMS rows in *devices* that resolve to the same NetBox device.
+
+    *devices* matches the list assembled by ``BulkImportConfirmView`` —
+    each item is a dict with at least ``device_id``, ``device_name`` and
+    ``validation`` keys.  ``None`` is accepted and treated as an empty list.
+
+    Returns a list of collision groups (one per offending NetBox device),
+    sorted by model type then ``nb_device_pk`` for stable rendering (the
+    composite key prevents false collisions when a Device and a
+    VirtualMachine share the same integer pk).  Each group:
+
+    .. code-block:: python
+
+        {
+            "nb_device_pk": int,
+            "nb_device_name": str,
+            "librenms_rows": [
+                {"device_id": int, "hostname": str, "role": str},
+                ...
+            ],
+        }
+
+    Rows are de-duplicated by ``device_id`` within a group (same LibreNMS
+    row touching the same NetBox device under multiple roles only appears
+    once, with all matching role labels joined by ``", "``).
+
+    A group is only emitted when at least two distinct LibreNMS
+    ``device_id`` values target the same NetBox pk.
+    """
+    # Key by (model_name, nb_pk) to avoid false collisions when a Device
+    # and a VirtualMachine happen to share the same integer pk.
+    by_nb_pk: dict[tuple[str, int], dict] = {}
+
+    for entry in devices or []:
+        # A single malformed row (non-dict entry, or a non-dict validation payload)
+        # must be skipped, not crash the whole bulk-confirm flow on .get().
+        if not isinstance(entry, dict):
+            continue
+        validation = entry.get("validation")
+        if not isinstance(validation, dict):
+            validation = {}
+        try:
+            libre_id = int(entry.get("device_id"))
+        except (TypeError, ValueError):
+            continue
+        hostname = entry.get("device_name") or f"device-{libre_id}"
+
+        for nb_pk, nb_name, role, model_name in _candidate_pks_for_row(validation):
+            bucket_key = (model_name, nb_pk)
+            bucket = by_nb_pk.setdefault(
+                bucket_key,
+                {"nb_device_pk": nb_pk, "nb_device_name": nb_name, "nb_model_name": model_name, "_rows": {}},
+            )
+            # Keep the first non-default name we see — rows often disagree
+            # on the cached display string, but the underlying pk is the
+            # source of truth.
+            if bucket["nb_device_name"].startswith("device-") and not nb_name.startswith("device-"):
+                bucket["nb_device_name"] = nb_name
+
+            row = bucket["_rows"].setdefault(
+                libre_id,
+                {"device_id": libre_id, "hostname": hostname, "roles": []},
+            )
+            if role not in row["roles"]:
+                row["roles"].append(role)
+
+    collisions: list[dict] = []
+    for _model_name, nb_pk in sorted(by_nb_pk.keys()):
+        bucket = by_nb_pk[(_model_name, nb_pk)]
+        rows = list(bucket["_rows"].values())
+        if len(rows) < 2:
+            continue
+        rows.sort(key=lambda r: r["device_id"])
+        collisions.append(
+            {
+                "nb_device_pk": bucket["nb_device_pk"],
+                "nb_device_name": bucket["nb_device_name"],
+                # Class name ("Device"/"VirtualMachine") so the template links to the right
+                # object type — a VM collision must not render a dcim:device URL.
+                "nb_model_name": bucket["nb_model_name"],
+                "librenms_rows": [
+                    {
+                        "device_id": r["device_id"],
+                        "hostname": r["hostname"],
+                        "role": ", ".join(r["roles"]),
+                    }
+                    for r in rows
+                ],
+            }
+        )
+    return collisions

--- a/netbox_librenms_plugin/import_utils/collisions.py
+++ b/netbox_librenms_plugin/import_utils/collisions.py
@@ -15,8 +15,37 @@ block the import and let the user adjust their selection.
 
 from __future__ import annotations
 
+from netbox_librenms_plugin.import_validation_helpers import MERGE_CANDIDATE_SLOTS
 
-def _candidate_pks_for_row(validation: dict) -> list[tuple[int, str, str, str]]:
+# Terminal match types where ``existing_device`` is an ARBITRARY duplicate the validator already
+# failed closed (can_import=False, actions cleared). Such a row will never write, so it must not
+# contend for a NetBox pk and block an otherwise-valid sibling import on that same pk.
+_TERMINAL_AMBIGUOUS_MATCH_TYPES = frozenset({"ambiguous_hostname_or_serial", "ambiguous_librenms_id"})
+
+# Maps each merge_candidates slot to the role label used in collision groups.
+_MERGE_SLOT_ROLES = {"host_named": "merge_host_named", "oob_named": "merge_oob_named"}
+
+
+def _model_name_of(obj) -> str:
+    """
+    Return the NetBox model name (``"device"`` / ``"virtualmachine"``) for *obj*.
+
+    Prefers Django's lowercase ``_meta.model_name`` to match the convention used across
+    the codebase (so a copied ``== "virtualmachine"`` check stays correct); falls back to
+    the lowercased class name for lightweight test stubs that have no ``_meta``.
+
+    Args:
+        obj: A NetBox object (Device / VirtualMachine) or a test stand-in.
+
+    Returns:
+        str: The lowercase model name.
+    """
+    meta = getattr(obj, "_meta", None)
+    model_name = getattr(meta, "model_name", None)
+    return model_name if model_name else type(obj).__name__.lower()
+
+
+def _candidate_pks_for_row(validation: dict) -> list[tuple[int, str | None, str, str]]:
     """
     Return the NetBox-device candidates a single LibreNMS row would touch.
 
@@ -32,55 +61,56 @@ def _candidate_pks_for_row(validation: dict) -> list[tuple[int, str, str, str]]:
     * ``"promote_target"`` — the row should be promoted to host of an existing NetBox
       device that currently only has an OOB link (``promote_to_host``).
 
-    ``model_name`` is the Python class name of the NetBox object (e.g. ``"Device"``,
-    ``"VirtualMachine"``) so that two objects of different types that happen to share
-    the same pk are not grouped as collisions.
+    ``model_name`` is the NetBox model name (``"device"`` / ``"virtualmachine"``) so that
+    two objects of different types that happen to share the same pk are not grouped as
+    collisions. Merge-candidate slots carry their own ``model_name`` (defaulting to
+    ``"device"`` — Stage-2 merge is Device-only today).
 
     Args:
         validation (dict): The per-row validation result to inspect.
 
     Returns:
-        list[tuple[int, str, str, str]]: ``(nb_device_pk, nb_device_name, role,
-            model_name)`` candidates, de-duplicated on ``(pk, role, model_name)`` (a
-            single row may legitimately surface the same pk under different roles).
+        list[tuple[int, str | None, str, str]]: ``(nb_device_pk, nb_device_name, role,
+            model_name)`` candidates. Each of the (at most five) sources emits a distinct
+            role, so no intra-row de-duplication is needed.
     """
-    candidates: list[tuple[int, str, str, str]] = []
-    seen: set[tuple[int, str, str]] = set()
+    from netbox_librenms_plugin.utils import coerce_positive_int
 
-    def _add(pk, name, role, model_name="Device"):
-        try:
-            pk_int = int(pk)
-        except (TypeError, ValueError):
+    candidates: list[tuple[int, str | None, str, str]] = []
+
+    def _add(pk, name, role, model_name="device"):
+        pk_int = coerce_positive_int(pk)
+        if pk_int is None:
             return
-        key = (pk_int, role, model_name)
-        if key in seen:
-            return
-        seen.add(key)
-        candidates.append((pk_int, str(name or f"device-{pk_int}"), role, model_name))
+        candidates.append((pk_int, name, role, model_name))
 
     existing = validation.get("existing_device")
-    if existing is not None and getattr(existing, "pk", None) is not None:
-        _add(existing.pk, getattr(existing, "name", None), "host", type(existing).__name__)
+    if (
+        existing is not None
+        and getattr(existing, "pk", None) is not None
+        and validation.get("existing_match_type") not in _TERMINAL_AMBIGUOUS_MATCH_TYPES
+    ):
+        _add(existing.pk, getattr(existing, "name", None), "host", _model_name_of(existing))
 
     oob_candidate = validation.get("oob_candidate") or {}
     oob_device = oob_candidate.get("device") if isinstance(oob_candidate, dict) else None
     if oob_device is not None and getattr(oob_device, "pk", None) is not None:
-        _add(oob_device.pk, getattr(oob_device, "name", None), "oob", type(oob_device).__name__)
+        _add(oob_device.pk, getattr(oob_device, "name", None), "oob", _model_name_of(oob_device))
 
     merge = validation.get("merge_candidates") or {}
     if isinstance(merge, dict):
-        for slot, role in (("host_named", "merge_host_named"), ("oob_named", "merge_oob_named")):
+        for slot in MERGE_CANDIDATE_SLOTS:
             entry = merge.get(slot) or {}
-            pk = entry.get("pk") if isinstance(entry, dict) else None
-            name = entry.get("name") if isinstance(entry, dict) else None
-            if pk is not None:
-                _add(pk, name, role)
+            if not isinstance(entry, dict):
+                continue
+            if entry.get("pk") is not None:
+                _add(entry.get("pk"), entry.get("name"), _MERGE_SLOT_ROLES[slot], entry.get("model_name") or "device")
 
     promote = validation.get("promote_to_host") or {}
     if isinstance(promote, dict):
         target = promote.get("existing_device")
         if target is not None and getattr(target, "pk", None) is not None:
-            _add(target.pk, getattr(target, "name", None), "promote_target", type(target).__name__)
+            _add(target.pk, getattr(target, "name", None), "promote_target", _model_name_of(target))
 
     return candidates
 
@@ -141,10 +171,11 @@ def detect_bulk_collisions(devices: list[dict] | None) -> list[dict]:
                 bucket_key,
                 {"nb_device_pk": nb_pk, "nb_device_name": nb_name, "nb_model_name": model_name, "_rows": {}},
             )
-            # Keep the first non-default name we see — rows often disagree
-            # on the cached display string, but the underlying pk is the
-            # source of truth.
-            if bucket["nb_device_name"].startswith("device-") and not nb_name.startswith("device-"):
+            # Keep the first non-empty name we see — rows often disagree on (or omit) the cached
+            # display string, but the underlying pk is the source of truth. The synthetic
+            # "device-<pk>" fallback is applied only at output, so a device legitimately named
+            # "device-*" is never mistaken for a placeholder.
+            if not bucket["nb_device_name"] and nb_name:
                 bucket["nb_device_name"] = nb_name
 
             row = bucket["_rows"].setdefault(
@@ -164,9 +195,11 @@ def detect_bulk_collisions(devices: list[dict] | None) -> list[dict]:
         collisions.append(
             {
                 "nb_device_pk": bucket["nb_device_pk"],
-                "nb_device_name": bucket["nb_device_name"],
-                # Class name ("Device"/"VirtualMachine") so the template links to the right
-                # object type — a VM collision must not render a dcim:device URL.
+                # Synthesize the "device-<pk>" placeholder only here, when no row supplied a real
+                # name — so a device actually named "device-*" keeps its real name above.
+                "nb_device_name": bucket["nb_device_name"] or f"device-{bucket['nb_device_pk']}",
+                # Model name ("device"/"virtualmachine") so the template links to the right object
+                # type — a VM collision must not render a dcim:device URL.
                 "nb_model_name": bucket["nb_model_name"],
                 "librenms_rows": [
                     {

--- a/netbox_librenms_plugin/import_utils/collisions.py
+++ b/netbox_librenms_plugin/import_utils/collisions.py
@@ -107,8 +107,12 @@ def _candidate_pks_for_row(validation: dict) -> list[tuple[int, str | None, str,
             entry = merge.get(slot) or {}
             if not isinstance(entry, dict):
                 continue
+            # Derive a fallback role rather than indexing: if MERGE_CANDIDATE_SLOTS is ever
+            # extended without updating _MERGE_SLOT_ROLES, a new slot degrades to a generated
+            # label instead of crashing the import gate with a KeyError.
+            role = _MERGE_SLOT_ROLES.get(slot, f"merge_{slot}")
             if entry.get("pk") is not None:
-                _add(entry.get("pk"), entry.get("name"), _MERGE_SLOT_ROLES[slot], entry.get("model_name") or "device")
+                _add(entry.get("pk"), entry.get("name"), role, entry.get("model_name") or "device")
 
     promote = validation.get("promote_to_host") or {}
     if isinstance(promote, dict):

--- a/netbox_librenms_plugin/import_utils/collisions.py
+++ b/netbox_librenms_plugin/import_utils/collisions.py
@@ -17,28 +17,32 @@ from __future__ import annotations
 
 
 def _candidate_pks_for_row(validation: dict) -> list[tuple[int, str, str, str]]:
-    """Return [(nb_device_pk, nb_device_name, role, model_name)] candidates for a single row.
+    """
+    Return the NetBox-device candidates a single LibreNMS row would touch.
 
-    ``role`` is a short human-readable label describing how this LibreNMS
-    row would touch the NetBox device:
+    ``role`` is a short human-readable label describing how this LibreNMS row would
+    touch the NetBox device:
 
-    * ``"host"`` — the device is the existing NetBox device this row would
-      update / link to (``existing_device``).
-    * ``"oob"`` — this LibreNMS row would be installed as the OOB
-      controller of the NetBox device (``oob_candidate.device``).
-    * ``"merge_host_named"`` / ``"merge_oob_named"`` — the row would feed
-      a Stage-2 merge of two NetBox devices.
-    * ``"promote_target"`` — the row should be promoted to host of an
-      existing NetBox device that currently only has an OOB link
-      (``promote_to_host``).
+    * ``"host"`` — the device is the existing NetBox device this row would update /
+      link to (``existing_device``).
+    * ``"oob"`` — this LibreNMS row would be installed as the OOB controller of the
+      NetBox device (``oob_candidate.device``).
+    * ``"merge_host_named"`` / ``"merge_oob_named"`` — the row would feed a Stage-2
+      merge of two NetBox devices.
+    * ``"promote_target"`` — the row should be promoted to host of an existing NetBox
+      device that currently only has an OOB link (``promote_to_host``).
 
-    ``model_name`` is the Python class name of the NetBox object
-    (e.g. ``"Device"``, ``"VirtualMachine"``) so that two objects of
-    different types that happen to share the same pk are not grouped as
-    collisions.
+    ``model_name`` is the Python class name of the NetBox object (e.g. ``"Device"``,
+    ``"VirtualMachine"``) so that two objects of different types that happen to share
+    the same pk are not grouped as collisions.
 
-    Duplicate ``(pk, role, model_name)`` tuples are de-duplicated; a
-    single row may legitimately surface the same pk under different roles.
+    Args:
+        validation (dict): The per-row validation result to inspect.
+
+    Returns:
+        list[tuple[int, str, str, str]]: ``(nb_device_pk, nb_device_name, role,
+            model_name)`` candidates, de-duplicated on ``(pk, role, model_name)`` (a
+            single row may legitimately surface the same pk under different roles).
     """
     candidates: list[tuple[int, str, str, str]] = []
     seen: set[tuple[int, str, str]] = set()
@@ -82,34 +86,32 @@ def _candidate_pks_for_row(validation: dict) -> list[tuple[int, str, str, str]]:
 
 
 def detect_bulk_collisions(devices: list[dict] | None) -> list[dict]:
-    """Find groups of LibreNMS rows in *devices* that resolve to the same NetBox device.
+    """
+    Find groups of LibreNMS rows that resolve to the same NetBox device.
 
-    *devices* matches the list assembled by ``BulkImportConfirmView`` —
-    each item is a dict with at least ``device_id``, ``device_name`` and
-    ``validation`` keys.  ``None`` is accepted and treated as an empty list.
-
-    Returns a list of collision groups (one per offending NetBox device),
-    sorted by model type then ``nb_device_pk`` for stable rendering (the
-    composite key prevents false collisions when a Device and a
-    VirtualMachine share the same integer pk).  Each group:
-
-    .. code-block:: python
-
-        {
-            "nb_device_pk": int,
-            "nb_device_name": str,
-            "librenms_rows": [
-                {"device_id": int, "hostname": str, "role": str},
-                ...
-            ],
-        }
-
-    Rows are de-duplicated by ``device_id`` within a group (same LibreNMS
-    row touching the same NetBox device under multiple roles only appears
+    A group is only emitted when at least two distinct LibreNMS ``device_id`` values
+    target the same NetBox pk. Rows are de-duplicated by ``device_id`` within a group
+    (same LibreNMS row touching the same NetBox device under multiple roles appears
     once, with all matching role labels joined by ``", "``).
 
-    A group is only emitted when at least two distinct LibreNMS
-    ``device_id`` values target the same NetBox pk.
+    Args:
+        devices (list[dict] | None): The list assembled by ``BulkImportConfirmView`` —
+            each item a dict with at least ``device_id``, ``device_name`` and
+            ``validation`` keys. None is accepted and treated as an empty list.
+
+    Returns:
+        list[dict]: Collision groups (one per offending NetBox device), sorted by
+            model type then ``nb_device_pk`` for stable rendering. Each group has the
+            shape::
+
+                {
+                    "nb_device_pk": int,
+                    "nb_device_name": str,
+                    "librenms_rows": [
+                        {"device_id": int, "hostname": str, "role": str},
+                        ...
+                    ],
+                }
     """
     # Key by (model_name, nb_pk) to avoid false collisions when a Device
     # and a VirtualMachine happen to share the same integer pk.

--- a/netbox_librenms_plugin/import_utils/collisions.py
+++ b/netbox_librenms_plugin/import_utils/collisions.py
@@ -85,7 +85,10 @@ def _candidate_pks_for_row(validation: dict) -> list[tuple[int, str | None, str,
         # model_name keys the collision bucket downstream; a non-string (e.g. a corrupt/foreign
         # merge_candidates entry) would mis-group or raise on the dict key. Normalize to a
         # lowercase string, defaulting to "device".
-        normalized_model = model_name.strip().lower() or "device" if isinstance(model_name, str) else "device"
+        if isinstance(model_name, str):
+            normalized_model = model_name.strip().lower() or "device"
+        else:
+            normalized_model = "device"
         candidates.append((pk_int, name, role, normalized_model))
 
     existing = validation.get("existing_device")

--- a/netbox_librenms_plugin/import_utils/collisions.py
+++ b/netbox_librenms_plugin/import_utils/collisions.py
@@ -213,6 +213,8 @@ def detect_bulk_collisions(devices: list[dict] | None) -> list[dict]:
                 # Model name ("device"/"virtualmachine") so the template links to the right object
                 # type — a VM collision must not render a dcim:device URL.
                 "nb_model_name": bucket["nb_model_name"],
+                # Display label computed once so the template doesn't repeat the ternary.
+                "nb_kind": "VM" if bucket["nb_model_name"] == "virtualmachine" else "device",
                 "librenms_rows": [
                     {
                         "device_id": r["device_id"],

--- a/netbox_librenms_plugin/import_utils/collisions.py
+++ b/netbox_librenms_plugin/import_utils/collisions.py
@@ -113,6 +113,8 @@ def detect_bulk_collisions(devices: list[dict] | None) -> list[dict]:
                     ],
                 }
     """
+    from netbox_librenms_plugin.utils import coerce_librenms_id
+
     # Key by (model_name, nb_pk) to avoid false collisions when a Device
     # and a VirtualMachine happen to share the same integer pk.
     by_nb_pk: dict[tuple[str, int], dict] = {}
@@ -125,9 +127,11 @@ def detect_bulk_collisions(devices: list[dict] | None) -> list[dict]:
         validation = entry.get("validation")
         if not isinstance(validation, dict):
             validation = {}
-        try:
-            libre_id = int(entry.get("device_id"))
-        except (TypeError, ValueError):
+        # coerce_librenms_id rejects bools, floats (1.9 would otherwise truncate to a valid-looking
+        # but WRONG pk), non-positive and non-numeric ids, and coerces a digit string — so a
+        # malformed row is skipped rather than silently mis-keyed under a truncated device id.
+        libre_id = coerce_librenms_id(entry.get("device_id"))
+        if libre_id is None:
             continue
         hostname = entry.get("device_name") or f"device-{libre_id}"
 

--- a/netbox_librenms_plugin/import_utils/collisions.py
+++ b/netbox_librenms_plugin/import_utils/collisions.py
@@ -82,7 +82,11 @@ def _candidate_pks_for_row(validation: dict) -> list[tuple[int, str | None, str,
         pk_int = coerce_positive_int(pk)
         if pk_int is None:
             return
-        candidates.append((pk_int, name, role, model_name))
+        # model_name keys the collision bucket downstream; a non-string (e.g. a corrupt/foreign
+        # merge_candidates entry) would mis-group or raise on the dict key. Normalize to a
+        # lowercase string, defaulting to "device".
+        normalized_model = model_name.strip().lower() or "device" if isinstance(model_name, str) else "device"
+        candidates.append((pk_int, name, role, normalized_model))
 
     existing = validation.get("existing_device")
     if (

--- a/netbox_librenms_plugin/import_utils/collisions.py
+++ b/netbox_librenms_plugin/import_utils/collisions.py
@@ -148,6 +148,7 @@ def detect_bulk_collisions(devices: list[dict] | None) -> list[dict]:
                 {
                     "nb_device_pk": int,
                     "nb_device_name": str,
+                    "nb_model_name": str,  # "device" | "virtualmachine"
                     "librenms_rows": [
                         {"device_id": int, "hostname": str, "role": str},
                         ...

--- a/netbox_librenms_plugin/import_utils/device_operations.py
+++ b/netbox_librenms_plugin/import_utils/device_operations.py
@@ -13,6 +13,7 @@ from virtualization.models import Cluster  # noqa: F401 — used by test mock.pa
 from ..librenms_api import LibreNMSAPI
 from ..utils import (
     AmbiguousLibreNMSIdError,
+    cached_row_matches,
     coerce_librenms_id,
     find_by_librenms_id,
     find_matching_platform,
@@ -1808,14 +1809,10 @@ def fetch_device_with_cache(
         >>> libre_device = fetch_device_with_cache(123, api, libre_devices_cache=cache_dict)
     """
     # Check pre-fetched cache dict first (fastest) — but only when the cached row's OWN device_id
-    # doesn't contradict the requested id, so a mis-keyed/stale entry (another device's row under
-    # this id) isn't served AS this device. A contradiction falls through to the Django cache / API
-    # fetch below. (A real LibreNMS row always carries device_id; one lacking it stays trusted.)
+    # doesn't contradict the requested id (cached_row_matches), so a mis-keyed/stale entry isn't
+    # served AS this device. A contradiction falls through to the Django cache / API fetch below.
     cached_row = libre_devices_cache.get(device_id) if libre_devices_cache else None
-    cached_row_id = cached_row.get("device_id") if isinstance(cached_row, dict) else None
-    if cached_row is not None and (
-        cached_row_id is None or coerce_librenms_id(cached_row_id) == coerce_librenms_id(device_id)
-    ):
+    if cached_row_matches(cached_row, device_id):
         return cached_row
 
     # Check Django cache

--- a/netbox_librenms_plugin/import_utils/device_operations.py
+++ b/netbox_librenms_plugin/import_utils/device_operations.py
@@ -1120,11 +1120,17 @@ def validate_device_for_import(
                                     "pk": _hostname_match.pk,
                                     "name": _hostname_match.name,
                                     "librenms_link": host_link,
+                                    # Carry the concrete model so bulk-collision detection keys the
+                                    # right bucket. Stage-2 merge is Device-only today (gated on
+                                    # not import_as_vm), but reading it from the object future-proofs
+                                    # a VM-side merge instead of assuming "device".
+                                    "model_name": _hostname_match._meta.model_name,
                                 },
                                 oob_named={
                                     "pk": _serial_match.pk,
                                     "name": _serial_match.name,
                                     "librenms_link": oob_link,
+                                    "model_name": _serial_match._meta.model_name,
                                 },
                                 warning=(
                                     f"Two NetBox devices appear to represent this physical box: "

--- a/netbox_librenms_plugin/import_utils/device_operations.py
+++ b/netbox_librenms_plugin/import_utils/device_operations.py
@@ -1168,6 +1168,10 @@ def validate_device_for_import(
                         )
                         result["can_import"] = False
                         result["is_ready"] = False
+                        # Terminal, like the ambiguous_librenms_id guard: return now so the
+                        # new-import validation below doesn't append unrelated site/role/device-type
+                        # blockers to a row that's already blocked on the duplicate-IP ambiguity.
+                        return result
                     elif device:
                         # Surface any existing host/OOB linkage so the import UI renders the
                         # correct row state (the librenms_id / serial branches do the same;

--- a/netbox_librenms_plugin/import_utils/device_operations.py
+++ b/netbox_librenms_plugin/import_utils/device_operations.py
@@ -1807,9 +1807,16 @@ def fetch_device_with_cache(
         >>> cache_dict = {123: {...}, 456: {...}}
         >>> libre_device = fetch_device_with_cache(123, api, libre_devices_cache=cache_dict)
     """
-    # Check pre-fetched cache dict first (fastest)
-    if libre_devices_cache and device_id in libre_devices_cache:
-        return libre_devices_cache[device_id]
+    # Check pre-fetched cache dict first (fastest) — but only when the cached row's OWN device_id
+    # doesn't contradict the requested id, so a mis-keyed/stale entry (another device's row under
+    # this id) isn't served AS this device. A contradiction falls through to the Django cache / API
+    # fetch below. (A real LibreNMS row always carries device_id; one lacking it stays trusted.)
+    cached_row = libre_devices_cache.get(device_id) if libre_devices_cache else None
+    cached_row_id = cached_row.get("device_id") if isinstance(cached_row, dict) else None
+    if cached_row is not None and (
+        cached_row_id is None or coerce_librenms_id(cached_row_id) == coerce_librenms_id(device_id)
+    ):
+        return cached_row
 
     # Check Django cache
     cache_key = get_import_device_cache_key(device_id, server_key or api.server_key)

--- a/netbox_librenms_plugin/import_utils/permissions.py
+++ b/netbox_librenms_plugin/import_utils/permissions.py
@@ -3,6 +3,16 @@
 from django.core.exceptions import PermissionDenied
 
 
+def required_import_permissions(device_ids, vm_imports):
+    """Return the model permissions required for a mixed import batch."""
+    permissions = set()
+    if device_ids:
+        permissions.update({"dcim.add_device", "dcim.change_device"})
+    if vm_imports:
+        permissions.add("virtualization.add_virtualmachine")
+    return sorted(permissions)
+
+
 def check_user_permissions(user, permissions):
     """
     Check if user has all required permissions.

--- a/netbox_librenms_plugin/import_validation_helpers.py
+++ b/netbox_librenms_plugin/import_validation_helpers.py
@@ -9,6 +9,33 @@ import logging
 
 logger = logging.getLogger(__name__)
 
+# The two slots a Stage-2 merge_candidates payload carries (the hostname-matched device and the
+# serial-matched device). Centralised so the merge view, collision detection, and any future
+# reader agree on the slot names rather than each hard-coding the strings.
+MERGE_CANDIDATE_SLOTS = ("host_named", "oob_named")
+
+
+def merge_candidate_pks(validation: dict) -> set:
+    """
+    Return the set of NetBox device pks a row's ``merge_candidates`` would touch.
+
+    Args:
+        validation (dict): A per-row validation dict (or None).
+
+    Returns:
+        set: The non-None ``pk`` values from the ``host_named`` / ``oob_named`` slots.
+    """
+    merge = (validation or {}).get("merge_candidates") or {}
+    if not isinstance(merge, dict):
+        return set()
+    pks = set()
+    for slot in MERGE_CANDIDATE_SLOTS:
+        entry = merge.get(slot) or {}
+        pk = entry.get("pk") if isinstance(entry, dict) else None
+        if pk is not None:
+            pks.add(pk)
+    return pks
+
 
 def fetch_model_by_id(model_class, pk):
     """

--- a/netbox_librenms_plugin/import_validation_helpers.py
+++ b/netbox_librenms_plugin/import_validation_helpers.py
@@ -27,7 +27,9 @@ def merge_candidate_pks(validation: dict) -> set:
     """
     from netbox_librenms_plugin.utils import coerce_positive_int
 
-    merge = (validation or {}).get("merge_candidates") or {}
+    if not isinstance(validation, dict):
+        return set()
+    merge = validation.get("merge_candidates") or {}
     if not isinstance(merge, dict):
         return set()
     pks = set()

--- a/netbox_librenms_plugin/import_validation_helpers.py
+++ b/netbox_librenms_plugin/import_validation_helpers.py
@@ -25,13 +25,18 @@ def merge_candidate_pks(validation: dict) -> set:
     Returns:
         set: The non-None ``pk`` values from the ``host_named`` / ``oob_named`` slots.
     """
+    from netbox_librenms_plugin.utils import coerce_positive_int
+
     merge = (validation or {}).get("merge_candidates") or {}
     if not isinstance(merge, dict):
         return set()
     pks = set()
     for slot in MERGE_CANDIDATE_SLOTS:
         entry = merge.get(slot) or {}
-        pk = entry.get("pk") if isinstance(entry, dict) else None
+        # Coerce to a positive int (a NetBox pk) before adding: a corrupt payload like
+        # {"pk": []} is unhashable and would crash set.add(), breaking the safe-extraction
+        # contract instead of failing closed on the bad slot.
+        pk = coerce_positive_int(entry.get("pk")) if isinstance(entry, dict) else None
         if pk is not None:
             pks.add(pk)
     return pks

--- a/netbox_librenms_plugin/jobs.py
+++ b/netbox_librenms_plugin/jobs.py
@@ -230,6 +230,10 @@ class ImportDevicesJob(JobRunner):
                     # cache-miss batch keeps issuing LibreNMS calls until the whole pre-check
                     # finishes and only the import loops below would honor the cancel.
                     job=self,
+                    # Each row validates in its actual import mode: a VM row checked in Device
+                    # mode would run the serial/IP matching bulk_import_vms skips and could
+                    # fabricate a collision that blocks a valid batch.
+                    vm_device_ids=vm_imports,
                 )
                 if len(collision_check_ids) >= 2
                 else ([], [])

--- a/netbox_librenms_plugin/jobs.py
+++ b/netbox_librenms_plugin/jobs.py
@@ -189,6 +189,7 @@ class ImportDevicesJob(JobRunner):
             classify_bulk_precheck,
             detect_collisions_for_device_ids,
             require_permissions,
+            required_import_permissions,
         )
         from netbox_librenms_plugin.import_utils.bulk_import import _is_job_cancelled
         from netbox_librenms_plugin.librenms_api import LibreNMSAPI
@@ -205,13 +206,9 @@ class ImportDevicesJob(JobRunner):
         # only run after it. The job executes outside any view's permission gate, so a
         # submitter whose import rights were revoked after enqueueing must be rejected
         # here, with the same standalone helper and perm sets the import paths enforce.
-        required_permissions = set()
-        if device_ids:
-            required_permissions.update({"dcim.add_device", "dcim.change_device"})
-        if vm_imports:
-            required_permissions.add("virtualization.add_virtualmachine")
+        required_permissions = required_import_permissions(device_ids, vm_imports)
         if required_permissions:
-            require_permissions(self.job.user, sorted(required_permissions), "import devices and VMs")
+            require_permissions(self.job.user, required_permissions, "import devices and VMs")
 
         # Initialize API client
         api = LibreNMSAPI(server_key=server_key)

--- a/netbox_librenms_plugin/jobs.py
+++ b/netbox_librenms_plugin/jobs.py
@@ -240,10 +240,13 @@ class ImportDevicesJob(JobRunner):
                 batch_blocked_msg = msg
             elif collisions:
                 pks = ", ".join(str(group["nb_device_pk"]) for group in collisions)
+                # Object-neutral wording: collision_check_ids includes vm_imports, so a blocked
+                # group can be a VirtualMachine, not just a Device. Mirror the confirm modal's
+                # "NetBox object collisions" copy so a VM-only block doesn't mislabel the type.
                 msg = (
-                    f"Import blocked: {len(collisions)} NetBox device collision(s) in this batch "
+                    f"Import blocked: {len(collisions)} NetBox object collision(s) in this batch "
                     f"(pk(s): {pks}). Two or more selected LibreNMS devices resolve to the same "
-                    f"NetBox device; resolve each individually."
+                    f"NetBox object; resolve each individually."
                 )
                 self.logger.error(msg)
                 device_result["failed"] = [{"device_id": device_id, "error": msg} for device_id in device_ids]

--- a/netbox_librenms_plugin/jobs.py
+++ b/netbox_librenms_plugin/jobs.py
@@ -188,6 +188,7 @@ class ImportDevicesJob(JobRunner):
             bulk_import_devices_shared,
             detect_collisions_for_device_ids,
         )
+        from netbox_librenms_plugin.import_utils.bulk_import import _is_job_cancelled
         from netbox_librenms_plugin.librenms_api import LibreNMSAPI
 
         total_count = len(device_ids) + len(vm_imports)
@@ -221,7 +222,14 @@ class ImportDevicesJob(JobRunner):
             # colliding batch either. A single row can never collide, so skip the extra pass.
             collisions, unresolved = (
                 detect_collisions_for_device_ids(
-                    collision_check_ids, api, libre_devices_cache=libre_devices_cache, sync_options=sync_options
+                    collision_check_ids,
+                    api,
+                    libre_devices_cache=libre_devices_cache,
+                    sync_options=sync_options,
+                    # Job context so a cancellation stops the scan itself — without it, a large
+                    # cache-miss batch keeps issuing LibreNMS calls until the whole pre-check
+                    # finishes and only the import loops below would honor the cancel.
+                    job=self,
                 )
                 if len(collision_check_ids) >= 2
                 else ([], [])
@@ -230,11 +238,19 @@ class ImportDevicesJob(JobRunner):
                 # Fail closed: these ids couldn't be fetched to collision-check, so don't import
                 # the batch unchecked (a transient get_device_info miss could otherwise let a
                 # colliding row through on retry). Block the whole batch like the collision path.
+                # A cancelled pre-check lands here too (its unscanned remainder is returned as
+                # unresolved) — report that as the cancellation it is, not as a fetch failure.
                 ids = ", ".join(str(d) for d in unresolved)
-                msg = (
-                    f"Import blocked: could not fetch LibreNMS device info for {len(unresolved)} "
-                    f"row(s) (id(s): {ids}) to verify collisions; retry the import."
-                )
+                if _is_job_cancelled(self):
+                    msg = (
+                        f"Import cancelled during the collision pre-check; {len(unresolved)} "
+                        f"row(s) (id(s): {ids}) were not checked and nothing was imported."
+                    )
+                else:
+                    msg = (
+                        f"Import blocked: could not fetch LibreNMS device info for {len(unresolved)} "
+                        f"row(s) (id(s): {ids}) to verify collisions; retry the import."
+                    )
                 self.logger.error(msg)
                 device_result["failed"] = [{"device_id": device_id, "error": msg} for device_id in device_ids]
                 batch_blocked_msg = msg

--- a/netbox_librenms_plugin/jobs.py
+++ b/netbox_librenms_plugin/jobs.py
@@ -206,6 +206,10 @@ class ImportDevicesJob(JobRunner):
             "skipped": [],
             "virtual_chassis_created": 0,
         }
+        # Set to the block reason when the device collision/unresolved gate fires, so the VM
+        # section below skips too — the synchronous view returns before importing ANY of the
+        # submitted batch, and the async path must not partially import the same batch's VMs.
+        batch_blocked_msg = None
         if device_ids:
             # Defense-in-depth: block a batch where two LibreNMS rows resolve to the same NetBox
             # device, mirroring the confirm-preview/sync-view gate so the async path can't import a
@@ -228,6 +232,7 @@ class ImportDevicesJob(JobRunner):
                 )
                 self.logger.error(msg)
                 device_result["failed"] = [{"device_id": device_id, "error": msg} for device_id in device_ids]
+                batch_blocked_msg = msg
             elif collisions:
                 pks = ", ".join(str(group["nb_device_pk"]) for group in collisions)
                 msg = (
@@ -237,6 +242,7 @@ class ImportDevicesJob(JobRunner):
                 )
                 self.logger.error(msg)
                 device_result["failed"] = [{"device_id": device_id, "error": msg} for device_id in device_ids]
+                batch_blocked_msg = msg
             else:
                 self.logger.info(f"Importing {len(device_ids)} devices...")
                 device_result = bulk_import_devices_shared(
@@ -252,12 +258,19 @@ class ImportDevicesJob(JobRunner):
         # Import VMs
         vm_result = {"success": [], "failed": [], "skipped": []}
         if vm_imports:
-            self.logger.info(f"Importing {len(vm_imports)} VMs...")
-            from netbox_librenms_plugin.import_utils import bulk_import_vms
+            if batch_blocked_msg:
+                # The device collision/unresolved gate blocked this submission; the synchronous
+                # view returns before importing anything, so fail the same batch's VMs closed with
+                # the block reason rather than partially importing them here.
+                self.logger.error(f"Skipping {len(vm_imports)} VM import(s); batch blocked: {batch_blocked_msg}")
+                vm_result["failed"] = [{"device_id": device_id, "error": batch_blocked_msg} for device_id in vm_imports]
+            else:
+                self.logger.info(f"Importing {len(vm_imports)} VMs...")
+                from netbox_librenms_plugin.import_utils import bulk_import_vms
 
-            vm_result = bulk_import_vms(
-                vm_imports, api, sync_options, libre_devices_cache, job=self, user=self.job.user
-            )
+                vm_result = bulk_import_vms(
+                    vm_imports, api, sync_options, libre_devices_cache, job=self, user=self.job.user
+                )
 
         # Combine results — partition device_result successes by model type since
         # bulk_import_devices_shared() may return VirtualMachine objects when import_as_vm=True.

--- a/netbox_librenms_plugin/jobs.py
+++ b/netbox_librenms_plugin/jobs.py
@@ -187,6 +187,7 @@ class ImportDevicesJob(JobRunner):
         from netbox_librenms_plugin.import_utils import (
             bulk_import_devices_shared,
             detect_collisions_for_device_ids,
+            require_permissions,
         )
         from netbox_librenms_plugin.import_utils.bulk_import import _is_job_cancelled
         from netbox_librenms_plugin.librenms_api import LibreNMSAPI
@@ -196,6 +197,22 @@ class ImportDevicesJob(JobRunner):
         self.logger.info(f"Device imports: {len(device_ids)}, VM imports: {len(vm_imports)}")
         if server_key:
             self.logger.info(f"Using LibreNMS server: {server_key}")
+
+        # Authorize BEFORE the collision pre-check: the scan below queries LibreNMS and
+        # surfaces collision details (NetBox pks) in the job output, while the
+        # require_permissions calls inside bulk_import_devices_shared / bulk_import_vms
+        # only run after it. The job executes outside any view's permission gate, so a
+        # submitter whose import rights were revoked after enqueueing must be rejected
+        # here, with the same standalone helper and perm sets the import paths enforce.
+        required_permissions = set()
+        if device_ids:
+            # Mirrors bulk_import_devices_shared: any device row may be flagged
+            # import_as_vm during validation, and VC master/member updates need change.
+            required_permissions.update({"dcim.add_device", "dcim.change_device", "virtualization.add_virtualmachine"})
+        if vm_imports:
+            required_permissions.add("virtualization.add_virtualmachine")
+        if required_permissions:
+            require_permissions(self.job.user, sorted(required_permissions), "import devices and VMs")
 
         # Initialize API client
         api = LibreNMSAPI(server_key=server_key)

--- a/netbox_librenms_plugin/jobs.py
+++ b/netbox_librenms_plugin/jobs.py
@@ -233,7 +233,7 @@ class ImportDevicesJob(JobRunner):
                 ids = ", ".join(str(d) for d in unresolved)
                 msg = (
                     f"Import blocked: could not fetch LibreNMS device info for {len(unresolved)} "
-                    f"device(s) (id(s): {ids}) to verify collisions; retry the import."
+                    f"row(s) (id(s): {ids}) to verify collisions; retry the import."
                 )
                 self.logger.error(msg)
                 device_result["failed"] = [{"device_id": device_id, "error": msg} for device_id in device_ids]

--- a/netbox_librenms_plugin/jobs.py
+++ b/netbox_librenms_plugin/jobs.py
@@ -207,9 +207,7 @@ class ImportDevicesJob(JobRunner):
         # here, with the same standalone helper and perm sets the import paths enforce.
         required_permissions = set()
         if device_ids:
-            # Mirrors bulk_import_devices_shared: any device row may be flagged
-            # import_as_vm during validation, and VC master/member updates need change.
-            required_permissions.update({"dcim.add_device", "dcim.change_device", "virtualization.add_virtualmachine"})
+            required_permissions.update({"dcim.add_device", "dcim.change_device"})
         if vm_imports:
             required_permissions.add("virtualization.add_virtualmachine")
         if required_permissions:
@@ -237,6 +235,7 @@ class ImportDevicesJob(JobRunner):
         # The shared block/skip decision (classify_bulk_precheck); None until the pre-check runs and
         # consulted by the VM section below so devices and VMs apply the SAME skip set.
         precheck_outcome = None
+        skipped_id_set = set()
         if collision_check_ids:
             # Defense-in-depth: block a batch where two LibreNMS rows resolve to the same NetBox
             # device, mirroring the confirm-preview/sync-view gate so the async path can't import a
@@ -276,6 +275,7 @@ class ImportDevicesJob(JobRunner):
                 # batch; rows that couldn't be collision-checked are SKIPPED (not a whole-batch
                 # block) so a transient miss on one row doesn't drop the entire import.
                 precheck_outcome = classify_bulk_precheck(collisions, unresolved, device_ids, vm_imports)
+                skipped_id_set = set(precheck_outcome.skipped_ids)
                 if precheck_outcome.blocked:
                     self.logger.error(precheck_outcome.block_message)
                     device_result["failed"] = [
@@ -296,7 +296,7 @@ class ImportDevicesJob(JobRunner):
                             job=self,  # Pass job context for logging and cancellation
                             user=self.job.user,  # Pass user for permission checks
                         )
-                    skipped_device_ids = [d for d in device_ids if d in set(precheck_outcome.skipped_ids)]
+                    skipped_device_ids = [d for d in device_ids if d in skipped_id_set]
                     if skipped_device_ids:
                         self.logger.warning(precheck_outcome.skip_message)
                         device_result.setdefault("failed", []).extend(
@@ -316,9 +316,7 @@ class ImportDevicesJob(JobRunner):
                 # Apply the same skip set to VMs: import the collision-checked VM rows, skip the
                 # unresolved ones (surfaced as failures with the shared message).
                 importable_vm_imports = precheck_outcome.importable_vm_imports if precheck_outcome else vm_imports
-                skipped_vm_ids = (
-                    [d for d in vm_imports if d in set(precheck_outcome.skipped_ids)] if precheck_outcome else []
-                )
+                skipped_vm_ids = [d for d in vm_imports if d in skipped_id_set] if precheck_outcome else []
                 if importable_vm_imports:
                     self.logger.info(f"Importing {len(importable_vm_imports)} VMs...")
                     from netbox_librenms_plugin.import_utils import bulk_import_vms

--- a/netbox_librenms_plugin/jobs.py
+++ b/netbox_librenms_plugin/jobs.py
@@ -210,15 +210,20 @@ class ImportDevicesJob(JobRunner):
         # section below skips too — the synchronous view returns before importing ANY of the
         # submitted batch, and the async path must not partially import the same batch's VMs.
         batch_blocked_msg = None
-        if device_ids:
+        # Collision-check the WHOLE submitted batch — device imports AND VM imports — exactly like
+        # the synchronous view, which passes its full parsed id set (devices + VMs) to the same
+        # gate. device_ids here excludes VM rows (split out upstream), so checking it alone would
+        # let a VM-only batch, or a collision involving a VM row, slip through to bulk_import_vms().
+        collision_check_ids = list(dict.fromkeys([*device_ids, *vm_imports]))
+        if collision_check_ids:
             # Defense-in-depth: block a batch where two LibreNMS rows resolve to the same NetBox
             # device, mirroring the confirm-preview/sync-view gate so the async path can't import a
-            # colliding batch either. A single device can never collide, so skip the extra pass.
+            # colliding batch either. A single row can never collide, so skip the extra pass.
             collisions, unresolved = (
                 detect_collisions_for_device_ids(
-                    device_ids, api, libre_devices_cache=libre_devices_cache, sync_options=sync_options
+                    collision_check_ids, api, libre_devices_cache=libre_devices_cache, sync_options=sync_options
                 )
-                if len(device_ids) >= 2
+                if len(collision_check_ids) >= 2
                 else ([], [])
             )
             if unresolved:
@@ -243,7 +248,9 @@ class ImportDevicesJob(JobRunner):
                 self.logger.error(msg)
                 device_result["failed"] = [{"device_id": device_id, "error": msg} for device_id in device_ids]
                 batch_blocked_msg = msg
-            else:
+            elif device_ids:
+                # Clean batch with real device rows — import them. (A VM-only batch falls through
+                # here with nothing to do; its VMs are handled in the vm_imports block below.)
                 self.logger.info(f"Importing {len(device_ids)} devices...")
                 device_result = bulk_import_devices_shared(
                     device_ids=device_ids,

--- a/netbox_librenms_plugin/jobs.py
+++ b/netbox_librenms_plugin/jobs.py
@@ -186,6 +186,7 @@ class ImportDevicesJob(JobRunner):
 
         from netbox_librenms_plugin.import_utils import (
             bulk_import_devices_shared,
+            classify_bulk_precheck,
             detect_collisions_for_device_ids,
             require_permissions,
         )
@@ -233,6 +234,9 @@ class ImportDevicesJob(JobRunner):
         # gate. device_ids here excludes VM rows (split out upstream), so checking it alone would
         # let a VM-only batch, or a collision involving a VM row, slip through to bulk_import_vms().
         collision_check_ids = list(dict.fromkeys([*device_ids, *vm_imports]))
+        # The shared block/skip decision (classify_bulk_precheck); None until the pre-check runs and
+        # consulted by the VM section below so devices and VMs apply the SAME skip set.
+        precheck_outcome = None
         if collision_check_ids:
             # Defense-in-depth: block a batch where two LibreNMS rows resolve to the same NetBox
             # device, mirroring the confirm-preview/sync-view gate so the async path can't import a
@@ -255,69 +259,78 @@ class ImportDevicesJob(JobRunner):
                 if len(collision_check_ids) >= 2
                 else ([], [])
             )
-            if unresolved:
-                # Fail closed: these ids couldn't be fetched to collision-check, so don't import
-                # the batch unchecked (a transient get_device_info miss could otherwise let a
-                # colliding row through on retry). Block the whole batch like the collision path.
-                # A cancelled pre-check lands here too (its unscanned remainder is returned as
-                # unresolved) — report that as the cancellation it is, not as a fetch failure.
+            if unresolved and _is_job_cancelled(self):
+                # A cancelled pre-check returns its unscanned remainder as unresolved. Cancellation
+                # is a hard stop (the user asked to stop), so fail the whole batch closed rather than
+                # skip-and-import the scanned portion — and report it as the cancellation it is.
                 ids = ", ".join(str(d) for d in unresolved)
-                if _is_job_cancelled(self):
-                    msg = (
-                        f"Import cancelled during the collision pre-check; {len(unresolved)} "
-                        f"row(s) (id(s): {ids}) were not checked and nothing was imported."
-                    )
-                else:
-                    msg = (
-                        f"Import blocked: could not fetch LibreNMS device info for {len(unresolved)} "
-                        f"row(s) (id(s): {ids}) to verify collisions; retry the import."
-                    )
-                self.logger.error(msg)
-                device_result["failed"] = [{"device_id": device_id, "error": msg} for device_id in device_ids]
-                batch_blocked_msg = msg
-            elif collisions:
-                pks = ", ".join(str(group["nb_device_pk"]) for group in collisions)
-                # Object-neutral wording: collision_check_ids includes vm_imports, so a blocked
-                # group can be a VirtualMachine, not just a Device. Mirror the confirm modal's
-                # "NetBox object collisions" copy so a VM-only block doesn't mislabel the type.
                 msg = (
-                    f"Import blocked: {len(collisions)} NetBox object collision(s) in this batch "
-                    f"(pk(s): {pks}). Two or more selected LibreNMS devices resolve to the same "
-                    f"NetBox object; resolve each individually."
+                    f"Import cancelled during the collision pre-check; {len(unresolved)} "
+                    f"row(s) (id(s): {ids}) were not checked and nothing was imported."
                 )
                 self.logger.error(msg)
                 device_result["failed"] = [{"device_id": device_id, "error": msg} for device_id in device_ids]
                 batch_blocked_msg = msg
-            elif device_ids:
-                # Clean batch with real device rows — import them. (A VM-only batch falls through
-                # here with nothing to do; its VMs are handled in the vm_imports block below.)
-                self.logger.info(f"Importing {len(device_ids)} devices...")
-                device_result = bulk_import_devices_shared(
-                    device_ids=device_ids,
-                    server_key=api.server_key,
-                    sync_options=sync_options,
-                    manual_mappings_per_device=manual_mappings_per_device,
-                    libre_devices_cache=libre_devices_cache,
-                    job=self,  # Pass job context for logging and cancellation
-                    user=self.job.user,  # Pass user for permission checks
-                )
+            else:
+                # Shared decision, identical to the sync view: genuine collisions block the whole
+                # batch; rows that couldn't be collision-checked are SKIPPED (not a whole-batch
+                # block) so a transient miss on one row doesn't drop the entire import.
+                precheck_outcome = classify_bulk_precheck(collisions, unresolved, device_ids, vm_imports)
+                if precheck_outcome.blocked:
+                    self.logger.error(precheck_outcome.block_message)
+                    device_result["failed"] = [
+                        {"device_id": device_id, "error": precheck_outcome.block_message} for device_id in device_ids
+                    ]
+                    batch_blocked_msg = precheck_outcome.block_message
+                else:
+                    if precheck_outcome.importable_device_ids:
+                        # Clean device rows — import them. (A VM-only batch has none; its VMs are
+                        # handled in the vm_imports block below.)
+                        self.logger.info(f"Importing {len(precheck_outcome.importable_device_ids)} devices...")
+                        device_result = bulk_import_devices_shared(
+                            device_ids=precheck_outcome.importable_device_ids,
+                            server_key=api.server_key,
+                            sync_options=sync_options,
+                            manual_mappings_per_device=manual_mappings_per_device,
+                            libre_devices_cache=libre_devices_cache,
+                            job=self,  # Pass job context for logging and cancellation
+                            user=self.job.user,  # Pass user for permission checks
+                        )
+                    skipped_device_ids = [d for d in device_ids if d in set(precheck_outcome.skipped_ids)]
+                    if skipped_device_ids:
+                        self.logger.warning(precheck_outcome.skip_message)
+                        device_result.setdefault("failed", []).extend(
+                            {"device_id": device_id, "error": precheck_outcome.skip_message}
+                            for device_id in skipped_device_ids
+                        )
 
         # Import VMs
         vm_result = {"success": [], "failed": [], "skipped": []}
         if vm_imports:
             if batch_blocked_msg:
-                # The device collision/unresolved gate blocked this submission; the synchronous
-                # view returns before importing anything, so fail the same batch's VMs closed with
-                # the block reason rather than partially importing them here.
+                # A genuine collision (or a cancellation) blocked this submission — fail the same
+                # batch's VMs closed with the block reason rather than partially importing them.
                 self.logger.error(f"Skipping {len(vm_imports)} VM import(s); batch blocked: {batch_blocked_msg}")
                 vm_result["failed"] = [{"device_id": device_id, "error": batch_blocked_msg} for device_id in vm_imports]
             else:
-                self.logger.info(f"Importing {len(vm_imports)} VMs...")
-                from netbox_librenms_plugin.import_utils import bulk_import_vms
-
-                vm_result = bulk_import_vms(
-                    vm_imports, api, sync_options, libre_devices_cache, job=self, user=self.job.user
+                # Apply the same skip set to VMs: import the collision-checked VM rows, skip the
+                # unresolved ones (surfaced as failures with the shared message).
+                importable_vm_imports = precheck_outcome.importable_vm_imports if precheck_outcome else vm_imports
+                skipped_vm_ids = (
+                    [d for d in vm_imports if d in set(precheck_outcome.skipped_ids)] if precheck_outcome else []
                 )
+                if importable_vm_imports:
+                    self.logger.info(f"Importing {len(importable_vm_imports)} VMs...")
+                    from netbox_librenms_plugin.import_utils import bulk_import_vms
+
+                    vm_result = bulk_import_vms(
+                        importable_vm_imports, api, sync_options, libre_devices_cache, job=self, user=self.job.user
+                    )
+                if skipped_vm_ids:
+                    self.logger.warning(precheck_outcome.skip_message)
+                    vm_result.setdefault("failed", []).extend(
+                        {"device_id": device_id, "error": precheck_outcome.skip_message} for device_id in skipped_vm_ids
+                    )
 
         # Combine results — partition device_result successes by model type since
         # bulk_import_devices_shared() may return VirtualMachine objects when import_as_vm=True.

--- a/netbox_librenms_plugin/jobs.py
+++ b/netbox_librenms_plugin/jobs.py
@@ -186,6 +186,7 @@ class ImportDevicesJob(JobRunner):
 
         from netbox_librenms_plugin.import_utils import (
             bulk_import_devices_shared,
+            detect_collisions_for_device_ids,
         )
         from netbox_librenms_plugin.librenms_api import LibreNMSAPI
 
@@ -206,16 +207,36 @@ class ImportDevicesJob(JobRunner):
             "virtual_chassis_created": 0,
         }
         if device_ids:
-            self.logger.info(f"Importing {len(device_ids)} devices...")
-            device_result = bulk_import_devices_shared(
-                device_ids=device_ids,
-                server_key=api.server_key,
-                sync_options=sync_options,
-                manual_mappings_per_device=manual_mappings_per_device,
-                libre_devices_cache=libre_devices_cache,
-                job=self,  # Pass job context for logging and cancellation
-                user=self.job.user,  # Pass user for permission checks
+            # Defense-in-depth: block a batch where two LibreNMS rows resolve to the same NetBox
+            # device, mirroring the confirm-preview/sync-view gate so the async path can't import a
+            # colliding batch either. A single device can never collide, so skip the extra pass.
+            collisions = (
+                detect_collisions_for_device_ids(
+                    device_ids, api, libre_devices_cache=libre_devices_cache, sync_options=sync_options
+                )
+                if len(device_ids) >= 2
+                else []
             )
+            if collisions:
+                pks = ", ".join(str(group["nb_device_pk"]) for group in collisions)
+                msg = (
+                    f"Import blocked: {len(collisions)} NetBox device collision(s) in this batch "
+                    f"(pk(s): {pks}). Two or more selected LibreNMS devices resolve to the same "
+                    f"NetBox device; resolve each individually."
+                )
+                self.logger.error(msg)
+                device_result["failed"] = [{"device_id": device_id, "error": msg} for device_id in device_ids]
+            else:
+                self.logger.info(f"Importing {len(device_ids)} devices...")
+                device_result = bulk_import_devices_shared(
+                    device_ids=device_ids,
+                    server_key=api.server_key,
+                    sync_options=sync_options,
+                    manual_mappings_per_device=manual_mappings_per_device,
+                    libre_devices_cache=libre_devices_cache,
+                    job=self,  # Pass job context for logging and cancellation
+                    user=self.job.user,  # Pass user for permission checks
+                )
 
         # Import VMs
         vm_result = {"success": [], "failed": [], "skipped": []}

--- a/netbox_librenms_plugin/jobs.py
+++ b/netbox_librenms_plugin/jobs.py
@@ -210,14 +210,25 @@ class ImportDevicesJob(JobRunner):
             # Defense-in-depth: block a batch where two LibreNMS rows resolve to the same NetBox
             # device, mirroring the confirm-preview/sync-view gate so the async path can't import a
             # colliding batch either. A single device can never collide, so skip the extra pass.
-            collisions = (
+            collisions, unresolved = (
                 detect_collisions_for_device_ids(
                     device_ids, api, libre_devices_cache=libre_devices_cache, sync_options=sync_options
                 )
                 if len(device_ids) >= 2
-                else []
+                else ([], [])
             )
-            if collisions:
+            if unresolved:
+                # Fail closed: these ids couldn't be fetched to collision-check, so don't import
+                # the batch unchecked (a transient get_device_info miss could otherwise let a
+                # colliding row through on retry). Block the whole batch like the collision path.
+                ids = ", ".join(str(d) for d in unresolved)
+                msg = (
+                    f"Import blocked: could not fetch LibreNMS device info for {len(unresolved)} "
+                    f"device(s) (id(s): {ids}) to verify collisions; retry the import."
+                )
+                self.logger.error(msg)
+                device_result["failed"] = [{"device_id": device_id, "error": msg} for device_id in device_ids]
+            elif collisions:
                 pks = ", ".join(str(group["nb_device_pk"]) for group in collisions)
                 msg = (
                     f"Import blocked: {len(collisions)} NetBox device collision(s) in this batch "

--- a/netbox_librenms_plugin/templates/netbox_librenms_plugin/htmx/bulk_import_collision.html
+++ b/netbox_librenms_plugin/templates/netbox_librenms_plugin/htmx/bulk_import_collision.html
@@ -1,7 +1,13 @@
 {# Bulk-import collision warning: shown when two or more selected LibreNMS rows resolve to the same NetBox device. #}
 <div class="modal-header">
   <h5 class="modal-title text-danger">
-    <i class="mdi mdi-alert-octagon"></i> Bulk import blocked: NetBox device collisions
+    <i class="mdi mdi-alert-octagon"></i>
+    {# The modal also renders non-collision failures (error_message branch below), so keep the title generic in that case. #}
+    {% if error_message %}
+      Bulk import blocked
+    {% else %}
+      Bulk import blocked: NetBox device collisions
+    {% endif %}
   </h5>
   <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
 </div>

--- a/netbox_librenms_plugin/templates/netbox_librenms_plugin/htmx/bulk_import_collision.html
+++ b/netbox_librenms_plugin/templates/netbox_librenms_plugin/htmx/bulk_import_collision.html
@@ -23,7 +23,7 @@
     <div class="border border-danger rounded-3 p-3 mb-3">
       <div class="d-flex flex-wrap align-items-center gap-2 mb-2">
         <span class="badge bg-danger text-white">Collision</span>
-        <span class="text-muted small">NetBox {% if group.nb_model_name == 'virtualmachine' %}VM{% else %}device{% endif %}:</span>
+        <span class="text-muted small">NetBox {{ group.nb_kind }}:</span>
         {% if group.nb_model_name == 'virtualmachine' %}
           <a href="{% url 'virtualization:virtualmachine' pk=group.nb_device_pk %}" target="_blank" rel="noopener" class="fw-bold">
             {{ group.nb_device_name }}
@@ -35,7 +35,7 @@
         {% endif %}
         <span class="text-muted small">(pk {{ group.nb_device_pk }})</span>
       </div>
-      <div class="text-muted small mb-1">Selected LibreNMS rows targeting this {% if group.nb_model_name == 'virtualmachine' %}VM{% else %}device{% endif %}:</div>
+      <div class="text-muted small mb-1">Selected LibreNMS rows targeting this {{ group.nb_kind }}:</div>
       <ul class="list-unstyled mb-0 ps-2 small">
         {% for row in group.librenms_rows %}
           <li class="mb-1">

--- a/netbox_librenms_plugin/templates/netbox_librenms_plugin/htmx/bulk_import_collision.html
+++ b/netbox_librenms_plugin/templates/netbox_librenms_plugin/htmx/bulk_import_collision.html
@@ -2,22 +2,11 @@
 <div class="modal-header">
   <h5 class="modal-title text-danger">
     <i class="mdi mdi-alert-octagon"></i>
-    {# The modal also renders non-collision failures (error_message branch below), so keep the title generic in that case. #}
-    {% if error_message %}
-      Bulk import blocked
-    {% else %}
-      Bulk import blocked: NetBox object collisions
-    {% endif %}
+    Bulk import blocked: NetBox object collisions
   </h5>
   <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
 </div>
 <div class="modal-body">
-  {% if error_message %}
-    {# Non-collision block (e.g. a selected device whose LibreNMS info couldn't be fetched to collision-check). #}
-    <div class="alert alert-danger mb-0">
-      <i class="mdi mdi-alert-octagon me-1"></i>{{ error_message }}
-    </div>
-  {% else %}
   <div class="alert alert-danger mb-3">
     <div>
       <i class="mdi mdi-alert-octagon me-1"></i>
@@ -70,7 +59,6 @@
       per-row action that you can run from the import button.
     </div>
   </div>
-  {% endif %}
 </div>
 <div class="modal-footer">
   <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">

--- a/netbox_librenms_plugin/templates/netbox_librenms_plugin/htmx/bulk_import_collision.html
+++ b/netbox_librenms_plugin/templates/netbox_librenms_plugin/htmx/bulk_import_collision.html
@@ -46,7 +46,7 @@
         {% endif %}
         <span class="text-muted small">(pk {{ group.nb_device_pk }})</span>
       </div>
-      <div class="text-muted small mb-1">Selected LibreNMS rows targeting this device:</div>
+      <div class="text-muted small mb-1">Selected LibreNMS rows targeting this {% if group.nb_model_name == 'virtualmachine' %}VM{% else %}device{% endif %}:</div>
       <ul class="list-unstyled mb-0 ps-2 small">
         {% for row in group.librenms_rows %}
           <li class="mb-1">

--- a/netbox_librenms_plugin/templates/netbox_librenms_plugin/htmx/bulk_import_collision.html
+++ b/netbox_librenms_plugin/templates/netbox_librenms_plugin/htmx/bulk_import_collision.html
@@ -1,0 +1,67 @@
+{# Bulk-import collision warning: shown when two or more selected LibreNMS rows resolve to the same NetBox device. #}
+<div class="modal-header">
+  <h5 class="modal-title text-danger">
+    <i class="mdi mdi-alert-octagon"></i> Bulk import blocked: NetBox device collisions
+  </h5>
+  <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+</div>
+<div class="modal-body">
+  <div class="alert alert-danger mb-3">
+    <div>
+      <i class="mdi mdi-alert-octagon me-1"></i>
+      Two or more selected LibreNMS devices would update the
+      <strong>same NetBox device</strong>. Importing them as a batch could
+      leave NetBox in an inconsistent state, so the whole import has been
+      blocked. Resolve each colliding NetBox device individually first
+      (use the per-row import action on the table), or deselect the
+      duplicates and try again.
+    </div>
+  </div>
+
+  {% for group in collisions %}
+    <div class="border border-danger rounded-3 p-3 mb-3">
+      <div class="d-flex flex-wrap align-items-center gap-2 mb-2">
+        <span class="badge bg-danger">Collision</span>
+        <span class="text-muted small">NetBox {% if group.nb_model_name == 'VirtualMachine' %}VM{% else %}device{% endif %}:</span>
+        {% if group.nb_model_name == 'VirtualMachine' %}
+          <a href="{% url 'virtualization:virtualmachine' pk=group.nb_device_pk %}" target="_blank" rel="noopener" class="fw-bold">
+            {{ group.nb_device_name }}
+          </a>
+        {% else %}
+          <a href="{% url 'dcim:device' pk=group.nb_device_pk %}" target="_blank" rel="noopener" class="fw-bold">
+            {{ group.nb_device_name }}
+          </a>
+        {% endif %}
+        <span class="text-muted small">(pk {{ group.nb_device_pk }})</span>
+      </div>
+      <div class="text-muted small mb-1">Selected LibreNMS rows targeting this device:</div>
+      <ul class="list-unstyled mb-0 ps-2 small">
+        {% for row in group.librenms_rows %}
+          <li class="mb-1">
+            <i class="mdi mdi-circle-small"></i>
+            <strong>{{ row.hostname }}</strong>
+            <span class="text-muted">(LibreNMS id {{ row.device_id }})</span>
+            <span class="badge bg-secondary-lt ms-1">{{ row.role }}</span>
+          </li>
+        {% endfor %}
+      </ul>
+    </div>
+  {% endfor %}
+
+  <div class="alert alert-info mb-0 small">
+    <div>
+      <i class="mdi mdi-lightbulb-outline me-1"></i>
+      <strong>How to fix:</strong> close this dialog, untick all but one
+      of the LibreNMS rows in each colliding group, and click
+      <em>Bulk Import</em> again. After the first row is imported, the
+      conflict for the second one usually resolves into an
+      <em>Add as OOB</em> or <em>Promote to host</em> action that you
+      can run from the per-row import button.
+    </div>
+  </div>
+</div>
+<div class="modal-footer">
+  <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">
+    <i class="mdi mdi-close"></i> Close
+  </button>
+</div>

--- a/netbox_librenms_plugin/templates/netbox_librenms_plugin/htmx/bulk_import_collision.html
+++ b/netbox_librenms_plugin/templates/netbox_librenms_plugin/htmx/bulk_import_collision.html
@@ -6,7 +6,7 @@
     {% if error_message %}
       Bulk import blocked
     {% else %}
-      Bulk import blocked: NetBox device collisions
+      Bulk import blocked: NetBox object collisions
     {% endif %}
   </h5>
   <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
@@ -21,10 +21,10 @@
   <div class="alert alert-danger mb-3">
     <div>
       <i class="mdi mdi-alert-octagon me-1"></i>
-      Two or more selected LibreNMS devices would update the
-      <strong>same NetBox device</strong>. Importing them as a batch could
+      Two or more selected LibreNMS rows would update the
+      <strong>same NetBox object</strong>. Importing them as a batch could
       leave NetBox in an inconsistent state, so the whole import has been
-      blocked. Resolve each colliding NetBox device individually first
+      blocked. Resolve each colliding NetBox object individually first
       (use the per-row import action on the table), or deselect the
       duplicates and try again.
     </div>
@@ -66,9 +66,8 @@
       <strong>How to fix:</strong> close this dialog, untick all but one
       of the LibreNMS rows in each colliding group, and click
       <em>Bulk Import</em> again. After the first row is imported, the
-      conflict for the second one usually resolves into an
-      <em>Add as OOB</em> or <em>Promote to host</em> action that you
-      can run from the per-row import button.
+      conflict for the second one usually resolves into a different
+      per-row action that you can run from the import button.
     </div>
   </div>
   {% endif %}

--- a/netbox_librenms_plugin/templates/netbox_librenms_plugin/htmx/bulk_import_collision.html
+++ b/netbox_librenms_plugin/templates/netbox_librenms_plugin/htmx/bulk_import_collision.html
@@ -21,7 +21,7 @@
   {% for group in collisions %}
     <div class="border border-danger rounded-3 p-3 mb-3">
       <div class="d-flex flex-wrap align-items-center gap-2 mb-2">
-        <span class="badge bg-danger">Collision</span>
+        <span class="badge bg-danger text-white">Collision</span>
         <span class="text-muted small">NetBox {% if group.nb_model_name == 'VirtualMachine' %}VM{% else %}device{% endif %}:</span>
         {% if group.nb_model_name == 'VirtualMachine' %}
           <a href="{% url 'virtualization:virtualmachine' pk=group.nb_device_pk %}" target="_blank" rel="noopener" class="fw-bold">

--- a/netbox_librenms_plugin/templates/netbox_librenms_plugin/htmx/bulk_import_collision.html
+++ b/netbox_librenms_plugin/templates/netbox_librenms_plugin/htmx/bulk_import_collision.html
@@ -1,4 +1,5 @@
 {# Bulk-import collision warning: shown when two or more selected LibreNMS rows resolve to the same NetBox device. #}
+{% if oob %}<div id="htmx-modal-content" hx-swap-oob="innerHTML">{% endif %}
 <div class="modal-header">
   <h5 class="modal-title text-danger">
     <i class="mdi mdi-alert-octagon"></i>
@@ -65,3 +66,4 @@
     <i class="mdi mdi-close"></i> Close
   </button>
 </div>
+{% if oob %}</div>{% endif %}

--- a/netbox_librenms_plugin/templates/netbox_librenms_plugin/htmx/bulk_import_collision.html
+++ b/netbox_librenms_plugin/templates/netbox_librenms_plugin/htmx/bulk_import_collision.html
@@ -22,8 +22,8 @@
     <div class="border border-danger rounded-3 p-3 mb-3">
       <div class="d-flex flex-wrap align-items-center gap-2 mb-2">
         <span class="badge bg-danger text-white">Collision</span>
-        <span class="text-muted small">NetBox {% if group.nb_model_name == 'VirtualMachine' %}VM{% else %}device{% endif %}:</span>
-        {% if group.nb_model_name == 'VirtualMachine' %}
+        <span class="text-muted small">NetBox {% if group.nb_model_name == 'virtualmachine' %}VM{% else %}device{% endif %}:</span>
+        {% if group.nb_model_name == 'virtualmachine' %}
           <a href="{% url 'virtualization:virtualmachine' pk=group.nb_device_pk %}" target="_blank" rel="noopener" class="fw-bold">
             {{ group.nb_device_name }}
           </a>

--- a/netbox_librenms_plugin/templates/netbox_librenms_plugin/htmx/bulk_import_collision.html
+++ b/netbox_librenms_plugin/templates/netbox_librenms_plugin/htmx/bulk_import_collision.html
@@ -6,6 +6,12 @@
   <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
 </div>
 <div class="modal-body">
+  {% if error_message %}
+    {# Non-collision block (e.g. a selected device whose LibreNMS info couldn't be fetched to collision-check). #}
+    <div class="alert alert-danger mb-0">
+      <i class="mdi mdi-alert-octagon me-1"></i>{{ error_message }}
+    </div>
+  {% else %}
   <div class="alert alert-danger mb-3">
     <div>
       <i class="mdi mdi-alert-octagon me-1"></i>
@@ -59,6 +65,7 @@
       can run from the per-row import button.
     </div>
   </div>
+  {% endif %}
 </div>
 <div class="modal-footer">
   <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">

--- a/netbox_librenms_plugin/templates/netbox_librenms_plugin/htmx/device_validation_details.html
+++ b/netbox_librenms_plugin/templates/netbox_librenms_plugin/htmx/device_validation_details.html
@@ -952,8 +952,6 @@
               hx-swap="none"
               hx-include="#use-sysname-toggle, #strip-domain-toggle">
           {% csrf_token %}
-          {# server_key keeps the action scoped to the active LibreNMS server (issue #106). #}
-          <input type="hidden" name="server_key" value="{{ server_key }}">
           <input type="hidden" name="existing_device_id" value="{{ validation.existing_device.pk }}">
           <input type="hidden" name="existing_device_type" value="{{ existing_device_model_name|default:'device' }}">
           {% comment %}

--- a/netbox_librenms_plugin/templates/netbox_librenms_plugin/htmx/module_mismatch_modal.html
+++ b/netbox_librenms_plugin/templates/netbox_librenms_plugin/htmx/module_mismatch_modal.html
@@ -68,6 +68,12 @@
         <em>Move</em> will update its location to this bay instead of creating a new entry.
     </small>
 </div>
+{% elif serial_conflict_hidden %}
+<div class="alert alert-warning py-2 mb-3">
+    <i class="mdi mdi-alert me-1"></i>
+    <strong>Serial conflict:</strong> This serial is assigned to a module you cannot view.
+    Ask an administrator to resolve the conflict.
+</div>
 {% elif serial_conflict_ambiguous %}
 <div class="alert alert-warning py-2 mb-3">
     <i class="mdi mdi-alert me-1"></i>
@@ -119,7 +125,7 @@
     {% endif %}
 
     {# Replace: delete current + install fresh from LibreNMS data #}
-    {% if installed_module and not serial_conflict_ambiguous %}
+    {% if installed_module and not serial_conflict_ambiguous and not serial_conflict_hidden %}
     <form method="post"
           action="{% url 'plugins:netbox_librenms_plugin:replace_module' pk=device_pk %}"
           hx-post="{% url 'plugins:netbox_librenms_plugin:replace_module' pk=device_pk %}"

--- a/netbox_librenms_plugin/templates/netbox_librenms_plugin/htmx/module_mismatch_modal.html
+++ b/netbox_librenms_plugin/templates/netbox_librenms_plugin/htmx/module_mismatch_modal.html
@@ -85,7 +85,7 @@
 <div class="d-flex gap-2 justify-content-end flex-wrap mt-3">
     <button type="button" class="btn btn-secondary" onclick="closeHtmxModal()">Cancel</button>
 
-    {% if serial_mismatch and not type_mismatch and not serial_conflict and not serial_conflict_ambiguous and installed_module %}
+    {% if serial_mismatch and not type_mismatch and not serial_conflict and not serial_conflict_hidden and not serial_conflict_ambiguous and installed_module %}
     {# Quick serial-only update — no delete/recreate needed #}
     <form method="post"
           action="{% url 'plugins:netbox_librenms_plugin:update_module_serial' pk=device_pk %}"

--- a/netbox_librenms_plugin/tests/conftest.py
+++ b/netbox_librenms_plugin/tests/conftest.py
@@ -214,7 +214,11 @@ def install_module(device, bay_name, model, *, serial="", child_bays=(), manufac
 def ip_on(device, address, ifname, *, iface_type="1000base-t"):
     """Create an Interface on *device* and assign a real IPAddress to it."""
     iface = make_interface(device, ifname, iface_type=iface_type)
-    return make_ip(address, assigned_object=iface)
+    ip = make_ip(address, assigned_object=iface)
+    # NetBox 4.4's IP pre-delete receiver reads address.version. Coerce the string passed to
+    # objects.create() through the model field before returning so every caller can delete safely.
+    ip.refresh_from_db()
+    return ip
 
 
 def delete_keeping_pk(obj):

--- a/netbox_librenms_plugin/tests/conftest.py
+++ b/netbox_librenms_plugin/tests/conftest.py
@@ -61,7 +61,7 @@ def make_device(name, *, serial="", librenms_cf=None):
     return dev
 
 
-def make_virtual_chassis(tag, count=2):
+def make_virtual_chassis_members(tag, count=2):
     """Create a VirtualChassis with members at consecutive positions."""
     from dcim.models import VirtualChassis
 

--- a/netbox_librenms_plugin/tests/conftest.py
+++ b/netbox_librenms_plugin/tests/conftest.py
@@ -14,15 +14,21 @@ def _clear_device_info_cache():
     name and a pk (``CacheMixin.get_cache_key`` → ``librenms_links_device_7_default``), so a
     value cached by one test is read by the next test that draws the same pk, with entirely
     different data behind it. ``librenms_*`` covers the per-object render caches (ports, links,
-    vlans, ip_addresses, inventory, last-fetched stamps, VLAN group overrides) as well as
-    ``get_device_info()``'s short-lived lookup cache.
+    vlans, ip_addresses, inventory, last-fetched stamps, VLAN group overrides), ``get_device_info()``'s
+    short-lived lookup cache and the cached import search results. ``import_device_data_*`` sits
+    outside that prefix: the bulk-import collision gate reads it via ``cache.get_many``
+    (actions.py) BEFORE falling back to the stubbed ``get_device_info``, so a leaked entry for a
+    selected id silently bypasses the stub and defeats the collision check.
     """
     from django.core.cache import cache
 
-    try:
-        cache.delete_pattern("librenms_*")
-    except (AttributeError, NotImplementedError):
-        cache.clear()
+    for pattern in ("librenms_*", "import_device_data_*"):
+        try:
+            cache.delete_pattern(pattern)
+        except (AttributeError, NotImplementedError):
+            # No django-redis delete_pattern (e.g. LocMemCache): a single clear() covers all.
+            cache.clear()
+            break
     yield
 
 

--- a/netbox_librenms_plugin/tests/conftest.py
+++ b/netbox_librenms_plugin/tests/conftest.py
@@ -7,17 +7,20 @@ import pytest
 
 @pytest.fixture(autouse=True)
 def _clear_device_info_cache():
-    """Clear get_device_info()'s short-lived cache between tests.
+    """Flush the plugin's caches between tests.
 
-    get_device_info() caches successful lookups in the shared cache. Without this,
-    a cached success from one test leaks into another that reuses the same
-    (server_key, device_id) but mocks a different response — e.g. the failure-path
-    tests keyed on device_id=123 that run after test_get_device_info_success.
+    NetBox uses Redis, which (unlike the test DB) is NOT rolled back between tests, while
+    primary keys ARE reused after each rollback. Every plugin cache key is built from a model
+    name and a pk (``CacheMixin.get_cache_key`` → ``librenms_links_device_7_default``), so a
+    value cached by one test is read by the next test that draws the same pk, with entirely
+    different data behind it. ``librenms_*`` covers the per-object render caches (ports, links,
+    vlans, ip_addresses, inventory, last-fetched stamps, VLAN group overrides) as well as
+    ``get_device_info()``'s short-lived lookup cache.
     """
     from django.core.cache import cache
 
     try:
-        cache.delete_pattern("librenms_device_info_*")
+        cache.delete_pattern("librenms_*")
     except (AttributeError, NotImplementedError):
         cache.clear()
     yield

--- a/netbox_librenms_plugin/tests/conftest.py
+++ b/netbox_librenms_plugin/tests/conftest.py
@@ -61,6 +61,21 @@ def make_device(name, *, serial="", librenms_cf=None):
     return dev
 
 
+def make_virtual_chassis(tag, count=2):
+    """Create a VirtualChassis with members at consecutive positions."""
+    from dcim.models import VirtualChassis
+
+    virtual_chassis = VirtualChassis.objects.create(name=f"vc-{tag}")
+    members = []
+    for position in range(1, count + 1):
+        member = make_device(f"{tag}-m{position}")
+        member.virtual_chassis = virtual_chassis
+        member.vc_position = position
+        member.save()
+        members.append(member)
+    return virtual_chassis, members
+
+
 def make_cluster(name):
     """Create a real Cluster on a shared ClusterType."""
     from virtualization.models import Cluster, ClusterType

--- a/netbox_librenms_plugin/tests/test_background_jobs.py
+++ b/netbox_librenms_plugin/tests/test_background_jobs.py
@@ -493,7 +493,7 @@ class TestImportDevicesJob:
         # get_device_info fails for the VM ids → they can't be collision-checked → the batch-wide
         # pre-check must skip those rows and the VM import (before the fix it only saw device_ids,
         # so a VM-only batch bypassed it entirely and bulk_import_vms ran unchecked).
-        mock_api_class.return_value.get_device_info.side_effect = lambda did: (False, None)
+        mock_api_class.return_value.get_device_info.side_effect = lambda did, **_kwargs: (False, None)
 
         job = create_mock_job_runner(ImportDevicesJob, job_pk=801)
 
@@ -506,6 +506,9 @@ class TestImportDevicesJob:
         # The VM import must NOT run because every submitted row was skipped.
         mock_bulk_vms.assert_not_called()
         mock_bulk_devices.assert_not_called()
+        errors = job.job.data["errors"]
+        assert {error["device_id"] for error in errors} == {10, 11}
+        assert all("Skipped" in error["error"] and "verify collisions" in error["error"] for error in errors)
         assert job.job.data["failed_count"] == 2
         assert job.job.data["success_count"] == 0
 
@@ -833,7 +836,7 @@ class TestImportDevicesJob:
 
         # Real collision gate against the DB: ids 1 and 10 resolve + validate cleanly (match no
         # existing NetBox device); id 2 is a get_device_info miss → unresolved → skipped, not a block.
-        def _get_device_info(did):
+        def _get_device_info(did, **_kwargs):
             if did == 2:
                 return (False, None)
             return (True, {"device_id": did, "hostname": f"job-skip-dev-{did}", "sysName": f"job-skip-dev-{did}"})
@@ -880,7 +883,7 @@ class TestImportDevicesJob:
         mock_api = MagicMock()
         mock_api.server_key = "default"
 
-        def _get_device_info(did):
+        def _get_device_info(did, **_kwargs):
             if did == 1:  # device import row → hostname-matches the existing device (fine alone)
                 return (
                     True,

--- a/netbox_librenms_plugin/tests/test_background_jobs.py
+++ b/netbox_librenms_plugin/tests/test_background_jobs.py
@@ -858,6 +858,10 @@ class TestImportDevicesJob:
         errors = job.job.data["errors"]
         assert {e["device_id"] for e in errors} == {1, 2, 10}
         assert all("Import blocked" in e["error"] for e in errors)
+        # The gate spans device + VM ids (vm_imports here), so the block message must be
+        # object-neutral — a VM collision must not be mislabelled a "NetBox device" collision.
+        assert all("NetBox object collision" in e["error"] for e in errors)
+        assert not any("NetBox device collision" in e["error"] for e in errors)
         assert job.job.data["failed_count"] == 3
         assert job.job.data["success_count"] == 0
 

--- a/netbox_librenms_plugin/tests/test_background_jobs.py
+++ b/netbox_librenms_plugin/tests/test_background_jobs.py
@@ -933,7 +933,7 @@ class TestImportDevicesJob:
         mock_bulk_devices.return_value = {"success": [], "failed": [], "skipped": [], "virtual_chassis_created": 0}
         mock_bulk_vms.return_value = {"success": [], "failed": [], "skipped": []}
 
-        job = create_mock_job_runner(ImportDevicesJob, job_pk=811)
+        job = create_mock_job_runner(ImportDevicesJob, job_pk=812)
         job.run(device_ids=[1, 2], vm_imports={10: {"cluster_id": 1}}, server_key="default")
 
         mock_bulk_devices.assert_not_called()

--- a/netbox_librenms_plugin/tests/test_background_jobs.py
+++ b/netbox_librenms_plugin/tests/test_background_jobs.py
@@ -691,6 +691,7 @@ class TestImportDevicesJob:
         assert job.job.data["failed_count"] == 2
         assert job.job.data["success_count"] == 0
 
+    @pytest.mark.django_db
     @patch("netbox_librenms_plugin.import_utils.bulk_import_vms")
     @patch("netbox_librenms_plugin.import_utils.bulk_import_devices_shared")
     @patch("netbox_librenms_plugin.librenms_api.LibreNMSAPI")
@@ -699,8 +700,14 @@ class TestImportDevicesJob:
         from netbox_librenms_plugin.jobs import ImportDevicesJob
 
         mock_api_class.return_value = MagicMock()
-        # Collision pre-check fetches each device; "not found" → skip cleanly.
-        mock_api_class.return_value.get_device_info.return_value = (False, None)
+        # Collision pre-check fetches each device; return distinct devices so the batch resolves
+        # cleanly (no collision/unresolved) and the import actually reaches
+        # bulk_import_devices_shared. A "not found" here would fail the batch closed in the
+        # unresolved branch, so the mocked all-failure payload below would never be exercised.
+        mock_api_class.return_value.get_device_info.side_effect = lambda did: (
+            True,
+            {"device_id": did, "hostname": f"job-fail-dev-{did}", "sysName": f"job-fail-dev-{did}"},
+        )
 
         mock_bulk_devices.return_value = {
             "success": [],
@@ -716,7 +723,13 @@ class TestImportDevicesJob:
 
         job.run(device_ids=[1, 2], vm_imports={})
 
-        # Should complete without exception
+        # The import path is actually exercised, and the bulk-import failures (not an
+        # unresolved/collision block message) are the stored errors.
+        mock_bulk_devices.assert_called_once()
+        assert job.job.data["errors"] == [
+            {"device_id": 1, "error": "Error 1"},
+            {"device_id": 2, "error": "Error 2"},
+        ]
         assert job.job.data["success_count"] == 0
         assert job.job.data["failed_count"] == 2
         assert job.job.data["completed"] is True

--- a/netbox_librenms_plugin/tests/test_background_jobs.py
+++ b/netbox_librenms_plugin/tests/test_background_jobs.py
@@ -509,6 +509,34 @@ class TestImportDevicesJob:
         assert job.job.data["failed_count"] == 2
         assert job.job.data["success_count"] == 0
 
+    @patch("netbox_librenms_plugin.import_utils.bulk_import_vms")
+    @patch("netbox_librenms_plugin.import_utils.bulk_import_devices_shared")
+    @patch("netbox_librenms_plugin.librenms_api.LibreNMSAPI")
+    def test_run_cancelled_during_precheck_blocks_batch_with_cancel_message(
+        self, mock_api_class, mock_bulk_devices, mock_bulk_vms
+    ):
+        """A job cancelled during the collision pre-check stops scanning immediately, imports nothing, and reports the block as a cancellation — not as the fetch-failure message the genuine unresolved path uses."""
+        from netbox_librenms_plugin.import_utils import bulk_import as bulk_import_module
+        from netbox_librenms_plugin.jobs import ImportDevicesJob
+
+        mock_api_class.return_value = MagicMock(server_key="default")
+        job = create_mock_job_runner(ImportDevicesJob, job_pk=802)
+
+        # _is_job_cancelled reads RQ/Redis job state — patch that one external boundary; the
+        # pre-check loop and the jobs.py message branch both read it through this module attr.
+        with patch.object(bulk_import_module, "_is_job_cancelled", return_value=True):
+            job.run(device_ids=[1, 2], vm_imports={10: {"cluster_id": 1}}, server_key="default")
+
+        mock_bulk_devices.assert_not_called()
+        mock_bulk_vms.assert_not_called()
+        # Cancelled at the first poll → the scan issued ZERO LibreNMS calls.
+        mock_api_class.return_value.get_device_info.assert_not_called()
+        errors = job.job.data["errors"]
+        assert errors, "blocked rows must surface as errors"
+        assert all("cancelled during the collision pre-check" in e["error"] for e in errors)
+        assert job.job.data["failed_count"] == 3  # 2 device rows + 1 VM row fail closed
+        assert job.job.data["success_count"] == 0
+
     # device + VM = 2 ids → the batch-wide collision pre-check runs over both; configure the api.
     @pytest.mark.django_db
     @patch("netbox_librenms_plugin.import_utils.bulk_import_vms")

--- a/netbox_librenms_plugin/tests/test_background_jobs.py
+++ b/netbox_librenms_plugin/tests/test_background_jobs.py
@@ -824,43 +824,43 @@ class TestImportDevicesJob:
     @patch("netbox_librenms_plugin.import_utils.bulk_import_vms")
     @patch("netbox_librenms_plugin.import_utils.bulk_import_devices_shared")
     @patch("netbox_librenms_plugin.librenms_api.LibreNMSAPI")
-    def test_unresolved_block_skips_vm_import(self, mock_api_class, mock_bulk_devices, mock_bulk_vms):
-        """An unresolved id blocks the batch and the same submission's VMs are NOT imported."""
+    def test_unresolved_row_is_skipped_not_batch_blocked(self, mock_api_class, mock_bulk_devices, mock_bulk_vms):
+        """An unresolved id is SKIPPED (not imported) while the rest of the batch — devices AND VMs — imports. A transient fetch miss on one row must not drop the whole submission (the old whole-batch block)."""
         from netbox_librenms_plugin.jobs import ImportDevicesJob
 
         mock_api = MagicMock()
         mock_api.server_key = "default"
 
-        # Real collision gate against the DB: id 1 resolves and validates cleanly (matches no
-        # existing NetBox device), id 2 is a get_device_info miss → unresolved → batch blocked.
+        # Real collision gate against the DB: ids 1 and 10 resolve + validate cleanly (match no
+        # existing NetBox device); id 2 is a get_device_info miss → unresolved → skipped, not a block.
         def _get_device_info(did):
             if did == 2:
                 return (False, None)
-            return (True, {"device_id": did, "hostname": f"job-block-dev-{did}", "sysName": f"job-block-dev-{did}"})
+            return (True, {"device_id": did, "hostname": f"job-skip-dev-{did}", "sysName": f"job-skip-dev-{did}"})
 
         mock_api.get_device_info.side_effect = _get_device_info
         mock_api_class.return_value = mock_api
-        # Valid payloads so the UNFIXED code (which falls through to the VM import) completes and
-        # the assert_not_called below is the clean red signal, not an incidental crash.
         mock_bulk_devices.return_value = {"success": [], "failed": [], "skipped": [], "virtual_chassis_created": 0}
         mock_bulk_vms.return_value = {"success": [], "failed": [], "skipped": []}
 
         job = create_mock_job_runner(ImportDevicesJob, job_pk=810)
         job.run(device_ids=[1, 2], vm_imports={10: {"cluster_id": 1}}, server_key="default")
 
-        # Blocked batch → neither devices nor VMs are imported.
-        mock_bulk_devices.assert_not_called()
-        mock_bulk_vms.assert_not_called()
+        # The fetchable rows import; only the unresolved id 2 is dropped. The importer is called
+        # with just the importable device id, and the VM section still runs.
+        mock_bulk_devices.assert_called_once()
+        assert mock_bulk_devices.call_args.kwargs["device_ids"] == [1]
+        mock_bulk_vms.assert_called_once()
+        assert mock_bulk_vms.call_args.args[0] == {10: {"cluster_id": 1}}
+
         errors = job.job.data["errors"]
-        # Both device ids AND the VM id are failed closed with the same block reason.
-        assert {e["device_id"] for e in errors} == {1, 2, 10}
-        assert all("Import blocked" in e["error"] for e in errors)
-        # Object-neutral wording: the unresolved ids come from collision_check_ids, which includes
-        # vm_imports, so the block message must not mislabel a VM row as a "device(s)" — mirror the
-        # collision branch's object-neutral copy.
+        # Only the unresolved row is reported (as a skip) — not the whole batch.
+        assert {e["device_id"] for e in errors} == {2}
+        assert all("Skipped" in e["error"] and "verify collisions" in e["error"] for e in errors)
+        # Object-neutral wording: "row(s)", never "device(s)".
         assert all("device(s)" not in e["error"] for e in errors)
         assert any("row(s)" in e["error"] for e in errors)
-        assert job.job.data["failed_count"] == 3
+        assert job.job.data["failed_count"] == 1
         assert job.job.data["success_count"] == 0
         assert job.job.data["completed"] is True
 
@@ -937,7 +937,8 @@ class TestImportDevicesJob:
         mock_bulk_vms.assert_not_called()
         errors = job.job.data["errors"]
         assert {e["device_id"] for e in errors} == {1, 2, 10}
-        assert all("Import blocked" in e["error"] for e in errors)
+        # Shared block wording (classify_bulk_precheck), identical to the sync view.
+        assert all("Bulk import blocked" in e["error"] for e in errors)
         # The gate spans device + VM ids (vm_imports here), so the block message must be
         # object-neutral — a VM collision must not be mislabelled a "NetBox device" collision.
         assert all("NetBox object collision" in e["error"] for e in errors)

--- a/netbox_librenms_plugin/tests/test_background_jobs.py
+++ b/netbox_librenms_plugin/tests/test_background_jobs.py
@@ -383,7 +383,10 @@ class TestImportDevicesJob:
         """Import devices without VMs."""
         from netbox_librenms_plugin.jobs import ImportDevicesJob
 
-        mock_api_class.return_value = MagicMock()
+        # Pin server_key to a real string: the collision pre-check uses api.server_key as a
+        # cache/Q discriminator, so a bare MagicMock() would let server-scoped logic pass on a
+        # non-string sentinel and miss the multi-server regression this path protects.
+        mock_api_class.return_value = MagicMock(server_key="default")
         # The collision pre-check fetches each device; return distinct devices so the batch
         # resolves cleanly with no collision (collision/unresolved handling has its own tests).
         # A "not found" here would now fail the batch closed (unresolved id), not skip silently.
@@ -575,7 +578,9 @@ class TestImportDevicesJob:
         """Manual mappings passed correctly."""
         from netbox_librenms_plugin.jobs import ImportDevicesJob
 
-        mock_api_class.return_value = MagicMock()
+        # Pin server_key to a real string so the collision pre-check's server-scoped cache/Q
+        # logic runs on a real discriminator, not a MagicMock sentinel.
+        mock_api_class.return_value = MagicMock(server_key="default")
         # Collision pre-check fetches each device; return distinct devices so the batch resolves
         # cleanly (a "not found" would now fail the batch closed as an unresolved id).
         mock_api_class.return_value.get_device_info.side_effect = lambda did: (
@@ -699,7 +704,9 @@ class TestImportDevicesJob:
         """All imports fail gracefully."""
         from netbox_librenms_plugin.jobs import ImportDevicesJob
 
-        mock_api_class.return_value = MagicMock()
+        # Pin server_key to a real string so the collision pre-check runs server-scoped cache/Q
+        # logic on a real discriminator rather than a MagicMock sentinel.
+        mock_api_class.return_value = MagicMock(server_key="default")
         # Collision pre-check fetches each device; return distinct devices so the batch resolves
         # cleanly (no collision/unresolved) and the import actually reaches
         # bulk_import_devices_shared. A "not found" here would fail the batch closed in the

--- a/netbox_librenms_plugin/tests/test_background_jobs.py
+++ b/netbox_librenms_plugin/tests/test_background_jobs.py
@@ -431,6 +431,9 @@ class TestImportDevicesJob:
         assert job.job.data["success_count"] == 2
         assert job.job.data["failed_count"] == 0
 
+    # Two VM ids (>=2) now trigger the job's collision pre-check too — it runs over the WHOLE
+    # batch (devices + VMs), so configure the api the same way the device-batch tests do.
+    @pytest.mark.django_db
     @patch("netbox_librenms_plugin.import_utils.bulk_import_vms")
     @patch("netbox_librenms_plugin.import_utils.bulk_import_devices_shared")
     @patch("netbox_librenms_plugin.librenms_api.LibreNMSAPI")
@@ -438,7 +441,13 @@ class TestImportDevicesJob:
         """Import VMs without devices."""
         from netbox_librenms_plugin.jobs import ImportDevicesJob
 
-        mock_api_class.return_value = MagicMock()
+        mock_api_class.return_value = MagicMock(server_key="default")
+        # The batch-wide collision pre-check now fetches each VM id; return distinct devices so the
+        # VM-only batch resolves cleanly (no collision) and the VM import still proceeds.
+        mock_api_class.return_value.get_device_info.side_effect = lambda did: (
+            True,
+            {"device_id": did, "hostname": f"job-vm-{did}", "sysName": f"job-vm-{did}"},
+        )
 
         # Mock successful VM imports
         mock_vm_1 = MagicMock()
@@ -476,12 +485,46 @@ class TestImportDevicesJob:
     @patch("netbox_librenms_plugin.import_utils.bulk_import_vms")
     @patch("netbox_librenms_plugin.import_utils.bulk_import_devices_shared")
     @patch("netbox_librenms_plugin.librenms_api.LibreNMSAPI")
+    def test_run_vm_only_batch_is_collision_gated(self, mock_api_class, mock_bulk_devices, mock_bulk_vms):
+        """A VM-only batch goes through the same fail-closed gate, so unverifiable ids block the VM import."""
+        from netbox_librenms_plugin.jobs import ImportDevicesJob
+
+        mock_api_class.return_value = MagicMock(server_key="default")
+        # get_device_info fails for the VM ids → they can't be collision-checked → the batch-wide
+        # gate must fail closed and skip the VM import (before the fix the gate only saw device_ids,
+        # so a VM-only batch bypassed it entirely and bulk_import_vms ran unchecked).
+        mock_api_class.return_value.get_device_info.side_effect = lambda did: (False, None)
+
+        job = create_mock_job_runner(ImportDevicesJob, job_pk=801)
+
+        job.run(
+            device_ids=[],
+            vm_imports={10: {"cluster_id": 1}, 11: {"cluster_id": 1}},
+            server_key="default",
+        )
+
+        # The VM import must NOT run — the batch is blocked closed.
+        mock_bulk_vms.assert_not_called()
+        mock_bulk_devices.assert_not_called()
+        assert job.job.data["failed_count"] == 2
+        assert job.job.data["success_count"] == 0
+
+    # device + VM = 2 ids → the batch-wide collision pre-check runs over both; configure the api.
+    @pytest.mark.django_db
+    @patch("netbox_librenms_plugin.import_utils.bulk_import_vms")
+    @patch("netbox_librenms_plugin.import_utils.bulk_import_devices_shared")
+    @patch("netbox_librenms_plugin.librenms_api.LibreNMSAPI")
     def test_run_mixed_device_and_vm_import(self, mock_api_class, mock_bulk_devices, mock_bulk_vms):
         """Import both devices and VMs."""
         from netbox_librenms_plugin.jobs import ImportDevicesJob
 
         mock_api = MagicMock()
         mock_api.server_key = "non-default"
+        # Distinct devices so the mixed batch resolves cleanly and both imports proceed.
+        mock_api.get_device_info.side_effect = lambda did: (
+            True,
+            {"device_id": did, "hostname": f"job-mix-{did}", "sysName": f"job-mix-{did}"},
+        )
         mock_api_class.return_value = mock_api
 
         # Mock device imports
@@ -662,6 +705,9 @@ class TestImportDevicesJob:
 
         assert 42 in job.job.data["imported_libre_device_ids"]
 
+    # device + VM = 2 ids → the batch-wide collision pre-check runs over both; configure the api so
+    # the batch resolves cleanly and the mocked device/VM error payloads are actually exercised.
+    @pytest.mark.django_db
     @patch("netbox_librenms_plugin.import_utils.bulk_import_vms")
     @patch("netbox_librenms_plugin.import_utils.bulk_import_devices_shared")
     @patch("netbox_librenms_plugin.librenms_api.LibreNMSAPI")
@@ -669,7 +715,11 @@ class TestImportDevicesJob:
         """Device and VM errors are combined in job.data."""
         from netbox_librenms_plugin.jobs import ImportDevicesJob
 
-        mock_api_class.return_value = MagicMock()
+        mock_api_class.return_value = MagicMock(server_key="default")
+        mock_api_class.return_value.get_device_info.side_effect = lambda did: (
+            True,
+            {"device_id": did, "hostname": f"job-agg-{did}", "sysName": f"job-agg-{did}"},
+        )
 
         # Mock mixed results
         mock_bulk_devices.return_value = {

--- a/netbox_librenms_plugin/tests/test_background_jobs.py
+++ b/netbox_librenms_plugin/tests/test_background_jobs.py
@@ -378,9 +378,13 @@ class TestImportDevicesJob:
         from netbox_librenms_plugin.jobs import ImportDevicesJob
 
         mock_api_class.return_value = MagicMock()
-        # The collision pre-check fetches each device; return "not found" so it skips cleanly
-        # (collision detection is covered by its own real-DB tests).
-        mock_api_class.return_value.get_device_info.return_value = (False, None)
+        # The collision pre-check fetches each device; return distinct devices so the batch
+        # resolves cleanly with no collision (collision/unresolved handling has its own tests).
+        # A "not found" here would now fail the batch closed (unresolved id), not skip silently.
+        mock_api_class.return_value.get_device_info.side_effect = lambda did: (
+            True,
+            {"device_id": did, "hostname": f"job-import-dev-{did}", "sysName": f"job-import-dev-{did}"},
+        )
 
         # Mock successful device imports
         mock_device_1 = MagicMock()
@@ -564,8 +568,12 @@ class TestImportDevicesJob:
         from netbox_librenms_plugin.jobs import ImportDevicesJob
 
         mock_api_class.return_value = MagicMock()
-        # Collision pre-check fetches each device; "not found" → skip cleanly.
-        mock_api_class.return_value.get_device_info.return_value = (False, None)
+        # Collision pre-check fetches each device; return distinct devices so the batch resolves
+        # cleanly (a "not found" would now fail the batch closed as an unresolved id).
+        mock_api_class.return_value.get_device_info.side_effect = lambda did: (
+            True,
+            {"device_id": did, "hostname": f"job-mm-dev-{did}", "sysName": f"job-mm-dev-{did}"},
+        )
 
         mock_bulk_devices.return_value = {
             "success": [],

--- a/netbox_librenms_plugin/tests/test_background_jobs.py
+++ b/netbox_librenms_plugin/tests/test_background_jobs.py
@@ -977,6 +977,106 @@ class TestImportDevicesJob:
         call_kwargs = mock_bulk_devices.call_args[1]
         assert call_kwargs.get("server_key") == "resolved-default"
 
+    @staticmethod
+    def _real_user(username, *vm_or_device_perms):
+        """Create a real NetBox user, granting perms the NetBox way (ObjectPermission).
+
+        NetBox's only enforcement backend is ObjectPermissionBackend, so Django's
+        ``user_permissions`` would not make ``has_perm`` pass — the gate must be
+        exercised through real ObjectPermission rows, not a mocked ``has_perm``.
+        """
+        from core.models import ObjectType
+        from django.contrib.auth import get_user_model
+        from users.models import ObjectPermission
+
+        user = get_user_model().objects.create_user(username=username)
+        for app_label, model, action in vm_or_device_perms:
+            perm = ObjectPermission.objects.create(name=f"{username}-{app_label}.{action}_{model}", actions=[action])
+            perm.object_types.add(ObjectType.objects.get_by_natural_key(app_label, model))
+            perm.users.add(user)
+        # Refetch: the permission backend caches per instance on first has_perm call.
+        return get_user_model().objects.get(pk=user.pk)
+
+    @pytest.mark.django_db
+    @patch("netbox_librenms_plugin.import_utils.bulk_import_vms")
+    @patch("netbox_librenms_plugin.import_utils.bulk_import_devices_shared")
+    @patch("netbox_librenms_plugin.librenms_api.LibreNMSAPI")
+    def test_run_unauthorized_user_is_blocked_before_any_librenms_call(
+        self, mock_api_class, mock_bulk_devices, mock_bulk_vms
+    ):
+        """A submitter without import permissions is rejected BEFORE the collision pre-check — no API client, no LibreNMS queries, no collision details computed (the per-path checks inside the import helpers only run after the scan)."""
+        from django.core.exceptions import PermissionDenied
+
+        from netbox_librenms_plugin.jobs import ImportDevicesJob
+
+        # Even if the gate were bypassed, keep the pre-check viable so the failure mode
+        # on unfixed code is "scan ran + import mocks reached", not an unpacking error.
+        mock_api_class.return_value = MagicMock(server_key="default")
+        mock_api_class.return_value.get_device_info.side_effect = lambda did: (
+            True,
+            {"device_id": did, "hostname": f"authgate-{did}", "sysName": f"authgate-{did}"},
+        )
+
+        job = create_mock_job_runner(ImportDevicesJob, job_pk=803)
+        job.job.user = self._real_user("import-noperms")
+
+        with pytest.raises(PermissionDenied):
+            job.run(device_ids=[1, 2], vm_imports={}, server_key="default")
+
+        mock_api_class.assert_not_called()
+        mock_api_class.return_value.get_device_info.assert_not_called()
+        mock_bulk_devices.assert_not_called()
+        mock_bulk_vms.assert_not_called()
+
+    @pytest.mark.django_db
+    @patch("netbox_librenms_plugin.import_utils.bulk_import_vms")
+    @patch("netbox_librenms_plugin.import_utils.bulk_import_devices_shared")
+    @patch("netbox_librenms_plugin.librenms_api.LibreNMSAPI")
+    def test_run_device_batch_rejected_with_only_the_vm_permission(
+        self, mock_api_class, mock_bulk_devices, mock_bulk_vms
+    ):
+        """A device batch needs the Device perm set (add/change device + add VM, mirroring bulk_import_devices_shared) — the VM permission alone must not open the pre-check."""
+        from django.core.exceptions import PermissionDenied
+
+        from netbox_librenms_plugin.jobs import ImportDevicesJob
+
+        mock_api_class.return_value = MagicMock(server_key="default")
+
+        job = create_mock_job_runner(ImportDevicesJob, job_pk=804)
+        job.job.user = self._real_user("import-vm-perm-only", ("virtualization", "virtualmachine", "add"))
+
+        with pytest.raises(PermissionDenied):
+            job.run(device_ids=[1, 2], vm_imports={}, server_key="default")
+
+        mock_api_class.assert_not_called()
+        mock_bulk_devices.assert_not_called()
+
+    @pytest.mark.django_db
+    @patch("netbox_librenms_plugin.import_utils.bulk_import_vms")
+    @patch("netbox_librenms_plugin.import_utils.bulk_import_devices_shared")
+    @patch("netbox_librenms_plugin.librenms_api.LibreNMSAPI")
+    def test_run_vm_only_batch_passes_with_only_the_vm_permission(
+        self, mock_api_class, mock_bulk_devices, mock_bulk_vms
+    ):
+        """The gate scopes to the batch: a VM-only submission requires only virtualization.add_virtualmachine, so that single grant reaches the pre-check and the VM import."""
+        from netbox_librenms_plugin.jobs import ImportDevicesJob
+
+        mock_api_class.return_value = MagicMock(server_key="default")
+        mock_api_class.return_value.get_device_info.side_effect = lambda did: (
+            True,
+            {"device_id": did, "hostname": f"vmgate-{did}", "sysName": f"vmgate-{did}"},
+        )
+        mock_bulk_vms.return_value = {"success": [], "failed": [], "skipped": []}
+
+        job = create_mock_job_runner(ImportDevicesJob, job_pk=805)
+        job.job.user = self._real_user("import-vm-only", ("virtualization", "virtualmachine", "add"))
+
+        job.run(device_ids=[], vm_imports={10: {"cluster_id": 1}, 11: {"cluster_id": 1}}, server_key="default")
+
+        # The gate let the batch through: the pre-check scanned it and the VM import ran.
+        mock_bulk_vms.assert_called_once()
+        mock_bulk_devices.assert_not_called()
+
 
 class TestLoadJobResults:
     """Test loading results from completed background jobs."""

--- a/netbox_librenms_plugin/tests/test_background_jobs.py
+++ b/netbox_librenms_plugin/tests/test_background_jobs.py
@@ -864,6 +864,53 @@ class TestImportDevicesJob:
         assert job.job.data["success_count"] == 0
         assert job.job.data["completed"] is True
 
+    @pytest.mark.django_db
+    @patch("netbox_librenms_plugin.import_utils.bulk_import_vms")
+    @patch("netbox_librenms_plugin.import_utils.bulk_import_devices_shared")
+    @patch("netbox_librenms_plugin.librenms_api.LibreNMSAPI")
+    def test_vm_row_is_collision_checked_in_vm_mode_not_device_mode(
+        self, mock_api_class, mock_bulk_devices, mock_bulk_vms
+    ):
+        """End-to-end through the job's REAL collision gate: a VM row whose serial happens to equal an existing Device's serial must not be Device-serial-matched onto it — that would fabricate a collision with the device row legitimately targeting that Device and block a valid batch that the real VM import (which skips serial matching) would import fine."""
+        from netbox_librenms_plugin.jobs import ImportDevicesJob
+        from netbox_librenms_plugin.tests.conftest import make_device
+
+        make_device("job-phantom-host", serial="ZZSER-JOB-PHANTOM")
+
+        mock_api = MagicMock()
+        mock_api.server_key = "default"
+
+        def _get_device_info(did):
+            if did == 1:  # device import row → hostname-matches the existing device (fine alone)
+                return (
+                    True,
+                    {"device_id": 1, "hostname": "job-phantom-host", "sysName": "job-phantom-host", "serial": ""},
+                )
+            # VM import row → hostname matches nothing; serial equals the Device's.
+            return (
+                True,
+                {
+                    "device_id": did,
+                    "hostname": "job-vm-unique",
+                    "sysName": "job-vm-unique",
+                    "serial": "ZZSER-JOB-PHANTOM",
+                },
+            )
+
+        mock_api.get_device_info.side_effect = _get_device_info
+        mock_api_class.return_value = mock_api
+        mock_bulk_devices.return_value = {"success": [], "failed": [], "skipped": [], "virtual_chassis_created": 0}
+        mock_bulk_vms.return_value = {"success": [], "failed": [], "skipped": []}
+
+        job = create_mock_job_runner(ImportDevicesJob, job_pk=811)
+        job.run(device_ids=[1], vm_imports={10: {"cluster_id": 1}}, server_key="default")
+
+        # No fabricated collision → the clean batch imports BOTH halves.
+        mock_bulk_devices.assert_called_once()
+        mock_bulk_vms.assert_called_once()
+        assert job.job.data["errors"] == []
+        assert job.job.data["failed_count"] == 0
+
     @patch("netbox_librenms_plugin.import_utils.detect_collisions_for_device_ids")
     @patch("netbox_librenms_plugin.import_utils.bulk_import_vms")
     @patch("netbox_librenms_plugin.import_utils.bulk_import_devices_shared")

--- a/netbox_librenms_plugin/tests/test_background_jobs.py
+++ b/netbox_librenms_plugin/tests/test_background_jobs.py
@@ -390,7 +390,7 @@ class TestImportDevicesJob:
         # The collision pre-check fetches each device; return distinct devices so the batch
         # resolves cleanly with no collision (collision/unresolved handling has its own tests).
         # A "not found" here would now fail the batch closed (unresolved id), not skip silently.
-        mock_api_class.return_value.get_device_info.side_effect = lambda did: (
+        mock_api_class.return_value.get_device_info.side_effect = lambda did, **_kwargs: (
             True,
             {"device_id": did, "hostname": f"job-import-dev-{did}", "sysName": f"job-import-dev-{did}"},
         )
@@ -444,7 +444,7 @@ class TestImportDevicesJob:
         mock_api_class.return_value = MagicMock(server_key="default")
         # The batch-wide collision pre-check now fetches each VM id; return distinct devices so the
         # VM-only batch resolves cleanly (no collision) and the VM import still proceeds.
-        mock_api_class.return_value.get_device_info.side_effect = lambda did: (
+        mock_api_class.return_value.get_device_info.side_effect = lambda did, **_kwargs: (
             True,
             {"device_id": did, "hostname": f"job-vm-{did}", "sysName": f"job-vm-{did}"},
         )
@@ -552,7 +552,7 @@ class TestImportDevicesJob:
         mock_api = MagicMock()
         mock_api.server_key = "non-default"
         # Distinct devices so the mixed batch resolves cleanly and both imports proceed.
-        mock_api.get_device_info.side_effect = lambda did: (
+        mock_api.get_device_info.side_effect = lambda did, **_kwargs: (
             True,
             {"device_id": did, "hostname": f"job-mix-{did}", "sysName": f"job-mix-{did}"},
         )
@@ -657,7 +657,7 @@ class TestImportDevicesJob:
         mock_api_class.return_value = MagicMock(server_key="default")
         # Collision pre-check fetches each device; return distinct devices so the batch resolves
         # cleanly (a "not found" would now fail the batch closed as an unresolved id).
-        mock_api_class.return_value.get_device_info.side_effect = lambda did: (
+        mock_api_class.return_value.get_device_info.side_effect = lambda did, **_kwargs: (
             True,
             {"device_id": did, "hostname": f"job-mm-dev-{did}", "sysName": f"job-mm-dev-{did}"},
         )
@@ -747,7 +747,7 @@ class TestImportDevicesJob:
         from netbox_librenms_plugin.jobs import ImportDevicesJob
 
         mock_api_class.return_value = MagicMock(server_key="default")
-        mock_api_class.return_value.get_device_info.side_effect = lambda did: (
+        mock_api_class.return_value.get_device_info.side_effect = lambda did, **_kwargs: (
             True,
             {"device_id": did, "hostname": f"job-agg-{did}", "sysName": f"job-agg-{did}"},
         )
@@ -792,7 +792,7 @@ class TestImportDevicesJob:
         # cleanly (no collision/unresolved) and the import actually reaches
         # bulk_import_devices_shared. A "not found" here would fail the batch closed in the
         # unresolved branch, so the mocked all-failure payload below would never be exercised.
-        mock_api_class.return_value.get_device_info.side_effect = lambda did: (
+        mock_api_class.return_value.get_device_info.side_effect = lambda did, **_kwargs: (
             True,
             {"device_id": did, "hostname": f"job-fail-dev-{did}", "sysName": f"job-fail-dev-{did}"},
         )
@@ -1016,7 +1016,7 @@ class TestImportDevicesJob:
         # Even if the gate were bypassed, keep the pre-check viable so the failure mode
         # on unfixed code is "scan ran + import mocks reached", not an unpacking error.
         mock_api_class.return_value = MagicMock(server_key="default")
-        mock_api_class.return_value.get_device_info.side_effect = lambda did: (
+        mock_api_class.return_value.get_device_info.side_effect = lambda did, **_kwargs: (
             True,
             {"device_id": did, "hostname": f"authgate-{did}", "sysName": f"authgate-{did}"},
         )
@@ -1095,7 +1095,7 @@ class TestImportDevicesJob:
         from netbox_librenms_plugin.jobs import ImportDevicesJob
 
         mock_api_class.return_value = MagicMock(server_key="default")
-        mock_api_class.return_value.get_device_info.side_effect = lambda did: (
+        mock_api_class.return_value.get_device_info.side_effect = lambda did, **_kwargs: (
             True,
             {"device_id": did, "hostname": f"vmgate-{did}", "sysName": f"vmgate-{did}"},
         )

--- a/netbox_librenms_plugin/tests/test_background_jobs.py
+++ b/netbox_librenms_plugin/tests/test_background_jobs.py
@@ -735,6 +735,75 @@ class TestImportDevicesJob:
         assert job.job.data["completed"] is True
         job.job.save.assert_called()
 
+    @pytest.mark.django_db
+    @patch("netbox_librenms_plugin.import_utils.bulk_import_vms")
+    @patch("netbox_librenms_plugin.import_utils.bulk_import_devices_shared")
+    @patch("netbox_librenms_plugin.librenms_api.LibreNMSAPI")
+    def test_unresolved_block_skips_vm_import(self, mock_api_class, mock_bulk_devices, mock_bulk_vms):
+        """An unresolved id blocks the batch and the same submission's VMs are NOT imported."""
+        from netbox_librenms_plugin.jobs import ImportDevicesJob
+
+        mock_api = MagicMock()
+        mock_api.server_key = "default"
+
+        # Real collision gate against the DB: id 1 resolves and validates cleanly (matches no
+        # existing NetBox device), id 2 is a get_device_info miss → unresolved → batch blocked.
+        def _get_device_info(did):
+            if did == 2:
+                return (False, None)
+            return (True, {"device_id": did, "hostname": f"job-block-dev-{did}", "sysName": f"job-block-dev-{did}"})
+
+        mock_api.get_device_info.side_effect = _get_device_info
+        mock_api_class.return_value = mock_api
+        # Valid payloads so the UNFIXED code (which falls through to the VM import) completes and
+        # the assert_not_called below is the clean red signal, not an incidental crash.
+        mock_bulk_devices.return_value = {"success": [], "failed": [], "skipped": [], "virtual_chassis_created": 0}
+        mock_bulk_vms.return_value = {"success": [], "failed": [], "skipped": []}
+
+        job = create_mock_job_runner(ImportDevicesJob, job_pk=810)
+        job.run(device_ids=[1, 2], vm_imports={10: {"cluster_id": 1}}, server_key="default")
+
+        # Blocked batch → neither devices nor VMs are imported.
+        mock_bulk_devices.assert_not_called()
+        mock_bulk_vms.assert_not_called()
+        errors = job.job.data["errors"]
+        # Both device ids AND the VM id are failed closed with the same block reason.
+        assert {e["device_id"] for e in errors} == {1, 2, 10}
+        assert all("Import blocked" in e["error"] for e in errors)
+        assert job.job.data["failed_count"] == 3
+        assert job.job.data["success_count"] == 0
+        assert job.job.data["completed"] is True
+
+    @patch("netbox_librenms_plugin.import_utils.detect_collisions_for_device_ids")
+    @patch("netbox_librenms_plugin.import_utils.bulk_import_vms")
+    @patch("netbox_librenms_plugin.import_utils.bulk_import_devices_shared")
+    @patch("netbox_librenms_plugin.librenms_api.LibreNMSAPI")
+    def test_collision_block_skips_vm_import(self, mock_api_class, mock_bulk_devices, mock_bulk_vms, mock_detect):
+        """A same-NetBox-device collision blocks the batch and skips the VM section too.
+
+        Collision DETECTION has its own real-DB tests; here the detector is stubbed to isolate
+        the job's collisions-branch block flow (the symmetric counterpart of the unresolved one).
+        """
+        from netbox_librenms_plugin.jobs import ImportDevicesJob
+
+        mock_api = MagicMock()
+        mock_api.server_key = "default"
+        mock_api_class.return_value = mock_api
+        mock_detect.return_value = ([{"nb_device_pk": 5}], [])  # one collision group, no unresolved
+        mock_bulk_devices.return_value = {"success": [], "failed": [], "skipped": [], "virtual_chassis_created": 0}
+        mock_bulk_vms.return_value = {"success": [], "failed": [], "skipped": []}
+
+        job = create_mock_job_runner(ImportDevicesJob, job_pk=811)
+        job.run(device_ids=[1, 2], vm_imports={10: {"cluster_id": 1}}, server_key="default")
+
+        mock_bulk_devices.assert_not_called()
+        mock_bulk_vms.assert_not_called()
+        errors = job.job.data["errors"]
+        assert {e["device_id"] for e in errors} == {1, 2, 10}
+        assert all("Import blocked" in e["error"] for e in errors)
+        assert job.job.data["failed_count"] == 3
+        assert job.job.data["success_count"] == 0
+
     def test_job_meta_name(self):
         """Job has correct Meta.name."""
         from netbox_librenms_plugin.jobs import ImportDevicesJob

--- a/netbox_librenms_plugin/tests/test_background_jobs.py
+++ b/netbox_librenms_plugin/tests/test_background_jobs.py
@@ -378,6 +378,9 @@ class TestImportDevicesJob:
         from netbox_librenms_plugin.jobs import ImportDevicesJob
 
         mock_api_class.return_value = MagicMock()
+        # The collision pre-check fetches each device; return "not found" so it skips cleanly
+        # (collision detection is covered by its own real-DB tests).
+        mock_api_class.return_value.get_device_info.return_value = (False, None)
 
         # Mock successful device imports
         mock_device_1 = MagicMock()
@@ -561,6 +564,8 @@ class TestImportDevicesJob:
         from netbox_librenms_plugin.jobs import ImportDevicesJob
 
         mock_api_class.return_value = MagicMock()
+        # Collision pre-check fetches each device; "not found" → skip cleanly.
+        mock_api_class.return_value.get_device_info.return_value = (False, None)
 
         mock_bulk_devices.return_value = {
             "success": [],
@@ -678,6 +683,8 @@ class TestImportDevicesJob:
         from netbox_librenms_plugin.jobs import ImportDevicesJob
 
         mock_api_class.return_value = MagicMock()
+        # Collision pre-check fetches each device; "not found" → skip cleanly.
+        mock_api_class.return_value.get_device_info.return_value = (False, None)
 
         mock_bulk_devices.return_value = {
             "success": [],

--- a/netbox_librenms_plugin/tests/test_background_jobs.py
+++ b/netbox_librenms_plugin/tests/test_background_jobs.py
@@ -827,6 +827,11 @@ class TestImportDevicesJob:
         # Both device ids AND the VM id are failed closed with the same block reason.
         assert {e["device_id"] for e in errors} == {1, 2, 10}
         assert all("Import blocked" in e["error"] for e in errors)
+        # Object-neutral wording: the unresolved ids come from collision_check_ids, which includes
+        # vm_imports, so the block message must not mislabel a VM row as a "device(s)" — mirror the
+        # collision branch's object-neutral copy.
+        assert all("device(s)" not in e["error"] for e in errors)
+        assert any("row(s)" in e["error"] for e in errors)
         assert job.job.data["failed_count"] == 3
         assert job.job.data["success_count"] == 0
         assert job.job.data["completed"] is True

--- a/netbox_librenms_plugin/tests/test_background_jobs.py
+++ b/netbox_librenms_plugin/tests/test_background_jobs.py
@@ -486,12 +486,12 @@ class TestImportDevicesJob:
     @patch("netbox_librenms_plugin.import_utils.bulk_import_devices_shared")
     @patch("netbox_librenms_plugin.librenms_api.LibreNMSAPI")
     def test_run_vm_only_batch_is_collision_gated(self, mock_api_class, mock_bulk_devices, mock_bulk_vms):
-        """A VM-only batch goes through the same fail-closed gate, so unverifiable ids block the VM import."""
+        """A VM-only batch skips unverifiable rows through the shared collision pre-check."""
         from netbox_librenms_plugin.jobs import ImportDevicesJob
 
         mock_api_class.return_value = MagicMock(server_key="default")
         # get_device_info fails for the VM ids → they can't be collision-checked → the batch-wide
-        # gate must fail closed and skip the VM import (before the fix the gate only saw device_ids,
+        # pre-check must skip those rows and the VM import (before the fix it only saw device_ids,
         # so a VM-only batch bypassed it entirely and bulk_import_vms ran unchecked).
         mock_api_class.return_value.get_device_info.side_effect = lambda did: (False, None)
 
@@ -503,7 +503,7 @@ class TestImportDevicesJob:
             server_key="default",
         )
 
-        # The VM import must NOT run — the batch is blocked closed.
+        # The VM import must NOT run because every submitted row was skipped.
         mock_bulk_vms.assert_not_called()
         mock_bulk_devices.assert_not_called()
         assert job.job.data["failed_count"] == 2
@@ -1036,7 +1036,7 @@ class TestImportDevicesJob:
     def test_run_device_batch_rejected_with_only_the_vm_permission(
         self, mock_api_class, mock_bulk_devices, mock_bulk_vms
     ):
-        """A device batch needs the Device perm set (add/change device + add VM, mirroring bulk_import_devices_shared) — the VM permission alone must not open the pre-check."""
+        """A device batch needs add/change Device permissions; the VM permission alone must not open the pre-check."""
         from django.core.exceptions import PermissionDenied
 
         from netbox_librenms_plugin.jobs import ImportDevicesJob
@@ -1051,6 +1051,35 @@ class TestImportDevicesJob:
 
         mock_api_class.assert_not_called()
         mock_bulk_devices.assert_not_called()
+
+    @pytest.mark.django_db
+    @patch("netbox_librenms_plugin.import_utils.bulk_import_vms")
+    @patch("netbox_librenms_plugin.import_utils.bulk_import_devices_shared")
+    @patch("netbox_librenms_plugin.librenms_api.LibreNMSAPI")
+    def test_run_device_batch_passes_without_vm_permission(self, mock_api_class, mock_bulk_devices, mock_bulk_vms):
+        """A device-only batch reaches the importer with add/change Device permissions."""
+        from netbox_librenms_plugin.jobs import ImportDevicesJob
+
+        mock_api_class.return_value = MagicMock(server_key="default")
+        mock_bulk_devices.return_value = {
+            "success": [],
+            "failed": [],
+            "skipped": [],
+            "virtual_chassis_created": 0,
+        }
+
+        job = create_mock_job_runner(ImportDevicesJob, job_pk=806)
+        job.job.user = self._real_user(
+            "import-device-without-vm",
+            ("dcim", "device", "add"),
+            ("dcim", "device", "change"),
+        )
+
+        job.run(device_ids=[1], vm_imports={}, server_key="default")
+
+        mock_api_class.assert_called_once()
+        mock_bulk_devices.assert_called_once()
+        mock_bulk_vms.assert_not_called()
 
     @pytest.mark.django_db
     @patch("netbox_librenms_plugin.import_utils.bulk_import_vms")

--- a/netbox_librenms_plugin/tests/test_background_jobs.py
+++ b/netbox_librenms_plugin/tests/test_background_jobs.py
@@ -10,6 +10,8 @@ All tests use mocking and direct attribute manipulation instead of HTTP requests
 
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 
 class TestShouldUseBackgroundJob:
     """Test background job decision logic."""
@@ -370,6 +372,10 @@ class TestFilterDevicesJob:
 class TestImportDevicesJob:
     """Test ImportDevicesJob background job."""
 
+    # Two LibreNMS ids (>=2) trigger the job's collision pre-check, which runs the real
+    # validate_device_for_import against the DB (as the production rqworker does). The
+    # fabricated hostnames match no existing NetBox object, so the batch resolves cleanly.
+    @pytest.mark.django_db
     @patch("netbox_librenms_plugin.import_utils.bulk_import_vms")
     @patch("netbox_librenms_plugin.import_utils.bulk_import_devices_shared")
     @patch("netbox_librenms_plugin.librenms_api.LibreNMSAPI")
@@ -560,6 +566,8 @@ class TestImportDevicesJob:
         call_kwargs = mock_bulk_devices.call_args.kwargs
         assert call_kwargs["sync_options"] == sync_options
 
+    # >=2 ids → the collision pre-check runs real validation against the DB (see note above).
+    @pytest.mark.django_db
     @patch("netbox_librenms_plugin.import_utils.bulk_import_vms")
     @patch("netbox_librenms_plugin.import_utils.bulk_import_devices_shared")
     @patch("netbox_librenms_plugin.librenms_api.LibreNMSAPI")

--- a/netbox_librenms_plugin/tests/test_cable_verify.py
+++ b/netbox_librenms_plugin/tests/test_cable_verify.py
@@ -476,6 +476,15 @@ class TestVerifyDualNameFallback:
         response = view.post(request)
         payload = json.loads(response.content)
 
+        # Prove the intended branch actually ran. The default empty row (post() fallback) carries
+        # cable_status "Missing Ports" and local_port "", so the None-checks below would pass
+        # vacuously on it. The matched-link-but-unresolved-interface branch instead reports
+        # "Missing Interface" and re-applies the OOB badge — pin both so a regression that drops to
+        # the empty row (or stops processing the OOB row) fails here.
+        assert "formatted_row" in payload
+        assert "local_port" in payload["formatted_row"]
+        assert payload["formatted_row"]["cable_status"] == "Missing Interface"
+        assert "From OOB controller" in payload["formatted_row"]["local_port"]
         # render_local_port in the table was fixed to normalize None→""; the verify path must match.
         assert payload["formatted_row"]["local_port"] != "None"
         assert "None" not in payload["formatted_row"]["local_port"]

--- a/netbox_librenms_plugin/tests/test_collisions.py
+++ b/netbox_librenms_plugin/tests/test_collisions.py
@@ -369,6 +369,7 @@ def test_collision_template_renders_correct_link_targets_and_escapes():
     assert "srv-collide" in html
     assert "vm-collide" in html
     assert "beta" in html
+    assert "Bulk import blocked: NetBox object collisions" in html
     # The copy must be VM-safe: this batch includes a VM collision, so the modal must not use
     # device-only wording or point at device-only follow-up actions (Add as OOB / Promote to host)
     # that don't exist for a VM collision. Object-neutral language is used instead.
@@ -395,27 +396,6 @@ def test_collision_template_renders_correct_link_targets_and_escapes():
         r'class="(?=[^"]*\bbadge\b)(?=[^"]*\bbg-danger\b)(?=[^"]*\btext-white\b)[^"]*"',
         html,
     ), "collision badge must pair bg-danger with text-white on one element"
-
-
-def test_collision_template_title_is_generic_for_non_collision_failures():
-    """The modal title must drop the 'NetBox device collisions' wording when rendering a non-collision error_message (the same modal serves LibreNMS fetch/check failures)."""
-    from django.template.loader import render_to_string
-
-    # Collision render → collision-specific title.
-    collision_html = render_to_string(
-        "netbox_librenms_plugin/htmx/bulk_import_collision.html",
-        {"collisions": [{"nb_device_pk": 1, "nb_device_name": "x", "nb_model_name": "device", "librenms_rows": []}]},
-    )
-    assert "Bulk import blocked: NetBox object collisions" in collision_html
-
-    # Non-collision failure render → generic title, NOT the collision wording.
-    error_html = render_to_string(
-        "netbox_librenms_plugin/htmx/bulk_import_collision.html",
-        {"error_message": "Could not fetch LibreNMS info for the selected device."},
-    )
-    assert "Bulk import blocked" in error_html
-    assert "NetBox object collisions" not in error_html
-    assert "Could not fetch LibreNMS info for the selected device." in error_html
 
 
 def test_non_string_merge_model_name_is_normalized():

--- a/netbox_librenms_plugin/tests/test_collisions.py
+++ b/netbox_librenms_plugin/tests/test_collisions.py
@@ -6,14 +6,7 @@ from netbox_librenms_plugin.import_utils.collisions import detect_bulk_collision
 
 
 class Device:
-    """Minimal NetBox Device stand-in for collision tests.
-
-    The class name matters: ``detect_bulk_collisions`` keys collision
-    buckets on ``type(obj).__name__`` so a Device and a VirtualMachine
-    sharing an integer pk are not falsely grouped. A ``SimpleNamespace``
-    would bucket as ``"SimpleNamespace"`` and never match the pk-only
-    merge/promote paths, which assume ``"Device"``.
-    """
+    """Minimal NetBox Device stand-in for collision tests."""
 
     def __init__(self, pk, name):
         self.pk = pk
@@ -119,9 +112,7 @@ def test_three_way_collision():
 
 
 def test_same_libre_row_under_multiple_roles_does_not_collide_with_itself():
-    """A single LibreNMS row whose validation lists the same NB pk under
-    multiple roles must NOT be reported as a collision — collisions
-    require at least two *distinct* LibreNMS device_ids."""
+    """A single LibreNMS row whose validation lists the same NB pk under multiple roles must NOT be reported as a collision — collisions require at least two *distinct* LibreNMS device_ids."""
     nb_device = Device(pk=12, name="solo")
     devices = [
         _row(
@@ -169,9 +160,7 @@ def test_groups_sorted_by_nb_pk_for_stable_render():
 
 
 def test_row_roles_are_joined_when_same_libre_row_targets_pk_via_multiple_paths():
-    """When LibreNMS row R touches NB pk P via both 'host' and
-    'merge_host_named' (rare but possible during transitional states),
-    its row entry in the collision group should list both roles."""
+    """When LibreNMS row R touches NB pk P via both 'host' and 'merge_host_named' (rare but possible during transitional states), its row entry in the collision group should list both roles."""
     devices = [
         _row(
             900,
@@ -195,9 +184,7 @@ def test_row_roles_are_joined_when_same_libre_row_targets_pk_via_multiple_paths(
 
 
 def test_malformed_rows_are_skipped_not_crashed():
-    """A single malformed entry (non-dict row, or a non-dict ``validation`` payload) must be
-    skipped rather than crashing the whole bulk-confirm flow on ``.get()``. Valid colliding
-    rows in the same batch must still be detected. Pre-fix this raised AttributeError."""
+    """A single malformed entry (non-dict row, or a non-dict ``validation`` payload) must be skipped rather than crashing the whole bulk-confirm flow on ``.get()``."""
     shared = Device(pk=55, name="shared")
     devices = [
         42,  # non-dict row
@@ -213,8 +200,7 @@ def test_malformed_rows_are_skipped_not_crashed():
 
 
 def test_device_and_vm_with_same_pk_do_not_collide():
-    """Device and VirtualMachine sharing a pk must NOT be reported as a collision
-    because detect_bulk_collisions keys buckets on (model_name, pk)."""
+    """Device and VirtualMachine sharing a pk must NOT be reported as a collision because detect_bulk_collisions keys buckets on (model_name, pk)."""
     devices = [
         _row(1000, "device-row", {"existing_device": Device(pk=42, name="srv")}),
         _row(1001, "vm-row", {"existing_device": VirtualMachine(pk=42, name="srv")}),
@@ -223,8 +209,7 @@ def test_device_and_vm_with_same_pk_do_not_collide():
 
 
 def test_collision_payload_carries_model_name_for_link_targeting():
-    """Each group must expose nb_model_name so the template links to the right object
-    type — a VM collision must not render a dcim:device URL."""
+    """Each group must expose nb_model_name so the template links to the right object type — a VM collision must not render a dcim:device URL."""
     vm = VirtualMachine(pk=77, name="vm-host")
     groups = detect_bulk_collisions(
         [
@@ -239,14 +224,7 @@ def test_collision_payload_carries_model_name_for_link_targeting():
 
 @pytest.mark.django_db
 def test_real_validator_output_feeds_detector_end_to_end():
-    """End-to-end contract test: the REAL ``validate_device_for_import`` output must carry
-    the exact keys ``detect_bulk_collisions`` reads.
-
-    The unit tests above hand-build the ``existing_device`` key, and the view-level test
-    stubs the validator — so neither would catch the validator renaming/moving that key
-    (collision detection would silently never fire while every test stayed green). Here two
-    LibreNMS rows resolve to the SAME real NetBox device by hostname, run through the real
-    validator (real ORM name-match), and the real detector must report one collision."""
+    """End-to-end contract test: the REAL ``validate_device_for_import`` output must carry the exact keys ``detect_bulk_collisions`` reads."""
     from netbox_librenms_plugin.import_utils.device_operations import validate_device_for_import
     from netbox_librenms_plugin.tests.conftest import make_device
 
@@ -272,13 +250,7 @@ def test_real_validator_output_feeds_detector_end_to_end():
 
 
 def test_collision_template_renders_correct_link_targets_and_escapes():
-    """The collision template must actually render: link to the right object type per
-    ``nb_model_name`` and auto-escape device-supplied names.
-
-    The view-level test mocks ``render`` (asserts only the template name), so a typo in the
-    VM ``{% url %}`` or a lost auto-escape would ship undetected. Render the real template
-    and assert the Device group emits a dcim:device URL, the VM group a
-    virtualization:virtualmachine URL, and a script-y hostname is HTML-escaped."""
+    """The collision template must actually render: link to the right object type per ``nb_model_name`` and auto-escape device-supplied names."""
     from django.template.loader import render_to_string
     from django.urls import reverse
 

--- a/netbox_librenms_plugin/tests/test_collisions.py
+++ b/netbox_librenms_plugin/tests/test_collisions.py
@@ -303,6 +303,8 @@ def test_collision_payload_carries_model_name_for_link_targeting():
     assert len(groups) == 1
     assert groups[0]["nb_device_pk"] == 77
     assert groups[0]["nb_model_name"] == "virtualmachine"
+    # The template renders the human label from the group (computed once, not a repeated ternary).
+    assert groups[0]["nb_kind"] == "VM"
 
 
 @pytest.mark.django_db
@@ -329,6 +331,7 @@ def test_real_validator_output_feeds_detector_end_to_end():
     assert len(groups) == 1
     assert groups[0]["nb_device_pk"] == nb_device.pk
     assert groups[0]["nb_model_name"] == "device"
+    assert groups[0]["nb_kind"] == "device"
     assert {r["device_id"] for r in groups[0]["librenms_rows"]} == {5001, 5002}
 
 
@@ -342,6 +345,7 @@ def test_collision_template_renders_correct_link_targets_and_escapes():
             "nb_device_pk": 42,
             "nb_device_name": "srv-collide",
             "nb_model_name": "device",
+            "nb_kind": "device",
             "librenms_rows": [
                 {"device_id": 1, "hostname": "<script>alpha</script>", "role": "host"},
                 {"device_id": 2, "hostname": "beta", "role": "oob"},
@@ -351,6 +355,7 @@ def test_collision_template_renders_correct_link_targets_and_escapes():
             "nb_device_pk": 7,
             "nb_device_name": "vm-collide",
             "nb_model_name": "virtualmachine",
+            "nb_kind": "VM",
             "librenms_rows": [
                 {"device_id": 3, "hostname": "gamma", "role": "merge_host_named"},
                 {"device_id": 4, "hostname": "delta", "role": "merge_oob_named"},

--- a/netbox_librenms_plugin/tests/test_collisions.py
+++ b/netbox_librenms_plugin/tests/test_collisions.py
@@ -376,6 +376,11 @@ def test_collision_template_renders_correct_link_targets_and_escapes():
     assert "same NetBox device" not in html
     assert "Add as OOB" not in html
     assert "Promote to host" not in html
+    # The per-group "targeting this ..." label must follow nb_model_name too: the VM group says
+    # "VM", the device group says "device". Line 49 previously hardcoded "device" for both, so a
+    # VM collision fell back to device-only wording.
+    assert "Selected LibreNMS rows targeting this VM:" in html
+    assert "Selected LibreNMS rows targeting this device:" in html
     # Device-supplied hostname is auto-escaped (no raw <script> injected into the modal).
     assert "<script>alpha</script>" not in html
     assert "&lt;script&gt;alpha&lt;/script&gt;" in html

--- a/netbox_librenms_plugin/tests/test_collisions.py
+++ b/netbox_librenms_plugin/tests/test_collisions.py
@@ -1,5 +1,7 @@
 """Unit tests for ``netbox_librenms_plugin.import_utils.collisions``."""
 
+import pytest
+
 from netbox_librenms_plugin.import_utils.collisions import detect_bulk_collisions
 
 
@@ -233,3 +235,85 @@ def test_collision_payload_carries_model_name_for_link_targeting():
     assert len(groups) == 1
     assert groups[0]["nb_device_pk"] == 77
     assert groups[0]["nb_model_name"] == "VirtualMachine"
+
+
+@pytest.mark.django_db
+def test_real_validator_output_feeds_detector_end_to_end():
+    """End-to-end contract test: the REAL ``validate_device_for_import`` output must carry
+    the exact keys ``detect_bulk_collisions`` reads.
+
+    The unit tests above hand-build the ``existing_device`` key, and the view-level test
+    stubs the validator — so neither would catch the validator renaming/moving that key
+    (collision detection would silently never fire while every test stayed green). Here two
+    LibreNMS rows resolve to the SAME real NetBox device by hostname, run through the real
+    validator (real ORM name-match), and the real detector must report one collision."""
+    from netbox_librenms_plugin.import_utils.device_operations import validate_device_for_import
+    from netbox_librenms_plugin.tests.conftest import make_device
+
+    nb_device = make_device("srv-collide-e2e")
+
+    # Two distinct LibreNMS devices whose name resolves to the one existing NetBox device.
+    libre_a = {"device_id": 5001, "sysName": "srv-collide-e2e", "hostname": "srv-collide-e2e"}
+    libre_b = {"device_id": 5002, "sysName": "srv-collide-e2e", "hostname": "srv-collide-e2e"}
+
+    devices = []
+    for libre in (libre_a, libre_b):
+        validation = validate_device_for_import(libre, include_vc_detection=False, use_sysname=True)
+        # Sanity: the real validator matched our device by hostname (the key the detector reads).
+        assert validation["existing_device"] is not None
+        assert validation["existing_device"].pk == nb_device.pk
+        devices.append({"device_id": libre["device_id"], "device_name": libre["sysName"], "validation": validation})
+
+    groups = detect_bulk_collisions(devices)
+    assert len(groups) == 1
+    assert groups[0]["nb_device_pk"] == nb_device.pk
+    assert groups[0]["nb_model_name"] == "Device"
+    assert {r["device_id"] for r in groups[0]["librenms_rows"]} == {5001, 5002}
+
+
+def test_collision_template_renders_correct_link_targets_and_escapes():
+    """The collision template must actually render: link to the right object type per
+    ``nb_model_name`` and auto-escape device-supplied names.
+
+    The view-level test mocks ``render`` (asserts only the template name), so a typo in the
+    VM ``{% url %}`` or a lost auto-escape would ship undetected. Render the real template
+    and assert the Device group emits a dcim:device URL, the VM group a
+    virtualization:virtualmachine URL, and a script-y hostname is HTML-escaped."""
+    from django.template.loader import render_to_string
+    from django.urls import reverse
+
+    collisions = [
+        {
+            "nb_device_pk": 42,
+            "nb_device_name": "srv-collide",
+            "nb_model_name": "Device",
+            "librenms_rows": [
+                {"device_id": 1, "hostname": "<script>alpha</script>", "role": "host"},
+                {"device_id": 2, "hostname": "beta", "role": "oob"},
+            ],
+        },
+        {
+            "nb_device_pk": 7,
+            "nb_device_name": "vm-collide",
+            "nb_model_name": "VirtualMachine",
+            "librenms_rows": [
+                {"device_id": 3, "hostname": "gamma", "role": "merge_host_named"},
+                {"device_id": 4, "hostname": "delta", "role": "merge_oob_named"},
+            ],
+        },
+    ]
+    html = render_to_string(
+        "netbox_librenms_plugin/htmx/bulk_import_collision.html",
+        {"collisions": collisions, "device_count": 2},
+    )
+
+    # Each group links to the correct object type — a VM collision must not get a device URL.
+    assert reverse("dcim:device", kwargs={"pk": 42}) in html
+    assert reverse("virtualization:virtualmachine", kwargs={"pk": 7}) in html
+    # The device names / rows render.
+    assert "srv-collide" in html
+    assert "vm-collide" in html
+    assert "beta" in html
+    # Device-supplied hostname is auto-escaped (no raw <script> injected into the modal).
+    assert "<script>alpha</script>" not in html
+    assert "&lt;script&gt;alpha&lt;/script&gt;" in html

--- a/netbox_librenms_plugin/tests/test_collisions.py
+++ b/netbox_librenms_plugin/tests/test_collisions.py
@@ -86,6 +86,27 @@ def test_merge_candidates_overlap_with_direct_existing():
     assert rows == {300, 301}
 
 
+def test_unknown_merge_slot_falls_back_instead_of_crashing(monkeypatch):
+    """A merge slot absent from _MERGE_SLOT_ROLES degrades to a generated role, not a KeyError."""
+    import netbox_librenms_plugin.import_utils.collisions as collisions_mod
+
+    # Simulate a future MERGE_CANDIDATE_SLOTS extended with a slot nobody added to
+    # _MERGE_SLOT_ROLES yet — the role map and the slot tuple are tightly coupled today.
+    monkeypatch.setattr(collisions_mod, "MERGE_CANDIDATE_SLOTS", ("host_named", "extra_named"))
+
+    devices = [
+        _row(300, "row-merge", {"merge_candidates": {"extra_named": {"pk": 99, "name": "x-side"}}}),
+        _row(301, "row-direct", {"existing_device": Device(pk=99, name="x-side")}),
+    ]
+
+    groups = detect_bulk_collisions(devices)  # must not raise KeyError on the unmapped slot
+
+    assert len(groups) == 1
+    rows = {r["device_id"]: r for r in groups[0]["librenms_rows"]}
+    # The unmapped slot got a generated fallback role rather than crashing the import gate.
+    assert rows[300]["role"] == "merge_extra_named"
+
+
 def test_promote_via_existing_device_field_collides_with_direct_match():
     """promote_to_host carries existing_device; collision fires against a direct existing_device row."""
     nb_device = Device(pk=55, name="shared")
@@ -351,9 +372,15 @@ def test_collision_template_renders_correct_link_targets_and_escapes():
     assert "<script>alpha</script>" not in html
     assert "&lt;script&gt;alpha&lt;/script&gt;" in html
     # The "Collision" badge must pair its red fill with a text colour: a bare bg-danger leaves
-    # Tabler's muted badge text (grey-on-red), unreadable in both themes.
-    assert "badge bg-danger text-white" in html
-    assert 'badge bg-danger"' not in html
+    # Tabler's muted badge text (grey-on-red), unreadable in both themes. Match order-agnostically
+    # so harmless class reordering doesn't break the test and a bare bg-danger elsewhere in the
+    # modal can't satisfy it.
+    import re
+
+    assert re.search(
+        r'class="(?=[^"]*\bbadge\b)(?=[^"]*\bbg-danger\b)(?=[^"]*\btext-white\b)[^"]*"',
+        html,
+    ), "collision badge must pair bg-danger with text-white on one element"
 
 
 def test_collision_template_title_is_generic_for_non_collision_failures():

--- a/netbox_librenms_plugin/tests/test_collisions.py
+++ b/netbox_librenms_plugin/tests/test_collisions.py
@@ -1,0 +1,235 @@
+"""Unit tests for ``netbox_librenms_plugin.import_utils.collisions``."""
+
+from netbox_librenms_plugin.import_utils.collisions import detect_bulk_collisions
+
+
+class Device:
+    """Minimal NetBox Device stand-in for collision tests.
+
+    The class name matters: ``detect_bulk_collisions`` keys collision
+    buckets on ``type(obj).__name__`` so a Device and a VirtualMachine
+    sharing an integer pk are not falsely grouped. A ``SimpleNamespace``
+    would bucket as ``"SimpleNamespace"`` and never match the pk-only
+    merge/promote paths, which assume ``"Device"``.
+    """
+
+    def __init__(self, pk, name):
+        self.pk = pk
+        self.name = name
+
+
+class VirtualMachine:
+    """Minimal VirtualMachine stand-in — same shape as Device but different class name."""
+
+    def __init__(self, pk, name):
+        self.pk = pk
+        self.name = name
+
+
+def _row(libre_id, hostname, validation):
+    return {"device_id": libre_id, "device_name": hostname, "validation": validation}
+
+
+def test_no_devices_returns_empty():
+    assert detect_bulk_collisions([]) == []
+    assert detect_bulk_collisions(None) == []
+
+
+def test_no_overlap_returns_empty():
+    devices = [
+        _row(1, "alpha", {"existing_device": Device(pk=10, name="nb-alpha")}),
+        _row(2, "beta", {"existing_device": Device(pk=11, name="nb-beta")}),
+    ]
+    assert detect_bulk_collisions(devices) == []
+
+
+def test_host_and_oob_collide_on_same_nb_device():
+    nb_device = Device(pk=42, name="srv-01")
+    devices = [
+        _row(100, "host-row", {"existing_device": nb_device}),
+        _row(101, "oob-row", {"oob_candidate": {"device": nb_device, "type": "idrac"}}),
+    ]
+    groups = detect_bulk_collisions(devices)
+    assert len(groups) == 1
+    g = groups[0]
+    assert g["nb_device_pk"] == 42
+    assert g["nb_device_name"] == "srv-01"
+    rows = {r["device_id"]: r for r in g["librenms_rows"]}
+    assert rows[100]["role"] == "host"
+    assert rows[101]["role"] == "oob"
+
+
+def test_two_promote_targets_to_same_nb_device_collide():
+    nb_device = Device(pk=7, name="core-sw")
+    devices = [
+        _row(200, "row-a", {"promote_to_host": {"existing_device": nb_device}}),
+        _row(201, "row-b", {"promote_to_host": {"existing_device": nb_device}}),
+    ]
+    groups = detect_bulk_collisions(devices)
+    assert len(groups) == 1
+    assert {r["device_id"] for r in groups[0]["librenms_rows"]} == {200, 201}
+
+
+def test_merge_candidates_overlap_with_direct_existing():
+    devices = [
+        _row(
+            300,
+            "row-merge",
+            {
+                "merge_candidates": {
+                    "host_named": {"pk": 99, "name": "host-side"},
+                    "oob_named": {"pk": 100, "name": "oob-side"},
+                }
+            },
+        ),
+        _row(301, "row-direct", {"existing_device": Device(pk=99, name="host-side")}),
+    ]
+    groups = detect_bulk_collisions(devices)
+    assert len(groups) == 1
+    assert groups[0]["nb_device_pk"] == 99
+    rows = {r["device_id"] for r in groups[0]["librenms_rows"]}
+    assert rows == {300, 301}
+
+
+def test_promote_via_existing_device_field_collides_with_direct_match():
+    """promote_to_host carries existing_device; collision fires against a direct existing_device row."""
+    nb_device = Device(pk=55, name="shared")
+    devices = [
+        _row(400, "row-a", {"promote_to_host": {"existing_device": nb_device, "existing_libre_id": 9}}),
+        _row(401, "row-b", {"existing_device": nb_device}),
+    ]
+    groups = detect_bulk_collisions(devices)
+    assert len(groups) == 1
+    assert groups[0]["nb_device_pk"] == 55
+    assert groups[0]["nb_device_name"] == "shared"
+
+
+def test_three_way_collision():
+    nb_device = Device(pk=8, name="busy")
+    devices = [
+        _row(500, "a", {"existing_device": nb_device}),
+        _row(501, "b", {"oob_candidate": {"device": nb_device}}),
+        _row(502, "c", {"promote_to_host": {"existing_device": nb_device}}),
+    ]
+    groups = detect_bulk_collisions(devices)
+    assert len(groups) == 1
+    assert {r["device_id"] for r in groups[0]["librenms_rows"]} == {500, 501, 502}
+
+
+def test_same_libre_row_under_multiple_roles_does_not_collide_with_itself():
+    """A single LibreNMS row whose validation lists the same NB pk under
+    multiple roles must NOT be reported as a collision — collisions
+    require at least two *distinct* LibreNMS device_ids."""
+    nb_device = Device(pk=12, name="solo")
+    devices = [
+        _row(
+            600,
+            "lonely",
+            {
+                "existing_device": nb_device,
+                "oob_candidate": {"device": nb_device},
+            },
+        ),
+    ]
+    assert detect_bulk_collisions(devices) == []
+
+
+def test_invalid_pks_are_skipped():
+    devices = [
+        _row(700, "a", {"existing_device": Device(pk=None, name="bad")}),
+        _row(701, "b", {"existing_device": Device(pk="not-int", name="worse")}),
+    ]
+    assert detect_bulk_collisions(devices) == []
+
+
+def test_invalid_libre_id_is_skipped():
+    """Rows with non-int device_id are dropped silently."""
+    nb_device = Device(pk=20, name="nb")
+    devices = [
+        _row("not-int", "weird", {"existing_device": nb_device}),
+        _row(800, "ok", {"existing_device": nb_device}),
+    ]
+    # Only one valid row -> no collision.
+    assert detect_bulk_collisions(devices) == []
+
+
+def test_groups_sorted_by_nb_pk_for_stable_render():
+    nb_high = Device(pk=999, name="z")
+    nb_low = Device(pk=1, name="a")
+    devices = [
+        _row(10, "x", {"existing_device": nb_high}),
+        _row(11, "y", {"existing_device": nb_high}),
+        _row(20, "p", {"existing_device": nb_low}),
+        _row(21, "q", {"existing_device": nb_low}),
+    ]
+    groups = detect_bulk_collisions(devices)
+    assert [g["nb_device_pk"] for g in groups] == [1, 999]
+
+
+def test_row_roles_are_joined_when_same_libre_row_targets_pk_via_multiple_paths():
+    """When LibreNMS row R touches NB pk P via both 'host' and
+    'merge_host_named' (rare but possible during transitional states),
+    its row entry in the collision group should list both roles."""
+    devices = [
+        _row(
+            900,
+            "dual",
+            {
+                "existing_device": Device(pk=77, name="shared"),
+                "merge_candidates": {
+                    "host_named": {"pk": 77, "name": "shared"},
+                    "oob_named": {"pk": 78, "name": "other"},
+                },
+            },
+        ),
+        _row(901, "neighbour", {"existing_device": Device(pk=77, name="shared")}),
+    ]
+    groups = detect_bulk_collisions(devices)
+    assert len(groups) == 1
+    rows = {r["device_id"]: r["role"] for r in groups[0]["librenms_rows"]}
+    roles_900 = {role.strip() for role in rows[900].split(",")}
+    assert {"host", "merge_host_named"} <= roles_900
+    assert rows[901] == "host"
+
+
+def test_malformed_rows_are_skipped_not_crashed():
+    """A single malformed entry (non-dict row, or a non-dict ``validation`` payload) must be
+    skipped rather than crashing the whole bulk-confirm flow on ``.get()``. Valid colliding
+    rows in the same batch must still be detected. Pre-fix this raised AttributeError."""
+    shared = Device(pk=55, name="shared")
+    devices = [
+        42,  # non-dict row
+        None,  # non-dict row
+        {"device_id": 700, "device_name": "bad-validation", "validation": "not-a-dict"},  # non-dict validation
+        _row(800, "host", {"existing_device": shared}),
+        _row(801, "neighbour", {"existing_device": shared}),
+    ]
+    groups = detect_bulk_collisions(devices)
+    assert len(groups) == 1
+    assert groups[0]["nb_device_pk"] == 55
+    assert {r["device_id"] for r in groups[0]["librenms_rows"]} == {800, 801}
+
+
+def test_device_and_vm_with_same_pk_do_not_collide():
+    """Device and VirtualMachine sharing a pk must NOT be reported as a collision
+    because detect_bulk_collisions keys buckets on (model_name, pk)."""
+    devices = [
+        _row(1000, "device-row", {"existing_device": Device(pk=42, name="srv")}),
+        _row(1001, "vm-row", {"existing_device": VirtualMachine(pk=42, name="srv")}),
+    ]
+    assert detect_bulk_collisions(devices) == []
+
+
+def test_collision_payload_carries_model_name_for_link_targeting():
+    """Each group must expose nb_model_name so the template links to the right object
+    type — a VM collision must not render a dcim:device URL."""
+    vm = VirtualMachine(pk=77, name="vm-host")
+    groups = detect_bulk_collisions(
+        [
+            _row(2000, "row-a", {"existing_device": vm}),
+            _row(2001, "row-b", {"existing_device": vm}),
+        ]
+    )
+    assert len(groups) == 1
+    assert groups[0]["nb_device_pk"] == 77
+    assert groups[0]["nb_model_name"] == "VirtualMachine"

--- a/netbox_librenms_plugin/tests/test_collisions.py
+++ b/netbox_librenms_plugin/tests/test_collisions.py
@@ -127,6 +127,33 @@ def test_same_libre_row_under_multiple_roles_does_not_collide_with_itself():
     assert detect_bulk_collisions(devices) == []
 
 
+def test_terminal_ambiguous_row_does_not_block_legit_sibling():
+    """A terminally-blocked ambiguous row must not count as a collision participant."""
+    # existing_device on an ambiguous_hostname_or_serial row is an ARBITRARY duplicate match the
+    # validator already failed-closed (can_import=False, actions cleared); it will never write, so
+    # it must not block an otherwise-valid sibling that genuinely targets the same pk.
+    nb_device = Device(pk=70, name="dup")
+    devices = [
+        _row(
+            1100,
+            "ambiguous",
+            {"existing_device": nb_device, "existing_match_type": "ambiguous_hostname_or_serial"},
+        ),
+        _row(1101, "legit-oob", {"oob_candidate": {"device": nb_device}}),
+    ]
+    assert detect_bulk_collisions(devices) == []
+
+
+def test_two_ambiguous_rows_on_same_pk_do_not_collide():
+    """Two terminal-ambiguous rows sharing an arbitrary pk must not fabricate a collision."""
+    nb_device = Device(pk=71, name="dup2")
+    devices = [
+        _row(1200, "amb-a", {"existing_device": nb_device, "existing_match_type": "ambiguous_hostname_or_serial"}),
+        _row(1201, "amb-b", {"existing_device": nb_device, "existing_match_type": "ambiguous_hostname_or_serial"}),
+    ]
+    assert detect_bulk_collisions(devices) == []
+
+
 def test_invalid_pks_are_skipped():
     devices = [
         _row(700, "a", {"existing_device": Device(pk=None, name="bad")}),
@@ -243,7 +270,7 @@ def test_collision_payload_carries_model_name_for_link_targeting():
     )
     assert len(groups) == 1
     assert groups[0]["nb_device_pk"] == 77
-    assert groups[0]["nb_model_name"] == "VirtualMachine"
+    assert groups[0]["nb_model_name"] == "virtualmachine"
 
 
 @pytest.mark.django_db
@@ -269,7 +296,7 @@ def test_real_validator_output_feeds_detector_end_to_end():
     groups = detect_bulk_collisions(devices)
     assert len(groups) == 1
     assert groups[0]["nb_device_pk"] == nb_device.pk
-    assert groups[0]["nb_model_name"] == "Device"
+    assert groups[0]["nb_model_name"] == "device"
     assert {r["device_id"] for r in groups[0]["librenms_rows"]} == {5001, 5002}
 
 
@@ -282,7 +309,7 @@ def test_collision_template_renders_correct_link_targets_and_escapes():
         {
             "nb_device_pk": 42,
             "nb_device_name": "srv-collide",
-            "nb_model_name": "Device",
+            "nb_model_name": "device",
             "librenms_rows": [
                 {"device_id": 1, "hostname": "<script>alpha</script>", "role": "host"},
                 {"device_id": 2, "hostname": "beta", "role": "oob"},
@@ -291,7 +318,7 @@ def test_collision_template_renders_correct_link_targets_and_escapes():
         {
             "nb_device_pk": 7,
             "nb_device_name": "vm-collide",
-            "nb_model_name": "VirtualMachine",
+            "nb_model_name": "virtualmachine",
             "librenms_rows": [
                 {"device_id": 3, "hostname": "gamma", "role": "merge_host_named"},
                 {"device_id": 4, "hostname": "delta", "role": "merge_oob_named"},
@@ -300,7 +327,7 @@ def test_collision_template_renders_correct_link_targets_and_escapes():
     ]
     html = render_to_string(
         "netbox_librenms_plugin/htmx/bulk_import_collision.html",
-        {"collisions": collisions, "device_count": 2},
+        {"collisions": collisions},
     )
 
     # Each group links to the correct object type — a VM collision must not get a device URL.

--- a/netbox_librenms_plugin/tests/test_collisions.py
+++ b/netbox_librenms_plugin/tests/test_collisions.py
@@ -184,6 +184,16 @@ def test_numeric_like_libre_id_is_skipped_not_truncated():
     assert detect_bulk_collisions(devices) == []
 
 
+def test_float_nb_pk_is_skipped_not_truncated():
+    """A float NetBox pk (1.9) must be dropped by coerce_positive_int, not int()-truncated to 1 — otherwise it fabricates a collision against the real pk=1 device."""
+    devices = [
+        _row(910, "float-pk-row", {"existing_device": Device(pk=1.9, name="nb-float-pk")}),  # must NOT become pk=1
+        _row(911, "real-pk-row", {"existing_device": Device(pk=1, name="nb-pk-1")}),
+    ]
+    # The float-pk row is dropped → only one valid NB pk is touched → no collision.
+    assert detect_bulk_collisions(devices) == []
+
+
 def test_digit_string_libre_id_is_accepted():
     """A plain digit-string device_id ('200') is still coerced and counted (regression guard for the coerce switch)."""
     nb_device = Device(pk=31, name="nb-strid")
@@ -344,6 +354,27 @@ def test_collision_template_renders_correct_link_targets_and_escapes():
     # Tabler's muted badge text (grey-on-red), unreadable in both themes.
     assert "badge bg-danger text-white" in html
     assert 'badge bg-danger"' not in html
+
+
+def test_collision_template_title_is_generic_for_non_collision_failures():
+    """The modal title must drop the 'NetBox device collisions' wording when rendering a non-collision error_message (the same modal serves LibreNMS fetch/check failures)."""
+    from django.template.loader import render_to_string
+
+    # Collision render → collision-specific title.
+    collision_html = render_to_string(
+        "netbox_librenms_plugin/htmx/bulk_import_collision.html",
+        {"collisions": [{"nb_device_pk": 1, "nb_device_name": "x", "nb_model_name": "device", "librenms_rows": []}]},
+    )
+    assert "Bulk import blocked: NetBox device collisions" in collision_html
+
+    # Non-collision failure render → generic title, NOT the collision wording.
+    error_html = render_to_string(
+        "netbox_librenms_plugin/htmx/bulk_import_collision.html",
+        {"error_message": "Could not fetch LibreNMS info for the selected device."},
+    )
+    assert "Bulk import blocked" in error_html
+    assert "NetBox device collisions" not in error_html
+    assert "Could not fetch LibreNMS info for the selected device." in error_html
 
 
 def test_non_string_merge_model_name_is_normalized():

--- a/netbox_librenms_plugin/tests/test_collisions.py
+++ b/netbox_librenms_plugin/tests/test_collisions.py
@@ -2,6 +2,7 @@
 
 import pytest
 
+from netbox_librenms_plugin.import_utils.bulk_import import classify_bulk_precheck
 from netbox_librenms_plugin.import_utils.collisions import detect_bulk_collisions
 
 
@@ -426,3 +427,43 @@ def test_non_string_merge_model_name_is_normalized():
     assert groups[0]["nb_device_pk"] == 88
     assert groups[0]["nb_model_name"] == "device"
     assert {r["device_id"] for r in groups[0]["librenms_rows"]} == {400, 401}
+
+
+# --- classify_bulk_precheck: shared block/skip decision for the non-modal import paths ---
+
+
+def test_classify_clean_batch_imports_everything():
+    """No collisions and no unresolved rows → nothing blocked or skipped; the whole batch is importable."""
+    outcome = classify_bulk_precheck([], [], device_ids=[1, 2], vm_imports={3: {"cluster_id": 9}})
+    assert outcome.blocked is False
+    assert outcome.block_message == ""
+    assert outcome.skipped_ids == []
+    assert outcome.skip_message == ""
+    assert outcome.importable_device_ids == [1, 2]
+    assert outcome.importable_vm_imports == {3: {"cluster_id": 9}}
+
+
+def test_classify_unresolved_rows_are_skipped_not_blocked():
+    """Unresolved rows are excluded from the importable sets (device AND VM) and surfaced via skip_message — NOT a whole-batch block."""
+    outcome = classify_bulk_precheck([], [2, 3], device_ids=[1, 2], vm_imports={3: {"cluster_id": 9}, 4: {}})
+    assert outcome.blocked is False
+    assert outcome.skipped_ids == [2, 3]
+    # id 2 (a device) and id 3 (a VM) drop out; the rest import.
+    assert outcome.importable_device_ids == [1]
+    assert outcome.importable_vm_imports == {4: {}}
+    # Object-neutral wording naming the skipped ids, never "device(s)".
+    assert "Skipped 2 selected row(s)" in outcome.skip_message
+    assert "id(s): 2, 3" in outcome.skip_message
+    assert "verify collisions" in outcome.skip_message
+    assert "device(s)" not in outcome.skip_message
+
+
+def test_classify_collisions_block_whole_batch():
+    """A genuine collision blocks the whole batch: blocked=True, block_message names the NetBox object pk(s)."""
+    outcome = classify_bulk_precheck([{"nb_device_pk": 7}], [], device_ids=[1, 2], vm_imports={})
+    assert outcome.blocked is True
+    assert "Bulk import blocked" in outcome.block_message
+    assert "1 NetBox object collision" in outcome.block_message
+    assert "pk(s): 7" in outcome.block_message
+    # Object-neutral: never mislabel a VM collision as a "NetBox device".
+    assert "NetBox device collision" not in outcome.block_message

--- a/netbox_librenms_plugin/tests/test_collisions.py
+++ b/netbox_librenms_plugin/tests/test_collisions.py
@@ -178,7 +178,7 @@ def test_two_ambiguous_rows_on_same_pk_do_not_collide():
 
 def test_invalid_pks_are_skipped():
     devices = [
-        _row(700, "a", {"existing_device": Device(pk=None, name="bad")}),
+        _row(700, "a", {"existing_device": Device(pk="not-int", name="bad")}),
         _row(701, "b", {"existing_device": Device(pk="not-int", name="worse")}),
     ]
     assert detect_bulk_collisions(devices) == []

--- a/netbox_librenms_plugin/tests/test_collisions.py
+++ b/netbox_librenms_plugin/tests/test_collisions.py
@@ -317,3 +317,7 @@ def test_collision_template_renders_correct_link_targets_and_escapes():
     # Device-supplied hostname is auto-escaped (no raw <script> injected into the modal).
     assert "<script>alpha</script>" not in html
     assert "&lt;script&gt;alpha&lt;/script&gt;" in html
+    # The "Collision" badge must pair its red fill with a text colour: a bare bg-danger leaves
+    # Tabler's muted badge text (grey-on-red), unreadable in both themes.
+    assert "badge bg-danger text-white" in html
+    assert 'badge bg-danger"' not in html

--- a/netbox_librenms_plugin/tests/test_collisions.py
+++ b/netbox_librenms_plugin/tests/test_collisions.py
@@ -344,3 +344,14 @@ def test_collision_template_renders_correct_link_targets_and_escapes():
     # Tabler's muted badge text (grey-on-red), unreadable in both themes.
     assert "badge bg-danger text-white" in html
     assert 'badge bg-danger"' not in html
+
+
+def test_non_string_merge_model_name_is_normalized():
+    """A corrupt/foreign merge_candidates model_name (non-string) must not crash the dict-key bucketing — it's normalized to the 'device' default and still collides correctly."""
+    bad = {"merge_candidates": {"host_named": {"pk": 88, "name": "shared", "model_name": ["not-a-str"]}}}
+    devices = [_row(400, "row-a", dict(bad)), _row(401, "row-b", dict(bad))]
+    groups = detect_bulk_collisions(devices)  # must not raise TypeError on an unhashable model_name key
+    assert len(groups) == 1
+    assert groups[0]["nb_device_pk"] == 88
+    assert groups[0]["nb_model_name"] == "device"
+    assert {r["device_id"] for r in groups[0]["librenms_rows"]} == {400, 401}

--- a/netbox_librenms_plugin/tests/test_collisions.py
+++ b/netbox_librenms_plugin/tests/test_collisions.py
@@ -146,6 +146,30 @@ def test_invalid_libre_id_is_skipped():
     assert detect_bulk_collisions(devices) == []
 
 
+def test_numeric_like_libre_id_is_skipped_not_truncated():
+    """A float/numeric-like device_id (1.9) must be skipped, not int()-truncated to a valid-looking pk — otherwise it keys a phantom row and fabricates a collision against the real row."""
+    nb_device = Device(pk=30, name="nb-float")
+    devices = [
+        _row(1.9, "float-row", {"existing_device": nb_device}),  # must NOT become 1
+        _row(900, "real-row", {"existing_device": nb_device}),
+    ]
+    # The float row is dropped → only one valid LibreNMS id touches the NB device → no collision.
+    assert detect_bulk_collisions(devices) == []
+
+
+def test_digit_string_libre_id_is_accepted():
+    """A plain digit-string device_id ('200') is still coerced and counted (regression guard for the coerce switch)."""
+    nb_device = Device(pk=31, name="nb-strid")
+    devices = [
+        _row("200", "str-row", {"existing_device": nb_device}),
+        _row(201, "int-row", {"existing_device": nb_device}),
+    ]
+    groups = detect_bulk_collisions(devices)
+    # Two distinct valid ids on one NB device → a real collision (string id was not dropped).
+    assert len(groups) == 1
+    assert {r["device_id"] for r in groups[0]["librenms_rows"]} == {200, 201}
+
+
 def test_groups_sorted_by_nb_pk_for_stable_render():
     nb_high = Device(pk=999, name="z")
     nb_low = Device(pk=1, name="a")

--- a/netbox_librenms_plugin/tests/test_collisions.py
+++ b/netbox_librenms_plugin/tests/test_collisions.py
@@ -452,3 +452,17 @@ def test_classify_collisions_block_whole_batch():
     assert "pk(s): 7" in outcome.block_message
     # Object-neutral: never mislabel a VM collision as a "NetBox device".
     assert "NetBox device collision" not in outcome.block_message
+
+
+def test_classify_blocked_batch_omits_imported_rows_message():
+    """A collision blocks every row, so unresolved-row copy must not claim that rows imported."""
+    outcome = classify_bulk_precheck(
+        [{"nb_device_pk": 7}],
+        [2],
+        device_ids=[1, 2],
+        vm_imports={},
+    )
+
+    assert outcome.blocked is True
+    assert outcome.skipped_ids == [2]
+    assert outcome.skip_message == ""

--- a/netbox_librenms_plugin/tests/test_collisions.py
+++ b/netbox_librenms_plugin/tests/test_collisions.py
@@ -368,6 +368,14 @@ def test_collision_template_renders_correct_link_targets_and_escapes():
     assert "srv-collide" in html
     assert "vm-collide" in html
     assert "beta" in html
+    # The copy must be VM-safe: this batch includes a VM collision, so the modal must not use
+    # device-only wording or point at device-only follow-up actions (Add as OOB / Promote to host)
+    # that don't exist for a VM collision. Object-neutral language is used instead.
+    assert "same NetBox object" in html
+    assert "selected LibreNMS rows" in html
+    assert "same NetBox device" not in html
+    assert "Add as OOB" not in html
+    assert "Promote to host" not in html
     # Device-supplied hostname is auto-escaped (no raw <script> injected into the modal).
     assert "<script>alpha</script>" not in html
     assert "&lt;script&gt;alpha&lt;/script&gt;" in html
@@ -392,7 +400,7 @@ def test_collision_template_title_is_generic_for_non_collision_failures():
         "netbox_librenms_plugin/htmx/bulk_import_collision.html",
         {"collisions": [{"nb_device_pk": 1, "nb_device_name": "x", "nb_model_name": "device", "librenms_rows": []}]},
     )
-    assert "Bulk import blocked: NetBox device collisions" in collision_html
+    assert "Bulk import blocked: NetBox object collisions" in collision_html
 
     # Non-collision failure render → generic title, NOT the collision wording.
     error_html = render_to_string(
@@ -400,7 +408,7 @@ def test_collision_template_title_is_generic_for_non_collision_failures():
         {"error_message": "Could not fetch LibreNMS info for the selected device."},
     )
     assert "Bulk import blocked" in error_html
-    assert "NetBox device collisions" not in error_html
+    assert "NetBox object collisions" not in error_html
     assert "Could not fetch LibreNMS info for the selected device." in error_html
 
 

--- a/netbox_librenms_plugin/tests/test_coverage_actions.py
+++ b/netbox_librenms_plugin/tests/test_coverage_actions.py
@@ -6624,6 +6624,26 @@ class TestMergeNetBoxDevicesViewOOBTransfer:
         ]
         assert locked, "OOB IP transfer did not lock the IPAddress row (no SELECT ... FOR UPDATE on ipam_ipaddress)"
 
+    def test_oob_ip_transfer_locks_the_owning_interface(self):
+        """The transfer must also SELECT ... FOR UPDATE the owning Interface row: locking the IPAddress alone leaves Interface.device_id free to change under a concurrent interface move, so the winner.oob_ip FK could be persisted onto an interface no longer owned by the winner (TOCTOU)."""
+        from django.db import connection
+        from django.test.utils import CaptureQueriesContext
+
+        with CaptureQueriesContext(connection) as ctx:
+            winner, _donor, oob_ip = self._run(oob_on_winner=True)
+
+        # The transfer still works through the locked interface read.
+        assert winner.oob_ip_id == oob_ip.pk
+        # A row-level lock on the owning Interface must have been issued during the merge.
+        locked = [
+            q["sql"]
+            for q in ctx.captured_queries
+            if "dcim_interface" in q["sql"].lower() and "for update" in q["sql"].lower()
+        ]
+        assert locked, (
+            "OOB IP transfer did not lock the owning Interface row (no SELECT ... FOR UPDATE on dcim_interface)"
+        )
+
     def test_save_failure_rolls_back_donor_oob_release_and_marker(self):
         """Forced persist failure mid-merge must roll back the donor's already-executed save."""
         from dcim.models import Device

--- a/netbox_librenms_plugin/tests/test_coverage_actions.py
+++ b/netbox_librenms_plugin/tests/test_coverage_actions.py
@@ -5704,10 +5704,10 @@ class TestBulkImportDevicesViewCollisionGate:
         # Gate cleared (distinct devices) → the importer ran.
         mock_import.assert_called_once()
 
-    def test_unfetchable_id_blocks_import(self):
-        """A selected id whose LibreNMS info can't be fetched (not cached + get_device_info fails) blocks the import (fail closed) — the importer is never reached."""
+    def test_unfetchable_id_is_skipped_rest_imports(self):
+        """A selected id whose LibreNMS info can't be fetched (not cached + get_device_info fails) is SKIPPED, not a whole-batch block: the fetchable rows still import and the skipped row is surfaced. Restores the per-device resilience the old fail-closed block removed."""
         view = self._make_view()
-        # id 2 isn't cached and its info fetch fails → it can't be collision-checked.
+        # id 2 isn't cached and its info fetch fails → it can't be collision-checked → skipped.
         view._librenms_api.get_device_info = MagicMock(return_value=(False, None))
         request = _make_request(post={"select": ["1", "2"]}, headers={"HX-Request": "true"})
         request.POST.getlist = MagicMock(return_value=["1", "2"])
@@ -5715,6 +5715,7 @@ class TestBulkImportDevicesViewCollisionGate:
 
         make_device("gate-unresolved-host")
         libre = {1: {"device_id": 1, "sysName": "gate-unresolved-host", "hostname": "gate-unresolved-host"}}
+        import_result = {"success": [], "failed": [], "skipped": [], "virtual_chassis_created": 0}
         with (
             patch.object(view, "require_write_permission", return_value=None),
             patch(
@@ -5722,20 +5723,62 @@ class TestBulkImportDevicesViewCollisionGate:
             ),
             patch(
                 "netbox_librenms_plugin.views.imports.actions.fetch_device_with_cache",
-                side_effect=lambda did, _api: libre.get(did),
+                side_effect=lambda did, _api, **_kw: libre.get(did),
             ),
-            patch("netbox_librenms_plugin.views.imports.actions.bulk_import_devices") as mock_import,
+            patch(
+                "netbox_librenms_plugin.views.imports.actions.bulk_import_devices", return_value=import_result
+            ) as mock_import,
         ):
             response = view.post(request)
 
+        # The fetchable id 1 imports; only the unresolved id 2 is dropped (not a whole-batch block).
         assert response.status_code == 200
+        mock_import.assert_called_once()
+        assert mock_import.call_args.kwargs["device_ids"] == [1]
         html = response.content.decode()
-        assert "could not fetch LibreNMS device info" in html
-        # Object-neutral copy: the batch can contain VM rows, so the block message says
-        # "row(s)", never "device(s)" — matching ImportDevicesJob's wording.
+        # The skipped row is surfaced, object-neutral ("row(s)", never "device(s)").
+        assert "Skipped" in html
+        assert "verify collisions" in html
         assert "selected row(s)" in html
         assert "selected device(s)" not in html
-        mock_import.assert_not_called()
+
+    def test_background_batch_defers_collision_precheck_to_job(self):
+        """A batch routed to a background job must NOT run the collision pre-check synchronously — it's deferred to ImportDevicesJob (which re-runs it), so the request doesn't pay the validation cost. The job is enqueued and the sync detector is never called."""
+        view = self._make_view()
+        request = _make_request(
+            post={"select": ["1", "2"], "use_background_job": "on"},
+            headers={"HX-Request": "true"},
+            user_is_superuser=True,
+        )
+        request.POST.getlist = MagicMock(return_value=["1", "2"])
+
+        libre = {
+            1: {"device_id": 1, "sysName": "bg-a", "hostname": "bg-a"},
+            2: {"device_id": 2, "sysName": "bg-b", "hostname": "bg-b"},
+        }
+        with (
+            patch.object(view, "require_write_permission", return_value=None),
+            patch(
+                "netbox_librenms_plugin.views.imports.actions.resolve_naming_preferences", return_value=(True, False)
+            ),
+            patch(
+                "netbox_librenms_plugin.views.imports.actions.fetch_device_with_cache",
+                side_effect=lambda did, _api, **_kw: libre.get(did),
+            ),
+            patch("utilities.rqworker.get_workers_for_queue", return_value=1),
+            patch(
+                "netbox_librenms_plugin.jobs.ImportDevicesJob.enqueue",
+                return_value=MagicMock(pk=4242, job_id="job-4242"),
+            ) as mock_enqueue,
+            patch("netbox_librenms_plugin.views.imports.actions.detect_collisions_for_device_ids") as mock_detect,
+            patch("netbox_librenms_plugin.views.imports.actions.messages"),
+        ):
+            response = view.post(request)
+
+        # The job is enqueued and the synchronous collision pre-check is skipped entirely (deferred).
+        mock_enqueue.assert_called_once()
+        mock_detect.assert_not_called()
+        assert response.status_code == 200
 
     def test_colliding_batch_non_htmx_message_is_object_neutral(self):
         """The non-HTMX collision block toast says "NetBox object", not "NetBox device".

--- a/netbox_librenms_plugin/tests/test_coverage_actions.py
+++ b/netbox_librenms_plugin/tests/test_coverage_actions.py
@@ -3039,7 +3039,10 @@ class TestDeviceConflictSelectForUpdateDoesNotExist:
 
         with patch.object(view, "require_all_permissions", return_value=None):
             with patch("dcim.models.Device") as MockDevice:
-                MockDevice.objects.restrict.return_value.get.return_value = mock_existing
+                # The locked re-read is reached through restrict(user, action), so hand back the
+                # same manager: the stubs below then describe both the primary read and the lock.
+                MockDevice.objects.restrict.return_value = MockDevice.objects
+                MockDevice.objects.get.return_value = mock_existing
                 # select_for_update().get() raises DoesNotExist
                 MockDevice.objects.select_for_update.return_value.get.side_effect = DoesNotExistExc("gone")
                 MockDevice.DoesNotExist = DoesNotExistExc
@@ -3156,8 +3159,10 @@ class TestMigrateLibreNMSIdMorePaths:
                             with patch("dcim.models.Device") as MockDevice2:
                                 # This inner patch shadows the outer one for the in-function
                                 # `from dcim.models import Device`, so it must serve BOTH the
-                                # pre-lock existing_device lookup and the locked re-read.
-                                MockDevice2.objects.restrict.return_value.get.return_value = mock_existing
+                                # pre-lock existing_device lookup and the locked re-read. Both go
+                                # through restrict(user, action), so it returns the same manager.
+                                MockDevice2.objects.restrict.return_value = MockDevice2.objects
+                                MockDevice2.objects.get.return_value = mock_existing
                                 MockDevice2.objects.select_for_update.return_value.get.return_value = locked_device
                                 MockDevice2.DoesNotExist = DoesNotExistExc
                                 with patch("netbox_librenms_plugin.utils.find_by_librenms_id", return_value=None):
@@ -3234,7 +3239,10 @@ class TestDeviceConflictMoreActions:
         stack.enter_context(patch.object(view, "require_all_permissions", return_value=None))
 
         MockDevice = MagicMock()
-        MockDevice.objects.restrict.return_value.get.return_value = mock_existing
+        # restrict() hands back the same manager, so the locked re-read reached through it
+        # resolves to the stubs below.
+        MockDevice.objects.restrict.return_value = MockDevice.objects
+        MockDevice.objects.get.return_value = mock_existing
         MockDevice.objects.select_for_update.return_value.get.return_value = mock_existing
         MockDevice.objects.filter.return_value.exclude.return_value.first.return_value = None
         MockDevice.DoesNotExist = DoesNotExistExc
@@ -3442,7 +3450,10 @@ class TestMoreSaveErrorPaths:
 
         DoesNotExistExc = type("DoesNotExist", (Exception,), {})
         MockDevice = MagicMock()
-        MockDevice.objects.restrict.return_value.get.return_value = mock_existing
+        # restrict() hands back the same manager, so the locked re-read reached through it
+        # resolves to the stubs below.
+        MockDevice.objects.restrict.return_value = MockDevice.objects
+        MockDevice.objects.get.return_value = mock_existing
         MockDevice.objects.select_for_update.return_value.get.return_value = mock_existing
         MockDevice.objects.filter.return_value.exclude.return_value.first.return_value = None
         MockDevice.DoesNotExist = DoesNotExistExc
@@ -3672,7 +3683,10 @@ class TestUpdateAndSerialSaveErrors:
 
         DoesNotExistExc = type("DoesNotExist", (Exception,), {})
         MockDevice = MagicMock()
-        MockDevice.objects.restrict.return_value.get.return_value = mock_existing
+        # restrict() hands back the same manager, so the locked re-read reached through it
+        # resolves to the stubs below.
+        MockDevice.objects.restrict.return_value = MockDevice.objects
+        MockDevice.objects.get.return_value = mock_existing
         MockDevice.objects.select_for_update.return_value.get.return_value = mock_existing
         MockDevice.objects.filter.return_value.exclude.return_value.first.return_value = None
         MockDevice.DoesNotExist = DoesNotExistExc
@@ -3750,7 +3764,10 @@ class TestSyncSerialMorePaths:
 
         DoesNotExistExc = type("DoesNotExist", (Exception,), {})
         MockDevice = MagicMock()
-        MockDevice.objects.restrict.return_value.get.return_value = mock_existing
+        # restrict() hands back the same manager so the locked re-read the tests stub as
+        # objects.select_for_update() resolves through it too.
+        MockDevice.objects.restrict.return_value = MockDevice.objects
+        MockDevice.objects.get.return_value = mock_existing
         MockDevice.DoesNotExist = DoesNotExistExc
         mock_tx = MagicMock()
         mock_tx.atomic.return_value.__enter__ = MagicMock(return_value=None)
@@ -3956,7 +3973,11 @@ class TestMigrateLibreNMSIdTransactionPaths:
         locked_device.name = "router01"
 
         MockDevice = MagicMock()
-        MockDevice.objects.restrict.return_value.get.return_value = mock_existing
+        # The view reaches the manager through restrict(user, action) for both the primary read
+        # and the locked re-read, so restrict() hands back the same manager: the stubs below then
+        # describe both chains, and a test can still override either one.
+        MockDevice.objects.restrict.return_value = MockDevice.objects
+        MockDevice.objects.get.return_value = mock_existing
         MockDevice.objects.select_for_update.return_value.get.return_value = locked_device
         MockDevice.DoesNotExist = DoesNotExistExc
 
@@ -4892,6 +4913,7 @@ class TestAddDeviceTypeMappingNoSecondRoundTrip:
             data={"device_type_id": str(dt.pk)},
         )
         request.user = user
+        view.request = request
 
         # Mock ONLY the LibreNMS HTTP boundary; have it raise if ever called after the cache hit,
         # so a second round-trip would be unmistakable. Also stub the auth gates and VC detection.
@@ -4949,6 +4971,7 @@ class TestAddDeviceTypeMappingNoSecondRoundTrip:
             data={"device_type_id": str(dt.pk)},
         )
         request.user = user
+        view.request = request
 
         spy_cache = MagicMock(wraps=cache)
         with (
@@ -5007,6 +5030,7 @@ class TestAddDeviceTypeMappingNoSecondRoundTrip:
             data={"device_type_id": str(dt.pk)},
         )
         request.user = user
+        view.request = request
 
         with (
             patch("netbox_librenms_plugin.import_utils.device_operations.get_librenms_device_by_id", return_value=None),
@@ -5067,6 +5091,7 @@ class TestAddDeviceTypeMappingNoSecondRoundTrip:
             data={"device_type_id": str(dt_new.pk)},
         )
         request.user = user
+        view.request = request
 
         with (
             patch("netbox_librenms_plugin.import_utils.device_operations.get_librenms_device_by_id", return_value=None),
@@ -5115,6 +5140,7 @@ class TestCreatePlatformAssignmentIndependence:
 
         request = MagicMock()
         request.POST = {"platform_name": "NewPlatPF"}
+        view.request = request  # dispatch() would set this; restricted_queryset reads request.user
 
         validation = {"existing_device": target}
         dvdv = MagicMock()
@@ -5154,6 +5180,7 @@ class TestCreatePlatformAssignmentIndependence:
 
         request = MagicMock()
         request.POST = {"platform_name": "NewPlatPF2"}
+        view.request = request  # dispatch() would set this; restricted_queryset reads request.user
 
         validation = {"existing_device": target}
         # Patched so the UNFIXED success path can still render its OOB modal swap cleanly,
@@ -5847,7 +5874,10 @@ class TestAddAsOOBViewPost:
             patch("netbox_librenms_plugin.utils.find_by_librenms_id", return_value=None) as mock_find,
         ):
             mock_device.DoesNotExist = Exception
-            mock_device.objects.restrict.return_value.get.return_value = existing_device
+            # The sync-device re-read under lock goes through restrict(user, action) too, so
+            # restrict() hands back the same manager and both stubs below apply.
+            mock_device.objects.restrict.return_value = mock_device.objects
+            mock_device.objects.get.return_value = existing_device
             mock_device.objects.select_for_update.return_value.get.return_value = locked_device
             response = view.post(request, device_id=17)
 
@@ -6891,7 +6921,10 @@ class TestResolveOOBInterface:
         view = self._view()
         dev = make_device("oob-res-existing")
         iface = make_interface(dev, "eth0")
-        req = _make_request(post={"oob_interface_id": str(iface.pk)})
+        # Superuser: the reused interface is now read through a restricted queryset, and this
+        # test is about resolving the selection, not about the grant (see
+        # TestGatedViewsRefuseOutOfScopeObjects for the scoping itself).
+        req = _make_request(post={"oob_interface_id": str(iface.pk)}, user_is_superuser=True)
         with transaction.atomic():
             result_iface, reason = view._resolve_oob_interface(req, dev)
         assert result_iface.pk == iface.pk and reason is None
@@ -7313,8 +7346,13 @@ class TestCreatePlatformFromImportManufacturer:
         view = self._view()
         req = _make_request(post={"platform_name": "New-OS", "manufacturer": "9999"})
 
+        view.request = req  # dispatch() would set this; restricted_queryset reads request.user
+
         mock_manuf = MagicMock()
         mock_manuf.DoesNotExist = type("DoesNotExist", (Exception,), {})
+        # The manufacturer is resolved through restrict(user, "view"), so hand back the same
+        # manager and the not-found stub below still describes that chain.
+        mock_manuf.objects.restrict.return_value = mock_manuf.objects
         mock_manuf.objects.get.side_effect = mock_manuf.DoesNotExist()
         mock_platform = MagicMock()
         mock_platform.objects.filter.return_value.exists.return_value = False
@@ -7354,10 +7392,13 @@ class TestCreatePlatformFromImportManufacturer:
         assert other_mfr.pk != device.device_type.manufacturer_id
 
         view = self._view()
+        # Superuser: the subject is the assignment failure, not the object gate.
         req = _make_request(
             post={"platform_name": "Mismatch-OS", "manufacturer": str(other_mfr.pk)},
             headers={"HX-Request": "true"},
+            user_is_superuser=True,
         )
+        view.request = req
 
         with (
             patch.object(view, "require_write_permission", return_value=None),
@@ -7388,10 +7429,14 @@ class TestCreatePlatformFromImportManufacturer:
         mfr = Manufacturer.objects.get(slug="test-mfr")  # make_device's device_type manufacturer
 
         view = self._view()
+        # Superuser: this test is about the platform assignment, not the object gate, and the
+        # manufacturer is now read through a restricted queryset.
         req = _make_request(
             post={"platform_name": "Match-OS", "manufacturer": str(mfr.pk)},
             headers={"HX-Request": "true"},
+            user_is_superuser=True,
         )
+        view.request = req
 
         with (
             patch.object(view, "require_write_permission", return_value=None),

--- a/netbox_librenms_plugin/tests/test_coverage_actions.py
+++ b/netbox_librenms_plugin/tests/test_coverage_actions.py
@@ -6952,10 +6952,17 @@ class TestMergeNetBoxDevicesViewOOBTransfer:
         state = {"moved": False}
 
         def moving_sfu(*args, **kwargs):
-            if not state["moved"]:
-                state["moved"] = True
-                Interface.objects.filter(pk=iface_pk).update(device=winner)
-            return real_sfu(*args, **kwargs)
+            queryset = real_sfu(*args, **kwargs)
+            real_filter = queryset.filter
+
+            def moving_filter(*filter_args, **filter_kwargs):
+                if not state["moved"] and filter_kwargs.get("pk") == iface_pk:
+                    state["moved"] = True
+                    Interface.objects.filter(pk=iface_pk).update(device=winner)
+                return real_filter(*filter_args, **filter_kwargs)
+
+            queryset.filter = moving_filter
+            return queryset
 
         with patch.object(Interface.objects, "select_for_update", moving_sfu):
             resp = view.post(request, device_id=99)

--- a/netbox_librenms_plugin/tests/test_coverage_actions.py
+++ b/netbox_librenms_plugin/tests/test_coverage_actions.py
@@ -5704,6 +5704,34 @@ class TestBulkImportDevicesViewCollisionGate:
         # Gate cleared (distinct devices) → the importer ran.
         mock_import.assert_called_once()
 
+    def test_unfetchable_id_blocks_import(self):
+        """A selected id whose LibreNMS info can't be fetched (not cached + get_device_info fails) blocks the import (fail closed) — the importer is never reached."""
+        view = self._make_view()
+        # id 2 isn't cached and its info fetch fails → it can't be collision-checked.
+        view._librenms_api.get_device_info = MagicMock(return_value=(False, None))
+        request = _make_request(post={"select": ["1", "2"]}, headers={"HX-Request": "true"})
+        request.POST.getlist = MagicMock(return_value=["1", "2"])
+        request.user = AnonymousUser()
+
+        make_device("gate-unresolved-host")
+        libre = {1: {"device_id": 1, "sysName": "gate-unresolved-host", "hostname": "gate-unresolved-host"}}
+        with (
+            patch.object(view, "require_write_permission", return_value=None),
+            patch(
+                "netbox_librenms_plugin.views.imports.actions.resolve_naming_preferences", return_value=(True, False)
+            ),
+            patch(
+                "netbox_librenms_plugin.views.imports.actions.fetch_device_with_cache",
+                side_effect=lambda did, _api: libre.get(did),
+            ),
+            patch("netbox_librenms_plugin.views.imports.actions.bulk_import_devices") as mock_import,
+        ):
+            response = view.post(request)
+
+        assert response.status_code == 200
+        assert "could not fetch LibreNMS device info" in response.content.decode()
+        mock_import.assert_not_called()
+
 
 # ---------------------------------------------------------------------------
 # AddAsOOBView / PromoteToHostView — generic "oob" sentinel regression tests

--- a/netbox_librenms_plugin/tests/test_coverage_actions.py
+++ b/netbox_librenms_plugin/tests/test_coverage_actions.py
@@ -6874,44 +6874,6 @@ class TestMergeNetBoxDevicesViewOOBTransfer:
         assert winner.oob_ip_id == oob_ip.pk
         assert donor.oob_ip_id is None
 
-    def test_oob_ip_transfer_locks_the_ip_row(self):
-        """The OOB-IP transfer must SELECT ... FOR UPDATE the IPAddress row before re-validating and moving it, so a concurrent reassignment can't strand the persisted oob_ip FK off a winner interface (TOCTOU)."""
-        from django.db import connection
-        from django.test.utils import CaptureQueriesContext
-
-        with CaptureQueriesContext(connection) as ctx:
-            winner, _donor, oob_ip = self._run(oob_on_winner=True)
-
-        # The transfer still works through the locked read.
-        assert winner.oob_ip_id == oob_ip.pk
-        # A row-level lock on the OOB IPAddress must have been issued during the merge.
-        locked = [
-            q["sql"]
-            for q in ctx.captured_queries
-            if "ipam_ipaddress" in q["sql"].lower() and "for update" in q["sql"].lower()
-        ]
-        assert locked, "OOB IP transfer did not lock the IPAddress row (no SELECT ... FOR UPDATE on ipam_ipaddress)"
-
-    def test_oob_ip_transfer_locks_the_owning_interface(self):
-        """The transfer must also SELECT ... FOR UPDATE the owning Interface row: locking the IPAddress alone leaves Interface.device_id free to change under a concurrent interface move, so the winner.oob_ip FK could be persisted onto an interface no longer owned by the winner (TOCTOU)."""
-        from django.db import connection
-        from django.test.utils import CaptureQueriesContext
-
-        with CaptureQueriesContext(connection) as ctx:
-            winner, _donor, oob_ip = self._run(oob_on_winner=True)
-
-        # The transfer still works through the locked interface read.
-        assert winner.oob_ip_id == oob_ip.pk
-        # A row-level lock on the owning Interface must have been issued during the merge.
-        locked = [
-            q["sql"]
-            for q in ctx.captured_queries
-            if "dcim_interface" in q["sql"].lower() and "for update" in q["sql"].lower()
-        ]
-        assert locked, (
-            "OOB IP transfer did not lock the owning Interface row (no SELECT ... FOR UPDATE on dcim_interface)"
-        )
-
     def test_save_failure_rolls_back_donor_oob_release_and_marker(self):
         """Forced persist failure mid-merge must roll back the donor's already-executed save."""
         from dcim.models import Device

--- a/netbox_librenms_plugin/tests/test_coverage_actions.py
+++ b/netbox_librenms_plugin/tests/test_coverage_actions.py
@@ -6606,6 +6606,24 @@ class TestMergeNetBoxDevicesViewOOBTransfer:
         assert winner.oob_ip_id == oob_ip.pk
         assert donor.oob_ip_id is None
 
+    def test_oob_ip_transfer_locks_the_ip_row(self):
+        """The OOB-IP transfer must SELECT ... FOR UPDATE the IPAddress row before re-validating and moving it, so a concurrent reassignment can't strand the persisted oob_ip FK off a winner interface (TOCTOU)."""
+        from django.db import connection
+        from django.test.utils import CaptureQueriesContext
+
+        with CaptureQueriesContext(connection) as ctx:
+            winner, _donor, oob_ip = self._run(oob_on_winner=True)
+
+        # The transfer still works through the locked read.
+        assert winner.oob_ip_id == oob_ip.pk
+        # A row-level lock on the OOB IPAddress must have been issued during the merge.
+        locked = [
+            q["sql"]
+            for q in ctx.captured_queries
+            if "ipam_ipaddress" in q["sql"].lower() and "for update" in q["sql"].lower()
+        ]
+        assert locked, "OOB IP transfer did not lock the IPAddress row (no SELECT ... FOR UPDATE on ipam_ipaddress)"
+
     def test_save_failure_rolls_back_donor_oob_release_and_marker(self):
         """Forced persist failure mid-merge must roll back the donor's already-executed save."""
         from dcim.models import Device

--- a/netbox_librenms_plugin/tests/test_coverage_actions.py
+++ b/netbox_librenms_plugin/tests/test_coverage_actions.py
@@ -8931,41 +8931,17 @@ class TestBulkImportPermGateRunsBeforeEnqueue:
 
     def test_unauthorized_background_import_is_denied_without_enqueueing(self):
         """A plugin-writer without dcim.add_device is denied and no ImportDevicesJob is enqueued."""
-        from django.contrib.messages.storage.fallback import FallbackStorage
-        from django.contrib.sessions.middleware import SessionMiddleware
-        from django.test import RequestFactory
-
         view = self._make_view()
         user = self._plugin_writer_without_import_perms("bulk-no-import-perms")
-
-        request = RequestFactory().post("/device-import/bulk/", data={"select": ["1"]})
-        request.user = user
-        SessionMiddleware(lambda req: None).process_request(request)
-        request.session.save()
-        request._messages = FallbackStorage(request)
+        request = self._request_for(user, {"select": ["1"]})
         view.request = request  # Django binds this in dispatch(); the perm gate reads it
 
-        def _fetch(device_id, *a, **k):
-            return {
-                "device_id": device_id,
-                "hostname": f"host{device_id}",
-                "sysName": f"host{device_id}",
-                "serial": f"SN{device_id}",
-                "hardware": "",
-                "os": "",
-            }
-
         with (
-            # The background branch is superuser-only, and a real superuser passes every has_perm;
-            # stub only that decision so the ordering under test is reachable with a real principal.
+            # Stub the background decision so this plugin writer reaches the ordering under test.
             patch.object(type(view), "should_use_background_job_for_import", return_value=True, create=False),
             patch("utilities.rqworker.get_workers_for_queue", return_value=1),
             patch("netbox_librenms_plugin.jobs.ImportDevicesJob.enqueue") as mock_enqueue,
-            patch("netbox_librenms_plugin.views.imports.actions.fetch_device_with_cache", side_effect=_fetch),
         ):
-            # A real pk so the too-late-gate path renders its "job started" link instead of
-            # crashing in reverse() — the failure under test is the enqueue, not the URL build.
-            mock_enqueue.return_value.pk = 4321
             response = view.post(request)
 
         mock_enqueue.assert_not_called()

--- a/netbox_librenms_plugin/tests/test_coverage_actions.py
+++ b/netbox_librenms_plugin/tests/test_coverage_actions.py
@@ -47,6 +47,19 @@ def _make_request(post=None, get=None, headers=None, user_is_superuser=False):
     return req
 
 
+def _import_authorized_user():
+    """A stand-in user authorized for device/VM import (``has_perm`` → True).
+
+    The synchronous import view authorizes the model add/change perms before the collision
+    pre-check (mirroring ImportDevicesJob), so a collision-gate test must supply an authorized
+    user — the gate runs downstream of authorization.
+    """
+    user = MagicMock()
+    user.has_perm.return_value = True
+    user.is_superuser = False
+    return user
+
+
 def _make_api():
     """Create a minimal LibreNMSAPI mock."""
     api = MagicMock()
@@ -668,6 +681,41 @@ class TestBulkImportDevicesViewPost:
         assert b"no workers are available" in response.content
         assert b"ran synchronously" in response.content
         assert b"devices synchronously" not in response.content
+
+    def test_import_denied_without_model_add_perms_before_collision_precheck(self):
+        """A user with the plugin change perm but WITHOUT dcim.add_device is denied BEFORE the sync collision pre-check (which surfaces NetBox object names/pks in its modal) — mirroring the async job's authorize-before-scan ordering."""
+        view = self._make_view()
+        request = _make_request(
+            post={"select": ["1", "2"]},  # >=2 ids: the collision pre-check would otherwise run
+            headers={"HX-Request": "true"},
+            user_is_superuser=False,
+        )
+        # require_write_permission (plugin perm) passes, but the user lacks the model add perms.
+        request.user.has_perm = lambda perm: (
+            perm
+            not in {
+                "dcim.add_device",
+                "dcim.change_device",
+                "virtualization.add_virtualmachine",
+            }
+        )
+        detect_spy = MagicMock(return_value=([], []))
+        with (
+            patch.object(view, "require_write_permission", return_value=None),
+            patch(
+                "netbox_librenms_plugin.views.imports.actions.detect_collisions_for_device_ids",
+                detect_spy,
+            ),
+            patch("netbox_librenms_plugin.views.imports.actions.bulk_import_devices") as mock_import,
+        ):
+            response = view.post(request)
+
+        # Denied before any collision scan or import: the detector and importer never ran, and the
+        # response is the permission redirect (HX-Redirect), not the collision modal or an import.
+        detect_spy.assert_not_called()
+        mock_import.assert_not_called()
+        assert response.status_code == 200
+        assert response.get("HX-Redirect")
 
 
 class TestDeviceImportHelperMixin:
@@ -5325,7 +5373,9 @@ class TestBulkImportRerenderVMClassification:
 
         view = self._make_view()
         User = get_user_model()
-        user = User.objects.create_user(username="u-rerender", password="x")
+        # Superuser so has_perm passes the import view's authorize-before-precheck gate; this test
+        # exercises the VM-classification re-render path, not permission enforcement.
+        user = User.objects.create_user(username="u-rerender", password="x", is_superuser=True)
 
         # device 1 → Device import; devices 2 & 3 → VM imports (a cluster is selected for them).
         request = RequestFactory().post(
@@ -5642,7 +5692,7 @@ class TestBulkImportDevicesViewCollisionGate:
         view = self._make_view()
         request = _make_request(post={"select": ["1", "2"]}, headers={"HX-Request": "true"})
         request.POST.getlist = MagicMock(return_value=["1", "2"])
-        request.user = AnonymousUser()
+        request.user = _import_authorized_user()
 
         nb = make_device("gate-collide-host")
         libre = {
@@ -5677,7 +5727,7 @@ class TestBulkImportDevicesViewCollisionGate:
         view = self._make_view()
         request = _make_request(post={"select": ["1", "2"]})
         request.POST.getlist = MagicMock(return_value=["1", "2"])
-        request.user = AnonymousUser()
+        request.user = _import_authorized_user()
 
         make_device("gate-clean-a")
         make_device("gate-clean-b")
@@ -5718,7 +5768,7 @@ class TestBulkImportDevicesViewCollisionGate:
         view._librenms_api.get_device_info = lambda did, *a, **k: (True, libre[did]) if did in libre else (False, None)
         request = _make_request(post={"select": ["1", "2"]}, headers={"HX-Request": "true"})
         request.POST.getlist = MagicMock(return_value=["1", "2"])
-        request.user = AnonymousUser()
+        request.user = _import_authorized_user()
 
         make_device("gate-unresolved-host")
         libre = {1: {"device_id": 1, "sysName": "gate-unresolved-host", "hostname": "gate-unresolved-host"}}
@@ -5797,7 +5847,7 @@ class TestBulkImportDevicesViewCollisionGate:
         # No HX-Request header → the messages.error + redirect branch.
         request = _make_request(post={"select": ["1", "2"]})
         request.POST.getlist = MagicMock(return_value=["1", "2"])
-        request.user = AnonymousUser()
+        request.user = _import_authorized_user()
 
         make_device("gate-collide-plain")
         libre = {
@@ -6911,6 +6961,52 @@ class TestMergeNetBoxDevicesViewOOBTransfer:
         entry = donor.custom_field_data["librenms_id"]["default"]
         assert entry == {"id": 10}
         assert "_migrated_to" not in entry
+
+    def test_transfer_survives_interface_move_onto_winner_between_read_and_lock(self):
+        """A concurrent interface move ONTO the winner, landing between the assigned_object read and the interface lock, must not spuriously fail the merge: the locked IP's GFK cache is refreshed to the freshly-locked (winner-owned) interface before set_device_ip_fk re-checks ownership."""
+        from dcim.models import Interface
+        from django.http import HttpResponse
+
+        from netbox_librenms_plugin.tests.conftest import ip_on
+
+        view = self._make_view()
+        winner = make_device("merge-winner-race", librenms_cf={"default": {"id": 20}})
+        donor = make_device("merge-donor-race", librenms_cf={"default": {"id": 10}})
+        # The IP starts on a DONOR interface, so the merge's assigned_object read caches device_id=donor.
+        oob_ip = ip_on(donor, "192.0.2.11/32", "mgmt0")
+        donor.oob_ip = oob_ip
+        donor.save()
+        iface_pk = oob_ip.assigned_object_id
+
+        request = _make_request(post={"winner_pk": str(winner.pk), "donor_pk": str(donor.pk)})
+        validation = {"merge_candidates": {"host_named": {"pk": winner.pk}, "oob_named": {"pk": donor.pk}}}
+        view.get_validated_device_with_selections = MagicMock(return_value=({"device_id": 99}, validation, {}))
+        view.render_device_row = MagicMock(return_value=HttpResponse("row"))
+
+        # Simulate the concurrent move: the first Interface SELECT ... FOR UPDATE (the oob_ip's owning
+        # interface lock) fires AFTER the merge cached assigned_object with device_id=donor. Move the
+        # interface onto the winner right then, so the freshly locked row is winner-owned while the
+        # cached GFK is stale — exactly the TOCTOU the freshen-after-lock guards against.
+        real_sfu = Interface.objects.select_for_update
+        state = {"moved": False}
+
+        def moving_sfu(*args, **kwargs):
+            if not state["moved"]:
+                state["moved"] = True
+                Interface.objects.filter(pk=iface_pk).update(device=winner)
+            return real_sfu(*args, **kwargs)
+
+        with patch.object(Interface.objects, "select_for_update", moving_sfu):
+            resp = view.post(request, device_id=99)
+
+        assert resp.status_code == 200
+        winner.refresh_from_db()
+        donor.refresh_from_db()
+        # The interface is now on the winner, so the transfer MUST complete — not be rejected against
+        # the stale cached device_id and roll the merge back.
+        assert winner.oob_ip_id == oob_ip.pk
+        assert donor.oob_ip_id is None
+        assert state["moved"], "the injected interface move never fired — test wiring is stale"
 
 
 def _two_member_vc(name, *, m1_cf=None, m2_cf=None):

--- a/netbox_librenms_plugin/tests/test_coverage_actions.py
+++ b/netbox_librenms_plugin/tests/test_coverage_actions.py
@@ -5764,14 +5764,14 @@ class TestBulkImportDevicesViewCollisionGate:
     def test_unfetchable_id_is_skipped_rest_imports(self):
         """A selected id whose LibreNMS info can't be fetched (not cached + get_device_info fails) is SKIPPED, not a whole-batch block: the fetchable rows still import and the skipped row is surfaced. Restores the per-device resilience the old fail-closed block removed."""
         view = self._make_view()
+        make_device("gate-unresolved-host")
+        libre = {1: {"device_id": 1, "sysName": "gate-unresolved-host", "hostname": "gate-unresolved-host"}}
         # id 2 isn't cached and its info fetch fails → it can't be collision-checked → skipped.
         view._librenms_api.get_device_info = lambda did, *a, **k: (True, libre[did]) if did in libre else (False, None)
         request = _make_request(post={"select": ["1", "2"]}, headers={"HX-Request": "true"})
         request.POST.getlist = MagicMock(return_value=["1", "2"])
         request.user = _import_authorized_user()
 
-        make_device("gate-unresolved-host")
-        libre = {1: {"device_id": 1, "sysName": "gate-unresolved-host", "hostname": "gate-unresolved-host"}}
         import_result = {"success": [], "failed": [], "skipped": [], "virtual_chassis_created": 0}
         with (
             patch.object(view, "require_write_permission", return_value=None),
@@ -8843,6 +8843,118 @@ class TestBulkImportPermGateRunsBeforeEnqueue:
         write.object_types.set([ObjectType.objects.get_for_model(LibreNMSSettings)])
         write.users.set([user])
         return get_user_model().objects.get(pk=user.pk)  # clear the per-request perm cache
+
+    @staticmethod
+    def _plugin_writer_with_device_perms(username):
+        """A real plugin writer with only the Device add/change permissions."""
+        from core.models import ObjectType
+        from dcim.models import Device
+        from django.contrib.auth import get_user_model
+        from users.models import ObjectPermission
+
+        user = TestBulkImportPermGateRunsBeforeEnqueue._plugin_writer_without_import_perms(username)
+        device_write = ObjectPermission.objects.create(
+            name=f"{username}-device-import",
+            actions=["add", "change"],
+        )
+        device_write.object_types.set([ObjectType.objects.get_for_model(Device)])
+        device_write.users.set([user])
+        return get_user_model().objects.get(pk=user.pk)  # clear the per-request perm cache
+
+    @staticmethod
+    def _request_for(user, data):
+        """Build a real POST request with session-backed message storage."""
+        from django.contrib.messages.storage.fallback import FallbackStorage
+        from django.contrib.sessions.middleware import SessionMiddleware
+        from django.test import RequestFactory
+
+        request = RequestFactory().post("/device-import/bulk/", data=data)
+        request.user = user
+        SessionMiddleware(lambda req: None).process_request(request)
+        request.session.save()
+        request._messages = FallbackStorage(request)
+        return request
+
+    def test_plain_device_background_batch_does_not_require_vm_permission(self):
+        """Device add/change grants reach enqueue without add_virtualmachine."""
+        view = self._make_view()
+        user = self._plugin_writer_with_device_perms("bulk-device-only-perms")
+        request = self._request_for(user, {"select": ["1"]})
+        view.request = request
+
+        assert user.has_perm("dcim.add_device")
+        assert user.has_perm("dcim.change_device")
+        assert not user.has_perm("virtualization.add_virtualmachine")
+
+        with (
+            patch.object(type(view), "should_use_background_job_for_import", return_value=True, create=False),
+            patch("utilities.rqworker.get_workers_for_queue", return_value=1),
+            patch(
+                "netbox_librenms_plugin.jobs.ImportDevicesJob.enqueue",
+                return_value=MagicMock(pk=4331, job_id="job-4331"),
+            ) as mock_enqueue,
+        ):
+            response = view.post(request)
+
+        mock_enqueue.assert_called_once()
+        assert mock_enqueue.call_args.kwargs["device_ids"] == [1]
+        assert mock_enqueue.call_args.kwargs["vm_imports"] == {}
+        messages_sent = [str(m) for m in request._messages]
+        assert not any("do not have permission to import" in m for m in messages_sent), messages_sent
+        assert response.status_code in (301, 302)
+
+    def test_explicit_vm_background_batch_still_requires_vm_permission(self):
+        """An explicit VM row is denied before enqueue without add_virtualmachine."""
+        view = self._make_view()
+        user = self._plugin_writer_with_device_perms("bulk-explicit-vm-no-perm")
+        request = self._request_for(user, {"select": ["1"], "cluster_1": "1"})
+        view.request = request
+
+        with (
+            patch.object(type(view), "should_use_background_job_for_import", return_value=True, create=False),
+            patch("utilities.rqworker.get_workers_for_queue", return_value=1),
+            patch("netbox_librenms_plugin.jobs.ImportDevicesJob.enqueue") as mock_enqueue,
+        ):
+            response = view.post(request)
+
+        mock_enqueue.assert_not_called()
+        messages_sent = [str(m) for m in request._messages]
+        assert any("virtualization.add_virtualmachine" in m for m in messages_sent), messages_sent
+        assert response.status_code in (301, 302)
+
+    def test_device_row_flipped_to_vm_fails_without_vm_permission(self):
+        """A validation-time Device→VM flip fails per-row without creating a VM."""
+        from virtualization.models import VirtualMachine
+
+        from netbox_librenms_plugin.import_utils import bulk_import_devices_shared
+
+        user = self._plugin_writer_with_device_perms("bulk-flipped-vm-no-perm")
+        existing_vm = make_vm("bulk-flipped-vm")
+        vm_count = VirtualMachine.objects.count()
+        libre_device = {
+            "device_id": 13,
+            "hostname": existing_vm.name,
+            "sysName": existing_vm.name,
+            "serial": "",
+            "hardware": "",
+            "os": "",
+        }
+        api = MagicMock(server_key="default", cache_timeout=300)
+
+        with patch("netbox_librenms_plugin.import_utils.bulk_import.LibreNMSAPI", return_value=api):
+            result = bulk_import_devices_shared(
+                device_ids=[13],
+                server_key="default",
+                libre_devices_cache={13: libre_device},
+                user=user,
+            )
+
+        assert VirtualMachine.objects.count() == vm_count
+        assert result["success"] == []
+        assert result["skipped"] == []
+        assert len(result["failed"]) == 1
+        assert result["failed"][0]["device_id"] == 13
+        assert "virtualization.add_virtualmachine" in result["failed"][0]["error"]
 
     def test_unauthorized_background_import_is_denied_without_enqueueing(self):
         """A plugin-writer without dcim.add_device is denied and no ImportDevicesJob is enqueued."""

--- a/netbox_librenms_plugin/tests/test_coverage_actions.py
+++ b/netbox_librenms_plugin/tests/test_coverage_actions.py
@@ -3,6 +3,7 @@
 from unittest.mock import MagicMock, patch
 
 import pytest
+from django.contrib.auth.models import AnonymousUser
 from django.test import RequestFactory
 
 from netbox_librenms_plugin.tests.conftest import (
@@ -5508,6 +5509,7 @@ class TestImportActionRebindGuard:
         assert response.status_code != 500
 
 
+@pytest.mark.django_db
 class TestBulkImportConfirmCollisions:
     """Tests for Stage 3 collision-blocking behaviour."""
 
@@ -5518,13 +5520,22 @@ class TestBulkImportConfirmCollisions:
         view._librenms_api = _make_api()
         return view
 
-    def _run_with_two_devices(self, validation_a, validation_b):
-        """Drive BulkImportConfirmView.post with two LibreNMS rows whose validations are stubbed to whatever the test wants."""
+    def _run_with_two_devices(self, validation_a, validation_b, *, real_render):
+        """Drive the real BulkImportConfirmView.post over two LibreNMS rows.
+
+        ``validation_a/b`` carry real NetBox Device objects so the real
+        detect_bulk_collisions + _model_name_of run; only validate_device_for_import (an
+        expensive VC-detection call covered by its own tests) is stubbed. When
+        ``real_render`` is True the real template engine renders (returning an HttpResponse);
+        otherwise render() is captured so the chosen template can be asserted without
+        building the full confirm-table context.
+        """
         view = self._make_view()
         request = _make_request(post={"select": ["1", "2"]})
         request.POST.getlist = MagicMock(return_value=["1", "2"])
         request.GET = MagicMock()
         request.GET.get = MagicMock(return_value=None)
+        request.user = AnonymousUser()
 
         libre_devices = {
             1: {"device_id": 1, "hostname": "alpha"},
@@ -5535,38 +5546,38 @@ class TestBulkImportConfirmCollisions:
         def fake_validate(libre_device, **_kwargs):
             return validations[libre_device["device_id"]]
 
-        with patch.object(view, "require_write_permission", return_value=None):
-            with patch(
+        with (
+            patch.object(view, "require_write_permission", return_value=None),
+            patch(
                 "netbox_librenms_plugin.views.imports.actions.fetch_device_with_cache",
                 side_effect=lambda did, _api: libre_devices.get(did),
-            ):
-                with patch(
-                    "netbox_librenms_plugin.views.imports.actions.extract_device_selections",
-                    return_value={"cluster_id": None, "role_id": None, "rack_id": None},
-                ):
-                    with patch(
-                        "netbox_librenms_plugin.views.imports.actions.validate_device_for_import",
-                        side_effect=fake_validate,
-                    ):
-                        with patch(
-                            "netbox_librenms_plugin.views.imports.actions.resolve_naming_preferences",
-                            return_value=(True, False),
-                        ):
-                            with patch(
-                                "netbox_librenms_plugin.views.imports.actions.render",
-                            ) as mock_render:
-                                mock_render.side_effect = lambda req, tpl, ctx, status=200: MagicMock(
-                                    status_code=status,
-                                    template_name=tpl,
-                                    context=ctx,
-                                )
-                                response = view.post(request)
-        return response
+            ),
+            patch(
+                "netbox_librenms_plugin.views.imports.actions.extract_device_selections",
+                return_value={"cluster_id": None, "role_id": None, "rack_id": None},
+            ),
+            patch(
+                "netbox_librenms_plugin.views.imports.actions.validate_device_for_import",
+                side_effect=fake_validate,
+            ),
+            patch(
+                "netbox_librenms_plugin.views.imports.actions.resolve_naming_preferences",
+                return_value=(True, False),
+            ),
+        ):
+            if real_render:
+                return view.post(request)
+            with patch("netbox_librenms_plugin.views.imports.actions.render") as mock_render:
+                mock_render.side_effect = lambda req, tpl, ctx, status=200: MagicMock(
+                    status_code=status, template_name=tpl, context=ctx
+                )
+                return view.post(request)
 
     def test_collision_path_renders_collision_template(self):
-        from types import SimpleNamespace
+        """A host row and an OOB row resolving to one real NetBox device render the collision modal."""
+        from django.urls import reverse
 
-        nb_device = SimpleNamespace(pk=42, name="srv-collide")
+        nb_device = make_device("srv-collide-confirm")
         validation_a = {
             "status": "importable",
             "resolved_name": "alpha",
@@ -5579,35 +5590,119 @@ class TestBulkImportConfirmCollisions:
             "virtual_chassis": {},
             "oob_candidate": {"device": nb_device, "type": "idrac"},
         }
-        response = self._run_with_two_devices(validation_a, validation_b)
-        # Collision modal is an interstitial swapped into #htmx-modal-content,
-        # so it must render at 200 -- a non-2xx status makes HTMX skip the swap.
-        assert response is not None, "view.post returned None instead of a rendered response"
-        assert "bulk_import_collision.html" in response.template_name
+        # Real render: the real collision template + real detect_bulk_collisions + real
+        # _model_name_of(real Device) must produce a dcim:device link for the colliding device.
+        response = self._run_with_two_devices(validation_a, validation_b, real_render=True)
         assert response.status_code == 200
-        assert len(response.context["collisions"]) == 1
-        assert response.context["collisions"][0]["nb_device_pk"] == 42
+        html = response.content.decode()
+        assert "Bulk import blocked" in html
+        assert reverse("dcim:device", kwargs={"pk": nb_device.pk}) in html
+        assert "srv-collide-confirm" in html
 
     def test_clean_batch_renders_normal_confirm_template(self):
-        from types import SimpleNamespace
-
+        """Two rows resolving to distinct real NetBox devices fall through to the confirm template."""
         validation_a = {
             "status": "importable",
             "resolved_name": "alpha",
             "virtual_chassis": {},
-            "existing_device": SimpleNamespace(pk=1, name="nb-a"),
+            "existing_device": make_device("nb-clean-a"),
         }
         validation_b = {
             "status": "importable",
             "resolved_name": "beta",
             "virtual_chassis": {},
-            "existing_device": SimpleNamespace(pk=2, name="nb-b"),
+            "existing_device": make_device("nb-clean-b"),
         }
-        response = self._run_with_two_devices(validation_a, validation_b)
-        assert response is not None, "view.post returned None instead of a rendered response"
+        # render captured (not the heavy confirm table) — assert no collision block fired and the
+        # confirm template was chosen.
+        response = self._run_with_two_devices(validation_a, validation_b, real_render=False)
+        assert response is not None
         assert "bulk_import_confirm.html" in response.template_name
-        # Default render() status is 200.
         assert response.status_code == 200
+
+
+@pytest.mark.django_db
+class TestBulkImportDevicesViewCollisionGate:
+    """The direct-import view re-runs the collision check the confirm preview can be bypassed on."""
+
+    def _make_view(self):
+        from netbox_librenms_plugin.views.imports.actions import BulkImportDevicesView
+
+        view = object.__new__(BulkImportDevicesView)
+        view._librenms_api = _make_api()
+        return view
+
+    def test_colliding_batch_blocked_before_import(self):
+        """Two selected LibreNMS rows resolving to one real device → collision modal, importer never called."""
+        from django.urls import reverse
+
+        view = self._make_view()
+        request = _make_request(post={"select": ["1", "2"]}, headers={"HX-Request": "true"})
+        request.POST.getlist = MagicMock(return_value=["1", "2"])
+        request.user = AnonymousUser()
+
+        nb = make_device("gate-collide-host")
+        libre = {
+            1: {"device_id": 1, "sysName": "gate-collide-host", "hostname": "gate-collide-host"},
+            2: {"device_id": 2, "sysName": "gate-collide-host", "hostname": "gate-collide-host"},
+        }
+        with (
+            patch.object(view, "require_write_permission", return_value=None),
+            patch(
+                "netbox_librenms_plugin.views.imports.actions.resolve_naming_preferences", return_value=(True, False)
+            ),
+            patch(
+                "netbox_librenms_plugin.views.imports.actions.fetch_device_with_cache",
+                side_effect=lambda did, _api: libre.get(did),
+            ),
+            patch("netbox_librenms_plugin.views.imports.actions.bulk_import_devices") as mock_import,
+        ):
+            response = view.post(request)
+
+        # Real validate + real detect via the gate → real collision template, importer never reached.
+        assert response.status_code == 200
+        html = response.content.decode()
+        assert "Bulk import blocked" in html
+        assert reverse("dcim:device", kwargs={"pk": nb.pk}) in html
+        mock_import.assert_not_called()
+
+    def test_clean_batch_passes_gate_and_imports(self):
+        """Two rows resolving to distinct real devices clear the gate and reach the importer."""
+        view = self._make_view()
+        request = _make_request(post={"select": ["1", "2"]})
+        request.POST.getlist = MagicMock(return_value=["1", "2"])
+        request.user = AnonymousUser()
+
+        make_device("gate-clean-a")
+        make_device("gate-clean-b")
+        libre = {
+            1: {"device_id": 1, "sysName": "gate-clean-a", "hostname": "gate-clean-a"},
+            2: {"device_id": 2, "sysName": "gate-clean-b", "hostname": "gate-clean-b"},
+        }
+        import_result = {"success": [], "failed": [], "skipped": [], "virtual_chassis_created": 0}
+        with (
+            patch.object(view, "require_write_permission", return_value=None),
+            patch(
+                "netbox_librenms_plugin.views.imports.actions.resolve_naming_preferences", return_value=(True, False)
+            ),
+            patch(
+                "netbox_librenms_plugin.views.imports.actions.fetch_device_with_cache",
+                side_effect=lambda did, _api: libre.get(did),
+            ),
+            patch(
+                "netbox_librenms_plugin.views.imports.actions.bulk_import_devices", return_value=import_result
+            ) as mock_import,
+            patch(
+                "netbox_librenms_plugin.views.imports.actions.bulk_import_vms",
+                return_value={"success": [], "failed": [], "skipped": []},
+            ),
+            patch("netbox_librenms_plugin.views.imports.actions.messages"),
+            patch("netbox_librenms_plugin.views.imports.actions.redirect", return_value=MagicMock(status_code=302)),
+        ):
+            view.post(request)
+
+        # Gate cleared (distinct devices) → the importer ran.
+        mock_import.assert_called_once()
 
 
 # ---------------------------------------------------------------------------

--- a/netbox_librenms_plugin/tests/test_coverage_actions.py
+++ b/netbox_librenms_plugin/tests/test_coverage_actions.py
@@ -8811,3 +8811,80 @@ class TestPromoteAndMergeObjectScope:
         assert "id" not in sync_entry
         assert sync_entry["_migrated_to"]["device_id"] == winner.pk
         assert Device.objects.get(pk=winner.pk).custom_field_data["librenms_id"]["default"]["oob"]["id"] == 30
+
+
+@pytest.mark.django_db
+class TestBulkImportPermGateRunsBeforeEnqueue:
+    """The import model-perm gate must run BEFORE the background job is dispatched.
+
+    Otherwise an unauthorized caller both enqueues a job that can only fail and is told
+    "Import job started", while the denial surfaces nowhere.
+    """
+
+    def _make_view(self):
+        from netbox_librenms_plugin.views.imports.actions import BulkImportDevicesView
+
+        view = object.__new__(BulkImportDevicesView)
+        view._librenms_api = _make_api()
+        return view
+
+    @staticmethod
+    def _plugin_writer_without_import_perms(username):
+        """A real active user with plugin write access but no dcim/virtualization add perms."""
+        from core.models import ObjectType
+        from django.apps import apps
+        from django.contrib.auth import get_user_model
+        from users.models import ObjectPermission
+
+        LibreNMSSettings = apps.get_model("netbox_librenms_plugin", "LibreNMSSettings")
+
+        user = get_user_model().objects.create_user(username=username, password="x")
+        write = ObjectPermission.objects.create(name=f"{username}-plugin-write", actions=["change"])
+        write.object_types.set([ObjectType.objects.get_for_model(LibreNMSSettings)])
+        write.users.set([user])
+        return get_user_model().objects.get(pk=user.pk)  # clear the per-request perm cache
+
+    def test_unauthorized_background_import_is_denied_without_enqueueing(self):
+        """A plugin-writer without dcim.add_device is denied and no ImportDevicesJob is enqueued."""
+        from django.contrib.messages.storage.fallback import FallbackStorage
+        from django.contrib.sessions.middleware import SessionMiddleware
+        from django.test import RequestFactory
+
+        view = self._make_view()
+        user = self._plugin_writer_without_import_perms("bulk-no-import-perms")
+
+        request = RequestFactory().post("/device-import/bulk/", data={"select": ["1"]})
+        request.user = user
+        SessionMiddleware(lambda req: None).process_request(request)
+        request.session.save()
+        request._messages = FallbackStorage(request)
+        view.request = request  # Django binds this in dispatch(); the perm gate reads it
+
+        def _fetch(device_id, *a, **k):
+            return {
+                "device_id": device_id,
+                "hostname": f"host{device_id}",
+                "sysName": f"host{device_id}",
+                "serial": f"SN{device_id}",
+                "hardware": "",
+                "os": "",
+            }
+
+        with (
+            # The background branch is superuser-only, and a real superuser passes every has_perm;
+            # stub only that decision so the ordering under test is reachable with a real principal.
+            patch.object(type(view), "should_use_background_job_for_import", return_value=True, create=False),
+            patch("utilities.rqworker.get_workers_for_queue", return_value=1),
+            patch("netbox_librenms_plugin.jobs.ImportDevicesJob.enqueue") as mock_enqueue,
+            patch("netbox_librenms_plugin.views.imports.actions.fetch_device_with_cache", side_effect=_fetch),
+        ):
+            # A real pk so the too-late-gate path renders its "job started" link instead of
+            # crashing in reverse() — the failure under test is the enqueue, not the URL build.
+            mock_enqueue.return_value.pk = 4321
+            response = view.post(request)
+
+        mock_enqueue.assert_not_called()
+        messages_sent = [str(m) for m in request._messages]
+        assert any("do not have permission to import" in m for m in messages_sent), messages_sent
+        assert not any("Import job started" in m for m in messages_sent), messages_sent
+        assert response.status_code in (301, 302)

--- a/netbox_librenms_plugin/tests/test_coverage_actions.py
+++ b/netbox_librenms_plugin/tests/test_coverage_actions.py
@@ -1803,12 +1803,11 @@ class TestDeviceConflictActionViewVMGuard:
                         with patch.object(
                             view, "get_validated_device_with_selections", return_value=(None, None, None)
                         ):
-                            try:
-                                view.post(request, device_id=1)
-                            except Exception:
-                                pass
+                            response = view.post(request, device_id=1)
 
         MockAPI.assert_called_with(server_key="secondary")
+        assert response.status_code == 200
+        assert response.headers.get("HX-Reswap") == "none"
 
 
 class TestDeviceRoleClusterRackViews:
@@ -8304,6 +8303,18 @@ class TestSerialActionsNormalizeAndLock:
             self._post_action("update", target, "SN-88")
         sqls = [q["sql"] for q in ctx.captured_queries]
         assert any("pg_advisory_xact_lock" in s for s in sqls)
+        assert self._serial_row_locks(sqls) == []
+
+    def test_update_serial_action_serializes_on_the_serial_advisory_lock(self):
+        """The dedicated update_serial action takes the same serial-keyed advisory lock."""
+        from django.db import connection
+        from django.test.utils import CaptureQueriesContext
+
+        target = make_device("ser-act-upd-serial-lock")
+        with CaptureQueriesContext(connection) as ctx:
+            self._post_action("update_serial", target, "SN-89")
+        sqls = [q["sql"] for q in ctx.captured_queries]
+        assert any("pg_advisory_xact_lock" in sql for sql in sqls)
         assert self._serial_row_locks(sqls) == []
 
     def test_conflict_toast_escapes_the_conflicting_device_name(self):

--- a/netbox_librenms_plugin/tests/test_coverage_actions.py
+++ b/netbox_librenms_plugin/tests/test_coverage_actions.py
@@ -5729,8 +5729,52 @@ class TestBulkImportDevicesViewCollisionGate:
             response = view.post(request)
 
         assert response.status_code == 200
-        assert "could not fetch LibreNMS device info" in response.content.decode()
+        html = response.content.decode()
+        assert "could not fetch LibreNMS device info" in html
+        # Object-neutral copy: the batch can contain VM rows, so the block message says
+        # "row(s)", never "device(s)" — matching ImportDevicesJob's wording.
+        assert "selected row(s)" in html
+        assert "selected device(s)" not in html
         mock_import.assert_not_called()
+
+    def test_colliding_batch_non_htmx_message_is_object_neutral(self):
+        """The non-HTMX collision block toast says "NetBox object", not "NetBox device".
+
+        The gate covers VM rows too (vm_device_ids=vm_imports), so a VM-only batch must not
+        be mislabelled — mirrors the deliberately neutral wording in ImportDevicesJob.
+        """
+        view = self._make_view()
+        # No HX-Request header → the messages.error + redirect branch.
+        request = _make_request(post={"select": ["1", "2"]})
+        request.POST.getlist = MagicMock(return_value=["1", "2"])
+        request.user = AnonymousUser()
+
+        make_device("gate-collide-plain")
+        libre = {
+            1: {"device_id": 1, "sysName": "gate-collide-plain", "hostname": "gate-collide-plain"},
+            2: {"device_id": 2, "sysName": "gate-collide-plain", "hostname": "gate-collide-plain"},
+        }
+        with (
+            patch.object(view, "require_write_permission", return_value=None),
+            patch(
+                "netbox_librenms_plugin.views.imports.actions.resolve_naming_preferences", return_value=(True, False)
+            ),
+            patch(
+                "netbox_librenms_plugin.views.imports.actions.fetch_device_with_cache",
+                side_effect=lambda did, _api: libre.get(did),
+            ),
+            patch("netbox_librenms_plugin.views.imports.actions.bulk_import_devices") as mock_import,
+            patch("netbox_librenms_plugin.views.imports.actions.messages") as mock_messages,
+            patch("netbox_librenms_plugin.views.imports.actions.redirect", return_value=MagicMock(status_code=302)),
+        ):
+            view.post(request)
+
+        mock_import.assert_not_called()
+        mock_messages.error.assert_called_once()
+        toast = mock_messages.error.call_args[0][1]
+        assert "NetBox object" in toast
+        assert "NetBox device" not in toast
+        assert "colliding device" not in toast
 
 
 # ---------------------------------------------------------------------------

--- a/netbox_librenms_plugin/tests/test_coverage_actions.py
+++ b/netbox_librenms_plugin/tests/test_coverage_actions.py
@@ -5719,6 +5719,8 @@ class TestBulkImportDevicesViewCollisionGate:
         html = response.content.decode()
         assert "Bulk import blocked" in html
         assert reverse("dcim:device", kwargs={"pk": nb.pk}) in html
+        assert 'id="htmx-modal-content"' in html
+        assert 'hx-swap-oob="innerHTML"' in html
         mock_import.assert_not_called()
 
     def test_clean_batch_passes_gate_and_imports(self):

--- a/netbox_librenms_plugin/tests/test_coverage_actions.py
+++ b/netbox_librenms_plugin/tests/test_coverage_actions.py
@@ -5508,6 +5508,115 @@ class TestImportActionRebindGuard:
         assert response.status_code != 500
 
 
+class TestBulkImportConfirmCollisions:
+    """Tests for Stage 3 collision-blocking behaviour."""
+
+    def _make_view(self):
+        from netbox_librenms_plugin.views.imports.actions import BulkImportConfirmView
+
+        view = object.__new__(BulkImportConfirmView)
+        view._librenms_api = _make_api()
+        return view
+
+    def _run_with_two_devices(self, validation_a, validation_b):
+        """Drive BulkImportConfirmView.post with two LibreNMS rows whose
+        validations are stubbed to whatever the test wants. Returns the
+        actual response object returned by view.post()."""
+        view = self._make_view()
+        request = _make_request(post={"select": ["1", "2"]})
+        request.POST.getlist = MagicMock(return_value=["1", "2"])
+        request.GET = MagicMock()
+        request.GET.get = MagicMock(return_value=None)
+
+        libre_devices = {
+            1: {"device_id": 1, "hostname": "alpha"},
+            2: {"device_id": 2, "hostname": "beta"},
+        }
+        validations = {1: validation_a, 2: validation_b}
+
+        def fake_validate(libre_device, **_kwargs):
+            return validations[libre_device["device_id"]]
+
+        with patch.object(view, "require_write_permission", return_value=None):
+            with patch(
+                "netbox_librenms_plugin.views.imports.actions.fetch_device_with_cache",
+                side_effect=lambda did, _api: libre_devices.get(did),
+            ):
+                with patch(
+                    "netbox_librenms_plugin.views.imports.actions.extract_device_selections",
+                    return_value={"cluster_id": None, "role_id": None, "rack_id": None},
+                ):
+                    with patch(
+                        "netbox_librenms_plugin.views.imports.actions.validate_device_for_import",
+                        side_effect=fake_validate,
+                    ):
+                        with patch(
+                            "netbox_librenms_plugin.views.imports.actions.resolve_naming_preferences",
+                            return_value=(True, False),
+                        ):
+                            with patch(
+                                "netbox_librenms_plugin.views.imports.actions.render",
+                            ) as mock_render:
+                                mock_render.side_effect = lambda req, tpl, ctx, status=200: MagicMock(
+                                    status_code=status,
+                                    template_name=tpl,
+                                    context=ctx,
+                                )
+                                response = view.post(request)
+        return response
+
+    def test_collision_path_renders_collision_template(self):
+        from types import SimpleNamespace
+
+        nb_device = SimpleNamespace(pk=42, name="srv-collide")
+        validation_a = {
+            "status": "importable",
+            "resolved_name": "alpha",
+            "virtual_chassis": {},
+            "existing_device": nb_device,
+        }
+        validation_b = {
+            "status": "importable",
+            "resolved_name": "beta",
+            "virtual_chassis": {},
+            "oob_candidate": {"device": nb_device, "type": "idrac"},
+        }
+        response = self._run_with_two_devices(validation_a, validation_b)
+        # Collision modal is an interstitial swapped into #htmx-modal-content,
+        # so it must render at 200 -- a non-2xx status makes HTMX skip the swap.
+        assert response is not None, "view.post returned None instead of a rendered response"
+        assert "bulk_import_collision.html" in response.template_name
+        assert response.status_code == 200
+        assert len(response.context["collisions"]) == 1
+        assert response.context["collisions"][0]["nb_device_pk"] == 42
+
+    def test_clean_batch_renders_normal_confirm_template(self):
+        from types import SimpleNamespace
+
+        validation_a = {
+            "status": "importable",
+            "resolved_name": "alpha",
+            "virtual_chassis": {},
+            "existing_device": SimpleNamespace(pk=1, name="nb-a"),
+        }
+        validation_b = {
+            "status": "importable",
+            "resolved_name": "beta",
+            "virtual_chassis": {},
+            "existing_device": SimpleNamespace(pk=2, name="nb-b"),
+        }
+        response = self._run_with_two_devices(validation_a, validation_b)
+        assert response is not None, "view.post returned None instead of a rendered response"
+        assert "bulk_import_confirm.html" in response.template_name
+        # Default render() status is 200.
+        assert response.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# AddAsOOBView / PromoteToHostView — generic "oob" sentinel regression tests
+# ---------------------------------------------------------------------------
+
+
 class TestAddAsOOBViewGenericSentinel:
     """AddAsOOBView must not return HTTP 400 when oob_candidate.type == "oob"."""
 

--- a/netbox_librenms_plugin/tests/test_coverage_actions.py
+++ b/netbox_librenms_plugin/tests/test_coverage_actions.py
@@ -5519,9 +5519,7 @@ class TestBulkImportConfirmCollisions:
         return view
 
     def _run_with_two_devices(self, validation_a, validation_b):
-        """Drive BulkImportConfirmView.post with two LibreNMS rows whose
-        validations are stubbed to whatever the test wants. Returns the
-        actual response object returned by view.post()."""
+        """Drive BulkImportConfirmView.post with two LibreNMS rows whose validations are stubbed to whatever the test wants."""
         view = self._make_view()
         request = _make_request(post={"select": ["1", "2"]})
         request.POST.getlist = MagicMock(return_value=["1", "2"])

--- a/netbox_librenms_plugin/tests/test_coverage_actions.py
+++ b/netbox_librenms_plugin/tests/test_coverage_actions.py
@@ -5354,6 +5354,9 @@ class TestBulkImportRerenderVMClassification:
                 "os": "",
             }
 
+        # detect_collisions falls back to api.get_device_info for cold-cache misses — feed it _fetch.
+        view._librenms_api.get_device_info = lambda did, *a, **k: (True, _fetch(did))
+
         # Mock ONLY genuine boundaries: the import process, the LibreNMS fetch, the template render,
         # and the permission/background-job gates. validate_device_for_import, the cache and the
         # request routing all run for real.
@@ -5646,6 +5649,9 @@ class TestBulkImportDevicesViewCollisionGate:
             1: {"device_id": 1, "sysName": "gate-collide-host", "hostname": "gate-collide-host"},
             2: {"device_id": 2, "sysName": "gate-collide-host", "hostname": "gate-collide-host"},
         }
+        # The collision pre-check reads the seeded libre cache (cold Django cache in the test) and
+        # falls back to api.get_device_info for the misses — stub that seam so the misses resolve.
+        view._librenms_api.get_device_info = lambda did, *a, **k: (True, libre[did]) if did in libre else (False, None)
         with (
             patch.object(view, "require_write_permission", return_value=None),
             patch(
@@ -5679,6 +5685,7 @@ class TestBulkImportDevicesViewCollisionGate:
             1: {"device_id": 1, "sysName": "gate-clean-a", "hostname": "gate-clean-a"},
             2: {"device_id": 2, "sysName": "gate-clean-b", "hostname": "gate-clean-b"},
         }
+        view._librenms_api.get_device_info = lambda did, *a, **k: (True, libre[did]) if did in libre else (False, None)
         import_result = {"success": [], "failed": [], "skipped": [], "virtual_chassis_created": 0}
         with (
             patch.object(view, "require_write_permission", return_value=None),
@@ -5708,7 +5715,7 @@ class TestBulkImportDevicesViewCollisionGate:
         """A selected id whose LibreNMS info can't be fetched (not cached + get_device_info fails) is SKIPPED, not a whole-batch block: the fetchable rows still import and the skipped row is surfaced. Restores the per-device resilience the old fail-closed block removed."""
         view = self._make_view()
         # id 2 isn't cached and its info fetch fails → it can't be collision-checked → skipped.
-        view._librenms_api.get_device_info = MagicMock(return_value=(False, None))
+        view._librenms_api.get_device_info = lambda did, *a, **k: (True, libre[did]) if did in libre else (False, None)
         request = _make_request(post={"select": ["1", "2"]}, headers={"HX-Request": "true"})
         request.POST.getlist = MagicMock(return_value=["1", "2"])
         request.user = AnonymousUser()
@@ -5797,6 +5804,7 @@ class TestBulkImportDevicesViewCollisionGate:
             1: {"device_id": 1, "sysName": "gate-collide-plain", "hostname": "gate-collide-plain"},
             2: {"device_id": 2, "sysName": "gate-collide-plain", "hostname": "gate-collide-plain"},
         }
+        view._librenms_api.get_device_info = lambda did, *a, **k: (True, libre[did]) if did in libre else (False, None)
         with (
             patch.object(view, "require_write_permission", return_value=None),
             patch(

--- a/netbox_librenms_plugin/tests/test_coverage_bulk_import.py
+++ b/netbox_librenms_plugin/tests/test_coverage_bulk_import.py
@@ -2846,7 +2846,7 @@ class TestCrossModelConflictDetection:
 class TestRefreshLibreNMSLinkage:
     """_refresh_librenms_linkage: re-classify a librenms-id match on cache-hit refresh."""
 
-    def _call(self, *, match_type, scanned_id, host_id, oob_id, expect_describe=True):
+    def _call(self, *, match_type, scanned_id, host_id, oob_id):
         from netbox_librenms_plugin.import_utils import bulk_import
 
         validation = {"existing_match_type": match_type}
@@ -2858,14 +2858,12 @@ class TestRefreshLibreNMSLinkage:
             return_value={"host_id": host_id, "oob_id": oob_id, "oob_type": None},
         ) as mock_describe:
             bulk_import._refresh_librenms_linkage(validation, device, libre_device, "default")
-        # The linkage read (which itself reads the OOB sub-object) must be scoped to the active
-        # server_key — a regression that dropped server_key would re-classify against the wrong
-        # server's mapping. The OOB id is taken from this describe result, not a second read.
-        # Only pin this in the librenms-id/oob re-classification cases where the scoping matters;
-        # a non-librenms match type may validly short-circuit before reading linkage data, so its
-        # test asserts the contract (match_type untouched) rather than the internal describe call.
-        if expect_describe:
-            mock_describe.assert_called_once_with(device, "default")
+        # _refresh_librenms_linkage ALWAYS reads the linkage (via _describe_existing_librenms_link)
+        # up front, before it branches on match_type — so every case, including a non-librenms
+        # match type, must issue that read scoped to the active server_key. A regression that
+        # dropped server_key (or short-circuited before the read) would re-classify against the
+        # wrong server's mapping, so assert the call unconditionally.
+        mock_describe.assert_called_once_with(device, "default")
         return validation
 
     def test_host_id_match_classifies_librenms_id(self):
@@ -2882,8 +2880,8 @@ class TestRefreshLibreNMSLinkage:
         assert v["existing_match_type"] is None
 
     def test_non_librenms_match_type_untouched(self):
-        """Serial/hostname/primary_ip matches are left alone (without forcing a linkage read)."""
-        v = self._call(match_type="serial", scanned_id=42, host_id=None, oob_id=None, expect_describe=False)
+        """Serial/hostname/primary_ip matches are left alone (the linkage read still runs first)."""
+        v = self._call(match_type="serial", scanned_id=42, host_id=None, oob_id=None)
         assert v["existing_match_type"] == "serial"
 
 

--- a/netbox_librenms_plugin/tests/test_coverage_bulk_import.py
+++ b/netbox_librenms_plugin/tests/test_coverage_bulk_import.py
@@ -1076,6 +1076,71 @@ class TestRefreshExistingDevice:
 
         assert validation["existing_match_type"] == "serial"
 
+    def test_serial_oob_candidate_promoted_to_host_clears_stale_action(self):
+        """A serial->librenms_id promotion drops the now-stale serial_action/oob_candidate."""
+        # Otherwise device_status.py renders a purple "Add as OOB controller" badge
+        # (is_oob_candidate = serial_action == "oob_candidate", match-type-independent) on a
+        # row that is actually host-linked.
+        from netbox_librenms_plugin.import_utils.bulk_import import _refresh_existing_device
+
+        dev = make_device("ref-serial-oob-now-linked", librenms_cf={"default": {"id": 6001}})
+        validation = self._device_validation(
+            existing_device=dev,
+            existing_match_type="serial",
+            serial_action="oob_candidate",
+            oob_candidate={"device": dev, "type": "idrac"},
+            device_role={"found": True, "role": dev.role},
+        )
+
+        _refresh_existing_device(validation, libre_device={"device_id": 6001, "hostname": "h"}, server_key="default")
+
+        assert validation["existing_match_type"] == "librenms_id"
+        assert validation.get("serial_action") is None
+        assert validation.get("oob_candidate") is None
+
+    def test_serial_merge_promoted_to_oob_clears_merge_candidates(self):
+        """A serial->librenms_oob promotion drops the now-stale serial_action/merge_candidates."""
+        # Otherwise device_validation_details.html (which checks serial_action ==
+        # "merge_netbox_devices" BEFORE the existing_match_type chain) renders a destructive
+        # "Merge two NetBox devices" form on a row that is already correctly OOB-linked.
+        from netbox_librenms_plugin.import_utils.bulk_import import _refresh_existing_device
+
+        dev = make_device("ref-serial-merge-now-linked", librenms_cf={"default": {"oob": {"id": 6002}}})
+        validation = self._device_validation(
+            existing_device=dev,
+            existing_match_type="serial",
+            serial_action="merge_netbox_devices",
+            merge_candidates={
+                "host_named": {"pk": 1, "name": "other"},
+                "oob_named": {"pk": dev.pk, "name": dev.name},
+            },
+            device_role={"found": True, "role": dev.role},
+        )
+
+        _refresh_existing_device(validation, libre_device={"device_id": 6002, "hostname": "h"}, server_key="default")
+
+        assert validation["existing_match_type"] == "librenms_oob"
+        assert validation.get("serial_action") is None
+        assert validation.get("merge_candidates") is None
+
+    def test_already_linked_row_promotion_preserves_derived_fields(self):
+        """A re-confirmed librenms_id row keeps its link-derived fields (no over-clear)."""
+        from netbox_librenms_plugin.import_utils.bulk_import import _refresh_existing_device
+
+        dev = make_device("ref-already-linked", librenms_cf={"default": {"id": 6003}})
+        validation = self._device_validation(
+            existing_device=dev,
+            existing_match_type="librenms_id",
+            serial_action="update_serial",  # a legitimate link-context action
+            device_role={"found": True, "role": dev.role},
+        )
+
+        _refresh_existing_device(validation, libre_device={"device_id": 6003, "hostname": "h"}, server_key="default")
+
+        assert validation["existing_match_type"] == "librenms_id"
+        # prior match was already a link type → no spurious clear of the link-context action.
+        assert validation.get("serial_action") == "update_serial"
+
     # ------------------------------------------------------------------
     # Deleted match → readiness recompute
     # ------------------------------------------------------------------
@@ -2787,21 +2852,16 @@ class TestRefreshLibreNMSLinkage:
         validation = {"existing_match_type": match_type}
         device = MagicMock()
         libre_device = {"device_id": scanned_id}
-        oob = {"id": oob_id} if oob_id is not None else None
-        with (
-            patch.object(
-                bulk_import,
-                "_describe_existing_librenms_link",
-                return_value={"host_id": host_id, "oob_id": oob_id, "oob_type": None},
-            ) as mock_describe,
-            patch.object(bulk_import, "get_librenms_oob", return_value=oob) as mock_oob,
-        ):
+        with patch.object(
+            bulk_import,
+            "_describe_existing_librenms_link",
+            return_value={"host_id": host_id, "oob_id": oob_id, "oob_type": None},
+        ) as mock_describe:
             bulk_import._refresh_librenms_linkage(validation, device, libre_device, "default")
-        # Both linkage reads must be scoped to the active server_key — a regression that
-        # dropped server_key would re-classify against the wrong server's mapping.
+        # The linkage read (which itself reads the OOB sub-object) must be scoped to the active
+        # server_key — a regression that dropped server_key would re-classify against the wrong
+        # server's mapping. The OOB id is taken from this describe result, not a second read.
         mock_describe.assert_called_once_with(device, "default")
-        if mock_oob.called:
-            mock_oob.assert_called_with(device, server_key="default")
         return validation
 
     def test_host_id_match_classifies_librenms_id(self):
@@ -2881,3 +2941,47 @@ class TestRefreshExistingDeviceVMMatch:
         assert validation["cluster"]["found"] is False
         assert validation["cluster"]["cluster"] is None
         assert validation["cluster"]["available_clusters"] == ["keep-me"]
+
+
+@pytest.mark.django_db
+class TestDetectCollisionsForDeviceIds:
+    """Real-DB coverage for ``detect_collisions_for_device_ids`` (the import-path gate helper)."""
+
+    @staticmethod
+    def _api():
+        from types import SimpleNamespace
+
+        # server_key only — get_device_info is never reached because the cache is pre-populated.
+        return SimpleNamespace(server_key="default")
+
+    def test_two_rows_resolving_to_one_device_collide(self):
+        """Two LibreNMS rows whose real validation resolves to one NetBox device → a collision."""
+        from netbox_librenms_plugin.import_utils.bulk_import import detect_collisions_for_device_ids
+
+        nb = make_device("collide-batch-host")
+        cache = {
+            8001: {"device_id": 8001, "sysName": "collide-batch-host", "hostname": "collide-batch-host"},
+            8002: {"device_id": 8002, "sysName": "collide-batch-host", "hostname": "collide-batch-host"},
+        }
+        collisions = detect_collisions_for_device_ids(
+            [8001, 8002], self._api(), libre_devices_cache=cache, sync_options={"use_sysname": True}
+        )
+        assert len(collisions) == 1
+        assert collisions[0]["nb_device_pk"] == nb.pk
+        assert collisions[0]["nb_model_name"] == "device"
+        assert {r["device_id"] for r in collisions[0]["librenms_rows"]} == {8001, 8002}
+
+    def test_distinct_devices_do_not_collide(self):
+        """Rows resolving to different NetBox devices → no collision."""
+        from netbox_librenms_plugin.import_utils.bulk_import import detect_collisions_for_device_ids
+
+        make_device("clean-a-host")
+        make_device("clean-b-host")
+        cache = {
+            8003: {"device_id": 8003, "sysName": "clean-a-host", "hostname": "clean-a-host"},
+            8004: {"device_id": 8004, "sysName": "clean-b-host", "hostname": "clean-b-host"},
+        }
+        result = detect_collisions_for_device_ids(
+            [8003, 8004], self._api(), libre_devices_cache=cache, sync_options={"use_sysname": True}
+        )
+        assert result == []

--- a/netbox_librenms_plugin/tests/test_coverage_bulk_import.py
+++ b/netbox_librenms_plugin/tests/test_coverage_bulk_import.py
@@ -3003,3 +3003,30 @@ class TestDetectCollisionsForDeviceIds:
         )
         assert unresolved == [9002]
         assert collisions == []  # only one resolvable row → no collision
+
+    def test_validation_error_id_is_reported_unresolved(self):
+        """A row whose validation raises is returned unresolved, not collision-checked on a partial result.
+
+        validate_device_for_import() catches any exception and appends a "Validation error: ..."
+        issue to an otherwise-incomplete result. The collision-relevant match fields may be
+        missing, so detect_collisions_for_device_ids must fail closed on it (mirroring the
+        unfetchable-id case) rather than group it on unreliable data.
+        """
+        from netbox_librenms_plugin.import_utils.bulk_import import detect_collisions_for_device_ids
+
+        make_device("validatable-host")
+        cache = {
+            9101: {"device_id": 9101, "sysName": "validatable-host", "hostname": "validatable-host"},
+            # A non-string sysName + strip_domain makes the REAL validator raise on `"." in name`
+            # inside _determine_device_name, so validate_device_for_import returns a partial result
+            # tagged "Validation error: ..." — exactly the except branch this fix must fail closed on.
+            9102: {"device_id": 9102, "sysName": 12345},
+        }
+        collisions, unresolved = detect_collisions_for_device_ids(
+            [9101, 9102],
+            self._api(),
+            libre_devices_cache=cache,
+            sync_options={"use_sysname": True, "strip_domain": True},
+        )
+        assert unresolved == [9102]
+        assert collisions == []  # only one validatable row → no collision

--- a/netbox_librenms_plugin/tests/test_coverage_bulk_import.py
+++ b/netbox_librenms_plugin/tests/test_coverage_bulk_import.py
@@ -2976,6 +2976,25 @@ class TestDetectCollisionsForDeviceIds:
         assert collisions[0]["nb_model_name"] == "device"
         assert {r["device_id"] for r in collisions[0]["librenms_rows"]} == {8001, 8002}
 
+    def test_two_rows_resolving_to_one_vm_collide(self):
+        """Two LibreNMS rows whose real validation resolves to one existing VirtualMachine → a collision keyed to the VM model, proving the pre-check gate covers the VM half of a batch (validation flips import_as_vm on the existing-VM match)."""
+        from netbox_librenms_plugin.import_utils.bulk_import import detect_collisions_for_device_ids
+        from netbox_librenms_plugin.tests.conftest import make_vm
+
+        vm = make_vm("collide-batch-vm")
+        cache = {
+            8005: {"device_id": 8005, "sysName": "collide-batch-vm", "hostname": "collide-batch-vm"},
+            8006: {"device_id": 8006, "sysName": "collide-batch-vm", "hostname": "collide-batch-vm"},
+        }
+        collisions, unresolved = detect_collisions_for_device_ids(
+            [8005, 8006], self._api(), libre_devices_cache=cache, sync_options={"use_sysname": True}
+        )
+        assert unresolved == []
+        assert len(collisions) == 1
+        assert collisions[0]["nb_device_pk"] == vm.pk
+        assert collisions[0]["nb_model_name"] == "virtualmachine"
+        assert {r["device_id"] for r in collisions[0]["librenms_rows"]} == {8005, 8006}
+
     def test_distinct_devices_do_not_collide(self):
         """Rows resolving to different NetBox devices → no collision."""
         from netbox_librenms_plugin.import_utils.bulk_import import detect_collisions_for_device_ids
@@ -3045,6 +3064,61 @@ class TestDetectCollisionsForDeviceIds:
             )
         assert unresolved == [9102]
         assert collisions == []  # only one validatable row → no collision
+
+    def test_cancelled_job_stops_scan_before_any_fetch(self):
+        """A job already cancelled when the scan starts issues ZERO LibreNMS calls; every id is returned unresolved so the caller's existing gate fails the batch closed instead of importing it unchecked."""
+        from types import SimpleNamespace
+
+        from netbox_librenms_plugin.import_utils import bulk_import as bulk_import_module
+        from netbox_librenms_plugin.import_utils.bulk_import import detect_collisions_for_device_ids
+
+        calls = []
+
+        def _get_device_info(did):
+            calls.append(did)
+            return True, {"device_id": did, "sysName": f"host-{did}", "hostname": f"host-{did}"}
+
+        api = SimpleNamespace(server_key="default", get_device_info=_get_device_info)
+        # _is_job_cancelled reads RQ/Redis job state — the one true external boundary here.
+        with patch.object(bulk_import_module, "_is_job_cancelled", return_value=True):
+            collisions, unresolved = detect_collisions_for_device_ids(
+                [8201, 8202, 8203],
+                api,
+                libre_devices_cache={},
+                sync_options={"use_sysname": True},
+                job=SimpleNamespace(logger=None),
+            )
+        assert calls == [], "cancelled scan must not keep calling LibreNMS"
+        assert unresolved == [8201, 8202, 8203]
+        assert collisions == []
+
+    def test_mid_scan_cancellation_marks_remainder_unresolved(self):
+        """Cancellation arriving mid-scan stops at the next poll (every 5th id); already-scanned ids stay checked and every unscanned id is returned unresolved, so a partial scan can never pass for a clean full one."""
+        from types import SimpleNamespace
+
+        from netbox_librenms_plugin.import_utils import bulk_import as bulk_import_module
+        from netbox_librenms_plugin.import_utils.bulk_import import detect_collisions_for_device_ids
+
+        ids = [8301, 8302, 8303, 8304, 8305, 8306, 8307]
+        calls = []
+
+        def _get_device_info(did):
+            calls.append(did)
+            return True, {"device_id": did, "sysName": f"host-{did}", "hostname": f"host-{did}"}
+
+        api = SimpleNamespace(server_key="default", get_device_info=_get_device_info)
+        # Not cancelled at the idx==1 poll, cancelled by the idx==5 poll → ids 5..7 unscanned.
+        with patch.object(bulk_import_module, "_is_job_cancelled", side_effect=[False, True]):
+            collisions, unresolved = detect_collisions_for_device_ids(
+                ids,
+                api,
+                libre_devices_cache={},
+                sync_options={"use_sysname": True},
+                job=SimpleNamespace(logger=None),
+            )
+        assert calls == [8301, 8302, 8303, 8304], "scan must stop at the cancellation poll"
+        assert unresolved == [8305, 8306, 8307]
+        assert collisions == []
 
     def test_fetched_row_is_written_back_into_shared_cache(self):
         """A cache-miss fetch is persisted into the caller's cache dict so the downstream import reuses it instead of re-fetching the same LibreNMS device."""

--- a/netbox_librenms_plugin/tests/test_coverage_bulk_import.py
+++ b/netbox_librenms_plugin/tests/test_coverage_bulk_import.py
@@ -3009,9 +3009,10 @@ class TestDetectCollisionsForDeviceIds:
         assert collisions == []  # only one resolvable row → no collision
 
     def test_validation_error_id_is_reported_unresolved(self):
-        """A row whose validator returns a "Validation error:" issue is reported unresolved, not collision-checked on the partial result."""
+        """A row whose validator returns a partial-result issue is reported unresolved, not collision-checked on the partial result."""
         from netbox_librenms_plugin.import_utils import bulk_import as bulk_import_module
         from netbox_librenms_plugin.import_utils.bulk_import import detect_collisions_for_device_ids
+        from netbox_librenms_plugin.import_utils.device_operations import VALIDATION_ERROR_ISSUE_PREFIX
 
         make_device("validatable-host")
         cache = {
@@ -3019,16 +3020,20 @@ class TestDetectCollisionsForDeviceIds:
             9102: {"device_id": 9102, "sysName": "unvalidatable-host", "hostname": "unvalidatable-host"},
         }
 
-        # Stub the consumer's validator so 9102 returns the except-branch shape ("Validation
-        # error: ...") directly, instead of relying on _determine_device_name crashing on a
-        # non-string sysName — which would silently stop exercising the fail-closed path if name
-        # coercion is ever hardened. 9101 delegates to the REAL validator so the clean-row
-        # collision logic this test asserts on stays genuine.
+        # Stub the consumer's validator so 9102 returns the except-branch shape directly, instead
+        # of relying on _determine_device_name crashing on a non-string sysName — which would
+        # silently stop exercising the fail-closed path if name coercion is ever hardened. Build the
+        # issue from the SHARED prefix constant so producer and consumer can't drift apart unnoticed
+        # (a rename of the marker moves both this input and the guard together). 9101 delegates to
+        # the REAL validator so the clean-row collision logic this test asserts on stays genuine.
         real_validate = bulk_import_module.validate_device_for_import
 
         def fake_validate(libre_device, *args, **kwargs):
             if libre_device.get("device_id") == 9102:
-                return {"issues": ["Validation error: simulated validator exception"], "resolved_name": None}
+                return {
+                    "issues": [f"{VALIDATION_ERROR_ISSUE_PREFIX} simulated validator exception"],
+                    "resolved_name": None,
+                }
             return real_validate(libre_device, *args, **kwargs)
 
         with patch.object(bulk_import_module, "validate_device_for_import", side_effect=fake_validate):

--- a/netbox_librenms_plugin/tests/test_coverage_bulk_import.py
+++ b/netbox_librenms_plugin/tests/test_coverage_bulk_import.py
@@ -275,6 +275,48 @@ class TestBulkImportDevicesShared:
         # importing device 99's data under the id-1 selection.
         mock_api.get_device_info.assert_called_once_with(1, use_cache=False)
 
+    @pytest.mark.parametrize(
+        "bad_payload",
+        [
+            {"device_id": 77, "hostname": "wrong-device"},  # another device's row
+            {},  # empty mapping — no identity to verify
+            ["not-a-dict"],  # non-dict payload
+        ],
+    )
+    def test_mismatched_fallback_fetch_is_failed_and_not_cached(self, bad_payload):
+        """A live-fetch payload not carrying the requested device_id is failed, not used or cached."""
+        # Same fail-closed identity rule as the multi-row collision pre-check (which single-row
+        # imports skip). The rejected mis-keyed cached row forces the live-fetch fallback.
+        stale_row = {"device_id": 99, "hostname": "someone-else"}
+        libre_cache = {1: dict(stale_row)}
+
+        with (
+            patch("netbox_librenms_plugin.import_utils.bulk_import.require_permissions"),
+            patch("netbox_librenms_plugin.import_utils.bulk_import.LibreNMSAPI") as mock_api_cls,
+            patch("netbox_librenms_plugin.import_utils.bulk_import.validate_device_for_import") as mock_validate,
+            patch("netbox_librenms_plugin.import_utils.bulk_import.import_single_device") as mock_import,
+        ):
+            mock_api = MagicMock()
+            mock_api.server_key = "default"
+            mock_api.get_device_info.return_value = (True, bad_payload)
+            mock_api_cls.return_value = mock_api
+
+            from netbox_librenms_plugin.import_utils.bulk_import import bulk_import_devices_shared
+
+            result = bulk_import_devices_shared(
+                device_ids=[1],
+                user=MagicMock(),
+                libre_devices_cache=libre_cache,
+            )
+
+        # The row fails closed instead of importing another device's data under id 1...
+        assert [row["device_id"] for row in result["failed"]] == [1]
+        assert result["success"] == []
+        mock_validate.assert_not_called()
+        mock_import.assert_not_called()
+        # ...and the bad payload must not overwrite the shared cache entry either.
+        assert libre_cache[1] == stale_row
+
     # ------------------------------------------------------------------
     # Line 183 – job.logger.info("Imported device X of Y")
     # ------------------------------------------------------------------

--- a/netbox_librenms_plugin/tests/test_coverage_bulk_import.py
+++ b/netbox_librenms_plugin/tests/test_coverage_bulk_import.py
@@ -2963,9 +2963,10 @@ class TestDetectCollisionsForDeviceIds:
             8001: {"device_id": 8001, "sysName": "collide-batch-host", "hostname": "collide-batch-host"},
             8002: {"device_id": 8002, "sysName": "collide-batch-host", "hostname": "collide-batch-host"},
         }
-        collisions = detect_collisions_for_device_ids(
+        collisions, unresolved = detect_collisions_for_device_ids(
             [8001, 8002], self._api(), libre_devices_cache=cache, sync_options={"use_sysname": True}
         )
+        assert unresolved == []
         assert len(collisions) == 1
         assert collisions[0]["nb_device_pk"] == nb.pk
         assert collisions[0]["nb_model_name"] == "device"
@@ -2981,7 +2982,24 @@ class TestDetectCollisionsForDeviceIds:
             8003: {"device_id": 8003, "sysName": "clean-a-host", "hostname": "clean-a-host"},
             8004: {"device_id": 8004, "sysName": "clean-b-host", "hostname": "clean-b-host"},
         }
-        result = detect_collisions_for_device_ids(
+        collisions, unresolved = detect_collisions_for_device_ids(
             [8003, 8004], self._api(), libre_devices_cache=cache, sync_options={"use_sysname": True}
         )
-        assert result == []
+        assert collisions == []
+        assert unresolved == []
+
+    def test_unfetchable_id_is_reported_unresolved(self):
+        """An id not in the cache whose get_device_info fails is returned as unresolved (not silently skipped), so the caller can fail closed instead of importing it unchecked."""
+        from types import SimpleNamespace
+
+        from netbox_librenms_plugin.import_utils.bulk_import import detect_collisions_for_device_ids
+
+        make_device("resolvable-host")
+        cache = {9001: {"device_id": 9001, "sysName": "resolvable-host", "hostname": "resolvable-host"}}
+        # 9002 isn't cached and its info fetch fails → it can't be collision-checked.
+        api = SimpleNamespace(server_key="default", get_device_info=lambda _did: (False, None))
+        collisions, unresolved = detect_collisions_for_device_ids(
+            [9001, 9002], api, libre_devices_cache=cache, sync_options={"use_sysname": True}
+        )
+        assert unresolved == [9002]
+        assert collisions == []  # only one resolvable row → no collision

--- a/netbox_librenms_plugin/tests/test_coverage_bulk_import.py
+++ b/netbox_librenms_plugin/tests/test_coverage_bulk_import.py
@@ -2846,7 +2846,7 @@ class TestCrossModelConflictDetection:
 class TestRefreshLibreNMSLinkage:
     """_refresh_librenms_linkage: re-classify a librenms-id match on cache-hit refresh."""
 
-    def _call(self, *, match_type, scanned_id, host_id, oob_id):
+    def _call(self, *, match_type, scanned_id, host_id, oob_id, expect_describe=True):
         from netbox_librenms_plugin.import_utils import bulk_import
 
         validation = {"existing_match_type": match_type}
@@ -2861,7 +2861,11 @@ class TestRefreshLibreNMSLinkage:
         # The linkage read (which itself reads the OOB sub-object) must be scoped to the active
         # server_key — a regression that dropped server_key would re-classify against the wrong
         # server's mapping. The OOB id is taken from this describe result, not a second read.
-        mock_describe.assert_called_once_with(device, "default")
+        # Only pin this in the librenms-id/oob re-classification cases where the scoping matters;
+        # a non-librenms match type may validly short-circuit before reading linkage data, so its
+        # test asserts the contract (match_type untouched) rather than the internal describe call.
+        if expect_describe:
+            mock_describe.assert_called_once_with(device, "default")
         return validation
 
     def test_host_id_match_classifies_librenms_id(self):
@@ -2878,8 +2882,8 @@ class TestRefreshLibreNMSLinkage:
         assert v["existing_match_type"] is None
 
     def test_non_librenms_match_type_untouched(self):
-        """Serial/hostname/primary_ip matches are left alone."""
-        v = self._call(match_type="serial", scanned_id=42, host_id=None, oob_id=None)
+        """Serial/hostname/primary_ip matches are left alone (without forcing a linkage read)."""
+        v = self._call(match_type="serial", scanned_id=42, host_id=None, oob_id=None, expect_describe=False)
         assert v["existing_match_type"] == "serial"
 
 

--- a/netbox_librenms_plugin/tests/test_coverage_bulk_import.py
+++ b/netbox_librenms_plugin/tests/test_coverage_bulk_import.py
@@ -3009,28 +3009,34 @@ class TestDetectCollisionsForDeviceIds:
         assert collisions == []  # only one resolvable row → no collision
 
     def test_validation_error_id_is_reported_unresolved(self):
-        """A row whose validation raises is returned unresolved, not collision-checked on a partial result.
-
-        validate_device_for_import() catches any exception and appends a "Validation error: ..."
-        issue to an otherwise-incomplete result. The collision-relevant match fields may be
-        missing, so detect_collisions_for_device_ids must fail closed on it (mirroring the
-        unfetchable-id case) rather than group it on unreliable data.
-        """
+        """A row whose validator returns a "Validation error:" issue is reported unresolved, not collision-checked on the partial result."""
+        from netbox_librenms_plugin.import_utils import bulk_import as bulk_import_module
         from netbox_librenms_plugin.import_utils.bulk_import import detect_collisions_for_device_ids
 
         make_device("validatable-host")
         cache = {
             9101: {"device_id": 9101, "sysName": "validatable-host", "hostname": "validatable-host"},
-            # A non-string sysName + strip_domain makes the REAL validator raise on `"." in name`
-            # inside _determine_device_name, so validate_device_for_import returns a partial result
-            # tagged "Validation error: ..." — exactly the except branch this fix must fail closed on.
-            9102: {"device_id": 9102, "sysName": 12345},
+            9102: {"device_id": 9102, "sysName": "unvalidatable-host", "hostname": "unvalidatable-host"},
         }
-        collisions, unresolved = detect_collisions_for_device_ids(
-            [9101, 9102],
-            self._api(),
-            libre_devices_cache=cache,
-            sync_options={"use_sysname": True, "strip_domain": True},
-        )
+
+        # Stub the consumer's validator so 9102 returns the except-branch shape ("Validation
+        # error: ...") directly, instead of relying on _determine_device_name crashing on a
+        # non-string sysName — which would silently stop exercising the fail-closed path if name
+        # coercion is ever hardened. 9101 delegates to the REAL validator so the clean-row
+        # collision logic this test asserts on stays genuine.
+        real_validate = bulk_import_module.validate_device_for_import
+
+        def fake_validate(libre_device, *args, **kwargs):
+            if libre_device.get("device_id") == 9102:
+                return {"issues": ["Validation error: simulated validator exception"], "resolved_name": None}
+            return real_validate(libre_device, *args, **kwargs)
+
+        with patch.object(bulk_import_module, "validate_device_for_import", side_effect=fake_validate):
+            collisions, unresolved = detect_collisions_for_device_ids(
+                [9101, 9102],
+                self._api(),
+                libre_devices_cache=cache,
+                sync_options={"use_sysname": True, "strip_domain": True},
+            )
         assert unresolved == [9102]
         assert collisions == []  # only one validatable row → no collision

--- a/netbox_librenms_plugin/tests/test_coverage_bulk_import.py
+++ b/netbox_librenms_plugin/tests/test_coverage_bulk_import.py
@@ -3208,3 +3208,28 @@ class TestDetectCollisionsForDeviceIds:
             [8101, 8102], api, libre_devices_cache=shared_cache, sync_options={"use_sysname": True}
         )
         assert calls == [], "second pass must hit the warmed cache, not re-fetch"
+
+    def test_fresh_fetch_mismatched_device_id_is_not_written_back(self):
+        """A freshly fetched payload whose device_id doesn't match the requested id is unresolved and never written back into the shared cache (fresh-fetch analog of the cached-mismatch guard)."""
+        from types import SimpleNamespace
+
+        from netbox_librenms_plugin.import_utils.bulk_import import detect_collisions_for_device_ids
+
+        # 8020 isn't cached; the fetch SUCCEEDS but returns a payload describing device 9999
+        # (a mis-keyed / stale LibreNMS response). It must fail closed WITHOUT persisting.
+        shared_cache = {}
+        api = SimpleNamespace(
+            server_key="default",
+            get_device_info=lambda _did: (
+                True,
+                {"device_id": 9999, "sysName": "wrong-row", "hostname": "wrong-row"},
+            ),
+        )
+        collisions, unresolved = detect_collisions_for_device_ids(
+            [8020], api, libre_devices_cache=shared_cache, sync_options={"use_sysname": True}
+        )
+        assert unresolved == [8020]
+        assert collisions == []
+        # The mismatched payload must NOT leak into the shared cache the caller passed in.
+        assert 8020 not in shared_cache, "mismatched fresh fetch poisoned the shared cache"
+        assert shared_cache == {}, "no mis-keyed payload may survive the collision gate"

--- a/netbox_librenms_plugin/tests/test_coverage_bulk_import.py
+++ b/netbox_librenms_plugin/tests/test_coverage_bulk_import.py
@@ -3045,3 +3045,36 @@ class TestDetectCollisionsForDeviceIds:
             )
         assert unresolved == [9102]
         assert collisions == []  # only one validatable row → no collision
+
+    def test_fetched_row_is_written_back_into_shared_cache(self):
+        """A cache-miss fetch is persisted into the caller's cache dict so the downstream import reuses it instead of re-fetching the same LibreNMS device."""
+        from types import SimpleNamespace
+
+        from netbox_librenms_plugin.import_utils.bulk_import import detect_collisions_for_device_ids
+
+        make_device("writeback-a-host")
+        make_device("writeback-b-host")
+        calls = []
+
+        def _get_device_info(did):
+            calls.append(did)
+            name = {8101: "writeback-a-host", 8102: "writeback-b-host"}[did]
+            return True, {"device_id": did, "sysName": name, "hostname": name}
+
+        api = SimpleNamespace(server_key="default", get_device_info=_get_device_info)
+        shared_cache = {}  # empty → both ids miss, must be fetched AND written back
+
+        detect_collisions_for_device_ids(
+            [8101, 8102], api, libre_devices_cache=shared_cache, sync_options={"use_sysname": True}
+        )
+        # Each id fetched once and persisted into the SAME dict object the caller passed.
+        assert sorted(calls) == [8101, 8102]
+        assert shared_cache[8101]["hostname"] == "writeback-a-host"
+        assert shared_cache[8102]["hostname"] == "writeback-b-host"
+
+        # A downstream consumer reusing that warmed cache adds ZERO further LibreNMS calls.
+        calls.clear()
+        detect_collisions_for_device_ids(
+            [8101, 8102], api, libre_devices_cache=shared_cache, sync_options={"use_sysname": True}
+        )
+        assert calls == [], "second pass must hit the warmed cache, not re-fetch"

--- a/netbox_librenms_plugin/tests/test_coverage_bulk_import.py
+++ b/netbox_librenms_plugin/tests/test_coverage_bulk_import.py
@@ -237,6 +237,44 @@ class TestBulkImportDevicesShared:
         mock_api.get_device_info.assert_not_called()
         assert len(result["success"]) == 1
 
+    def test_mis_keyed_cache_row_is_refetched_not_trusted(self):
+        """A cached row whose own device_id contradicts the requested id (mis-keyed/stale) is NOT imported as this device — a live fetch runs instead.
+
+        The multi-row collision pre-check verifies this, but its callers skip it for single-row
+        imports, so the import path must re-check at the point of use.
+        """
+        # Requested id 1, but the cached payload describes device 99 (a mis-keyed/stale entry).
+        libre_cache = {1: {"device_id": 99, "hostname": "someone-else"}}
+
+        with (
+            patch("netbox_librenms_plugin.import_utils.bulk_import.require_permissions"),
+            patch("netbox_librenms_plugin.import_utils.bulk_import.LibreNMSAPI") as mock_api_cls,
+            patch(
+                "netbox_librenms_plugin.import_utils.bulk_import.validate_device_for_import",
+                return_value=_make_validation(),
+            ),
+            patch(
+                "netbox_librenms_plugin.import_utils.bulk_import.import_single_device",
+                return_value=_make_import_result(),
+            ),
+        ):
+            mock_api = MagicMock()
+            mock_api.server_key = "default"
+            mock_api.get_device_info.return_value = (True, {"device_id": 1, "hostname": "real-device-1"})
+            mock_api_cls.return_value = mock_api
+
+            from netbox_librenms_plugin.import_utils.bulk_import import bulk_import_devices_shared
+
+            bulk_import_devices_shared(
+                device_ids=[1],
+                user=MagicMock(),
+                libre_devices_cache=libre_cache,
+            )
+
+        # The mis-keyed cache row is rejected → a live fetch for the REAL id 1 runs instead of
+        # importing device 99's data under the id-1 selection.
+        mock_api.get_device_info.assert_called_once_with(1, use_cache=False)
+
     # ------------------------------------------------------------------
     # Line 183 – job.logger.info("Imported device X of Y")
     # ------------------------------------------------------------------
@@ -2997,6 +3035,23 @@ class TestDetectCollisionsForDeviceIds:
         )
         assert collisions == []
         assert unresolved == [8011]
+
+    def test_get_device_info_exception_is_unresolved_not_crash(self):
+        """A get_device_info that RAISES (e.g. a cache-backend outage — its cache.get runs before its own try) must fail closed to unresolved, not crash the whole gate."""
+        from types import SimpleNamespace
+
+        from netbox_librenms_plugin.import_utils.bulk_import import detect_collisions_for_device_ids
+
+        def _boom(device_id):
+            raise RuntimeError("cache backend unavailable")
+
+        # Id not in the cache → the gate must fetch it; get_device_info raises instead of returning
+        # (False, None). The row can't be collision-checked, so it's recorded unresolved (the caller
+        # fails closed on it) rather than propagating and aborting the whole batch.
+        api = SimpleNamespace(server_key="default", get_device_info=_boom)
+        collisions, unresolved = detect_collisions_for_device_ids([8099], api, libre_devices_cache={})
+        assert collisions == []
+        assert unresolved == [8099]
 
     def test_two_rows_resolving_to_one_vm_collide(self):
         """Two LibreNMS rows whose real validation resolves to one existing VirtualMachine → a collision keyed to the VM model, proving the pre-check gate covers the VM half of a batch (validation flips import_as_vm on the existing-VM match)."""

--- a/netbox_librenms_plugin/tests/test_coverage_bulk_import.py
+++ b/netbox_librenms_plugin/tests/test_coverage_bulk_import.py
@@ -2974,6 +2974,30 @@ class TestDetectCollisionsForDeviceIds:
         assert collisions[0]["nb_model_name"] == "device"
         assert {r["device_id"] for r in collisions[0]["librenms_rows"]} == {8001, 8002}
 
+    def test_empty_cached_row_is_unresolved_not_a_clean_scan(self):
+        """A negatively-cached empty payload can't be collision-checked → unresolved, never importable."""
+        from netbox_librenms_plugin.import_utils.bulk_import import detect_collisions_for_device_ids
+
+        # A prior failed lookup left an empty dict in the shared cache. Without the fix this reaches
+        # validation as a brand-new device and the gate reports a clean scan for an unverified id.
+        collisions, unresolved = detect_collisions_for_device_ids(
+            [8010], self._api(), libre_devices_cache={8010: {}}, sync_options={"use_sysname": True}
+        )
+        assert collisions == []
+        assert unresolved == [8010]
+
+    def test_mismatched_cached_device_id_is_unresolved(self):
+        """A cached row whose device_id doesn't match the requested id is unresolved, not scanned."""
+        from netbox_librenms_plugin.import_utils.bulk_import import detect_collisions_for_device_ids
+
+        # Stale/mis-keyed cache entry: id 8011 requested but the payload describes device 9999.
+        cache = {8011: {"device_id": 9999, "sysName": "wrong-row", "hostname": "wrong-row"}}
+        collisions, unresolved = detect_collisions_for_device_ids(
+            [8011], self._api(), libre_devices_cache=cache, sync_options={"use_sysname": True}
+        )
+        assert collisions == []
+        assert unresolved == [8011]
+
     def test_two_rows_resolving_to_one_vm_collide(self):
         """Two LibreNMS rows whose real validation resolves to one existing VirtualMachine → a collision keyed to the VM model, proving the pre-check gate covers the VM half of a batch (validation flips import_as_vm on the existing-VM match)."""
         from netbox_librenms_plugin.import_utils.bulk_import import detect_collisions_for_device_ids

--- a/netbox_librenms_plugin/tests/test_coverage_bulk_import.py
+++ b/netbox_librenms_plugin/tests/test_coverage_bulk_import.py
@@ -3036,13 +3036,13 @@ class TestDetectCollisionsForDeviceIds:
         assert collisions == []
         assert unresolved == [8011]
 
-    def test_get_device_info_exception_is_unresolved_not_crash(self):
-        """A get_device_info that RAISES (e.g. a cache-backend outage — its cache.get runs before its own try) must fail closed to unresolved, not crash the whole gate."""
+    def test_get_device_info_exception_is_unresolved_not_crash(self, caplog):
+        """A raised fetch failure must be logged and fail closed to unresolved, not crash the gate."""
         from types import SimpleNamespace
 
         from netbox_librenms_plugin.import_utils.bulk_import import detect_collisions_for_device_ids
 
-        def _boom(device_id):
+        def _boom(device_id, **_kwargs):
             raise RuntimeError("cache backend unavailable")
 
         # Id not in the cache → the gate must fetch it; get_device_info raises instead of returning
@@ -3052,6 +3052,8 @@ class TestDetectCollisionsForDeviceIds:
         collisions, unresolved = detect_collisions_for_device_ids([8099], api, libre_devices_cache={})
         assert collisions == []
         assert unresolved == [8099]
+        assert "Collision pre-check couldn't fetch device 8099" in caplog.text
+        assert "cache backend unavailable" in caplog.text
 
     def test_two_rows_resolving_to_one_vm_collide(self):
         """Two LibreNMS rows whose real validation resolves to one existing VirtualMachine → a collision keyed to the VM model, proving the pre-check gate covers the VM half of a batch (validation flips import_as_vm on the existing-VM match)."""
@@ -3131,7 +3133,7 @@ class TestDetectCollisionsForDeviceIds:
         make_device("resolvable-host")
         cache = {9001: {"device_id": 9001, "sysName": "resolvable-host", "hostname": "resolvable-host"}}
         # 9002 isn't cached and its info fetch fails → it can't be collision-checked.
-        api = SimpleNamespace(server_key="default", get_device_info=lambda _did: (False, None))
+        api = SimpleNamespace(server_key="default", get_device_info=lambda _did, **_kwargs: (False, None))
         collisions, unresolved = detect_collisions_for_device_ids(
             [9001, 9002], api, libre_devices_cache=cache, sync_options={"use_sysname": True}
         )
@@ -3185,7 +3187,7 @@ class TestDetectCollisionsForDeviceIds:
 
         calls = []
 
-        def _get_device_info(did):
+        def _get_device_info(did, **_kwargs):
             calls.append(did)
             return True, {"device_id": did, "sysName": f"host-{did}", "hostname": f"host-{did}"}
 
@@ -3213,7 +3215,7 @@ class TestDetectCollisionsForDeviceIds:
         ids = [8301, 8302, 8303, 8304, 8305, 8306, 8307]
         calls = []
 
-        def _get_device_info(did):
+        def _get_device_info(did, **_kwargs):
             calls.append(did)
             return True, {"device_id": did, "sysName": f"host-{did}", "hostname": f"host-{did}"}
 
@@ -3241,8 +3243,8 @@ class TestDetectCollisionsForDeviceIds:
         make_device("writeback-b-host")
         calls = []
 
-        def _get_device_info(did):
-            calls.append(did)
+        def _get_device_info(did, **kwargs):
+            calls.append((did, kwargs))
             name = {8101: "writeback-a-host", 8102: "writeback-b-host"}[did]
             return True, {"device_id": did, "sysName": name, "hostname": name}
 
@@ -3253,7 +3255,7 @@ class TestDetectCollisionsForDeviceIds:
             [8101, 8102], api, libre_devices_cache=shared_cache, sync_options={"use_sysname": True}
         )
         # Each id fetched once and persisted into the SAME dict object the caller passed.
-        assert sorted(calls) == [8101, 8102]
+        assert calls == [(8101, {"use_cache": False}), (8102, {"use_cache": False})]
         assert shared_cache[8101]["hostname"] == "writeback-a-host"
         assert shared_cache[8102]["hostname"] == "writeback-b-host"
 
@@ -3275,7 +3277,7 @@ class TestDetectCollisionsForDeviceIds:
         shared_cache = {}
         api = SimpleNamespace(
             server_key="default",
-            get_device_info=lambda _did: (
+            get_device_info=lambda _did, **_kwargs: (
                 True,
                 {"device_id": 9999, "sysName": "wrong-row", "hostname": "wrong-row"},
             ),

--- a/netbox_librenms_plugin/tests/test_coverage_bulk_import.py
+++ b/netbox_librenms_plugin/tests/test_coverage_bulk_import.py
@@ -1054,6 +1054,28 @@ class TestRefreshExistingDevice:
 
         assert validation["existing_match_type"] is None
 
+    def test_serial_cached_row_promoted_to_librenms_id_when_now_linked(self):
+        """A row cached as a serial conflict that has since gained the matching host librenms_id must promote to a librenms_id match, not keep the stale serial badge."""
+        from netbox_librenms_plugin.import_utils.bulk_import import _refresh_librenms_linkage
+
+        dev = make_device("ref-serial-now-linked", librenms_cf={"default": {"id": 42}})
+        validation = self._device_validation(existing_device=dev, existing_match_type="serial")
+
+        _refresh_librenms_linkage(validation, dev, {"device_id": 42, "hostname": "h"}, "default")
+
+        assert validation["existing_match_type"] == "librenms_id"
+
+    def test_serial_cached_row_untouched_when_no_current_link_matches(self):
+        """A serial-matched row whose device has no matching librenms link stays 'serial' — only prior id/OOB matches are cleared."""
+        from netbox_librenms_plugin.import_utils.bulk_import import _refresh_librenms_linkage
+
+        dev = make_device("ref-serial-no-link")  # no librenms_id CF
+        validation = self._device_validation(existing_device=dev, existing_match_type="serial")
+
+        _refresh_librenms_linkage(validation, dev, {"device_id": 42, "hostname": "h"}, "default")
+
+        assert validation["existing_match_type"] == "serial"
+
     # ------------------------------------------------------------------
     # Deleted match → readiness recompute
     # ------------------------------------------------------------------

--- a/netbox_librenms_plugin/tests/test_coverage_bulk_import.py
+++ b/netbox_librenms_plugin/tests/test_coverage_bulk_import.py
@@ -2987,13 +2987,47 @@ class TestDetectCollisionsForDeviceIds:
             8006: {"device_id": 8006, "sysName": "collide-batch-vm", "hostname": "collide-batch-vm"},
         }
         collisions, unresolved = detect_collisions_for_device_ids(
-            [8005, 8006], self._api(), libre_devices_cache=cache, sync_options={"use_sysname": True}
+            [8005, 8006],
+            self._api(),
+            libre_devices_cache=cache,
+            sync_options={"use_sysname": True},
+            # Mirror the real callers: VM-selected ids are passed so each row validates in
+            # its actual import mode (the hostname→existing-VM match works either way, but
+            # the wiring under test is the per-row mode the view/job now supply).
+            vm_device_ids={8005, 8006},
         )
         assert unresolved == []
         assert len(collisions) == 1
         assert collisions[0]["nb_device_pk"] == vm.pk
         assert collisions[0]["nb_model_name"] == "virtualmachine"
         assert {r["device_id"] for r in collisions[0]["librenms_rows"]} == {8005, 8006}
+
+    def test_vm_row_serial_match_does_not_fabricate_a_collision(self):
+        """A VM-selected row must be validated in VM mode: Device-only serial matching (which bulk_import_vms intentionally skips) would otherwise resolve the VM row onto a Device another row targets and block a perfectly valid batch."""
+        from netbox_librenms_plugin.import_utils.bulk_import import detect_collisions_for_device_ids
+
+        nb = make_device("phantom-host", serial="ZZSER-PHANTOM")
+        cache = {
+            # Device row: hostname-matches the existing device — legitimate single-row target.
+            8401: {"device_id": 8401, "sysName": "phantom-host", "hostname": "phantom-host", "serial": ""},
+            # VM row: hostname matches nothing, but its serial equals the device's. Device-mode
+            # validation would serial-match it onto nb; the real VM import never would.
+            8402: {
+                "device_id": 8402,
+                "sysName": "vm-unrelated",
+                "hostname": "vm-unrelated",
+                "serial": "ZZSER-PHANTOM",
+            },
+        }
+        collisions, unresolved = detect_collisions_for_device_ids(
+            [8401, 8402],
+            self._api(),
+            libre_devices_cache=cache,
+            sync_options={"use_sysname": True},
+            vm_device_ids={8402},
+        )
+        assert unresolved == []
+        assert collisions == [], f"VM-mode row must not serial-match onto Device pk={nb.pk}"
 
     def test_distinct_devices_do_not_collide(self):
         """Rows resolving to different NetBox devices → no collision."""

--- a/netbox_librenms_plugin/tests/test_coverage_device_fields.py
+++ b/netbox_librenms_plugin/tests/test_coverage_device_fields.py
@@ -7,16 +7,24 @@ field is verified by reloading from the DB rather than asserting on a MagicMock 
 .save() is a no-op. A genuine duplicate-name conflict produces a REAL ValidationError.
 """
 
+from contextlib import contextmanager
 from unittest.mock import MagicMock, patch
 
 import pytest
 
-from netbox_librenms_plugin.tests.conftest import make_device
+from netbox_librenms_plugin.tests.conftest import make_device, make_vm
 
 
+from netbox_librenms_plugin.tests.view_test_helpers import (
+    make_request,
+    make_user_with_perms,
+    make_view,
+    message_texts,
+)
 from netbox_librenms_plugin.tests.view_test_helpers import post as _post
 
 
+@pytest.mark.django_db
 @pytest.mark.parametrize(
     "view_name",
     ["UpdateDeviceNameView", "UpdateDeviceSerialView", "UpdateDeviceTypeView", "UpdateDevicePlatformView"],
@@ -50,19 +58,111 @@ def test_write_views_fetch_device_info_live_not_cached(view_name):
 # ---------------------------------------------------------------------------
 
 
-def _make_view(ViewClass):
-    """Create a view instance bypassing __init__, with a mock LibreNMS API."""
-    view = object.__new__(ViewClass)
-    view._librenms_api = MagicMock()
-    view._librenms_api.server_key = "default"
-    view.require_all_permissions = MagicMock(return_value=None)
-    return view
+def _make_view(ViewClass, request=None):
+    """A real view instance; only the LibreNMS client is stubbed (the one external boundary)."""
+    return make_view(ViewClass, request)
 
 
-def _make_request(post_data=None):
-    req = MagicMock()
-    req.POST = post_data or {}
-    return req
+def _make_request(post_data=None, *, user=None):
+    """A real POST request: real user, real session, real message storage."""
+    return make_request("post", post_data or {}, user=user)
+
+
+def _plugins_config(*, servers, librenms_url):
+    """Override the plugin's configured servers for the protected-key checks."""
+    from django.test import override_settings
+
+    return override_settings(
+        PLUGINS_CONFIG={"netbox_librenms_plugin": {"servers": servers, "librenms_url": librenms_url}}
+    )
+
+
+@contextmanager
+def _before_restricted_read(view, action, *, on_call):
+    """Run *action* just before the view's *on_call*-th ``restricted_queryset`` call.
+
+    These views reach the DB only through that accessor, so wrapping it is how a test lands a
+    committed change from "another session" in a precise window without a second connection.
+    The queryset handed back is the real restricted one, and the call count is asserted so a
+    view that stops taking that path fails the test instead of silently skipping the race.
+    """
+    real = view.restricted_queryset
+    calls = []
+
+    def _wrapper(model, action_name="view"):
+        calls.append(model)
+        if len(calls) == on_call:
+            action()
+        return real(model, action_name)
+
+    view.restricted_queryset = _wrapper
+    try:
+        yield
+    finally:
+        view.restricted_queryset = real
+    assert len(calls) >= on_call, f"the view made {len(calls)} restricted reads — the race window was never hit"
+
+
+def _before_lock(view, action):
+    """Run *action* between the view's first read and its ``select_for_update`` re-read."""
+    return _before_restricted_read(view, action, on_call=2)
+
+
+def _skip_once(method):
+    """Return *method* with its first invocation turned into a no-op."""
+    skipped = []
+
+    def _wrapper(self, *args, **kwargs):
+        if not skipped:
+            skipped.append(True)
+            return None
+        return method(self, *args, **kwargs)
+
+    return _wrapper
+
+
+def _deleted_before_lock(view, obj):
+    """Delete *obj* for real in the window before the view locks it."""
+
+    def _delete():
+        type(obj).objects.filter(pk=obj.pk).delete()
+
+    return _before_lock(view, _delete)
+
+
+def _cf_changed_before_lock(view, obj, librenms_id):
+    """Rewrite *obj*'s librenms_id custom field in the window before the view locks it.
+
+    ``update()`` writes the column directly, so the change is committed the way another
+    session's would be, and the locked re-read is what surfaces it.
+    """
+
+    def _change():
+        type(obj).objects.filter(pk=obj.pk).update(custom_field_data={"librenms_id": librenms_id})
+
+    return _before_lock(view, _change)
+
+
+@contextmanager
+def _deleted_when_platform_saved(device):
+    """Delete *device* for real the moment a Platform is saved.
+
+    ``CreateAndAssignPlatformView`` resolves the device once before its transaction and again
+    under ``select_for_update`` inside it, with the platform insert in between. Hooking the
+    insert lands a real DELETE in that exact window, which is the only way another session's
+    delete can reach the lock branch.
+    """
+    from dcim.models import Device, Platform
+    from django.db.models.signals import post_save
+
+    def _receiver(sender, **kwargs):
+        Device.objects.filter(pk=device.pk).delete()
+
+    post_save.connect(_receiver, sender=Platform, weak=False)
+    try:
+        yield
+    finally:
+        post_save.disconnect(_receiver, sender=Platform)
 
 
 # ---------------------------------------------------------------------------
@@ -72,10 +172,10 @@ def _make_request(post_data=None):
 
 @pytest.mark.django_db
 class TestUpdateDeviceNameView:
-    def _view(self):
+    def _view(self, request=None):
         from netbox_librenms_plugin.views.sync.device_fields import UpdateDeviceNameView
 
-        return _make_view(UpdateDeviceNameView)
+        return _make_view(UpdateDeviceNameView, request)
 
     def test_permission_denied_returns_error(self):
         view = self._view()
@@ -243,10 +343,10 @@ class TestUpdateDeviceNameView:
 
 @pytest.mark.django_db
 class TestUpdateDeviceSerialView:
-    def _view(self):
+    def _view(self, request=None):
         from netbox_librenms_plugin.views.sync.device_fields import UpdateDeviceSerialView
 
-        return _make_view(UpdateDeviceSerialView)
+        return _make_view(UpdateDeviceSerialView, request)
 
     def test_permission_denied(self):
         view = self._view()
@@ -452,10 +552,10 @@ class TestUpdateDeviceSerialView:
 
 @pytest.mark.django_db
 class TestUpdateDeviceTypeView:
-    def _view(self):
+    def _view(self, request=None):
         from netbox_librenms_plugin.views.sync.device_fields import UpdateDeviceTypeView
 
-        return _make_view(UpdateDeviceTypeView)
+        return _make_view(UpdateDeviceTypeView, request)
 
     @staticmethod
     def _new_device_type():
@@ -651,10 +751,10 @@ class TestUpdateDeviceTypeView:
 
 @pytest.mark.django_db
 class TestUpdateDevicePlatformView:
-    def _view(self):
+    def _view(self, request=None):
         from netbox_librenms_plugin.views.sync.device_fields import UpdateDevicePlatformView
 
-        return _make_view(UpdateDevicePlatformView)
+        return _make_view(UpdateDevicePlatformView, request)
 
     @staticmethod
     def _platform(slug):
@@ -883,10 +983,10 @@ class TestUpdateDevicePlatformView:
 
 @pytest.mark.django_db
 class TestCreateAndAssignPlatformView:
-    def _view(self):
+    def _view(self, request=None):
         from netbox_librenms_plugin.views.sync.device_fields import CreateAndAssignPlatformView
 
-        return _make_view(CreateAndAssignPlatformView)
+        return _make_view(CreateAndAssignPlatformView, request)
 
     def test_permission_denied(self):
         view = self._view()
@@ -1004,90 +1104,43 @@ class TestCreateAndAssignPlatformView:
 
     def test_mapping_existing_points_to_different_platform_warns(self):
         """An existing OS mapping that targets a DIFFERENT platform must not be reported as 'already exists' — surface a warning and don't create a new mapping."""
-        view = self._view()
+        from dcim.models import Device, Platform
+
+        from netbox_librenms_plugin.models import PlatformMapping
+
+        wanted = Platform.objects.create(name="ios", slug="ios")
+        other = Platform.objects.create(name="junos", slug="junos")
+        PlatformMapping.objects.create(librenms_os="ios", netbox_platform=other)
+        dev = make_device("plat-map-conflict")
         req = _make_request({"platform_name": "ios", "manufacturer": "", "librenms_os": "ios", "create_mapping": "1"})
+        view = self._view(req)
 
-        found_platform = MagicMock(pk=5)
-        mock_platform_cls = MagicMock()
-        mock_platform_cls.objects.restrict.return_value = mock_platform_cls.objects
-        mock_platform_cls.objects.filter.return_value.first.return_value = found_platform
+        _post(view, req, pk=dev.pk)
 
-        mock_device_cls = MagicMock()
-        mock_device_cls.DoesNotExist = type("DoesNotExist", (Exception,), {})
-        mock_locked = MagicMock()
-        mock_device_cls.objects.restrict.return_value = mock_device_cls.objects
-        mock_device_cls.objects.select_for_update.return_value.get.return_value = mock_locked
-
-        # Existing mapping for "ios" points at a different platform (id 999, not 5).
-        other_mapping = MagicMock(netbox_platform_id=999)
-        mock_mapping_cls = MagicMock()
-        mock_mapping_cls.objects.restrict.return_value = mock_mapping_cls.objects
-        mock_mapping_cls.objects.filter.return_value.first.return_value = other_mapping
-
-        with (
-            patch(
-                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
-                return_value=MagicMock(),
-            ),
-            patch("netbox_librenms_plugin.views.sync.device_fields.Platform", mock_platform_cls),
-            patch("netbox_librenms_plugin.views.sync.device_fields.Device", mock_device_cls),
-            patch("netbox_librenms_plugin.views.sync.device_fields.PlatformMapping", mock_mapping_cls),
-            patch("netbox_librenms_plugin.views.sync.device_fields.transaction"),
-            patch("netbox_librenms_plugin.views.sync.device_fields.messages") as mock_msg,
-            patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
-        ):
-            view.request = req
-            view.post(req, pk=1)
-
-        # No new mapping created (PlatformMapping class never instantiated for a create), and
-        # the platform-mismatch is surfaced as a warning rather than a silent "already exists".
-        mock_mapping_cls.assert_not_called()
-        assert any("pointing to" in str(c.args) for c in mock_msg.warning.call_args_list)
+        # The pre-existing mapping is left pointing where it did, and no second one is added.
+        assert PlatformMapping.objects.filter(librenms_os__iexact="ios").count() == 1
+        assert PlatformMapping.objects.get(librenms_os__iexact="ios").netbox_platform_id == other.pk
+        assert any("pointing to" in t for t in message_texts(req, "warning"))
         # The mapping conflict is non-fatal: the primary action (assign the found platform to
-        # the locked device and persist it) must still happen, not warn-and-return.
-        assert mock_locked.platform is found_platform
-        mock_locked.save.assert_called_once()
+        # the device and persist it) must still happen, not warn-and-return.
+        assert Device.objects.get(pk=dev.pk).platform_id == wanted.pk
 
     def test_manufacturer_not_found(self):
-        """manufacturer_id provided but Manufacturer.DoesNotExist: manufacturer stays None."""
-        view = self._view()
-        req = _make_request({"platform_name": "ios", "manufacturer": "99"})
+        """An unresolvable manufacturer id is ignored: the platform is still created, unscoped."""
+        from dcim.models import Device, Manufacturer, Platform
 
-        mock_platform_cls = MagicMock()
-        mock_platform_cls.objects.restrict.return_value = mock_platform_cls.objects
-        mock_platform_cls.objects.filter.return_value.first.return_value = None
-        mock_platform_instance = MagicMock()
-        mock_platform_cls.return_value = mock_platform_instance
+        dev = make_device("plat-nomanuf")
+        missing_id = (Manufacturer.objects.order_by("-pk").first().pk if Manufacturer.objects.exists() else 0) + 1000
+        req = _make_request({"platform_name": "ios", "manufacturer": str(missing_id)})
+        view = self._view(req)
 
-        mock_manuf_cls = MagicMock()
-        mock_manuf_cls.DoesNotExist = type("DoesNotExist", (Exception,), {})
-        mock_manuf_cls.objects.restrict.return_value = mock_manuf_cls.objects
-        mock_manuf_cls.objects.get.side_effect = mock_manuf_cls.DoesNotExist()
+        _post(view, req, pk=dev.pk)
 
-        mock_device_cls = MagicMock()
-        mock_device_cls.DoesNotExist = type("DoesNotExist", (Exception,), {})
-        mock_locked = MagicMock()
-        mock_device_cls.objects.restrict.return_value = mock_device_cls.objects
-        mock_device_cls.objects.select_for_update.return_value.get.return_value = mock_locked
-
-        with (
-            patch(
-                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
-                return_value=MagicMock(),
-            ),
-            patch("netbox_librenms_plugin.views.sync.device_fields.Platform", mock_platform_cls),
-            patch("netbox_librenms_plugin.views.sync.device_fields.Manufacturer", mock_manuf_cls),
-            patch("netbox_librenms_plugin.views.sync.device_fields.Device", mock_device_cls),
-            patch("netbox_librenms_plugin.views.sync.device_fields.transaction"),
-            patch("netbox_librenms_plugin.views.sync.device_fields.messages") as mock_msg,
-            patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
-        ):
-            view.request = req
-            view.post(req, pk=1)
-        # Should succeed (manufacturer silently ignored)
-        mock_msg.success.assert_called_once()
-        assert mock_locked.platform == mock_platform_instance
-        mock_locked.save.assert_called_once()
+        platform = Platform.objects.get(name="ios")
+        assert platform.manufacturer_id is None
+        assert Device.objects.get(pk=dev.pk).platform_id == platform.pk
+        assert message_texts(req, "success")
+        assert not message_texts(req, "error")
 
     def test_success_no_manufacturer(self):
         """A new platform (no manufacturer) is created and assigned to the device (real)."""
@@ -1137,459 +1190,254 @@ class TestCreateAndAssignPlatformView:
         assert Platform.objects.get(name=platform_name).slug == slugify(platform_name)
 
     def test_platform_validation_error(self):
-        from django.core.exceptions import ValidationError
+        """A real unique-slug collision aborts the create: nothing persists and the user is told."""
+        from dcim.models import Device, Platform
 
-        view = self._view()
-        req = _make_request({"platform_name": "ios", "manufacturer": ""})
+        Platform.objects.create(name="Cisco IOS", slug="cisco-ios")
+        dev = make_device("plat-badslug")
+        # A DIFFERENT name that slugifies to the SAME slug: it misses the name__iexact reuse
+        # short-circuit, so the create path runs and trips the real unique-slug validation.
+        req = _make_request({"platform_name": "Cisco  IOS", "manufacturer": ""})
+        view = self._view(req)
 
-        mock_platform_cls = MagicMock()
-        mock_platform_cls.objects.restrict.return_value = mock_platform_cls.objects
-        mock_platform_cls.objects.filter.return_value.first.return_value = None
-        mock_platform_instance = MagicMock()
-        mock_platform_instance.full_clean.side_effect = ValidationError({"name": ["err"]})
-        mock_platform_cls.return_value = mock_platform_instance
+        _post(view, req, pk=dev.pk)
 
-        mock_txn = MagicMock()
-        mock_txn.set_rollback = MagicMock()
-
-        with (
-            patch(
-                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
-                return_value=MagicMock(),
-            ),
-            patch("netbox_librenms_plugin.views.sync.device_fields.Platform", mock_platform_cls),
-            patch("netbox_librenms_plugin.views.sync.device_fields.transaction", mock_txn),
-            patch("netbox_librenms_plugin.views.sync.device_fields.messages") as mock_msg,
-            patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
-        ):
-            view.request = req
-            view.post(req, pk=1)
-        mock_msg.error.assert_called_once()
-        mock_txn.set_rollback.assert_called_once_with(True)
+        assert any("could not be created" in t for t in message_texts(req, "error"))
+        assert not Platform.objects.filter(name="Cisco  IOS").exists()
+        assert Device.objects.get(pk=dev.pk).platform_id is None
 
     def test_device_does_not_exist_inside_transaction(self):
-        view = self._view()
+        """A concurrent delete between the first lookup and the lock rolls the whole action back."""
+        from dcim.models import Device, Platform
+
+        dev = make_device("plat-vanishes")
         req = _make_request({"platform_name": "ios", "manufacturer": ""})
+        view = self._view(req)
 
-        mock_platform_cls = MagicMock()
-        mock_platform_cls.objects.restrict.return_value = mock_platform_cls.objects
-        mock_platform_cls.objects.filter.return_value.first.return_value = None
-        mock_platform_instance = MagicMock()
-        mock_platform_cls.return_value = mock_platform_instance
+        with _deleted_when_platform_saved(dev):
+            _post(view, req, pk=dev.pk)
 
-        DoesNotExist = type("DoesNotExist", (Exception,), {})
-        mock_device_cls = MagicMock()
-        mock_device_cls.DoesNotExist = DoesNotExist
-        mock_device_cls.objects.restrict.return_value = mock_device_cls.objects
-        mock_device_cls.objects.select_for_update.return_value.get.side_effect = DoesNotExist()
-
-        mock_txn = MagicMock()
-        mock_txn.set_rollback = MagicMock()
-
-        with (
-            patch(
-                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
-                return_value=MagicMock(),
-            ),
-            patch("netbox_librenms_plugin.views.sync.device_fields.Platform", mock_platform_cls),
-            patch("netbox_librenms_plugin.views.sync.device_fields.Device", mock_device_cls),
-            patch("netbox_librenms_plugin.views.sync.device_fields.transaction", mock_txn),
-            patch("netbox_librenms_plugin.views.sync.device_fields.messages") as mock_msg,
-            patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
-        ):
-            view.request = req
-            view.post(req, pk=1)
-        mock_msg.error.assert_called_once()
-        mock_txn.set_rollback.assert_called_once_with(True)
+        assert any("no longer exists" in t for t in message_texts(req, "error"))
+        # set_rollback(True) unwinds the whole savepoint — the platform insert must not survive.
+        assert not Platform.objects.filter(name="ios").exists()
+        assert Device.objects.filter(pk=dev.pk).exists()  # the delete rolled back with it
 
     def test_device_validation_error(self):
-        from django.core.exceptions import ValidationError
+        """A platform scoped to another vendor fails the device's real clean(); nothing persists."""
+        from dcim.models import Device, Manufacturer, Platform
 
-        view = self._view()
-        req = _make_request({"platform_name": "ios", "manufacturer": ""})
+        other_vendor = Manufacturer.objects.create(name="OtherVendor", slug="other-vendor")
+        dev = make_device("plat-vendor-clash")
+        assert dev.device_type.manufacturer_id != other_vendor.pk
+        # NetBox's Device.clean() rejects a platform limited to a different manufacturer.
+        req = _make_request({"platform_name": "vendor-locked", "manufacturer": str(other_vendor.pk)})
+        view = self._view(req)
 
-        mock_platform_cls = MagicMock()
-        mock_platform_cls.objects.restrict.return_value = mock_platform_cls.objects
-        mock_platform_cls.objects.filter.return_value.first.return_value = None
-        mock_platform_instance = MagicMock()
-        mock_platform_cls.return_value = mock_platform_instance
+        _post(view, req, pk=dev.pk)
 
-        DoesNotExist = type("DoesNotExist", (Exception,), {})
-        mock_locked = MagicMock()
-        mock_locked.full_clean.side_effect = ValidationError({"platform": ["err"]})
-
-        mock_device_cls = MagicMock()
-        mock_device_cls.DoesNotExist = DoesNotExist
-        mock_device_cls.objects.restrict.return_value = mock_device_cls.objects
-        mock_device_cls.objects.select_for_update.return_value.get.return_value = mock_locked
-
-        mock_txn = MagicMock()
-        mock_txn.set_rollback = MagicMock()
-
-        with (
-            patch(
-                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
-                return_value=MagicMock(),
-            ),
-            patch("netbox_librenms_plugin.views.sync.device_fields.Platform", mock_platform_cls),
-            patch("netbox_librenms_plugin.views.sync.device_fields.Device", mock_device_cls),
-            patch("netbox_librenms_plugin.views.sync.device_fields.transaction", mock_txn),
-            patch("netbox_librenms_plugin.views.sync.device_fields.messages") as mock_msg,
-            patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
-        ):
-            view.request = req
-            view.post(req, pk=1)
-        mock_msg.error.assert_called_once()
-        mock_txn.set_rollback.assert_called_once_with(True)
+        assert any("validation failed" in t for t in message_texts(req, "error"))
+        assert not Platform.objects.filter(name="vendor-locked").exists()
+        assert Device.objects.get(pk=dev.pk).platform_id is None
 
     def test_integrity_error(self):
+        """An IntegrityError with no row behind it aborts the action rather than claiming success."""
+        from dcim.models import Device, Platform
         from django.db import IntegrityError
 
-        view = self._view()
+        dev = make_device("plat-integrity")
         req = _make_request({"platform_name": "ios", "manufacturer": ""})
+        view = self._view(req)
 
-        mock_platform_cls = MagicMock()
-        mock_platform_cls.objects.restrict.return_value = mock_platform_cls.objects
-        mock_platform_cls.objects.filter.return_value.first.return_value = None
-        mock_platform_instance = MagicMock()
-        # Make save raise IntegrityError
-        mock_platform_instance.save.side_effect = IntegrityError("duplicate")
-        mock_platform_cls.return_value = mock_platform_instance
+        # A lost insert race is not reproducible against a single local connection; inject it at
+        # the one statement that would raise, leaving the manager, the queries and the
+        # transaction real. The re-query then finds nothing, which is the branch under test.
+        with patch.object(Platform, "save", side_effect=IntegrityError("duplicate key")):
+            _post(view, req, pk=dev.pk)
 
-        # transaction.atomic().__exit__ must return False so IntegrityError propagates
-        mock_atomic_cm = MagicMock()
-        mock_atomic_cm.__enter__ = MagicMock(return_value=None)
-        mock_atomic_cm.__exit__ = MagicMock(return_value=False)
-        mock_txn = MagicMock()
-        mock_txn.atomic.return_value = mock_atomic_cm
-        mock_txn.set_rollback = MagicMock()
-
-        with (
-            patch(
-                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
-                return_value=MagicMock(),
-            ),
-            patch("netbox_librenms_plugin.views.sync.device_fields.Platform", mock_platform_cls),
-            patch("netbox_librenms_plugin.views.sync.device_fields.transaction", mock_txn),
-            patch("netbox_librenms_plugin.views.sync.device_fields.messages") as mock_msg,
-            patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
-        ):
-            view.request = req
-            view.post(req, pk=1)
-        mock_msg.error.assert_called_once()
-        mock_txn.set_rollback.assert_called_once_with(True)
+        assert any("could not be created" in t for t in message_texts(req, "error"))
+        assert not Platform.objects.filter(name__iexact="ios").exists()
+        assert Device.objects.get(pk=dev.pk).platform_id is None
 
     def test_integrity_error_reuses_concurrently_created_platform(self):
         """IntegrityError on create, but the same-named platform now exists (a concurrent insert won the race): reuse it and assign — no error, no rollback."""
-        from django.db import IntegrityError
+        from dcim.models import Device, Platform
 
-        view = self._view()
+        dev = make_device("plat-race")
         req = _make_request({"platform_name": "ios", "manufacturer": ""})
+        view = self._view(req)
 
-        reused_platform = MagicMock()
-        mock_platform_cls = MagicMock()
-        # First .first() is the up-front existence check (None → take the create path);
-        # the second is the post-IntegrityError re-query (the concurrently-created row).
-        mock_platform_cls.objects.restrict.return_value = mock_platform_cls.objects
-        mock_platform_cls.objects.filter.return_value.first.side_effect = [None, reused_platform]
-        mock_platform_instance = MagicMock()
-        mock_platform_instance.save.side_effect = IntegrityError("duplicate")
-        mock_platform_cls.return_value = mock_platform_instance
+        def _rival_commits_first():
+            Platform.objects.create(name="ios", slug="ios")
 
-        mock_device_cls = MagicMock()
-        mock_device_cls.DoesNotExist = type("DoesNotExist", (Exception,), {})
-        mock_locked = MagicMock()
-        mock_device_cls.objects.restrict.return_value = mock_device_cls.objects
-        mock_device_cls.objects.select_for_update.return_value.get.return_value = mock_locked
-
-        # __exit__ must return False so the IntegrityError propagates out of the nested atomic.
-        mock_atomic_cm = MagicMock()
-        mock_atomic_cm.__enter__ = MagicMock(return_value=None)
-        mock_atomic_cm.__exit__ = MagicMock(return_value=False)
-        mock_txn = MagicMock()
-        mock_txn.atomic.return_value = mock_atomic_cm
-        mock_txn.set_rollback = MagicMock()
-
+        # Land the rival's row after the view's up-front existence check, so the view takes the
+        # create path; the hook runs outside the view's savepoint, so the rollback of the failed
+        # insert cannot undo it. Skipping full_clean for that one insert puts the rival's commit
+        # in the only window this branch exists for — between validation and INSERT — and leaves
+        # the DB's unique constraint to raise the IntegrityError for real.
         with (
-            patch(
-                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
-                return_value=MagicMock(),
-            ),
-            patch("netbox_librenms_plugin.views.sync.device_fields.Platform", mock_platform_cls),
-            patch("netbox_librenms_plugin.views.sync.device_fields.Device", mock_device_cls),
-            patch("netbox_librenms_plugin.views.sync.device_fields.transaction", mock_txn),
-            patch("netbox_librenms_plugin.views.sync.device_fields.messages") as mock_msg,
-            patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
+            _before_restricted_read(view, _rival_commits_first, on_call=1),
+            patch.object(Platform, "full_clean", _skip_once(Platform.full_clean)),
         ):
-            view.request = req
-            view.post(req, pk=1)
+            _post(view, req, pk=dev.pk)
 
-        # Reuse path: the concurrently-created platform is assigned and persisted, with
-        # no error/rollback. The save() assertion guards against a regression that wires
-        # up the FK but skips persistence.
-        mock_msg.error.assert_not_called()
-        # Nested atomic() boundaries isolate the Platform.save() that may raise IntegrityError so
-        # the outer transaction stays usable for the re-query. The mock makes atomic() a no-op, so
-        # a single-atomic regression would otherwise still pass — pin the nesting explicitly.
-        assert mock_txn.atomic.call_count >= 2
-        mock_txn.set_rollback.assert_not_called()
-        assert mock_locked.platform is reused_platform
-        mock_locked.save.assert_called_once()
-        mock_msg.success.assert_called_once()
+        winner = Platform.objects.get(name__iexact="ios")
+        assert Platform.objects.filter(name__iexact="ios").count() == 1
+        # The reuse path must still assign AND persist — a regression that wires up the FK but
+        # skips the save would leave the device unchanged here.
+        assert Device.objects.get(pk=dev.pk).platform_id == winner.pk
+        assert not message_texts(req, "error")
+        assert message_texts(req, "success")
 
-    def _success_patches(self, platform_name="ios", librenms_os="ios", create_mapping="1"):
-        """Return (view, req, mock_platform_cls, mock_platform_instance, mock_device_cls, mock_locked)."""
-        view = self._view()
+    def _success_setup(self, platform_name="ios", librenms_os="ios", create_mapping="1", user=None):
+        """Return ``(view, request, device)`` for a run that reaches the mapping block."""
+        from django.utils.text import slugify
+
         req = _make_request(
             {
                 "platform_name": platform_name,
                 "manufacturer": "",
                 "librenms_os": librenms_os,
                 "create_mapping": create_mapping,
-            }
+            },
+            user=user,
         )
-        mock_platform_cls = MagicMock()
-        mock_platform_cls.objects.restrict.return_value = mock_platform_cls.objects
-        mock_platform_cls.objects.filter.return_value.first.return_value = None
-        mock_platform_cls.objects.restrict.return_value = mock_platform_cls.objects
-        mock_platform_instance = MagicMock()
-        mock_platform_cls.return_value = mock_platform_instance
-        mock_device_cls = MagicMock()
-        mock_device_cls.DoesNotExist = type("DoesNotExist", (Exception,), {})
-        mock_locked = MagicMock()
-        mock_device_cls.objects.restrict.return_value = mock_device_cls.objects
-        mock_device_cls.objects.select_for_update.return_value.get.return_value = mock_locked
-        mock_device_cls.objects.restrict.return_value = mock_device_cls.objects
-        return view, req, mock_platform_cls, mock_platform_instance, mock_device_cls, mock_locked
+        dev = make_device(f"plat-map-{slugify(platform_name)}-{create_mapping or 'off'}")
+        return self._view(req), req, dev
 
     def test_mapping_created_when_name_differs(self):
         """A PlatformMapping is created when name differs from librenms_os and checkbox is on."""
-        view, req, mock_platform_cls, mock_platform_instance, mock_device_cls, _ = self._success_patches(
-            platform_name="Cisco IOS", librenms_os="ios", create_mapping="1"
-        )
-        mock_mapping_cls = MagicMock()
-        mock_mapping_instance = MagicMock()
-        mock_mapping_cls.return_value = mock_mapping_instance
-        mock_mapping_cls.objects.restrict.return_value = mock_mapping_cls.objects
-        mock_mapping_cls.objects.filter.return_value.first.return_value = None
+        from dcim.models import Device, Platform
 
-        with (
-            patch(
-                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
-                return_value=MagicMock(),
-            ),
-            patch("netbox_librenms_plugin.views.sync.device_fields.Platform", mock_platform_cls),
-            patch("netbox_librenms_plugin.views.sync.device_fields.Device", mock_device_cls),
-            patch("netbox_librenms_plugin.views.sync.device_fields.transaction"),
-            patch("netbox_librenms_plugin.views.sync.device_fields.messages") as mock_msg,
-            patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
-            patch("netbox_librenms_plugin.views.sync.device_fields.PlatformMapping", mock_mapping_cls),
-        ):
-            view.request = req
-            view.post(req, pk=1)
+        from netbox_librenms_plugin.models import PlatformMapping
 
-        mock_mapping_cls.assert_called_once_with(librenms_os="ios", netbox_platform=mock_platform_instance)
-        mock_mapping_instance.full_clean.assert_called_once()
-        mock_mapping_instance.save.assert_called_once()
-        success_msg = mock_msg.success.call_args[0][1]
-        assert "platform mapping" in success_msg
+        view, req, dev = self._success_setup(platform_name="Cisco IOS", librenms_os="ios", create_mapping="1")
+
+        _post(view, req, pk=dev.pk)
+
+        platform = Platform.objects.get(name="Cisco IOS")
+        mapping = PlatformMapping.objects.get(librenms_os="ios")
+        assert mapping.netbox_platform_id == platform.pk
+        assert Device.objects.get(pk=dev.pk).platform_id == platform.pk
+        assert any("platform mapping" in t for t in message_texts(req, "success"))
 
     def test_mapping_skipped_when_checkbox_off(self):
         """No PlatformMapping is created when checkbox is unchecked."""
-        view, req, mock_platform_cls, mock_platform_instance, mock_device_cls, _ = self._success_patches(
-            platform_name="Cisco IOS", librenms_os="ios", create_mapping=""
-        )
-        mock_mapping_cls = MagicMock()
+        from netbox_librenms_plugin.models import PlatformMapping
 
-        with (
-            patch(
-                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
-                return_value=MagicMock(),
-            ),
-            patch("netbox_librenms_plugin.views.sync.device_fields.Platform", mock_platform_cls),
-            patch("netbox_librenms_plugin.views.sync.device_fields.Device", mock_device_cls),
-            patch("netbox_librenms_plugin.views.sync.device_fields.transaction"),
-            patch("netbox_librenms_plugin.views.sync.device_fields.messages"),
-            patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
-            patch("netbox_librenms_plugin.views.sync.device_fields.PlatformMapping", mock_mapping_cls),
-        ):
-            view.request = req
-            view.post(req, pk=1)
+        view, req, dev = self._success_setup(platform_name="Cisco IOS", librenms_os="ios", create_mapping="")
 
-        mock_mapping_cls.assert_not_called()
+        _post(view, req, pk=dev.pk)
+
+        assert not PlatformMapping.objects.filter(librenms_os="ios").exists()
 
     def test_mapping_skipped_when_already_exists(self):
         """No duplicate PlatformMapping is created when one already exists for the OS."""
-        view, req, mock_platform_cls, mock_platform_instance, mock_device_cls, _ = self._success_patches(
-            platform_name="Cisco IOS", librenms_os="ios", create_mapping="1"
-        )
-        mock_mapping_cls = MagicMock()
-        mock_mapping_cls.objects.restrict.return_value = mock_mapping_cls.objects
-        mock_mapping_cls.objects.filter.return_value.first.return_value = MagicMock()  # existing mapping
+        from dcim.models import Platform
 
-        with (
-            patch(
-                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
-                return_value=MagicMock(),
-            ),
-            patch("netbox_librenms_plugin.views.sync.device_fields.Platform", mock_platform_cls),
-            patch("netbox_librenms_plugin.views.sync.device_fields.Device", mock_device_cls),
-            patch("netbox_librenms_plugin.views.sync.device_fields.transaction"),
-            patch("netbox_librenms_plugin.views.sync.device_fields.messages"),
-            patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
-            patch("netbox_librenms_plugin.views.sync.device_fields.PlatformMapping", mock_mapping_cls),
-        ):
-            view.request = req
-            view.post(req, pk=1)
+        from netbox_librenms_plugin.models import PlatformMapping
 
-        mock_mapping_cls.assert_not_called()
+        platform = Platform.objects.create(name="Cisco IOS", slug="cisco-ios")
+        PlatformMapping.objects.create(librenms_os="ios", netbox_platform=platform)
+        view, req, dev = self._success_setup(platform_name="Cisco IOS", librenms_os="ios", create_mapping="1")
+
+        _post(view, req, pk=dev.pk)
+
+        assert PlatformMapping.objects.filter(librenms_os__iexact="ios").count() == 1
+        assert any("already exists" in t for t in message_texts(req, "info"))
 
     def test_mapping_skipped_when_lacking_add_perm_at_write(self):
-        """TOCTOU guard: a mapping existed at the preflight gate (so add wasn't required) but was deleted before the write."""
-        view, req, mock_platform_cls, mock_platform_instance, mock_device_cls, mock_locked = self._success_patches(
-            platform_name="Cisco IOS", librenms_os="ios", create_mapping="1"
+        """A user who may assign platforms but not add mappings gets the platform and a warning."""
+        from dcim.models import Device, Platform
+
+        from netbox_librenms_plugin.models import PlatformMapping
+
+        # The upfront gate deliberately omits ('add', PlatformMapping) — the write-site re-check
+        # is the only thing standing between this user and a mapping they may not create.
+        user = make_user_with_perms("plat-nomapping", [("change", Device), ("add", Platform)])
+        assert not user.has_perm("netbox_librenms_plugin.add_platformmapping")
+        view, req, dev = self._success_setup(
+            platform_name="Cisco IOS", librenms_os="ios", create_mapping="1", user=user
         )
-        # Upfront object-permission gate passes (user has change Device / add Platform); the
-        # write-site re-check is what must catch the missing PlatformMapping add permission.
-        view.require_object_permissions = MagicMock(return_value=None)
-        # Deny ONLY the PlatformMapping add permission at the write site; every other perm
-        # check must pass, so the test can't succeed via an unrelated permission-denied path.
-        mapping_add_perm = "netbox_librenms_plugin.add_platformmapping"
-        req.user.has_perm = MagicMock(side_effect=lambda perm: perm != mapping_add_perm)
-        mock_mapping_cls = MagicMock()
-        mock_mapping_cls.objects.restrict.return_value = mock_mapping_cls.objects
-        mock_mapping_cls.objects.filter.return_value.first.return_value = None  # deleted since preflight
 
-        with (
-            patch(
-                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
-                return_value=MagicMock(),
-            ),
-            patch("netbox_librenms_plugin.views.sync.device_fields.Platform", mock_platform_cls),
-            patch("netbox_librenms_plugin.views.sync.device_fields.Device", mock_device_cls),
-            patch("netbox_librenms_plugin.views.sync.device_fields.transaction"),
-            patch("netbox_librenms_plugin.views.sync.device_fields.messages") as mock_msg,
-            patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
-            patch("netbox_librenms_plugin.views.sync.device_fields.PlatformMapping", mock_mapping_cls),
-            patch("utilities.permissions.get_permission_for_model", return_value=mapping_add_perm),
-        ):
-            view.request = req
-            view.post(req, pk=1)
+        _post(view, req, pk=dev.pk)
 
-        # Prove the write-site permission check actually ran (so the skip is due to the TOCTOU
-        # re-check, not some unrelated path), then that no mapping was created and the user warned.
-        req.user.has_perm.assert_any_call(mapping_add_perm)
-        # No mapping created without permission, and the user is told why.
-        mock_mapping_cls.assert_not_called()
-        assert any("not created" in c.args[1] for c in mock_msg.warning.call_args_list)
-        # The platform itself must still be assigned to the locked device and persisted — only
-        # the secondary mapping is skipped, so this branch can't silently return pre-persist.
-        assert mock_locked.platform is mock_platform_instance
-        mock_locked.save.assert_called_once()
+        assert not PlatformMapping.objects.exists()
+        assert any("not created" in t for t in message_texts(req, "warning"))
+        # The platform itself must still be assigned and persisted — only the secondary mapping
+        # is skipped, so this branch can't silently return pre-persist.
+        platform = Platform.objects.get(name="Cisco IOS")
+        assert Device.objects.get(pk=dev.pk).platform_id == platform.pk
+
+    def _capture_required_perms(self, view):
+        """Record the perms the view computes for POST without changing what the gate decides."""
+        captured = {}
+        real = view.require_all_permissions
+
+        def _spy(method="POST"):
+            captured["perms"] = list(view.required_object_permissions.get(method, []))
+            return real(method)
+
+        view.require_all_permissions = _spy
+        return captured
 
     def test_required_object_permissions_never_include_platformmapping_upfront(self):
         """Even when create_mapping is on, an OS is supplied, and no mapping exists yet, the upfront POST gate must NOT require ('add', PlatformMapping): assigning the platform is the primary action and must not be blocked for a user who can't create mappings."""
-        view, req, mock_platform_cls, _, mock_device_cls, _ = self._success_patches(
-            platform_name="Cisco IOS", librenms_os="ios", create_mapping="1"
+        from dcim.models import Device, Platform
+
+        from netbox_librenms_plugin.models import PlatformMapping
+
+        user = make_user_with_perms("perms-upfront", [("change", Device), ("add", Platform)])
+        view, req, dev = self._success_setup(
+            platform_name="Cisco IOS", librenms_os="ios", create_mapping="1", user=user
         )
-        # The upfront gate no longer reads PlatformMapping at all (neither .exists() nor
-        # .first()), so no lookup stub is needed — the gate must not require the perm
-        # regardless of whether a mapping exists. Assert against the REAL model symbol so a
-        # regression that left ('add', PlatformMapping) in the perms can't slip past a
-        # MagicMock that never equals the real class.
-        from netbox_librenms_plugin.models import PlatformMapping as RealPlatformMapping
+        captured = self._capture_required_perms(view)
 
-        captured = {}
+        _post(view, req, pk=dev.pk)
 
-        def fake_require(method):
-            captured["perms"] = view.required_object_permissions.get(method, [])
-            # Short-circuit by returning a sentinel response so post() exits early.
-            return MagicMock()
-
-        view.require_all_permissions = fake_require
-
-        with (
-            patch(
-                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
-                return_value=MagicMock(),
-            ),
-            patch("netbox_librenms_plugin.views.sync.device_fields.Platform", mock_platform_cls),
-            patch("netbox_librenms_plugin.views.sync.device_fields.Device", mock_device_cls),
-            patch("netbox_librenms_plugin.views.sync.device_fields.PlatformMapping", RealPlatformMapping),
-        ):
-            view.request = req
-            view.post(req, pk=1)
-
-        assert ("add", RealPlatformMapping) not in captured["perms"], (
+        assert ("add", PlatformMapping) not in captured["perms"], (
             "('add', PlatformMapping) must not gate the upfront POST — the mapping is gated "
             "at the write site so the primary platform-assign isn't blocked"
         )
+        # And the gate really let this user through: the platform was assigned for real.
+        assert Device.objects.get(pk=dev.pk).platform_id == Platform.objects.get(name="Cisco IOS").pk
 
     def test_required_object_permissions_exclude_platformmapping_when_mapping_exists(self):
         """create_mapping on but a mapping for the OS already exists → no mapping write occurs, so ('add', PlatformMapping) must NOT be required (don't block the assign)."""
-        view, req, mock_platform_cls, _, mock_device_cls, _ = self._success_patches(
-            platform_name="Cisco IOS", librenms_os="ios", create_mapping="1"
+        from dcim.models import Device, Platform
+
+        from netbox_librenms_plugin.models import PlatformMapping
+
+        platform = Platform.objects.create(name="Cisco IOS", slug="cisco-ios")
+        PlatformMapping.objects.create(librenms_os="ios", netbox_platform=platform)
+        user = make_user_with_perms("perms-mapexists", [("change", Device)])
+        view, req, dev = self._success_setup(
+            platform_name="Cisco IOS", librenms_os="ios", create_mapping="1", user=user
         )
-        # The upfront gate no longer reads PlatformMapping (see the sibling test); the perm
-        # is never required upfront, the mapping write gates itself at its own site. Assert
-        # against the REAL model symbol so a regression can't hide behind a MagicMock.
-        from netbox_librenms_plugin.models import PlatformMapping as RealPlatformMapping
+        captured = self._capture_required_perms(view)
 
-        captured = {}
+        _post(view, req, pk=dev.pk)
 
-        def fake_require(method):
-            captured["perms"] = view.required_object_permissions.get(method, [])
-            return MagicMock()
-
-        view.require_all_permissions = fake_require
-
-        with (
-            patch(
-                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
-                return_value=MagicMock(),
-            ),
-            patch("netbox_librenms_plugin.views.sync.device_fields.Platform", mock_platform_cls),
-            patch("netbox_librenms_plugin.views.sync.device_fields.Device", mock_device_cls),
-            patch("netbox_librenms_plugin.views.sync.device_fields.PlatformMapping", RealPlatformMapping),
-        ):
-            view.request = req
-            view.post(req, pk=1)
-
-        assert ("add", RealPlatformMapping) not in captured["perms"], (
+        assert ("add", PlatformMapping) not in captured["perms"], (
             "Did not expect ('add', PlatformMapping) when a mapping for the OS already exists"
         )
+        assert Device.objects.get(pk=dev.pk).platform_id == platform.pk
 
     def test_required_object_permissions_exclude_platformmapping_when_no_create_mapping(self):
         """When create_mapping is NOT checked, ('add', PlatformMapping) must NOT be added."""
-        from netbox_librenms_plugin.models import PlatformMapping as RealPlatformMapping
+        from dcim.models import Device, Platform
 
-        view, req, mock_platform_cls, _, mock_device_cls, _ = self._success_patches(
-            platform_name="Cisco IOS", librenms_os="ios", create_mapping=""
-        )
+        from netbox_librenms_plugin.models import PlatformMapping
 
-        captured = {}
+        user = make_user_with_perms("perms-nomapping", [("change", Device), ("add", Platform)])
+        view, req, dev = self._success_setup(platform_name="Cisco IOS", librenms_os="ios", create_mapping="", user=user)
+        captured = self._capture_required_perms(view)
 
-        def fake_require(method):
-            captured["perms"] = view.required_object_permissions.get(method, [])
-            return MagicMock()
+        _post(view, req, pk=dev.pk)
 
-        view.require_all_permissions = fake_require
-
-        with (
-            patch(
-                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
-                return_value=MagicMock(),
-            ),
-            patch("netbox_librenms_plugin.views.sync.device_fields.Platform", mock_platform_cls),
-            patch("netbox_librenms_plugin.views.sync.device_fields.Device", mock_device_cls),
-            patch("netbox_librenms_plugin.views.sync.device_fields.PlatformMapping", RealPlatformMapping),
-        ):
-            view.request = req
-            view.post(req, pk=1)
-
-        assert ("add", RealPlatformMapping) not in captured["perms"], (
+        assert ("add", PlatformMapping) not in captured["perms"], (
             "Did not expect ('add', PlatformMapping) when create_mapping is unchecked"
         )
+        assert Device.objects.get(pk=dev.pk).platform_id == Platform.objects.get(name="Cisco IOS").pk
 
 
 # ---------------------------------------------------------------------------
@@ -1597,271 +1445,168 @@ class TestCreateAndAssignPlatformView:
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.django_db
 class TestAssignVCSerialView:
-    def _view(self):
+    def _view(self, request=None):
         from netbox_librenms_plugin.views.sync.device_fields import AssignVCSerialView
 
-        return _make_view(AssignVCSerialView)
+        return _make_view(AssignVCSerialView, request)
 
-    @pytest.mark.django_db
+    def _vc(self, tag, member_serials=("OLD",)):
+        """A real VirtualChassis: a host at position 1, then one member per entry."""
+        from dcim.models import VirtualChassis
+
+        vc = VirtualChassis.objects.create(name=f"vc-{tag}")
+        host = make_device(f"vc-{tag}-host")
+        host.virtual_chassis = vc
+        host.vc_position = 1
+        host.save()
+        members = []
+        for i, serial in enumerate(member_serials, start=2):
+            member = make_device(f"vc-{tag}-member-{i}", serial=serial)
+            member.virtual_chassis = vc
+            member.vc_position = i
+            member.save()
+            members.append(member)
+        return vc, host, members
+
     def test_member_save_success_persists_serial(self):
         """A serial is assigned to a real VC member and persisted (verified via DB reload)."""
-        from dcim.models import Device, VirtualChassis
+        from dcim.models import Device
 
-        view = self._view()
-        vc = VirtualChassis.objects.create(name="vc-serial")
-        host = make_device("vc-host")
-        host.virtual_chassis = vc
-        host.vc_position = 1
-        host.save()
-        member = make_device("vc-member", serial="OLD")
-        member.virtual_chassis = vc
-        member.vc_position = 2
-        member.save()
-
+        _vc, host, (member,) = self._vc("serial")
         req = _make_request({"serial_1": "SN100", "member_id_1": str(member.pk)})
-        with (
-            patch("netbox_librenms_plugin.views.sync.device_fields.messages") as mock_msg,
-            patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
-        ):
-            _post(view, req, pk=host.pk)
-        mock_msg.success.assert_called_once()
+
+        _post(self._view(req), req, pk=host.pk)
+
+        assert message_texts(req, "success")
         assert Device.objects.get(pk=member.pk).serial == "SN100"  # real save committed
 
-    @pytest.mark.django_db
     def test_member_serial_is_normalized_before_persisting(self):
         """Whitespace from the posted LibreNMS VC inventory is stripped before Device.save()."""
-        from dcim.models import Device, VirtualChassis
+        from dcim.models import Device
 
-        view = self._view()
-        vc = VirtualChassis.objects.create(name="vc-serial-padded")
-        host = make_device("vc-padded-host")
-        host.virtual_chassis = vc
-        host.vc_position = 1
-        host.save()
-        member = make_device("vc-padded-member", serial="OLD")
-        member.virtual_chassis = vc
-        member.vc_position = 2
-        member.save()
-
+        _vc, host, (member,) = self._vc("padded")
         req = _make_request({"serial_1": "\t SN-VC-1 \n", "member_id_1": str(member.pk)})
-        with (
-            patch("netbox_librenms_plugin.views.sync.device_fields.messages"),
-            patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
-        ):
-            _post(view, req, pk=host.pk)
+
+        _post(self._view(req), req, pk=host.pk)
 
         assert Device.objects.get(pk=member.pk).serial == "SN-VC-1"
 
     def test_permission_denied(self):
-        view = self._view()
-        err = MagicMock()
-        view.require_all_permissions = MagicMock(return_value=err)
-        with patch("netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404"):
-            _r = _make_request()
-            view.request = _r
-            result = view.post(_r, pk=1)
-        assert result is err
+        """A user without change_device never reaches the assignment loop."""
+        from dcim.models import Device
+
+        _vc, host, (member,) = self._vc("denied")
+        user = make_user_with_perms("vc-serial-viewer", [("view", Device)])
+        req = _make_request({"serial_1": "SN100", "member_id_1": str(member.pk)}, user=user)
+
+        _post(self._view(req), req, pk=host.pk)
+
+        assert Device.objects.get(pk=member.pk).serial == "OLD"
+        assert any("Missing permissions" in t for t in message_texts(req, "error"))
 
     def test_not_virtual_chassis(self):
-        view = self._view()
-        mock_device = MagicMock()
-        mock_device.virtual_chassis = None
-        with (
-            patch(
-                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
-                return_value=mock_device,
-            ),
-            patch("netbox_librenms_plugin.views.sync.device_fields.messages") as mock_msg,
-            patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
-        ):
-            _post(view, _make_request(), pk=1)
-        mock_msg.error.assert_called_once()
+        dev = make_device("vc-standalone")
+        req = _make_request()
+
+        _post(self._view(req), req, pk=dev.pk)
+
+        assert any("not part of a virtual chassis" in t for t in message_texts(req, "error"))
 
     def test_no_serial_assignments_no_errors(self):
         """Loop doesn't execute — no serial_N keys in POST."""
-        view = self._view()
-        mock_device = MagicMock()
-        mock_device.virtual_chassis = MagicMock()
-        with (
-            patch(
-                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
-                return_value=mock_device,
-            ),
-            patch("netbox_librenms_plugin.views.sync.device_fields.messages") as mock_msg,
-            patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
-        ):
-            _r = _make_request({})
-            view.request = _r
-            view.post(_r, pk=1)
-        mock_msg.info.assert_called_once()
+        _vc, host, _members = self._vc("noserials")
+        req = _make_request({})
+
+        _post(self._view(req), req, pk=host.pk)
+
+        assert message_texts(req, "info") == ["No serial assignments were made"]
 
     def test_member_id_missing(self):
-        """member_id_{N} key is absent → counter incremented, no assignment."""
-        view = self._view()
-        mock_device = MagicMock()
-        mock_device.virtual_chassis = MagicMock()
-        # serial_1 exists but member_id_1 is empty
+        """member_id_{N} key is empty → counter incremented, no assignment."""
+        _vc, host, _members = self._vc("nomemberid")
         req = _make_request({"serial_1": "SN100", "member_id_1": ""})
-        with (
-            patch(
-                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
-                return_value=mock_device,
-            ),
-            patch("netbox_librenms_plugin.views.sync.device_fields.messages") as mock_msg,
-            patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
-        ):
-            view.request = req
-            view.post(req, pk=1)
-        mock_msg.info.assert_called_once()
+
+        _post(self._view(req), req, pk=host.pk)
+
+        assert message_texts(req, "info") == ["No serial assignments were made"]
 
     def test_member_not_found(self):
-        view = self._view()
-        mock_device = MagicMock()
-        mock_device.virtual_chassis = MagicMock(pk=10)
+        from dcim.models import Device
 
-        DoesNotExist = type("DoesNotExist", (Exception,), {})
-        mock_device_cls = MagicMock()
-        mock_device_cls.DoesNotExist = DoesNotExist
-        mock_device_cls.objects.restrict.return_value = mock_device_cls.objects
-        mock_device_cls.objects.get.side_effect = DoesNotExist()
+        _vc, host, _members = self._vc("missing")
+        gone = make_device("vc-missing-gone")
+        gone_pk = gone.pk
+        gone.delete()
+        req = _make_request({"serial_1": "SN100", "member_id_1": str(gone_pk)})
 
-        req = _make_request({"serial_1": "SN100", "member_id_1": "99"})
-        with (
-            patch(
-                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
-                return_value=mock_device,
-            ),
-            patch("netbox_librenms_plugin.views.sync.device_fields.Device", mock_device_cls),
-            # Members are resolved through the SCOPED queryset (their serial is overwritten),
-            # so that is the seam this test stubs.
-            patch.object(view, "restricted_queryset", return_value=mock_device_cls.objects),
-            patch("netbox_librenms_plugin.views.sync.device_fields.messages") as mock_msg,
-            patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
-        ):
-            _post(view, req, pk=1)
-        # Should call error for the missing device
-        mock_msg.error.assert_called()
+        _post(self._view(req), req, pk=host.pk)
+
+        assert any(f"Device with ID {gone_pk} not found" in t for t in message_texts(req, "error"))
+        assert not Device.objects.filter(pk=gone_pk).exists()
+
+    def test_member_outside_the_grant_is_reported_as_not_found(self):
+        """A constrained grant must not let a raw member pk reach the serial write."""
+        from dcim.models import Device
+
+        _vc, host, (member,) = self._vc("scoped")
+        # The grant covers the host but not the member, though both share the chassis: the
+        # same-VC check alone would happily overwrite the member's serial.
+        user = make_user_with_perms("vc-serial-scoped", [("change", Device)], constraints={"name": "vc-scoped-host"})
+        req = _make_request({"serial_1": "SN100", "member_id_1": str(member.pk)}, user=user)
+
+        _post(self._view(req), req, pk=host.pk)
+
+        assert Device.objects.get(pk=member.pk).serial == "OLD"
+        assert any(f"Device with ID {member.pk} not found" in t for t in message_texts(req, "error"))
 
     def test_member_different_chassis(self):
-        view = self._view()
-        vc = MagicMock(pk=10)
-        mock_device = MagicMock()
-        mock_device.virtual_chassis = vc
+        from dcim.models import Device
 
-        member = MagicMock()
-        member.name = "sw-member"
-        member.virtual_chassis = MagicMock(pk=99)  # different VC!
+        _vc, host, _members = self._vc("chassis-a")
+        _other_vc, _other_host, (outsider,) = self._vc("chassis-b")
+        req = _make_request({"serial_1": "SN100", "member_id_1": str(outsider.pk)})
 
-        DoesNotExist = type("DoesNotExist", (Exception,), {})
-        mock_device_cls = MagicMock()
-        mock_device_cls.DoesNotExist = DoesNotExist
-        mock_device_cls.objects.restrict.return_value = mock_device_cls.objects
-        mock_device_cls.objects.get.return_value = member
+        _post(self._view(req), req, pk=host.pk)
 
-        req = _make_request({"serial_1": "SN100", "member_id_1": "5"})
-        with (
-            patch(
-                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
-                return_value=mock_device,
-            ),
-            patch("netbox_librenms_plugin.views.sync.device_fields.Device", mock_device_cls),
-            # Members are resolved through the SCOPED queryset (their serial is overwritten),
-            # so that is the seam this test stubs.
-            patch.object(view, "restricted_queryset", return_value=mock_device_cls.objects),
-            patch("netbox_librenms_plugin.views.sync.device_fields.messages") as mock_msg,
-            patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
-        ):
-            _post(view, req, pk=1)
-        mock_msg.error.assert_called()
+        assert any("not part of the same virtual chassis" in t for t in message_texts(req, "error"))
+        assert Device.objects.get(pk=outsider.pk).serial == "OLD"
 
     def test_member_save_validation_error(self):
-        from django.core.exceptions import ValidationError
+        """A serial the field itself rejects is reported per member, and the old value stands."""
+        from dcim.models import Device
 
-        view = self._view()
-        vc = MagicMock(pk=10)
-        mock_device = MagicMock()
-        mock_device.virtual_chassis = vc
+        _vc, host, (member,) = self._vc("badserial")
+        too_long = "S" * (Device._meta.get_field("serial").max_length + 1)
+        req = _make_request({"serial_1": too_long, "member_id_1": str(member.pk)})
 
-        member = MagicMock()
-        member.name = "sw-member"
-        member.virtual_chassis = vc  # same VC
-        member.serial = "OLD"
-        member.full_clean.side_effect = ValidationError({"serial": ["err"]})
+        _post(self._view(req), req, pk=host.pk)
 
-        DoesNotExist = type("DoesNotExist", (Exception,), {})
-        mock_device_cls = MagicMock()
-        mock_device_cls.DoesNotExist = DoesNotExist
-        mock_device_cls.objects.restrict.return_value = mock_device_cls.objects
-        mock_device_cls.objects.get.return_value = member
-
-        req = _make_request({"serial_1": "SN100", "member_id_1": "5"})
-        with (
-            patch(
-                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
-                return_value=mock_device,
-            ),
-            patch("netbox_librenms_plugin.views.sync.device_fields.Device", mock_device_cls),
-            # Members are resolved through the SCOPED queryset (their serial is overwritten),
-            # so that is the seam this test stubs.
-            patch.object(view, "restricted_queryset", return_value=mock_device_cls.objects),
-            patch("netbox_librenms_plugin.views.sync.device_fields.messages") as mock_msg,
-            patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
-        ):
-            _post(view, req, pk=1)
-        mock_msg.error.assert_called()
+        assert any(f"Failed to set serial on {member.name}" in t for t in message_texts(req, "error"))
+        assert Device.objects.get(pk=member.pk).serial == "OLD"
 
     def test_assignments_and_errors_both_reported(self):
-        """One success + one error → both messages emitted."""
-        from django.core.exceptions import ValidationError
+        """One success + one rejected serial → both messages, and only the good one persists."""
+        from dcim.models import Device
 
-        view = self._view()
-        vc = MagicMock(pk=10)
-        mock_device = MagicMock()
-        mock_device.virtual_chassis = vc
-
-        good_member = MagicMock()
-        good_member.name = "sw1"
-        good_member.virtual_chassis = vc
-        good_member.serial = ""
-
-        bad_member = MagicMock()
-        bad_member.name = "sw2"
-        bad_member.virtual_chassis = vc
-        bad_member.serial = ""
-        bad_member.full_clean.side_effect = ValidationError({"serial": ["dup"]})
-
-        DoesNotExist = type("DoesNotExist", (Exception,), {})
-        mock_device_cls = MagicMock()
-        mock_device_cls.DoesNotExist = DoesNotExist
-        mock_device_cls.objects.restrict.return_value = mock_device_cls.objects
-        mock_device_cls.objects.get.side_effect = [good_member, bad_member]
-
+        _vc, host, (good, bad) = self._vc("mixed", member_serials=("", ""))
+        too_long = "S" * (Device._meta.get_field("serial").max_length + 1)
         req = _make_request(
             {
                 "serial_1": "SN001",
-                "member_id_1": "1",
-                "serial_2": "SN002",
-                "member_id_2": "2",
+                "member_id_1": str(good.pk),
+                "serial_2": too_long,
+                "member_id_2": str(bad.pk),
             }
         )
-        with (
-            patch(
-                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
-                return_value=mock_device,
-            ),
-            patch("netbox_librenms_plugin.views.sync.device_fields.Device", mock_device_cls),
-            # Members are resolved through the SCOPED queryset (their serial is overwritten),
-            # so that is the seam this test stubs.
-            patch.object(view, "restricted_queryset", return_value=mock_device_cls.objects),
-            patch("netbox_librenms_plugin.views.sync.device_fields.messages") as mock_msg,
-            patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
-        ):
-            _post(view, req, pk=1)
-        mock_msg.success.assert_called()
-        mock_msg.error.assert_called()
-        assert good_member.serial == "SN001"
-        good_member.save.assert_called_once()
+
+        _post(self._view(req), req, pk=host.pk)
+
+        assert any("Successfully assigned 1 serial" in t for t in message_texts(req, "success"))
+        assert any(f"Failed to set serial on {bad.name}" in t for t in message_texts(req, "error"))
+        assert Device.objects.get(pk=good.pk).serial == "SN001"
+        assert Device.objects.get(pk=bad.pk).serial == ""
 
 
 # ---------------------------------------------------------------------------
@@ -1869,13 +1614,12 @@ class TestAssignVCSerialView:
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.django_db
 class TestRemoveServerMappingViewHelpers:
-    def _view(self):
+    def _view(self, request=None):
         from netbox_librenms_plugin.views.sync.device_fields import RemoveServerMappingView
 
-        view = object.__new__(RemoveServerMappingView)
-        view.require_all_permissions = MagicMock(return_value=None)
-        return view
+        return _make_view(RemoveServerMappingView, request)
 
     def test_get_object_device(self):
         view = self._view()
@@ -1940,345 +1684,176 @@ class TestRemoveServerMappingViewHelpers:
 
 @pytest.mark.django_db
 class TestRemoveServerMappingViewPost:
-    def _view(self):
+    def _view(self, request=None):
         from netbox_librenms_plugin.views.sync.device_fields import RemoveServerMappingView
 
-        view = object.__new__(RemoveServerMappingView)
-        view.require_all_permissions = MagicMock(return_value=None)
-        return view
+        return _make_view(RemoveServerMappingView, request)
 
     def test_invalid_object_type_returns_400(self):
-        view = self._view()
         req = _make_request({"object_type": "badtype"})
-        view.request = req
-        result = view.post(req, pk=1)
+
+        result = _post(self._view(req), req, pk=1)
+
         assert result.status_code == 400
 
     def test_virtualmachine_object_type_normalized_to_vm(self):
-        """object_type='virtualmachine' is normalised to 'vm'."""
-        view = self._view()
-        mock_obj = MagicMock()
-        mock_obj.custom_field_data = {"librenms_id": {"orphan": 5}}
+        """object_type='virtualmachine' is normalised to 'vm' and the VM's mapping is removed."""
+        from virtualization.models import VirtualMachine
 
+        vm = make_vm("rm-vm-orphan")
+        vm.custom_field_data["librenms_id"] = {"orphan": 5}
+        vm.save()
         req = _make_request({"object_type": "virtualmachine", "server_key": "orphan"})
 
-        DoesNotExist = type("DoesNotExist", (Exception,), {})
-        mock_vm_cls = MagicMock()
-        mock_vm_cls.DoesNotExist = DoesNotExist
-        mock_locked = MagicMock()
-        mock_locked.custom_field_data = {"librenms_id": {"orphan": 5}}
-        mock_vm_cls.objects.restrict.return_value = mock_vm_cls.objects
-        mock_vm_cls.objects.select_for_update.return_value.get.return_value = mock_locked
+        with _plugins_config(servers={}, librenms_url=""):
+            _post(self._view(req), req, pk=vm.pk)
 
-        mock_cfg = {"netbox_librenms_plugin": {"servers": {}, "librenms_url": ""}}
-
-        with (
-            patch(
-                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
-                return_value=mock_obj,
-            ),
-            patch("netbox_librenms_plugin.views.sync.device_fields.VirtualMachine", mock_vm_cls),
-            patch("netbox_librenms_plugin.views.sync.device_fields.transaction"),
-            patch("netbox_librenms_plugin.views.sync.device_fields.messages") as mock_msg,
-            patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
-            patch("django.conf.settings") as mock_settings,
-        ):
-            mock_settings.PLUGINS_CONFIG = mock_cfg
-            view.request = req
-            view.post(req, pk=1)
-        mock_msg.success.assert_called_once()
+        assert message_texts(req, "success")
+        assert VirtualMachine.objects.get(pk=vm.pk).custom_field_data["librenms_id"] is None
 
     def test_permission_denied(self):
-        view = self._view()
-        err = MagicMock()
-        view.require_all_permissions = MagicMock(return_value=err)
-        req = _make_request({"object_type": "device", "server_key": "x"})
-        view.request = req
-        result = view.post(req, pk=1)
-        assert result is err
+        """Without change_device the orphaned mapping survives."""
+        from dcim.models import Device
+
+        dev = make_device("rm-denied", librenms_cf={"orphan": 5})
+        user = make_user_with_perms("rm-viewer", [("view", Device)])
+        req = _make_request({"object_type": "device", "server_key": "orphan"}, user=user)
+
+        with _plugins_config(servers={}, librenms_url=""):
+            _post(self._view(req), req, pk=dev.pk)
+
+        assert Device.objects.get(pk=dev.pk).custom_field_data["librenms_id"] == {"orphan": 5}
+        assert any("Missing permissions" in t for t in message_texts(req, "error"))
 
     def test_no_server_key(self):
-        view = self._view()
+        dev = make_device("rm-nokey", librenms_cf={"orphan": 5})
         req = _make_request({"object_type": "device", "server_key": ""})
 
-        with (
-            patch(
-                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
-                return_value=MagicMock(),
-            ),
-            patch("netbox_librenms_plugin.views.sync.device_fields.messages") as mock_msg,
-            patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
-        ):
-            view.request = req
-            view.post(req, pk=1)
-        mock_msg.error.assert_called_once()
+        _post(self._view(req), req, pk=dev.pk)
+
+        assert message_texts(req, "error") == ["No server_key provided."]
 
     def test_mapping_not_found_wrong_type(self):
         """cf_value is not a dict → warning."""
-        view = self._view()
-        mock_obj = MagicMock()
-        mock_obj.custom_field_data = {"librenms_id": None}
-
+        dev = make_device("rm-nulcf", librenms_cf=None)
         req = _make_request({"object_type": "device", "server_key": "default"})
 
-        with (
-            patch(
-                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
-                return_value=mock_obj,
-            ),
-            patch("netbox_librenms_plugin.views.sync.device_fields.messages") as mock_msg,
-            patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
-        ):
-            view.request = req
-            view.post(req, pk=1)
-        mock_msg.warning.assert_called_once()
+        _post(self._view(req), req, pk=dev.pk)
+
+        assert message_texts(req, "warning") == ["No mapping found for server 'default'."]
 
     def test_mapping_not_found_missing_key(self):
         """server_key not in cf_value dict → warning."""
-        view = self._view()
-        mock_obj = MagicMock()
-        mock_obj.custom_field_data = {"librenms_id": {"other": 5}}
-
+        dev = make_device("rm-otherkey", librenms_cf={"other": 5})
         req = _make_request({"object_type": "device", "server_key": "default"})
 
-        with (
-            patch(
-                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
-                return_value=mock_obj,
-            ),
-            patch("netbox_librenms_plugin.views.sync.device_fields.messages") as mock_msg,
-            patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
-        ):
-            view.request = req
-            view.post(req, pk=1)
-        mock_msg.warning.assert_called_once()
+        _post(self._view(req), req, pk=dev.pk)
+
+        assert message_texts(req, "warning") == ["No mapping found for server 'default'."]
 
     def test_configured_servers_non_dict_treated_as_empty(self):
-        """servers config is a list (non-dict) → treated as empty dict, orphan key can be removed."""
-        view = self._view()
-        mock_obj = MagicMock()
-        mock_obj.custom_field_data = {"librenms_id": {"orphan": 5}}
+        """A non-dict servers config is normalised to {}, so the orphan key can be removed."""
+        from dcim.models import Device
 
+        dev = make_device("rm-badcfg", librenms_cf={"orphan": 5})
         req = _make_request({"object_type": "device", "server_key": "orphan"})
 
-        DoesNotExist = type("DoesNotExist", (Exception,), {})
-        mock_locked = MagicMock()
-        mock_locked.custom_field_data = {"librenms_id": {"orphan": 5}}
+        with _plugins_config(servers=["not", "a", "dict"], librenms_url=""):
+            _post(self._view(req), req, pk=dev.pk)
 
-        mock_device_cls = MagicMock()
-        mock_device_cls.__name__ = "Device"
-        mock_device_cls.DoesNotExist = DoesNotExist
-        mock_device_cls.objects.restrict.return_value = mock_device_cls.objects
-        mock_device_cls.objects.select_for_update.return_value.get.return_value = mock_locked
-
-        # servers is a list (non-dict) → line 496 normalises it to {}
-        mock_cfg = {"netbox_librenms_plugin": {"servers": ["not", "a", "dict"], "librenms_url": ""}}
-        with (
-            patch(
-                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
-                return_value=mock_obj,
-            ),
-            patch("netbox_librenms_plugin.views.sync.device_fields.Device", mock_device_cls),
-            patch("netbox_librenms_plugin.views.sync.device_fields.transaction"),
-            patch("netbox_librenms_plugin.views.sync.device_fields.messages") as mock_msg,
-            patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
-            patch("django.conf.settings") as mock_settings,
-        ):
-            mock_settings.PLUGINS_CONFIG = mock_cfg
-            view.request = req
-            view.post(req, pk=1)
-        mock_msg.success.assert_called_once()
+        assert message_texts(req, "success")
+        assert Device.objects.get(pk=dev.pk).custom_field_data["librenms_id"] is None
 
     def test_configured_server_key_in_servers_dict(self):
-        """server_key is in configured servers → error."""
-        view = self._view()
-        mock_obj = MagicMock()
-        mock_obj.custom_field_data = {"librenms_id": {"production": 10}}
+        """server_key is in configured servers → refused, mapping untouched."""
+        from dcim.models import Device
 
+        dev = make_device("rm-configured", librenms_cf={"production": 10})
         req = _make_request({"object_type": "device", "server_key": "production"})
 
-        mock_cfg = {"netbox_librenms_plugin": {"servers": {"production": {}}, "librenms_url": ""}}
-        with (
-            patch(
-                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
-                return_value=mock_obj,
-            ),
-            patch("netbox_librenms_plugin.views.sync.device_fields.messages") as mock_msg,
-            patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
-            patch("django.conf.settings") as mock_settings,
-        ):
-            mock_settings.PLUGINS_CONFIG = mock_cfg
-            view.request = req
-            view.post(req, pk=1)
-        mock_msg.error.assert_called_once()
-        assert "Cannot remove" in mock_msg.error.call_args[0][1]
+        with _plugins_config(servers={"production": {}}, librenms_url=""):
+            _post(self._view(req), req, pk=dev.pk)
+
+        assert any("Cannot remove" in t for t in message_texts(req, "error"))
+        assert Device.objects.get(pk=dev.pk).custom_field_data["librenms_id"] == {"production": 10}
 
     def test_legacy_default_server_protected(self):
-        """Legacy mode with librenms_url set and server_key='default' → error."""
-        view = self._view()
-        mock_obj = MagicMock()
-        mock_obj.custom_field_data = {"librenms_id": {"default": 7}}
+        """Legacy mode with librenms_url set and server_key='default' → refused."""
+        from dcim.models import Device
 
+        dev = make_device("rm-legacy", librenms_cf={"default": 7})
         req = _make_request({"object_type": "device", "server_key": "default"})
 
-        mock_cfg = {"netbox_librenms_plugin": {"servers": {}, "librenms_url": "https://librenms.example.com"}}
-        with (
-            patch(
-                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
-                return_value=mock_obj,
-            ),
-            patch("netbox_librenms_plugin.views.sync.device_fields.messages") as mock_msg,
-            patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
-            patch("django.conf.settings") as mock_settings,
-        ):
-            mock_settings.PLUGINS_CONFIG = mock_cfg
-            view.request = req
-            view.post(req, pk=1)
-        mock_msg.error.assert_called_once()
+        with _plugins_config(servers={}, librenms_url="https://librenms.example.com"):
+            _post(self._view(req), req, pk=dev.pk)
+
+        assert any("Cannot remove" in t for t in message_texts(req, "error"))
+        assert Device.objects.get(pk=dev.pk).custom_field_data["librenms_id"] == {"default": 7}
 
     def test_object_no_longer_exists_inside_transaction(self):
-        view = self._view()
-        mock_obj = MagicMock()
-        mock_obj.custom_field_data = {"librenms_id": {"orphan": 5}}
+        """The row is deleted between the first read and the lock: report, don't crash."""
+        from dcim.models import Device
 
+        dev = make_device("rm-vanishes", librenms_cf={"orphan": 5})
         req = _make_request({"object_type": "device", "server_key": "orphan"})
+        view = self._view(req)
 
-        DoesNotExist = type("DoesNotExist", (Exception,), {})
-        mock_device_cls = MagicMock()
-        mock_device_cls.__name__ = "Device"
-        mock_device_cls.DoesNotExist = DoesNotExist
-        mock_device_cls.objects.restrict.return_value = mock_device_cls.objects
-        mock_device_cls.objects.select_for_update.return_value.get.side_effect = DoesNotExist()
+        with _plugins_config(servers={}, librenms_url=""), _deleted_before_lock(view, dev):
+            _post(view, req, pk=dev.pk)
 
-        mock_cfg = {"netbox_librenms_plugin": {"servers": {}, "librenms_url": ""}}
-        with (
-            patch(
-                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
-                return_value=mock_obj,
-            ),
-            patch("netbox_librenms_plugin.views.sync.device_fields.Device", mock_device_cls),
-            patch("netbox_librenms_plugin.views.sync.device_fields.transaction"),
-            patch("netbox_librenms_plugin.views.sync.device_fields.messages") as mock_msg,
-            patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
-            patch("django.conf.settings") as mock_settings,
-        ):
-            mock_settings.PLUGINS_CONFIG = mock_cfg
-            view.request = req
-            view.post(req, pk=1)
-        mock_msg.error.assert_called_once()
+        assert message_texts(req, "error") == ["Device no longer exists."]
+        assert not Device.objects.filter(pk=dev.pk).exists()
 
     def test_mapping_already_removed_in_lock(self):
-        """server_key is gone from the locked object's cf → warning."""
-        view = self._view()
-        mock_obj = MagicMock()
-        mock_obj.custom_field_data = {"librenms_id": {"orphan": 5}}
+        """server_key is gone from the locked row's cf → warning, no write."""
+        from dcim.models import Device
 
+        dev = make_device("rm-raced", librenms_cf={"orphan": 5})
         req = _make_request({"object_type": "device", "server_key": "orphan"})
+        view = self._view(req)
 
-        DoesNotExist = type("DoesNotExist", (Exception,), {})
-        mock_locked = MagicMock()
-        # Key was removed between the first read and the lock
-        mock_locked.custom_field_data = {"librenms_id": {}}
+        def _drop_the_key():
+            Device.objects.filter(pk=dev.pk).update(custom_field_data={"librenms_id": {}})
 
-        mock_device_cls = MagicMock()
-        mock_device_cls.DoesNotExist = DoesNotExist
-        mock_device_cls.objects.restrict.return_value = mock_device_cls.objects
-        mock_device_cls.objects.select_for_update.return_value.get.return_value = mock_locked
+        with _plugins_config(servers={}, librenms_url=""), _before_lock(view, _drop_the_key):
+            _post(view, req, pk=dev.pk)
 
-        mock_cfg = {"netbox_librenms_plugin": {"servers": {}, "librenms_url": ""}}
-        with (
-            patch(
-                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
-                return_value=mock_obj,
-            ),
-            patch("netbox_librenms_plugin.views.sync.device_fields.Device", mock_device_cls),
-            patch("netbox_librenms_plugin.views.sync.device_fields.transaction"),
-            patch("netbox_librenms_plugin.views.sync.device_fields.messages") as mock_msg,
-            patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
-            patch("django.conf.settings") as mock_settings,
-        ):
-            mock_settings.PLUGINS_CONFIG = mock_cfg
-            view.request = req
-            view.post(req, pk=1)
-        mock_msg.warning.assert_called_once()
+        assert message_texts(req, "warning") == ["Mapping for server 'orphan' was already removed."]
 
     def test_validation_error_on_save(self):
+        """A rejected write is surfaced and rolled back, leaving the mapping in place."""
+        from dcim.models import Device
         from django.core.exceptions import ValidationError
 
-        view = self._view()
-        mock_obj = MagicMock()
-        mock_obj.custom_field_data = {"librenms_id": {"orphan": 5}}
-
+        dev = make_device("rm-validationerr", librenms_cf={"orphan": 5})
         req = _make_request({"object_type": "device", "server_key": "orphan"})
 
-        DoesNotExist = type("DoesNotExist", (Exception,), {})
-        mock_locked = MagicMock()
-        mock_locked.custom_field_data = {"librenms_id": {"orphan": 5}}
-        mock_locked.full_clean.side_effect = ValidationError({"librenms_id": ["err"]})
-
-        mock_device_cls = MagicMock()
-        mock_device_cls.DoesNotExist = DoesNotExist
-        mock_device_cls.objects.restrict.return_value = mock_device_cls.objects
-        mock_device_cls.objects.select_for_update.return_value.get.return_value = mock_locked
-
-        mock_txn = MagicMock()
-        mock_txn.set_rollback = MagicMock()
-
-        mock_cfg = {"netbox_librenms_plugin": {"servers": {}, "librenms_url": ""}}
+        # full_clean() accepts any dict for this custom field, so the rejection has to be
+        # injected; the manager, the lock and the transaction all stay real.
         with (
-            patch(
-                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
-                return_value=mock_obj,
-            ),
-            patch("netbox_librenms_plugin.views.sync.device_fields.Device", mock_device_cls),
-            patch("netbox_librenms_plugin.views.sync.device_fields.transaction", mock_txn),
-            patch("netbox_librenms_plugin.views.sync.device_fields.messages") as mock_msg,
-            patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
-            patch("django.conf.settings") as mock_settings,
+            _plugins_config(servers={}, librenms_url=""),
+            patch.object(Device, "full_clean", side_effect=ValidationError({"custom_field_data": ["err"]})),
         ):
-            mock_settings.PLUGINS_CONFIG = mock_cfg
-            view.request = req
-            view.post(req, pk=1)
-        mock_msg.error.assert_called_once()
-        mock_txn.set_rollback.assert_called_once_with(True)
+            _post(self._view(req), req, pk=dev.pk)
+
+        assert any("Validation error removing" in t for t in message_texts(req, "error"))
+        assert Device.objects.get(pk=dev.pk).custom_field_data["librenms_id"] == {"orphan": 5}
 
     def test_unexpected_error_on_save(self):
-        view = self._view()
-        mock_obj = MagicMock()
-        mock_obj.custom_field_data = {"librenms_id": {"orphan": 5}}
+        """A non-ValidationError is caught, reported and rolled back rather than 500ing."""
+        from dcim.models import Device
 
+        dev = make_device("rm-unexpected", librenms_cf={"orphan": 5})
         req = _make_request({"object_type": "device", "server_key": "orphan"})
 
-        DoesNotExist = type("DoesNotExist", (Exception,), {})
-        mock_locked = MagicMock()
-        mock_locked.custom_field_data = {"librenms_id": {"orphan": 5}}
-        mock_locked.full_clean.side_effect = RuntimeError("disk full")
-
-        mock_device_cls = MagicMock()
-        mock_device_cls.DoesNotExist = DoesNotExist
-        mock_device_cls.objects.restrict.return_value = mock_device_cls.objects
-        mock_device_cls.objects.select_for_update.return_value.get.return_value = mock_locked
-
-        mock_txn = MagicMock()
-        mock_txn.set_rollback = MagicMock()
-
-        mock_cfg = {"netbox_librenms_plugin": {"servers": {}, "librenms_url": ""}}
         with (
-            patch(
-                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
-                return_value=mock_obj,
-            ),
-            patch("netbox_librenms_plugin.views.sync.device_fields.Device", mock_device_cls),
-            patch("netbox_librenms_plugin.views.sync.device_fields.transaction", mock_txn),
-            patch("netbox_librenms_plugin.views.sync.device_fields.messages") as mock_msg,
-            patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
-            patch("django.conf.settings") as mock_settings,
+            _plugins_config(servers={}, librenms_url=""),
+            patch.object(Device, "full_clean", side_effect=RuntimeError("disk full")),
         ):
-            mock_settings.PLUGINS_CONFIG = mock_cfg
-            view.request = req
-            view.post(req, pk=1)
-        mock_msg.error.assert_called_once()
-        mock_txn.set_rollback.assert_called_once_with(True)
+            _post(self._view(req), req, pk=dev.pk)
+
+        assert any("Unexpected error removing" in t for t in message_texts(req, "error"))
+        assert Device.objects.get(pk=dev.pk).custom_field_data["librenms_id"] == {"orphan": 5}
 
     def test_success_removes_mapping(self):
         """Happy path: an UNCONFIGURED server's mapping is removed; last entry → cf None."""
@@ -2319,51 +1894,66 @@ class TestRemoveServerMappingViewPost:
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.django_db
 class TestConvertLegacyLibreNMSIdViewHelpers:
-    def _view(self):
+    def _view(self, request=None):
         from netbox_librenms_plugin.views.sync.device_fields import ConvertLegacyLibreNMSIdView
 
-        view = object.__new__(ConvertLegacyLibreNMSIdView)
-        view._librenms_api = MagicMock()
-        view._librenms_api.server_key = "default"
-        view.require_all_permissions = MagicMock(return_value=None)
-        return view
+        return _make_view(ConvertLegacyLibreNMSIdView, request)
 
     def test_get_model_and_object_device(self):
+        from dcim.models import Device
+
+        dev = make_device("helper-device")
         view = self._view()
-        mock_device = MagicMock()
-        with patch(
-            "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
-            return_value=mock_device,
-        ):
-            model, obj = view._get_model_and_object("device", 1)
-        assert obj is mock_device
+
+        model, obj = view._get_model_and_object("device", dev.pk)
+
+        assert model is Device
+        assert obj == dev
 
     def test_get_model_and_object_vm(self):
+        from virtualization.models import VirtualMachine
+
+        vm = make_vm("helper-vm")
         view = self._view()
-        mock_vm = MagicMock()
-        with patch(
-            "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
-            return_value=mock_vm,
-        ):
-            model, obj = view._get_model_and_object("vm", 1)
-        assert obj is mock_vm
+
+        model, obj = view._get_model_and_object("vm", vm.pk)
+
+        assert model is VirtualMachine
+        assert obj == vm
+
+    def test_get_model_and_object_404s_outside_the_grant(self):
+        """The helper resolves a client-supplied pk, so it must fail closed on a constrained grant."""
+        from dcim.models import Device
+        from django.http import Http404
+
+        make_device("helper-mine")
+        theirs = make_device("helper-theirs")
+        user = make_user_with_perms("helper-scoped", [("change", Device)], constraints={"name": "helper-mine"})
+        view = self._view(_make_request(user=user))
+
+        with pytest.raises(Http404):
+            view._get_model_and_object("device", theirs.pk)
 
     def test_sync_url_device(self):
+        """Invoked outside dispatch (no bound request) the helper emits the bare sync URL."""
         view = self._view()
-        with patch("netbox_librenms_plugin.views.sync.device_fields.redirect") as mock_redir:
-            view._sync_url("device", 1)
-        # No request/server_key in scope → bare reversed sync URL (no query string).
-        (url,), _ = mock_redir.call_args
-        assert isinstance(url, str) and "server_key" not in url
-        assert "1" in url
+        del view.request
+
+        response = view._sync_url("device", 1)
+
+        assert "server_key" not in response["Location"]
+        assert response["Location"].endswith("/1/librenms-sync/")
 
     def test_sync_url_vm(self):
         view = self._view()
-        with patch("netbox_librenms_plugin.views.sync.device_fields.redirect") as mock_redir:
-            view._sync_url("vm", 1)
-        (url,), _ = mock_redir.call_args
-        assert isinstance(url, str) and "server_key" not in url
+        del view.request
+
+        response = view._sync_url("vm", 1)
+
+        assert "server_key" not in response["Location"]
+        assert response["Location"].endswith("/1/librenms-sync/")
 
     @staticmethod
     def _request(post):
@@ -2454,218 +2044,116 @@ class TestConvertLegacyLibreNMSIdViewHelpers:
 
 @pytest.mark.django_db
 class TestConvertLegacyLibreNMSIdViewPost:
-    def _view(self):
+    def _view(self, request=None):
         from netbox_librenms_plugin.views.sync.device_fields import ConvertLegacyLibreNMSIdView
 
-        view = object.__new__(ConvertLegacyLibreNMSIdView)
-        view._librenms_api = MagicMock()
-        view._librenms_api.server_key = "default"
-        view.require_all_permissions = MagicMock(return_value=None)
-        return view
+        return _make_view(ConvertLegacyLibreNMSIdView, request)
+
+    def _device_view(self, dev, *, librenms_serial="SN-MATCH", post=None):
+        """Return ``(view, request)`` for converting *dev*, with LibreNMS reporting *librenms_serial*."""
+        req = _make_request({"object_type": "device", **(post or {})})
+        view = self._view(req)
+        view._librenms_api.get_device_info.return_value = (True, {"serial": librenms_serial})
+        return view, req
 
     def test_invalid_object_type_returns_400(self):
-        view = self._view()
         req = _make_request({"object_type": "badtype"})
-        with patch("netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404"):
-            view.request = req
-            result = view.post(req, pk=1)
+
+        result = _post(self._view(req), req, pk=1)
+
         assert result.status_code == 400
 
     def test_virtualmachine_object_type_normalised(self):
-        """object_type='virtualmachine' is accepted as 'vm'."""
-        view = self._view()
-        # Provide a legacy string int as cf_value
-        mock_obj = MagicMock()
-        mock_obj.custom_field_data = {"librenms_id": "42"}
-        mock_obj.serial = "SN-MATCH"
+        """object_type='virtualmachine' is accepted as 'vm' and the VM's legacy id converts."""
+        from virtualization.models import VirtualMachine
 
-        view._librenms_api.get_device_info.return_value = (True, {"serial": "SN-MATCH"})
-        view._librenms_api.server_key = "default"
+        vm = make_vm("convert-vm")
+        vm.custom_field_data["librenms_id"] = "42"
+        vm.save()
+        req = _make_request({"object_type": "virtualmachine"})
+        view = self._view(req)
+        # VMs have no serial field, so the serial gate is skipped for them.
+        view._librenms_api.get_device_info.return_value = (True, {"serial": "SN-ANY"})
 
-        DoesNotExist = type("DoesNotExist", (Exception,), {})
-        mock_locked = MagicMock()
-        mock_locked.custom_field_data = {"librenms_id": "42"}
-        mock_locked.serial = "SN-MATCH"
+        _post(view, req, pk=vm.pk)
 
-        mock_vm_cls = MagicMock()
-        mock_vm_cls.DoesNotExist = DoesNotExist
-        mock_vm_cls.objects.restrict.return_value = mock_vm_cls.objects
-        mock_vm_cls.objects.select_for_update.return_value.get.return_value = mock_locked
-
-        with (
-            patch(
-                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
-                return_value=mock_obj,
-            ),
-            patch("netbox_librenms_plugin.views.sync.device_fields.VirtualMachine", mock_vm_cls),
-            patch("netbox_librenms_plugin.views.sync.device_fields.find_by_librenms_id", return_value=None),
-            patch(
-                "netbox_librenms_plugin.views.sync.device_fields.migrate_legacy_librenms_id", return_value=True
-            ) as mock_migrate,
-            patch("netbox_librenms_plugin.views.sync.device_fields.transaction"),
-            patch("netbox_librenms_plugin.views.sync.device_fields.messages") as mock_msg,
-            patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
-        ):
-            _r = _make_request({"object_type": "virtualmachine"})
-            view.request = _r
-            view.post(_r, pk=1)
-        mock_msg.success.assert_called_once()
-        mock_migrate.assert_called_once()
-        mock_locked.full_clean.assert_called_once()
-        mock_locked.save.assert_called_once()
+        assert message_texts(req, "success")
+        assert VirtualMachine.objects.get(pk=vm.pk).custom_field_data["librenms_id"] == {"default": 42}
 
     def test_whitespace_padded_legacy_id_is_convertible_not_dead_end(self):
         """A padded legacy id (' 42 ') the badge shows via is_legacy_librenms_id must convert, not hit the isdigit() dead-end."""
-        view = self._view()
-        mock_obj = MagicMock()
-        mock_obj.custom_field_data = {"librenms_id": " 42 "}
-        mock_obj.serial = "SN-MATCH"
-        view._librenms_api.get_device_info.return_value = (True, {"serial": "SN-MATCH"})
+        from dcim.models import Device
 
-        DoesNotExist = type("DoesNotExist", (Exception,), {})
-        mock_locked = MagicMock()
-        mock_locked.custom_field_data = {"librenms_id": " 42 "}
-        mock_locked.serial = "SN-MATCH"
-        mock_dev_cls = MagicMock()
-        mock_dev_cls.DoesNotExist = DoesNotExist
-        mock_dev_cls.objects.restrict.return_value = mock_dev_cls.objects
-        mock_dev_cls.objects.select_for_update.return_value.get.return_value = mock_locked
+        dev = make_device("convert-padded", serial="SN-MATCH", librenms_cf=" 42 ")
+        view, req = self._device_view(dev)
 
-        with (
-            patch(
-                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
-                return_value=mock_obj,
-            ),
-            patch("netbox_librenms_plugin.views.sync.device_fields.Device", mock_dev_cls),
-            patch("netbox_librenms_plugin.views.sync.device_fields.find_by_librenms_id", return_value=None),
-            patch(
-                "netbox_librenms_plugin.views.sync.device_fields.migrate_legacy_librenms_id", return_value=True
-            ) as mock_migrate,
-            patch("netbox_librenms_plugin.views.sync.device_fields.transaction"),
-            patch("netbox_librenms_plugin.views.sync.device_fields.messages") as mock_msg,
-            patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
-        ):
-            _r = _make_request({"object_type": "device"})
-            view.request = _r
-            view.post(_r, pk=1)
-        # Unfixed: ' 42 '.isdigit() is False → error "not a valid integer" and migrate NOT called.
-        mock_migrate.assert_called_once()
-        assert not any("not a valid integer" in str(c) for c in mock_msg.error.call_args_list)
+        _post(view, req, pk=dev.pk)
+
+        # Unfixed: ' 42 '.isdigit() is False → error "not a valid integer" and no conversion.
+        assert not any("not a valid integer" in t for t in message_texts(req, "error"))
+        assert Device.objects.get(pk=dev.pk).custom_field_data["librenms_id"] == {"default": 42}
         # The serial gate must read live info (use_cache=False), not a stale sync-tab cache snapshot.
         assert view._librenms_api.get_device_info.call_args.kwargs.get("use_cache") is False
 
     def test_numeric_librenms_serial_passes_the_serial_gate(self):
         """An all-digit LibreNMS serial can arrive as an int; the gate must coerce it before stripping, not raise."""
-        view = self._view()
-        mock_obj = MagicMock()
-        mock_obj.custom_field_data = {"librenms_id": "42"}
-        mock_obj.serial = "987654"
+        from dcim.models import Device
+
+        dev = make_device("convert-numserial", serial="987654", librenms_cf="42")
+        req = _make_request({"object_type": "device"})
+        view = self._view(req)
         view._librenms_api.get_device_info.return_value = (True, {"serial": 987654})
 
-        DoesNotExist = type("DoesNotExist", (Exception,), {})
-        mock_locked = MagicMock()
-        mock_locked.custom_field_data = {"librenms_id": "42"}
-        mock_locked.serial = "987654"
-        mock_dev_cls = MagicMock()
-        mock_dev_cls.DoesNotExist = DoesNotExist
-        mock_dev_cls.objects.restrict.return_value = mock_dev_cls.objects
-        mock_dev_cls.objects.select_for_update.return_value.get.return_value = mock_locked
+        _post(view, req, pk=dev.pk)
 
-        with (
-            patch(
-                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
-                return_value=mock_obj,
-            ),
-            patch("netbox_librenms_plugin.views.sync.device_fields.Device", mock_dev_cls),
-            patch("netbox_librenms_plugin.views.sync.device_fields.find_by_librenms_id", return_value=None),
-            patch(
-                "netbox_librenms_plugin.views.sync.device_fields.migrate_legacy_librenms_id", return_value=True
-            ) as mock_migrate,
-            patch("netbox_librenms_plugin.views.sync.device_fields.transaction"),
-            patch("netbox_librenms_plugin.views.sync.device_fields.messages") as mock_msg,
-            patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
-        ):
-            _r = _make_request({"object_type": "device"})
-            view.request = _r
-            view.post(_r, pk=1)
-
-        mock_migrate.assert_called_once()
-        assert not any("Serial number mismatch" in str(c) for c in mock_msg.error.call_args_list)
+        assert not any("Serial number mismatch" in t for t in message_texts(req, "error"))
+        assert Device.objects.get(pk=dev.pk).custom_field_data["librenms_id"] == {"default": 42}
 
     def test_permission_denied(self):
-        view = self._view()
-        err = MagicMock()
-        view.require_all_permissions = MagicMock(return_value=err)
-        req = _make_request({"object_type": "device"})
-        with patch("netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404"):
-            view.request = req
-            result = view.post(req, pk=1)
-        assert result is err
+        """Without change_device the legacy id is left alone."""
+        from dcim.models import Device
+
+        dev = make_device("convert-denied", serial="SN-MATCH", librenms_cf=42)
+        user = make_user_with_perms("convert-viewer", [("view", Device)])
+        req = _make_request({"object_type": "device"}, user=user)
+        view = self._view(req)
+        view._librenms_api.get_device_info.return_value = (True, {"serial": "SN-MATCH"})
+
+        _post(view, req, pk=dev.pk)
+
+        assert Device.objects.get(pk=dev.pk).custom_field_data["librenms_id"] == 42
+        assert any("Missing permissions" in t for t in message_texts(req, "error"))
 
     def test_already_json_format_dict(self):
-        view = self._view()
-        mock_obj = MagicMock()
-        mock_obj.custom_field_data = {"librenms_id": {"default": 5}}
+        from dcim.models import Device
 
-        with (
-            patch(
-                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
-                return_value=mock_obj,
-            ),
-            patch("netbox_librenms_plugin.views.sync.device_fields.messages") as mock_msg,
-            patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
-        ):
-            _r = _make_request({"object_type": "device"})
-            view.request = _r
-            view.post(_r, pk=1)
-        mock_msg.warning.assert_called_once()
-        assert "already" in mock_msg.warning.call_args[0][1].lower()
+        dev = make_device("convert-alreadyjson", serial="SN-MATCH", librenms_cf={"default": 5})
+        view, req = self._device_view(dev)
+
+        _post(view, req, pk=dev.pk)
+
+        assert any("already" in t.lower() for t in message_texts(req, "warning"))
+        assert Device.objects.get(pk=dev.pk).custom_field_data["librenms_id"] == {"default": 5}
 
     def test_already_json_format_bool(self):
-        view = self._view()
-        mock_obj = MagicMock()
-        mock_obj.custom_field_data = {"librenms_id": True}
+        dev = make_device("convert-bool", serial="SN-MATCH", librenms_cf=True)
+        view, req = self._device_view(dev)
 
-        with (
-            patch(
-                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
-                return_value=mock_obj,
-            ),
-            patch("netbox_librenms_plugin.views.sync.device_fields.messages") as mock_msg,
-            patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
-        ):
-            _r = _make_request({"object_type": "device"})
-            view.request = _r
-            view.post(_r, pk=1)
-        mock_msg.error.assert_called_once()
+        _post(view, req, pk=dev.pk)
+
+        assert message_texts(req, "error") == ["librenms_id has an invalid boolean value; cannot convert."]
 
     def test_non_digit_string_cf_value(self):
-        view = self._view()
-        mock_obj = MagicMock()
-        mock_obj.custom_field_data = {"librenms_id": "not-a-number"}
+        dev = make_device("convert-nondigit", serial="SN-MATCH", librenms_cf="not-a-number")
+        view, req = self._device_view(dev)
 
-        with (
-            patch(
-                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
-                return_value=mock_obj,
-            ),
-            patch("netbox_librenms_plugin.views.sync.device_fields.messages") as mock_msg,
-            patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
-        ):
-            _r = _make_request({"object_type": "device"})
-            view.request = _r
-            view.post(_r, pk=1)
-        mock_msg.error.assert_called_once()
+        _post(view, req, pk=dev.pk)
 
-    @pytest.mark.django_db
+        assert message_texts(req, "error") == ["librenms_id is not a valid integer; cannot convert."]
+
     def test_convert_refused_when_id_collides_with_another_devices_oob(self):
         """Fail-closed pin: converting a legacy id is refused when another device uses it as its OOB controller id."""
         from dcim.models import Device
-
-        view = self._view()
-        # Blank-key rebind returns "default" without rebuilding the (mock) client.
-        view.rebind_api_for_server = MagicMock(return_value="default")
-        view._librenms_api.get_device_info.return_value = (True, {"serial": "SN-A"})
 
         # Device A: legacy bare-int librenms_id 42, serial matches LibreNMS so the convert proceeds
         # to the conflict check.
@@ -2673,451 +2161,195 @@ class TestConvertLegacyLibreNMSIdViewPost:
         # Device B: a DIFFERENT device using 42 as its OOB controller id under "default" — only the
         # OOB sub-key query (oob_q) surfaces this collision.
         make_device("convert-b", librenms_cf={"default": {"id": 99, "oob": {"id": 42}}})
+        view, req = self._device_view(dev_a, librenms_serial="SN-A")
 
-        with (
-            patch(
-                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
-                return_value=dev_a,
-            ),
-            patch("netbox_librenms_plugin.views.sync.device_fields.messages") as mock_msg,
-            patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
-        ):
-            _r = _make_request({"object_type": "device"})
-            view.request = _r
-            view.post(_r, pk=dev_a.pk)
+        _post(view, req, pk=dev_a.pk)
 
         # Refused (fail closed): an error, never a success, and the legacy id is left untouched
         # (NOT silently converted to the JSON dict form).
-        mock_msg.success.assert_not_called()
-        mock_msg.error.assert_called_once()
-        body = mock_msg.error.call_args[0][1].lower()
-        assert "ambiguous" in body or "already has" in body
+        assert not message_texts(req, "success")
+        errors = message_texts(req, "error")
+        assert len(errors) == 1
+        assert "ambiguous" in errors[0].lower() or "already has" in errors[0].lower()
         assert Device.objects.get(pk=dev_a.pk).custom_field_data["librenms_id"] == 42
 
     def test_get_device_info_failure(self):
-        view = self._view()
-        mock_obj = MagicMock()
-        mock_obj.custom_field_data = {"librenms_id": 42}
+        from dcim.models import Device
+
+        dev = make_device("convert-infofail", serial="SN-MATCH", librenms_cf=42)
+        req = _make_request({"object_type": "device"})
+        view = self._view(req)
         view._librenms_api.get_device_info.return_value = (False, None)
 
-        with (
-            patch(
-                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
-                return_value=mock_obj,
-            ),
-            patch("netbox_librenms_plugin.views.sync.device_fields.messages") as mock_msg,
-            patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
-        ):
-            _post(view, _make_request({"object_type": "device"}), pk=1)
-        mock_msg.error.assert_called_once()
+        _post(view, req, pk=dev.pk)
+
+        assert message_texts(req, "error") == ["Could not retrieve device info from LibreNMS to verify serial."]
+        assert Device.objects.get(pk=dev.pk).custom_field_data["librenms_id"] == 42
 
     def test_serial_mismatch_empty_netbox_serial(self):
-        view = self._view()
-        mock_obj = MagicMock()
-        mock_obj.custom_field_data = {"librenms_id": 42}
-        mock_obj.serial = ""
-        view._librenms_api.get_device_info.return_value = (True, {"serial": "SN-ABC"})
+        from dcim.models import Device
 
-        with (
-            patch(
-                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
-                return_value=mock_obj,
-            ),
-            patch("netbox_librenms_plugin.views.sync.device_fields.messages") as mock_msg,
-            patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
-        ):
-            _r = _make_request({"object_type": "device"})
-            view.request = _r
-            view.post(_r, pk=1)
-        mock_msg.error.assert_called_once()
-        assert "Serial" in mock_msg.error.call_args[0][1]
+        dev = make_device("convert-noserial", serial="", librenms_cf=42)
+        view, req = self._device_view(dev, librenms_serial="SN-ABC")
+
+        _post(view, req, pk=dev.pk)
+
+        assert any("Serial number mismatch" in t for t in message_texts(req, "error"))
+        assert Device.objects.get(pk=dev.pk).custom_field_data["librenms_id"] == 42
 
     def test_serial_mismatch_different(self):
-        view = self._view()
-        mock_obj = MagicMock()
-        mock_obj.custom_field_data = {"librenms_id": 42}
-        mock_obj.serial = "SN-XYZ"
-        view._librenms_api.get_device_info.return_value = (True, {"serial": "SN-ABC"})
+        from dcim.models import Device
 
-        with (
-            patch(
-                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
-                return_value=mock_obj,
-            ),
-            patch("netbox_librenms_plugin.views.sync.device_fields.messages") as mock_msg,
-            patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
-        ):
-            _r = _make_request({"object_type": "device"})
-            view.request = _r
-            view.post(_r, pk=1)
-        mock_msg.error.assert_called_once()
+        dev = make_device("convert-wrongserial", serial="SN-XYZ", librenms_cf=42)
+        view, req = self._device_view(dev, librenms_serial="SN-ABC")
+
+        _post(view, req, pk=dev.pk)
+
+        assert any("Serial number mismatch" in t for t in message_texts(req, "error"))
+        assert Device.objects.get(pk=dev.pk).custom_field_data["librenms_id"] == 42
 
     def test_object_no_longer_exists_in_lock(self):
-        view = self._view()
-        mock_obj = MagicMock()
-        mock_obj.custom_field_data = {"librenms_id": 42}
-        mock_obj.serial = "SN-MATCH"
-        view._librenms_api.get_device_info.return_value = (True, {"serial": "SN-MATCH"})
+        """The row is deleted between the serial check and the lock: report, don't crash."""
+        from dcim.models import Device
 
-        DoesNotExist = type("DoesNotExist", (Exception,), {})
-        mock_device_cls = MagicMock()
-        mock_device_cls.__name__ = "Device"
-        mock_device_cls.DoesNotExist = DoesNotExist
-        mock_device_cls.objects.restrict.return_value = mock_device_cls.objects
-        mock_device_cls.objects.select_for_update.return_value.get.side_effect = DoesNotExist()
+        dev = make_device("convert-vanishes", serial="SN-MATCH", librenms_cf=42)
+        view, req = self._device_view(dev)
 
-        with (
-            patch(
-                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
-                return_value=mock_obj,
-            ),
-            patch("netbox_librenms_plugin.views.sync.device_fields.Device", mock_device_cls),
-            patch("netbox_librenms_plugin.views.sync.device_fields.transaction"),
-            patch("netbox_librenms_plugin.views.sync.device_fields.messages") as mock_msg,
-            patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
-        ):
-            _r = _make_request({"object_type": "device"})
-            view.request = _r
-            view.post(_r, pk=1)
-        mock_msg.error.assert_called_once()
+        with _deleted_before_lock(view, dev):
+            _post(view, req, pk=dev.pk)
+
+        assert message_texts(req, "error") == ["Device no longer exists."]
+        assert not Device.objects.filter(pk=dev.pk).exists()
 
     def test_cf_value_changed_to_json_after_lock(self):
-        """Locked row shows cf_value already as dict → warning."""
-        view = self._view()
-        mock_obj = MagicMock()
-        mock_obj.custom_field_data = {"librenms_id": 42}
-        mock_obj.serial = "SN-MATCH"
-        view._librenms_api.get_device_info.return_value = (True, {"serial": "SN-MATCH"})
+        """Another session converted it first: warn, don't convert twice."""
+        from dcim.models import Device
 
-        DoesNotExist = type("DoesNotExist", (Exception,), {})
-        mock_locked = MagicMock()
-        mock_locked.custom_field_data = {"librenms_id": {"default": 42}}  # already dict
+        dev = make_device("convert-raced-json", serial="SN-MATCH", librenms_cf=42)
+        view, req = self._device_view(dev)
 
-        mock_device_cls = MagicMock()
-        mock_device_cls.DoesNotExist = DoesNotExist
-        mock_device_cls.objects.restrict.return_value = mock_device_cls.objects
-        mock_device_cls.objects.select_for_update.return_value.get.return_value = mock_locked
+        with _cf_changed_before_lock(view, dev, {"default": 42}):
+            _post(view, req, pk=dev.pk)
 
-        with (
-            patch(
-                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
-                return_value=mock_obj,
-            ),
-            patch("netbox_librenms_plugin.views.sync.device_fields.Device", mock_device_cls),
-            patch("netbox_librenms_plugin.views.sync.device_fields.transaction"),
-            patch("netbox_librenms_plugin.views.sync.device_fields.messages") as mock_msg,
-            patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
-        ):
-            _r = _make_request({"object_type": "device"})
-            view.request = _r
-            view.post(_r, pk=1)
-        mock_msg.warning.assert_called_once()
+        assert any("already in the server-scoped JSON format" in t for t in message_texts(req, "warning"))
+        assert Device.objects.get(pk=dev.pk).custom_field_data["librenms_id"] == {"default": 42}
 
     def test_cf_value_not_int_after_lock(self):
-        """Locked row shows non-digit string → error: cannot convert."""
-        view = self._view()
-        mock_obj = MagicMock()
-        mock_obj.custom_field_data = {"librenms_id": 42}
-        mock_obj.serial = "SN-MATCH"
-        view._librenms_api.get_device_info.return_value = (True, {"serial": "SN-MATCH"})
+        """The locked row shows a non-numeric id: abort rather than convert a value we never checked."""
+        from dcim.models import Device
 
-        DoesNotExist = type("DoesNotExist", (Exception,), {})
-        mock_locked = MagicMock()
-        mock_locked.custom_field_data = {"librenms_id": "not-a-digit"}
+        dev = make_device("convert-raced-junk", serial="SN-MATCH", librenms_cf=42)
+        view, req = self._device_view(dev)
 
-        mock_device_cls = MagicMock()
-        mock_device_cls.DoesNotExist = DoesNotExist
-        mock_device_cls.objects.restrict.return_value = mock_device_cls.objects
-        mock_device_cls.objects.select_for_update.return_value.get.return_value = mock_locked
+        with _cf_changed_before_lock(view, dev, "not-a-digit"):
+            _post(view, req, pk=dev.pk)
 
-        with (
-            patch(
-                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
-                return_value=mock_obj,
-            ),
-            patch("netbox_librenms_plugin.views.sync.device_fields.Device", mock_device_cls),
-            patch("netbox_librenms_plugin.views.sync.device_fields.transaction"),
-            patch("netbox_librenms_plugin.views.sync.device_fields.messages") as mock_msg,
-            patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
-        ):
-            _r = _make_request({"object_type": "device"})
-            view.request = _r
-            view.post(_r, pk=1)
-        mock_msg.error.assert_called_once()
+        assert message_texts(req, "error") == ["librenms_id changed before lock was acquired; aborting."]
+        assert Device.objects.get(pk=dev.pk).custom_field_data["librenms_id"] == "not-a-digit"
 
     def test_data_changed_before_lock(self):
-        """locked_id or locked_serial differs → error: aborting."""
-        view = self._view()
-        mock_obj = MagicMock()
-        mock_obj.custom_field_data = {"librenms_id": 42}
-        mock_obj.serial = "SN-MATCH"
-        view._librenms_api.get_device_info.return_value = (True, {"serial": "SN-MATCH"})
+        """The locked row carries a different id than the one whose serial was verified."""
+        from dcim.models import Device
 
-        DoesNotExist = type("DoesNotExist", (Exception,), {})
-        mock_locked = MagicMock()
-        mock_locked.custom_field_data = {"librenms_id": 99}  # different id
-        mock_locked.serial = "SN-MATCH"
+        dev = make_device("convert-raced-id", serial="SN-MATCH", librenms_cf=42)
+        view, req = self._device_view(dev)
 
-        mock_device_cls = MagicMock()
-        mock_device_cls.DoesNotExist = DoesNotExist
-        mock_device_cls.objects.restrict.return_value = mock_device_cls.objects
-        mock_device_cls.objects.select_for_update.return_value.get.return_value = mock_locked
+        with _cf_changed_before_lock(view, dev, 99):
+            _post(view, req, pk=dev.pk)
 
-        with (
-            patch(
-                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
-                return_value=mock_obj,
-            ),
-            patch("netbox_librenms_plugin.views.sync.device_fields.Device", mock_device_cls),
-            patch("netbox_librenms_plugin.views.sync.device_fields.transaction"),
-            patch("netbox_librenms_plugin.views.sync.device_fields.messages") as mock_msg,
-            patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
-        ):
-            _r = _make_request({"object_type": "device"})
-            view.request = _r
-            view.post(_r, pk=1)
-        mock_msg.error.assert_called_once()
+        assert message_texts(req, "error") == ["Device data changed before lock was acquired; aborting conversion."]
+        assert Device.objects.get(pk=dev.pk).custom_field_data["librenms_id"] == 99
 
     def test_conflict_with_another_object(self):
-        """Another object already has the same librenms_id for this server."""
-        view = self._view()
-        mock_obj = MagicMock()
-        mock_obj.custom_field_data = {"librenms_id": 42}
-        mock_obj.serial = "SN-MATCH"
-        view._librenms_api.get_device_info.return_value = (True, {"serial": "SN-MATCH"})
-        view._librenms_api.server_key = "default"
+        """Another device already owns this id for this server → refuse and roll back.
 
-        DoesNotExist = type("DoesNotExist", (Exception,), {})
-        mock_locked = MagicMock()
-        mock_locked.pk = 1
-        mock_locked.custom_field_data = {"librenms_id": 42}
-        mock_locked.serial = "SN-MATCH"
+        The bare-int form is a universal fallback, so the conflict query sees BOTH rows and
+        fails closed on ambiguity rather than naming the other owner. Either way the contract
+        that matters holds: no conversion, and neither row is touched.
+        """
+        from dcim.models import Device
 
-        other_obj = MagicMock()
-        other_obj.pk = 99  # different pk → conflict
+        dev = make_device("convert-loser", serial="SN-MATCH", librenms_cf=42)
+        owner = make_device("convert-owner", librenms_cf={"default": 42})
+        view, req = self._device_view(dev)
 
-        mock_device_cls = MagicMock()
-        mock_device_cls.__name__ = "Device"
-        mock_device_cls.DoesNotExist = DoesNotExist
-        mock_device_cls.objects.restrict.return_value = mock_device_cls.objects
-        mock_device_cls.objects.select_for_update.return_value.get.return_value = mock_locked
+        _post(view, req, pk=dev.pk)
 
-        mock_txn = MagicMock()
-        mock_txn.set_rollback = MagicMock()
-
-        with (
-            patch(
-                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
-                return_value=mock_obj,
-            ),
-            patch("netbox_librenms_plugin.views.sync.device_fields.Device", mock_device_cls),
-            patch("netbox_librenms_plugin.views.sync.device_fields.find_by_librenms_id", return_value=other_obj),
-            patch("netbox_librenms_plugin.views.sync.device_fields.transaction", mock_txn),
-            patch("netbox_librenms_plugin.views.sync.device_fields.messages") as mock_msg,
-            patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
-        ):
-            _r = _make_request({"object_type": "device"})
-            view.request = _r
-            view.post(_r, pk=1)
-        mock_msg.error.assert_called_once()
-        mock_txn.set_rollback.assert_called_once_with(True)
-
-    def test_migrate_returns_false(self):
-        """migrate_legacy_librenms_id returns False → warning."""
-        view = self._view()
-        mock_obj = MagicMock()
-        mock_obj.custom_field_data = {"librenms_id": 42}
-        mock_obj.serial = "SN-MATCH"
-        view._librenms_api.get_device_info.return_value = (True, {"serial": "SN-MATCH"})
-        view._librenms_api.server_key = "default"
-
-        DoesNotExist = type("DoesNotExist", (Exception,), {})
-        mock_locked = MagicMock()
-        mock_locked.pk = 1
-        mock_locked.custom_field_data = {"librenms_id": 42}
-        mock_locked.serial = "SN-MATCH"
-
-        mock_device_cls = MagicMock()
-        mock_device_cls.DoesNotExist = DoesNotExist
-        mock_device_cls.objects.restrict.return_value = mock_device_cls.objects
-        mock_device_cls.objects.select_for_update.return_value.get.return_value = mock_locked
-
-        with (
-            patch(
-                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
-                return_value=mock_obj,
-            ),
-            patch("netbox_librenms_plugin.views.sync.device_fields.Device", mock_device_cls),
-            patch("netbox_librenms_plugin.views.sync.device_fields.find_by_librenms_id", return_value=None),
-            patch("netbox_librenms_plugin.views.sync.device_fields.migrate_legacy_librenms_id", return_value=False),
-            patch("netbox_librenms_plugin.views.sync.device_fields.transaction"),
-            patch("netbox_librenms_plugin.views.sync.device_fields.messages") as mock_msg,
-            patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
-        ):
-            _r = _make_request({"object_type": "device"})
-            view.request = _r
-            view.post(_r, pk=1)
-        mock_msg.warning.assert_called_once()
+        errors = message_texts(req, "error")
+        assert any("ambiguous" in t.lower() or "already has librenms_id 42" in t for t in errors)
+        assert not message_texts(req, "success")
+        assert Device.objects.get(pk=dev.pk).custom_field_data["librenms_id"] == 42
+        assert Device.objects.get(pk=owner.pk).custom_field_data["librenms_id"] == {"default": 42}
 
     def test_validation_error_on_save(self):
+        """A rejected write is surfaced and rolled back, leaving the legacy id in place."""
+        from dcim.models import Device
         from django.core.exceptions import ValidationError
 
-        view = self._view()
-        mock_obj = MagicMock()
-        mock_obj.custom_field_data = {"librenms_id": 42}
-        mock_obj.serial = "SN-MATCH"
-        view._librenms_api.get_device_info.return_value = (True, {"serial": "SN-MATCH"})
-        view._librenms_api.server_key = "default"
+        dev = make_device("convert-validationerr", serial="SN-MATCH", librenms_cf=42)
+        view, req = self._device_view(dev)
 
-        DoesNotExist = type("DoesNotExist", (Exception,), {})
-        mock_locked = MagicMock()
-        mock_locked.pk = 1
-        mock_locked.custom_field_data = {"librenms_id": 42}
-        mock_locked.serial = "SN-MATCH"
-        mock_locked.full_clean.side_effect = ValidationError({"librenms_id": ["err"]})
+        # full_clean() accepts the converted dict, so the rejection has to be injected; the
+        # manager, the lock, the conflict query and the transaction all stay real.
+        with patch.object(Device, "full_clean", side_effect=ValidationError({"custom_field_data": ["err"]})):
+            _post(view, req, pk=dev.pk)
 
-        mock_device_cls = MagicMock()
-        mock_device_cls.DoesNotExist = DoesNotExist
-        mock_device_cls.objects.restrict.return_value = mock_device_cls.objects
-        mock_device_cls.objects.select_for_update.return_value.get.return_value = mock_locked
-
-        mock_txn = MagicMock()
-        mock_txn.set_rollback = MagicMock()
-
-        with (
-            patch(
-                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
-                return_value=mock_obj,
-            ),
-            patch("netbox_librenms_plugin.views.sync.device_fields.Device", mock_device_cls),
-            patch("netbox_librenms_plugin.views.sync.device_fields.find_by_librenms_id", return_value=None),
-            patch("netbox_librenms_plugin.views.sync.device_fields.migrate_legacy_librenms_id", return_value=True),
-            patch("netbox_librenms_plugin.views.sync.device_fields.transaction", mock_txn),
-            patch("netbox_librenms_plugin.views.sync.device_fields.messages") as mock_msg,
-            patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
-        ):
-            _r = _make_request({"object_type": "device"})
-            view.request = _r
-            view.post(_r, pk=1)
-        mock_msg.error.assert_called_once()
-        mock_txn.set_rollback.assert_called_once_with(True)
+        assert any("Failed to save converted librenms_id" in t for t in message_texts(req, "error"))
+        assert Device.objects.get(pk=dev.pk).custom_field_data["librenms_id"] == 42
 
     def test_unexpected_error_on_save(self):
-        view = self._view()
-        mock_obj = MagicMock()
-        mock_obj.custom_field_data = {"librenms_id": 42}
-        mock_obj.serial = "SN-MATCH"
-        view._librenms_api.get_device_info.return_value = (True, {"serial": "SN-MATCH"})
-        view._librenms_api.server_key = "default"
+        """A non-ValidationError is caught, reported and rolled back rather than 500ing."""
+        from dcim.models import Device
 
-        DoesNotExist = type("DoesNotExist", (Exception,), {})
-        mock_locked = MagicMock()
-        mock_locked.pk = 1
-        mock_locked.custom_field_data = {"librenms_id": 42}
-        mock_locked.serial = "SN-MATCH"
-        mock_locked.full_clean.side_effect = RuntimeError("disk full")
+        dev = make_device("convert-unexpected", serial="SN-MATCH", librenms_cf=42)
+        view, req = self._device_view(dev)
 
-        mock_device_cls = MagicMock()
-        mock_device_cls.DoesNotExist = DoesNotExist
-        mock_device_cls.objects.restrict.return_value = mock_device_cls.objects
-        mock_device_cls.objects.select_for_update.return_value.get.return_value = mock_locked
+        with patch.object(Device, "full_clean", side_effect=RuntimeError("disk full")):
+            _post(view, req, pk=dev.pk)
 
-        mock_txn = MagicMock()
-        mock_txn.set_rollback = MagicMock()
-
-        with (
-            patch(
-                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
-                return_value=mock_obj,
-            ),
-            patch("netbox_librenms_plugin.views.sync.device_fields.Device", mock_device_cls),
-            patch("netbox_librenms_plugin.views.sync.device_fields.find_by_librenms_id", return_value=None),
-            patch("netbox_librenms_plugin.views.sync.device_fields.migrate_legacy_librenms_id", return_value=True),
-            patch("netbox_librenms_plugin.views.sync.device_fields.transaction", mock_txn),
-            patch("netbox_librenms_plugin.views.sync.device_fields.messages") as mock_msg,
-            patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
-        ):
-            _r = _make_request({"object_type": "device"})
-            view.request = _r
-            view.post(_r, pk=1)
-        mock_msg.error.assert_called_once()
-        mock_txn.set_rollback.assert_called_once_with(True)
+        assert any("Failed to save converted librenms_id" in t for t in message_texts(req, "error"))
+        assert Device.objects.get(pk=dev.pk).custom_field_data["librenms_id"] == 42
 
     def test_success_integer_cf_value(self):
         """Happy path, legacy int cf_value: the real migrate + save converts it to the dict form."""
         from dcim.models import Device
 
-        view = self._view()
-        view._librenms_api.get_device_info.return_value = (True, {"serial": "SN-MATCH"})
         dev = make_device("convert-int", serial="SN-MATCH", librenms_cf=42)
+        view, req = self._device_view(dev)
 
-        with (
-            patch("netbox_librenms_plugin.views.sync.device_fields.messages") as mock_msg,
-            patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
-        ):
-            _post(view, _make_request({"object_type": "device"}), pk=dev.pk)
-        mock_msg.success.assert_called_once()
-        assert "42" in mock_msg.success.call_args[0][1]
+        _post(view, req, pk=dev.pk)
+
+        assert any("42" in t for t in message_texts(req, "success"))
         assert Device.objects.get(pk=dev.pk).custom_field_data["librenms_id"] == {"default": 42}
 
     def test_success_string_cf_value(self):
         """Happy path, legacy string-digit cf_value '42' → converted to {'default': 42}."""
         from dcim.models import Device
 
-        view = self._view()
-        view._librenms_api.get_device_info.return_value = (True, {"serial": "SN-MATCH"})
         dev = make_device("convert-str", serial="SN-MATCH", librenms_cf="42")
+        view, req = self._device_view(dev)
 
-        with (
-            patch("netbox_librenms_plugin.views.sync.device_fields.messages") as mock_msg,
-            patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
-        ):
-            _post(view, _make_request({"object_type": "device"}), pk=dev.pk)
-        mock_msg.success.assert_called_once()
+        _post(view, req, pk=dev.pk)
+
+        assert message_texts(req, "success")
         assert Device.objects.get(pk=dev.pk).custom_field_data["librenms_id"] == {"default": 42}
 
     def test_conflict_same_object_is_not_conflict(self):
-        """find_by_librenms_id returns the same object → no conflict, proceeds."""
-        view = self._view()
-        mock_obj = MagicMock()
-        mock_obj.custom_field_data = {"librenms_id": 42}
-        mock_obj.serial = "SN-MATCH"
-        view._librenms_api.get_device_info.return_value = (True, {"serial": "SN-MATCH"})
-        view._librenms_api.server_key = "default"
+        """The legacy id resolves to the device being converted — that is not a conflict."""
+        from dcim.models import Device
 
-        DoesNotExist = type("DoesNotExist", (Exception,), {})
-        mock_locked = MagicMock()
-        mock_locked.pk = 1
-        mock_locked.custom_field_data = {"librenms_id": 42}
-        mock_locked.serial = "SN-MATCH"
+        from netbox_librenms_plugin.utils import find_by_librenms_id
 
-        # find_by_librenms_id returns the SAME object → match.pk == locked.pk → no conflict
-        same_obj = MagicMock()
-        same_obj.pk = 1
+        dev = make_device("convert-self", serial="SN-MATCH", librenms_cf=42)
+        # The bare-int form is a universal fallback, so the conflict query DOES find this very
+        # device; the branch under test is the `match.pk != locked.pk` guard that lets it through.
+        assert find_by_librenms_id(Device, 42, "default").pk == dev.pk
+        view, req = self._device_view(dev)
 
-        mock_device_cls = MagicMock()
-        mock_device_cls.DoesNotExist = DoesNotExist
-        mock_device_cls.objects.restrict.return_value = mock_device_cls.objects
-        mock_device_cls.objects.select_for_update.return_value.get.return_value = mock_locked
+        _post(view, req, pk=dev.pk)
 
-        with (
-            patch(
-                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
-                return_value=mock_obj,
-            ),
-            patch("netbox_librenms_plugin.views.sync.device_fields.Device", mock_device_cls),
-            patch("netbox_librenms_plugin.views.sync.device_fields.find_by_librenms_id", return_value=same_obj),
-            patch("netbox_librenms_plugin.views.sync.device_fields.migrate_legacy_librenms_id", return_value=True),
-            patch("netbox_librenms_plugin.views.sync.device_fields.transaction"),
-            patch("netbox_librenms_plugin.views.sync.device_fields.messages") as mock_msg,
-            patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
-        ):
-            _r = _make_request({"object_type": "device"})
-            view.request = _r
-            view.post(_r, pk=1)
-        mock_msg.success.assert_called_once()
-        mock_locked.full_clean.assert_called_once()
-        mock_locked.save.assert_called_once()
+        assert not message_texts(req, "error")
+        assert Device.objects.get(pk=dev.pk).custom_field_data["librenms_id"] == {"default": 42}
 
 
 # ---------------------------------------------------------------------------
@@ -3195,6 +2427,7 @@ class TestNormalizeLibreNMSMapping:
 # ---------------------------------------------------------------------------
 # CreateAndAssignPlatformView — full_clean before save
 # ---------------------------------------------------------------------------
+@pytest.mark.django_db
 class TestCreatePlatformFullClean:
     """CreateAndAssignPlatformView must surface a real Platform.full_clean() ValidationError, not 500."""
 
@@ -3248,6 +2481,7 @@ class TestCreatePlatformFullClean:
         assert "could not be created" in mock_messages.error.call_args[0][1]
 
 
+@pytest.mark.django_db
 class TestSyncRedirectServerKeyValidation:
     """_sync_redirect must only reflect a server_key that matches a configured server, so untrusted request input can't be steered into the redirect URL (open-redirect)."""
 

--- a/netbox_librenms_plugin/tests/test_coverage_device_fields.py
+++ b/netbox_librenms_plugin/tests/test_coverage_device_fields.py
@@ -2635,7 +2635,6 @@ class TestUpdateDeviceFieldsServerRebind:
             patch("netbox_librenms_plugin.views.sync.device_fields.messages"),
             patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
         ):
-            view.request = request
             view.post(request, pk=pk)
 
     def test_update_name_rebinds_and_renames_from_posted_server(self):

--- a/netbox_librenms_plugin/tests/test_coverage_device_fields.py
+++ b/netbox_librenms_plugin/tests/test_coverage_device_fields.py
@@ -16,6 +16,7 @@ from netbox_librenms_plugin.tests.conftest import make_device, make_vm
 
 
 from netbox_librenms_plugin.tests.view_test_helpers import (
+    grant,
     make_request,
     make_user_with_perms,
     make_view,
@@ -1019,8 +1020,8 @@ class TestCreateAndAssignPlatformView:
         mock_msg.error.assert_called_once()
         assert "required" in mock_msg.error.call_args[0][1].lower()
 
-    def test_non_numeric_manufacturer_is_treated_as_unresolved(self):
-        """A stale or forged manufacturer value must not crash platform creation."""
+    def test_non_numeric_manufacturer_is_rejected(self):
+        """A stale or forged manufacturer value must not remove the requested scope."""
         from dcim.models import Device, Platform
 
         device = make_device("plat-invalid-manufacturer")
@@ -1029,9 +1030,9 @@ class TestCreateAndAssignPlatformView:
 
         _post(view, request, pk=device.pk)
 
-        platform = Platform.objects.get(name="Invalid Manufacturer Platform")
-        assert platform.manufacturer_id is None
-        assert Device.objects.get(pk=device.pk).platform_id == platform.pk
+        assert not Platform.objects.filter(name="Invalid Manufacturer Platform").exists()
+        assert Device.objects.get(pk=device.pk).platform_id is None
+        assert message_texts(request, "error") == ["Selected manufacturer is not available."]
 
     @pytest.mark.django_db
     def test_rebinds_to_posted_server_for_redirect_fallback(self):
@@ -1144,7 +1145,7 @@ class TestCreateAndAssignPlatformView:
         assert Device.objects.get(pk=dev.pk).platform_id == wanted.pk
 
     def test_manufacturer_not_found(self):
-        """An unresolvable manufacturer id is ignored: the platform is still created, unscoped."""
+        """An unresolvable manufacturer ID stops the platform write."""
         from dcim.models import Device, Manufacturer, Platform
 
         dev = make_device("plat-nomanuf")
@@ -1154,11 +1155,33 @@ class TestCreateAndAssignPlatformView:
 
         _post(view, req, pk=dev.pk)
 
-        platform = Platform.objects.get(name="ios")
-        assert platform.manufacturer_id is None
-        assert Device.objects.get(pk=dev.pk).platform_id == platform.pk
-        assert message_texts(req, "success")
-        assert not message_texts(req, "error")
+        assert not Platform.objects.filter(name="ios").exists()
+        assert Device.objects.get(pk=dev.pk).platform_id is None
+        assert message_texts(req, "error") == ["Selected manufacturer is not available."]
+
+    def test_manufacturer_outside_the_grant_is_rejected(self):
+        """A constrained grant must not let a hidden manufacturer become an unscoped platform."""
+        from dcim.models import Device, Manufacturer, Platform
+
+        Manufacturer.objects.create(name="Visible Vendor", slug="visible-vendor")
+        hidden = Manufacturer.objects.create(name="Hidden Vendor", slug="hidden-vendor")
+        device = make_device("plat-hidden-manufacturer")
+        user = make_user_with_perms(
+            "platform-manufacturer-scoped",
+            [("change", Device), ("add", Platform)],
+        )
+        user = grant(user, "view", Manufacturer, constraints={"name": "Visible Vendor"})
+        request = _make_request(
+            {"platform_name": "Hidden Vendor Platform", "manufacturer": str(hidden.pk)},
+            user=user,
+        )
+        view = self._view(request)
+
+        _post(view, request, pk=device.pk)
+
+        assert not Platform.objects.filter(name="Hidden Vendor Platform").exists()
+        assert Device.objects.get(pk=device.pk).platform_id is None
+        assert message_texts(request, "error") == ["Selected manufacturer is not available."]
 
     def test_success_no_manufacturer(self):
         """A new platform (no manufacturer) is created and assigned to the device (real)."""

--- a/netbox_librenms_plugin/tests/test_coverage_device_fields.py
+++ b/netbox_librenms_plugin/tests/test_coverage_device_fields.py
@@ -1019,6 +1019,20 @@ class TestCreateAndAssignPlatformView:
         mock_msg.error.assert_called_once()
         assert "required" in mock_msg.error.call_args[0][1].lower()
 
+    def test_non_numeric_manufacturer_is_treated_as_unresolved(self):
+        """A stale or forged manufacturer value must not crash platform creation."""
+        from dcim.models import Device, Platform
+
+        device = make_device("plat-invalid-manufacturer")
+        request = _make_request({"platform_name": "Invalid Manufacturer Platform", "manufacturer": "not-a-pk"})
+        view = self._view(request)
+
+        _post(view, request, pk=device.pk)
+
+        platform = Platform.objects.get(name="Invalid Manufacturer Platform")
+        assert platform.manufacturer_id is None
+        assert Device.objects.get(pk=device.pk).platform_id == platform.pk
+
     @pytest.mark.django_db
     def test_rebinds_to_posted_server_for_redirect_fallback(self):
         """The view rebinds to the POSTed server so the _sync_redirect server_key fallback is live, not a dead None."""

--- a/netbox_librenms_plugin/tests/test_coverage_device_fields.py
+++ b/netbox_librenms_plugin/tests/test_coverage_device_fields.py
@@ -145,12 +145,16 @@ def _cf_changed_before_lock(view, obj, librenms_id):
 
 @contextmanager
 def _deleted_when_platform_saved(device):
-    """Delete *device* for real the moment a Platform is saved.
+    """Issue a real DELETE for *device* the moment a Platform is saved.
 
     ``CreateAndAssignPlatformView`` resolves the device once before its transaction and again
-    under ``select_for_update`` inside it, with the platform insert in between. Hooking the
-    insert lands a real DELETE in that exact window, which is the only way another session's
-    delete can reach the lock branch.
+    under ``select_for_update`` inside it, with the platform insert in between; hooking the
+    insert puts the DELETE in that window so the locked re-read misses the row.
+
+    This is NOT a faithful concurrent delete: the statement runs on the test's own connection
+    inside the view's transaction, so the view's ``set_rollback(True)`` unwinds it along with
+    the platform insert. A real other-session delete would already be committed and would
+    survive. What the test pins is the view's branch, not the other session's durability.
     """
     from dcim.models import Device, Platform
     from django.db.models.signals import post_save
@@ -1207,7 +1211,7 @@ class TestCreateAndAssignPlatformView:
         assert Device.objects.get(pk=dev.pk).platform_id is None
 
     def test_device_does_not_exist_inside_transaction(self):
-        """A concurrent delete between the first lookup and the lock rolls the whole action back."""
+        """The device vanishing between the first lookup and the lock rolls the whole action back."""
         from dcim.models import Device, Platform
 
         dev = make_device("plat-vanishes")
@@ -1220,7 +1224,8 @@ class TestCreateAndAssignPlatformView:
         assert any("no longer exists" in t for t in message_texts(req, "error"))
         # set_rollback(True) unwinds the whole savepoint — the platform insert must not survive.
         assert not Platform.objects.filter(name="ios").exists()
-        assert Device.objects.filter(pk=dev.pk).exists()  # the delete rolled back with it
+        # The DELETE was issued inside that same savepoint, so it is unwound too (see the helper).
+        assert Device.objects.filter(pk=dev.pk).exists()
 
     def test_device_validation_error(self):
         """A platform scoped to another vendor fails the device's real clean(); nothing persists."""
@@ -1271,9 +1276,10 @@ class TestCreateAndAssignPlatformView:
 
         # Land the rival's row after the view's up-front existence check, so the view takes the
         # create path; the hook runs outside the view's savepoint, so the rollback of the failed
-        # insert cannot undo it. Skipping full_clean for that one insert puts the rival's commit
-        # in the only window this branch exists for — between validation and INSERT — and leaves
-        # the DB's unique constraint to raise the IntegrityError for real.
+        # insert cannot undo it. The rival is in place before the view validates, which real
+        # concurrency would not guarantee, so full_clean is skipped for that one insert to model
+        # a rival that committed after validation. The IntegrityError itself is then raised by
+        # the DB's unique constraint, and the re-query that follows is entirely real.
         with (
             _before_restricted_read(view, _rival_commits_first, on_call=1),
             patch.object(Platform, "full_clean", _skip_once(Platform.full_clean)),
@@ -1842,13 +1848,16 @@ class TestRemoveServerMappingViewPost:
     def test_unexpected_error_on_save(self):
         """A non-ValidationError is caught, reported and rolled back rather than 500ing."""
         from dcim.models import Device
+        from django.db import OperationalError
 
         dev = make_device("rm-unexpected", librenms_cf={"orphan": 5})
         req = _make_request({"object_type": "device", "server_key": "orphan"})
 
+        # Injected at the persistence boundary, which is where an unexpected failure of this
+        # kind actually originates; full_clean still runs for real ahead of it.
         with (
             _plugins_config(servers={}, librenms_url=""),
-            patch.object(Device, "full_clean", side_effect=RuntimeError("disk full")),
+            patch.object(Device, "save", side_effect=OperationalError("disk full")),
         ):
             _post(self._view(req), req, pk=dev.pk)
 
@@ -2300,11 +2309,14 @@ class TestConvertLegacyLibreNMSIdViewPost:
     def test_unexpected_error_on_save(self):
         """A non-ValidationError is caught, reported and rolled back rather than 500ing."""
         from dcim.models import Device
+        from django.db import OperationalError
 
         dev = make_device("convert-unexpected", serial="SN-MATCH", librenms_cf=42)
         view, req = self._device_view(dev)
 
-        with patch.object(Device, "full_clean", side_effect=RuntimeError("disk full")):
+        # Injected at the persistence boundary, which is where an unexpected failure of this
+        # kind actually originates; full_clean still runs for real ahead of it.
+        with patch.object(Device, "save", side_effect=OperationalError("disk full")):
             _post(view, req, pk=dev.pk)
 
         assert any("Failed to save converted librenms_id" in t for t in message_texts(req, "error"))

--- a/netbox_librenms_plugin/tests/test_coverage_device_fields.py
+++ b/netbox_librenms_plugin/tests/test_coverage_device_fields.py
@@ -1986,22 +1986,26 @@ class TestConvertLegacyLibreNMSIdViewHelpers:
 
     def test_sync_url_device(self):
         """Invoked outside dispatch (no bound request) the helper emits the bare sync URL."""
+        from django.urls import reverse
+
         view = self._view()
         del view.request
 
         response = view._sync_url("device", 1)
 
         assert "server_key" not in response["Location"]
-        assert response["Location"].endswith("/1/librenms-sync/")
+        assert response["Location"] == reverse("plugins:netbox_librenms_plugin:device_librenms_sync", kwargs={"pk": 1})
 
     def test_sync_url_vm(self):
+        from django.urls import reverse
+
         view = self._view()
         del view.request
 
         response = view._sync_url("vm", 1)
 
         assert "server_key" not in response["Location"]
-        assert response["Location"].endswith("/1/librenms-sync/")
+        assert response["Location"] == reverse("plugins:netbox_librenms_plugin:vm_librenms_sync", kwargs={"pk": 1})
 
     @staticmethod
     def _request(post):

--- a/netbox_librenms_plugin/tests/test_coverage_device_fields.py
+++ b/netbox_librenms_plugin/tests/test_coverage_device_fields.py
@@ -14,6 +14,26 @@ import pytest
 from netbox_librenms_plugin.tests.conftest import make_device
 
 
+def _bind_and_call(view, request, method, **kwargs):
+    """Call *view*.<method>, binding the request the way ``View.setup()`` does under dispatch().
+
+    A direct ``view.post(request, ...)`` leaves ``self.request`` unset, which the object-scoped
+    lookups read — production always goes through dispatch(), so bind it here too.
+    """
+    view.setup(request)
+    return getattr(view, method)(request, **kwargs)
+
+
+def _post(view, request, **kwargs):
+    """POST into *view* with the request bound (see :func:`_bind_and_call`)."""
+    return _bind_and_call(view, request, "post", **kwargs)
+
+
+def _get(view, request, **kwargs):
+    """GET into *view* with the request bound (see :func:`_bind_and_call`)."""
+    return _bind_and_call(view, request, "get", **kwargs)
+
+
 @pytest.mark.parametrize(
     "view_name",
     ["UpdateDeviceNameView", "UpdateDeviceSerialView", "UpdateDeviceTypeView", "UpdateDevicePlatformView"],
@@ -28,7 +48,10 @@ def test_write_views_fetch_device_info_live_not_cached(view_name):
     mock_device = MagicMock()
     mock_device.virtual_chassis = None
     with (
-        patch("netbox_librenms_plugin.views.sync.device_fields.get_object_or_404", return_value=mock_device),
+        patch(
+            "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+            return_value=mock_device,
+        ),
         patch("netbox_librenms_plugin.views.sync.device_fields.messages"),
         patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
     ):
@@ -74,7 +97,9 @@ class TestUpdateDeviceNameView:
         error_response = MagicMock()
         view.require_all_permissions = MagicMock(return_value=error_response)
 
-        with patch("netbox_librenms_plugin.views.sync.device_fields.get_object_or_404") as mock_get:
+        with patch(
+            "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404"
+        ) as mock_get:
             result = view.post(_make_request(), pk=1)
 
         assert result is error_response
@@ -93,7 +118,7 @@ class TestUpdateDeviceNameView:
             # → redirect_with_server_key), so patch that rather than the bare redirect.
             patch("netbox_librenms_plugin.views.sync.device_fields.redirect_with_server_key") as mock_redir,
         ):
-            view.post(_make_request(), pk=dev.pk)
+            _post(view, _make_request(), pk=dev.pk)
 
         mock_msg.error.assert_called_once()
         mock_redir.assert_called_once()
@@ -111,7 +136,7 @@ class TestUpdateDeviceNameView:
             patch("netbox_librenms_plugin.views.sync.device_fields.messages") as mock_msg,
             patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
         ):
-            view.post(_make_request(), pk=dev.pk)
+            _post(view, _make_request(), pk=dev.pk)
 
         mock_msg.error.assert_called_once()
         assert Device.objects.get(pk=dev.pk).name == "name-infofail"
@@ -127,7 +152,7 @@ class TestUpdateDeviceNameView:
             patch("netbox_librenms_plugin.views.sync.device_fields.messages") as mock_msg,
             patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
         ):
-            view.post(_make_request(), pk=dev.pk)
+            _post(view, _make_request(), pk=dev.pk)
 
         # empty dict is falsy → triggers "Failed to retrieve device info" error
         mock_msg.error.assert_called_once()
@@ -145,7 +170,7 @@ class TestUpdateDeviceNameView:
             patch("netbox_librenms_plugin.views.sync.device_fields.messages") as mock_msg,
             patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
         ):
-            view.post(_make_request(), pk=dev.pk)
+            _post(view, _make_request(), pk=dev.pk)
 
         mock_msg.warning.assert_called_once()
 
@@ -165,7 +190,7 @@ class TestUpdateDeviceNameView:
             patch("netbox_librenms_plugin.views.sync.device_fields.messages") as mock_msg,
             patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
         ):
-            view.post(_make_request(), pk=dev.pk)
+            _post(view, _make_request(), pk=dev.pk)
 
         # Real full_clean + save committed the rename — reload from the DB.
         assert Device.objects.get(pk=dev.pk).name == "router1-renamed"
@@ -189,7 +214,7 @@ class TestUpdateDeviceNameView:
             patch("netbox_librenms_plugin.views.sync.device_fields.messages") as mock_msg,
             patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
         ):
-            view.post(_make_request(), pk=dev.pk)
+            _post(view, _make_request(), pk=dev.pk)
 
         mock_msg.error.assert_called_once()
         assert Device.objects.get(pk=dev.pk).name == "orig-name"  # unchanged
@@ -205,7 +230,10 @@ class TestUpdateDeviceNameView:
         dev.save = MagicMock(side_effect=IntegrityError("duplicate key"))  # inject the save failure
 
         with (
-            patch("netbox_librenms_plugin.views.sync.device_fields.get_object_or_404", return_value=dev),
+            patch(
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+                return_value=dev,
+            ),
             patch(
                 "netbox_librenms_plugin.views.sync.device_fields.resolve_naming_preferences",
                 return_value=(True, False),
@@ -236,7 +264,9 @@ class TestUpdateDeviceSerialView:
         err = MagicMock()
         view.require_all_permissions = MagicMock(return_value=err)
 
-        with patch("netbox_librenms_plugin.views.sync.device_fields.get_object_or_404") as mock_get:
+        with patch(
+            "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404"
+        ) as mock_get:
             result = view.post(_make_request(), pk=1)
         assert result is err
         mock_get.assert_not_called()
@@ -246,7 +276,10 @@ class TestUpdateDeviceSerialView:
         view._librenms_api.get_librenms_id.return_value = None
 
         with (
-            patch("netbox_librenms_plugin.views.sync.device_fields.get_object_or_404", return_value=MagicMock()),
+            patch(
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+                return_value=MagicMock(),
+            ),
             patch("netbox_librenms_plugin.views.sync.device_fields.messages") as mock_msg,
             patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
         ):
@@ -259,11 +292,14 @@ class TestUpdateDeviceSerialView:
         view._librenms_api.get_device_info.return_value = (False, None)
 
         with (
-            patch("netbox_librenms_plugin.views.sync.device_fields.get_object_or_404", return_value=MagicMock()),
+            patch(
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+                return_value=MagicMock(),
+            ),
             patch("netbox_librenms_plugin.views.sync.device_fields.messages") as mock_msg,
             patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
         ):
-            view.post(_make_request(), pk=1)
+            _post(view, _make_request(), pk=1)
         mock_msg.error.assert_called_once()
 
     def test_serial_is_none(self):
@@ -272,7 +308,10 @@ class TestUpdateDeviceSerialView:
         view._librenms_api.get_device_info.return_value = (True, {"serial": None})
 
         with (
-            patch("netbox_librenms_plugin.views.sync.device_fields.get_object_or_404", return_value=MagicMock()),
+            patch(
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+                return_value=MagicMock(),
+            ),
             patch("netbox_librenms_plugin.views.sync.device_fields.messages") as mock_msg,
             patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
         ):
@@ -285,7 +324,10 @@ class TestUpdateDeviceSerialView:
         view._librenms_api.get_device_info.return_value = (True, {"serial": "-"})
 
         with (
-            patch("netbox_librenms_plugin.views.sync.device_fields.get_object_or_404", return_value=MagicMock()),
+            patch(
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+                return_value=MagicMock(),
+            ),
             patch("netbox_librenms_plugin.views.sync.device_fields.messages") as mock_msg,
             patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
         ):
@@ -304,7 +346,7 @@ class TestUpdateDeviceSerialView:
             patch("netbox_librenms_plugin.views.sync.device_fields.messages") as mock_msg,
             patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
         ):
-            view.post(_make_request(), pk=dev.pk)
+            _post(view, _make_request(), pk=dev.pk)
         mock_msg.success.assert_called_once()
         assert "OLDSERIAL" in mock_msg.success.call_args[0][1]
         assert Device.objects.get(pk=dev.pk).serial == "SN001"  # real save committed
@@ -321,7 +363,7 @@ class TestUpdateDeviceSerialView:
             patch("netbox_librenms_plugin.views.sync.device_fields.messages") as mock_msg,
             patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
         ):
-            view.post(_make_request(), pk=dev.pk)
+            _post(view, _make_request(), pk=dev.pk)
         mock_msg.success.assert_called_once()
         assert "set to" in mock_msg.success.call_args[0][1]
         assert Device.objects.get(pk=dev.pk).serial == "SN001"
@@ -339,7 +381,7 @@ class TestUpdateDeviceSerialView:
             patch("netbox_librenms_plugin.views.sync.device_fields.messages"),
             patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
         ):
-            view.post(_make_request(), pk=dev.pk)
+            _post(view, _make_request(), pk=dev.pk)
 
         assert Device.objects.get(pk=dev.pk).serial == "SN-SYNC-1"
 
@@ -356,7 +398,7 @@ class TestUpdateDeviceSerialView:
             patch("netbox_librenms_plugin.views.sync.device_fields.messages"),
             patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
         ):
-            view.post(_make_request(), pk=dev.pk)
+            _post(view, _make_request(), pk=dev.pk)
 
         assert Device.objects.get(pk=dev.pk).serial == "0"
 
@@ -371,7 +413,10 @@ class TestUpdateDeviceSerialView:
         dev = make_device("serial-valerr", serial="OLD")
         dev.full_clean = MagicMock(side_effect=ValidationError({"serial": ["err"]}))
         with (
-            patch("netbox_librenms_plugin.views.sync.device_fields.get_object_or_404", return_value=dev),
+            patch(
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+                return_value=dev,
+            ),
             patch("netbox_librenms_plugin.views.sync.device_fields.messages") as mock_msg,
             patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
         ):
@@ -394,7 +439,10 @@ class TestUpdateDeviceSerialView:
         # handling pass unnoticed. This test must cover the save IntegrityError path.
         dev.save = MagicMock(side_effect=IntegrityError("dup"))
         with (
-            patch("netbox_librenms_plugin.views.sync.device_fields.get_object_or_404", return_value=dev),
+            patch(
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+                return_value=dev,
+            ),
             patch("netbox_librenms_plugin.views.sync.device_fields.messages") as mock_msg,
             patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
         ):
@@ -425,7 +473,9 @@ class TestUpdateDeviceTypeView:
         view = self._view()
         err = MagicMock()
         view.require_all_permissions = MagicMock(return_value=err)
-        with patch("netbox_librenms_plugin.views.sync.device_fields.get_object_or_404") as mock_get:
+        with patch(
+            "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404"
+        ) as mock_get:
             result = view.post(_make_request(), pk=1)
         assert result is err
         mock_get.assert_not_called()
@@ -434,7 +484,10 @@ class TestUpdateDeviceTypeView:
         view = self._view()
         view._librenms_api.get_librenms_id.return_value = None
         with (
-            patch("netbox_librenms_plugin.views.sync.device_fields.get_object_or_404", return_value=MagicMock()),
+            patch(
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+                return_value=MagicMock(),
+            ),
             patch("netbox_librenms_plugin.views.sync.device_fields.messages") as mock_msg,
             patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
         ):
@@ -446,11 +499,14 @@ class TestUpdateDeviceTypeView:
         view._librenms_api.get_librenms_id.return_value = 7
         view._librenms_api.get_device_info.return_value = (False, None)
         with (
-            patch("netbox_librenms_plugin.views.sync.device_fields.get_object_or_404", return_value=MagicMock()),
+            patch(
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+                return_value=MagicMock(),
+            ),
             patch("netbox_librenms_plugin.views.sync.device_fields.messages") as mock_msg,
             patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
         ):
-            view.post(_make_request(), pk=1)
+            _post(view, _make_request(), pk=1)
         mock_msg.error.assert_called_once()
 
     def test_no_hardware(self):
@@ -458,7 +514,10 @@ class TestUpdateDeviceTypeView:
         view._librenms_api.get_librenms_id.return_value = 7
         view._librenms_api.get_device_info.return_value = (True, {"hardware": None})
         with (
-            patch("netbox_librenms_plugin.views.sync.device_fields.get_object_or_404", return_value=MagicMock()),
+            patch(
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+                return_value=MagicMock(),
+            ),
             patch("netbox_librenms_plugin.views.sync.device_fields.messages") as mock_msg,
             patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
         ):
@@ -470,7 +529,10 @@ class TestUpdateDeviceTypeView:
         view._librenms_api.get_librenms_id.return_value = 7
         view._librenms_api.get_device_info.return_value = (True, {"hardware": "Cisco 3750"})
         with (
-            patch("netbox_librenms_plugin.views.sync.device_fields.get_object_or_404", return_value=MagicMock()),
+            patch(
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+                return_value=MagicMock(),
+            ),
             patch(
                 "netbox_librenms_plugin.views.sync.device_fields.match_librenms_hardware_to_device_type",
                 return_value={"matched": False},
@@ -488,7 +550,10 @@ class TestUpdateDeviceTypeView:
         view._librenms_api.get_device_info.return_value = (True, {"hardware": "Cisco 3750"})
         mock_device = MagicMock()
         with (
-            patch("netbox_librenms_plugin.views.sync.device_fields.get_object_or_404", return_value=mock_device),
+            patch(
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+                return_value=mock_device,
+            ),
             patch(
                 "netbox_librenms_plugin.views.sync.device_fields.match_librenms_hardware_to_device_type",
                 return_value=None,
@@ -518,7 +583,7 @@ class TestUpdateDeviceTypeView:
             patch("netbox_librenms_plugin.views.sync.device_fields.messages") as mock_msg,
             patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
         ):
-            view.post(_make_request(), pk=dev.pk)
+            _post(view, _make_request(), pk=dev.pk)
         mock_msg.success.assert_called_once()
         assert Device.objects.get(pk=dev.pk).device_type_id == new_dt.pk  # real save committed
 
@@ -535,7 +600,10 @@ class TestUpdateDeviceTypeView:
         new_dt = self._new_device_type()
         dev.full_clean = MagicMock(side_effect=ValidationError({"device_type": ["err"]}))
         with (
-            patch("netbox_librenms_plugin.views.sync.device_fields.get_object_or_404", return_value=dev),
+            patch(
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+                return_value=dev,
+            ),
             patch(
                 "netbox_librenms_plugin.views.sync.device_fields.match_librenms_hardware_to_device_type",
                 return_value={"matched": True, "device_type": new_dt},
@@ -560,7 +628,10 @@ class TestUpdateDeviceTypeView:
         # handling pass unnoticed. This test must cover the save IntegrityError path.
         dev.save = MagicMock(side_effect=IntegrityError("dup"))
         with (
-            patch("netbox_librenms_plugin.views.sync.device_fields.get_object_or_404", return_value=dev),
+            patch(
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+                return_value=dev,
+            ),
             patch(
                 "netbox_librenms_plugin.views.sync.device_fields.match_librenms_hardware_to_device_type",
                 return_value={"matched": True, "device_type": new_dt},
@@ -594,7 +665,7 @@ class TestUpdateDevicePlatformView:
         view = self._view()
         err = MagicMock()
         view.require_all_permissions = MagicMock(return_value=err)
-        with patch("netbox_librenms_plugin.views.sync.device_fields.get_object_or_404"):
+        with patch("netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404"):
             result = view.post(_make_request(), pk=1)
         assert result is err
 
@@ -602,7 +673,10 @@ class TestUpdateDevicePlatformView:
         view = self._view()
         view._librenms_api.get_librenms_id.return_value = None
         with (
-            patch("netbox_librenms_plugin.views.sync.device_fields.get_object_or_404", return_value=MagicMock()),
+            patch(
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+                return_value=MagicMock(),
+            ),
             patch("netbox_librenms_plugin.views.sync.device_fields.messages") as mock_msg,
             patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
         ):
@@ -614,11 +688,14 @@ class TestUpdateDevicePlatformView:
         view._librenms_api.get_librenms_id.return_value = 3
         view._librenms_api.get_device_info.return_value = (False, None)
         with (
-            patch("netbox_librenms_plugin.views.sync.device_fields.get_object_or_404", return_value=MagicMock()),
+            patch(
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+                return_value=MagicMock(),
+            ),
             patch("netbox_librenms_plugin.views.sync.device_fields.messages") as mock_msg,
             patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
         ):
-            view.post(_make_request(), pk=1)
+            _post(view, _make_request(), pk=1)
         mock_msg.error.assert_called_once()
 
     def test_no_os(self):
@@ -626,7 +703,10 @@ class TestUpdateDevicePlatformView:
         view._librenms_api.get_librenms_id.return_value = 3
         view._librenms_api.get_device_info.return_value = (True, {"os": None})
         with (
-            patch("netbox_librenms_plugin.views.sync.device_fields.get_object_or_404", return_value=MagicMock()),
+            patch(
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+                return_value=MagicMock(),
+            ),
             patch("netbox_librenms_plugin.views.sync.device_fields.messages") as mock_msg,
             patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
         ):
@@ -640,7 +720,10 @@ class TestUpdateDevicePlatformView:
         view._librenms_api.get_device_info.return_value = (True, {"os": "ios"})
 
         with (
-            patch("netbox_librenms_plugin.views.sync.device_fields.get_object_or_404", return_value=MagicMock()),
+            patch(
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+                return_value=MagicMock(),
+            ),
             patch(
                 "netbox_librenms_plugin.views.sync.device_fields.find_matching_platform",
                 return_value={"found": False, "platform": None, "match_type": None},
@@ -663,7 +746,10 @@ class TestUpdateDevicePlatformView:
         dev.save()
 
         with (
-            patch("netbox_librenms_plugin.views.sync.device_fields.get_object_or_404", return_value=dev),
+            patch(
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+                return_value=dev,
+            ),
             patch(
                 "netbox_librenms_plugin.views.sync.device_fields.find_matching_platform",
                 return_value={"found": True, "platform": new_platform, "match_type": "exact"},
@@ -686,7 +772,10 @@ class TestUpdateDevicePlatformView:
         dev = make_device("plat-noold")  # no platform set
 
         with (
-            patch("netbox_librenms_plugin.views.sync.device_fields.get_object_or_404", return_value=dev),
+            patch(
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+                return_value=dev,
+            ),
             patch(
                 "netbox_librenms_plugin.views.sync.device_fields.find_matching_platform",
                 return_value={"found": True, "platform": new_platform, "match_type": "exact"},
@@ -710,7 +799,10 @@ class TestUpdateDevicePlatformView:
         dev = make_device("plat-mapping")
 
         with (
-            patch("netbox_librenms_plugin.views.sync.device_fields.get_object_or_404", return_value=dev),
+            patch(
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+                return_value=dev,
+            ),
             patch(
                 "netbox_librenms_plugin.views.sync.device_fields.find_matching_platform",
                 return_value={"found": True, "platform": new_platform, "match_type": "mapping"},
@@ -728,7 +820,10 @@ class TestUpdateDevicePlatformView:
         view._librenms_api.get_device_info.return_value = (True, {"os": "ios"})
 
         with (
-            patch("netbox_librenms_plugin.views.sync.device_fields.get_object_or_404", return_value=MagicMock()),
+            patch(
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+                return_value=MagicMock(),
+            ),
             patch(
                 "netbox_librenms_plugin.views.sync.device_fields.find_matching_platform",
                 return_value={"found": False, "platform": None, "match_type": "ambiguous"},
@@ -754,7 +849,10 @@ class TestUpdateDevicePlatformView:
         dev.full_clean = MagicMock(side_effect=ValidationError({"platform": ["err"]}))
 
         with (
-            patch("netbox_librenms_plugin.views.sync.device_fields.get_object_or_404", return_value=dev),
+            patch(
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+                return_value=dev,
+            ),
             patch(
                 "netbox_librenms_plugin.views.sync.device_fields.find_matching_platform",
                 return_value={"found": True, "platform": new_platform, "match_type": "exact"},
@@ -783,7 +881,7 @@ class TestCreateAndAssignPlatformView:
         view = self._view()
         err = MagicMock()
         view.require_all_permissions = MagicMock(return_value=err)
-        with patch("netbox_librenms_plugin.views.sync.device_fields.get_object_or_404"):
+        with patch("netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404"):
             result = view.post(_make_request(), pk=1)
         assert result is err
 
@@ -792,7 +890,10 @@ class TestCreateAndAssignPlatformView:
         req = _make_request({"platform_name": ""})
 
         with (
-            patch("netbox_librenms_plugin.views.sync.device_fields.get_object_or_404", return_value=MagicMock()),
+            patch(
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+                return_value=MagicMock(),
+            ),
             patch("netbox_librenms_plugin.views.sync.device_fields.messages") as mock_msg,
             patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
         ):
@@ -816,7 +917,10 @@ class TestCreateAndAssignPlatformView:
         }
         with (
             override_settings(PLUGINS_CONFIG={"netbox_librenms_plugin": {"servers": servers}}),
-            patch("netbox_librenms_plugin.views.sync.device_fields.get_object_or_404", return_value=dev),
+            patch(
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+                return_value=dev,
+            ),
             patch("netbox_librenms_plugin.views.sync.device_fields.messages"),
             patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
         ):
@@ -837,7 +941,10 @@ class TestCreateAndAssignPlatformView:
         req = _make_request({"platform_name": "ios", "manufacturer": "", "create_mapping": ""})
 
         with (
-            patch("netbox_librenms_plugin.views.sync.device_fields.get_object_or_404", return_value=dev),
+            patch(
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+                return_value=dev,
+            ),
             patch("netbox_librenms_plugin.views.sync.device_fields.messages") as mock_msg,
             patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
         ):
@@ -863,7 +970,10 @@ class TestCreateAndAssignPlatformView:
         req.user.has_perm = MagicMock(return_value=True)
 
         with (
-            patch("netbox_librenms_plugin.views.sync.device_fields.get_object_or_404", return_value=dev),
+            patch(
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+                return_value=dev,
+            ),
             patch("netbox_librenms_plugin.views.sync.device_fields.messages") as mock_msg,
             patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
         ):
@@ -895,7 +1005,10 @@ class TestCreateAndAssignPlatformView:
         mock_mapping_cls.objects.filter.return_value.first.return_value = other_mapping
 
         with (
-            patch("netbox_librenms_plugin.views.sync.device_fields.get_object_or_404", return_value=MagicMock()),
+            patch(
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+                return_value=MagicMock(),
+            ),
             patch("netbox_librenms_plugin.views.sync.device_fields.Platform", mock_platform_cls),
             patch("netbox_librenms_plugin.views.sync.device_fields.Device", mock_device_cls),
             patch("netbox_librenms_plugin.views.sync.device_fields.PlatformMapping", mock_mapping_cls),
@@ -934,7 +1047,10 @@ class TestCreateAndAssignPlatformView:
         mock_device_cls.objects.select_for_update.return_value.get.return_value = mock_locked
 
         with (
-            patch("netbox_librenms_plugin.views.sync.device_fields.get_object_or_404", return_value=MagicMock()),
+            patch(
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+                return_value=MagicMock(),
+            ),
             patch("netbox_librenms_plugin.views.sync.device_fields.Platform", mock_platform_cls),
             patch("netbox_librenms_plugin.views.sync.device_fields.Manufacturer", mock_manuf_cls),
             patch("netbox_librenms_plugin.views.sync.device_fields.Device", mock_device_cls),
@@ -957,7 +1073,10 @@ class TestCreateAndAssignPlatformView:
         req = _make_request({"platform_name": "ios-new", "manufacturer": ""})
 
         with (
-            patch("netbox_librenms_plugin.views.sync.device_fields.get_object_or_404", return_value=dev),
+            patch(
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+                return_value=dev,
+            ),
             patch("netbox_librenms_plugin.views.sync.device_fields.messages") as mock_msg,
             patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
         ):
@@ -979,7 +1098,10 @@ class TestCreateAndAssignPlatformView:
         req = _make_request({"platform_name": platform_name, "manufacturer": ""})
 
         with (
-            patch("netbox_librenms_plugin.views.sync.device_fields.get_object_or_404", return_value=dev),
+            patch(
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+                return_value=dev,
+            ),
             patch("netbox_librenms_plugin.views.sync.device_fields.messages"),
             patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
         ):
@@ -1003,7 +1125,10 @@ class TestCreateAndAssignPlatformView:
         mock_txn.set_rollback = MagicMock()
 
         with (
-            patch("netbox_librenms_plugin.views.sync.device_fields.get_object_or_404", return_value=MagicMock()),
+            patch(
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+                return_value=MagicMock(),
+            ),
             patch("netbox_librenms_plugin.views.sync.device_fields.Platform", mock_platform_cls),
             patch("netbox_librenms_plugin.views.sync.device_fields.transaction", mock_txn),
             patch("netbox_librenms_plugin.views.sync.device_fields.messages") as mock_msg,
@@ -1031,7 +1156,10 @@ class TestCreateAndAssignPlatformView:
         mock_txn.set_rollback = MagicMock()
 
         with (
-            patch("netbox_librenms_plugin.views.sync.device_fields.get_object_or_404", return_value=MagicMock()),
+            patch(
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+                return_value=MagicMock(),
+            ),
             patch("netbox_librenms_plugin.views.sync.device_fields.Platform", mock_platform_cls),
             patch("netbox_librenms_plugin.views.sync.device_fields.Device", mock_device_cls),
             patch("netbox_librenms_plugin.views.sync.device_fields.transaction", mock_txn),
@@ -1065,7 +1193,10 @@ class TestCreateAndAssignPlatformView:
         mock_txn.set_rollback = MagicMock()
 
         with (
-            patch("netbox_librenms_plugin.views.sync.device_fields.get_object_or_404", return_value=MagicMock()),
+            patch(
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+                return_value=MagicMock(),
+            ),
             patch("netbox_librenms_plugin.views.sync.device_fields.Platform", mock_platform_cls),
             patch("netbox_librenms_plugin.views.sync.device_fields.Device", mock_device_cls),
             patch("netbox_librenms_plugin.views.sync.device_fields.transaction", mock_txn),
@@ -1098,7 +1229,10 @@ class TestCreateAndAssignPlatformView:
         mock_txn.set_rollback = MagicMock()
 
         with (
-            patch("netbox_librenms_plugin.views.sync.device_fields.get_object_or_404", return_value=MagicMock()),
+            patch(
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+                return_value=MagicMock(),
+            ),
             patch("netbox_librenms_plugin.views.sync.device_fields.Platform", mock_platform_cls),
             patch("netbox_librenms_plugin.views.sync.device_fields.transaction", mock_txn),
             patch("netbox_librenms_plugin.views.sync.device_fields.messages") as mock_msg,
@@ -1138,7 +1272,10 @@ class TestCreateAndAssignPlatformView:
         mock_txn.set_rollback = MagicMock()
 
         with (
-            patch("netbox_librenms_plugin.views.sync.device_fields.get_object_or_404", return_value=MagicMock()),
+            patch(
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+                return_value=MagicMock(),
+            ),
             patch("netbox_librenms_plugin.views.sync.device_fields.Platform", mock_platform_cls),
             patch("netbox_librenms_plugin.views.sync.device_fields.Device", mock_device_cls),
             patch("netbox_librenms_plugin.views.sync.device_fields.transaction", mock_txn),
@@ -1192,7 +1329,10 @@ class TestCreateAndAssignPlatformView:
         mock_mapping_cls.objects.filter.return_value.first.return_value = None
 
         with (
-            patch("netbox_librenms_plugin.views.sync.device_fields.get_object_or_404", return_value=MagicMock()),
+            patch(
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+                return_value=MagicMock(),
+            ),
             patch("netbox_librenms_plugin.views.sync.device_fields.Platform", mock_platform_cls),
             patch("netbox_librenms_plugin.views.sync.device_fields.Device", mock_device_cls),
             patch("netbox_librenms_plugin.views.sync.device_fields.transaction"),
@@ -1216,7 +1356,10 @@ class TestCreateAndAssignPlatformView:
         mock_mapping_cls = MagicMock()
 
         with (
-            patch("netbox_librenms_plugin.views.sync.device_fields.get_object_or_404", return_value=MagicMock()),
+            patch(
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+                return_value=MagicMock(),
+            ),
             patch("netbox_librenms_plugin.views.sync.device_fields.Platform", mock_platform_cls),
             patch("netbox_librenms_plugin.views.sync.device_fields.Device", mock_device_cls),
             patch("netbox_librenms_plugin.views.sync.device_fields.transaction"),
@@ -1237,7 +1380,10 @@ class TestCreateAndAssignPlatformView:
         mock_mapping_cls.objects.filter.return_value.first.return_value = MagicMock()  # existing mapping
 
         with (
-            patch("netbox_librenms_plugin.views.sync.device_fields.get_object_or_404", return_value=MagicMock()),
+            patch(
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+                return_value=MagicMock(),
+            ),
             patch("netbox_librenms_plugin.views.sync.device_fields.Platform", mock_platform_cls),
             patch("netbox_librenms_plugin.views.sync.device_fields.Device", mock_device_cls),
             patch("netbox_librenms_plugin.views.sync.device_fields.transaction"),
@@ -1265,7 +1411,10 @@ class TestCreateAndAssignPlatformView:
         mock_mapping_cls.objects.filter.return_value.first.return_value = None  # deleted since preflight
 
         with (
-            patch("netbox_librenms_plugin.views.sync.device_fields.get_object_or_404", return_value=MagicMock()),
+            patch(
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+                return_value=MagicMock(),
+            ),
             patch("netbox_librenms_plugin.views.sync.device_fields.Platform", mock_platform_cls),
             patch("netbox_librenms_plugin.views.sync.device_fields.Device", mock_device_cls),
             patch("netbox_librenms_plugin.views.sync.device_fields.transaction"),
@@ -1309,7 +1458,10 @@ class TestCreateAndAssignPlatformView:
         view.require_all_permissions = fake_require
 
         with (
-            patch("netbox_librenms_plugin.views.sync.device_fields.get_object_or_404", return_value=MagicMock()),
+            patch(
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+                return_value=MagicMock(),
+            ),
             patch("netbox_librenms_plugin.views.sync.device_fields.Platform", mock_platform_cls),
             patch("netbox_librenms_plugin.views.sync.device_fields.Device", mock_device_cls),
             patch("netbox_librenms_plugin.views.sync.device_fields.PlatformMapping", RealPlatformMapping),
@@ -1340,7 +1492,10 @@ class TestCreateAndAssignPlatformView:
         view.require_all_permissions = fake_require
 
         with (
-            patch("netbox_librenms_plugin.views.sync.device_fields.get_object_or_404", return_value=MagicMock()),
+            patch(
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+                return_value=MagicMock(),
+            ),
             patch("netbox_librenms_plugin.views.sync.device_fields.Platform", mock_platform_cls),
             patch("netbox_librenms_plugin.views.sync.device_fields.Device", mock_device_cls),
             patch("netbox_librenms_plugin.views.sync.device_fields.PlatformMapping", RealPlatformMapping),
@@ -1368,7 +1523,10 @@ class TestCreateAndAssignPlatformView:
         view.require_all_permissions = fake_require
 
         with (
-            patch("netbox_librenms_plugin.views.sync.device_fields.get_object_or_404", return_value=MagicMock()),
+            patch(
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+                return_value=MagicMock(),
+            ),
             patch("netbox_librenms_plugin.views.sync.device_fields.Platform", mock_platform_cls),
             patch("netbox_librenms_plugin.views.sync.device_fields.Device", mock_device_cls),
             patch("netbox_librenms_plugin.views.sync.device_fields.PlatformMapping", RealPlatformMapping),
@@ -1412,7 +1570,7 @@ class TestAssignVCSerialView:
             patch("netbox_librenms_plugin.views.sync.device_fields.messages") as mock_msg,
             patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
         ):
-            view.post(req, pk=host.pk)
+            _post(view, req, pk=host.pk)
         mock_msg.success.assert_called_once()
         assert Device.objects.get(pk=member.pk).serial == "SN100"  # real save committed
 
@@ -1437,7 +1595,7 @@ class TestAssignVCSerialView:
             patch("netbox_librenms_plugin.views.sync.device_fields.messages"),
             patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
         ):
-            view.post(req, pk=host.pk)
+            _post(view, req, pk=host.pk)
 
         assert Device.objects.get(pk=member.pk).serial == "SN-VC-1"
 
@@ -1445,7 +1603,7 @@ class TestAssignVCSerialView:
         view = self._view()
         err = MagicMock()
         view.require_all_permissions = MagicMock(return_value=err)
-        with patch("netbox_librenms_plugin.views.sync.device_fields.get_object_or_404"):
+        with patch("netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404"):
             result = view.post(_make_request(), pk=1)
         assert result is err
 
@@ -1454,7 +1612,10 @@ class TestAssignVCSerialView:
         mock_device = MagicMock()
         mock_device.virtual_chassis = None
         with (
-            patch("netbox_librenms_plugin.views.sync.device_fields.get_object_or_404", return_value=mock_device),
+            patch(
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+                return_value=mock_device,
+            ),
             patch("netbox_librenms_plugin.views.sync.device_fields.messages") as mock_msg,
             patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
         ):
@@ -1467,7 +1628,10 @@ class TestAssignVCSerialView:
         mock_device = MagicMock()
         mock_device.virtual_chassis = MagicMock()
         with (
-            patch("netbox_librenms_plugin.views.sync.device_fields.get_object_or_404", return_value=mock_device),
+            patch(
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+                return_value=mock_device,
+            ),
             patch("netbox_librenms_plugin.views.sync.device_fields.messages") as mock_msg,
             patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
         ):
@@ -1482,7 +1646,10 @@ class TestAssignVCSerialView:
         # serial_1 exists but member_id_1 is empty
         req = _make_request({"serial_1": "SN100", "member_id_1": ""})
         with (
-            patch("netbox_librenms_plugin.views.sync.device_fields.get_object_or_404", return_value=mock_device),
+            patch(
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+                return_value=mock_device,
+            ),
             patch("netbox_librenms_plugin.views.sync.device_fields.messages") as mock_msg,
             patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
         ):
@@ -1501,7 +1668,10 @@ class TestAssignVCSerialView:
 
         req = _make_request({"serial_1": "SN100", "member_id_1": "99"})
         with (
-            patch("netbox_librenms_plugin.views.sync.device_fields.get_object_or_404", return_value=mock_device),
+            patch(
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+                return_value=mock_device,
+            ),
             patch("netbox_librenms_plugin.views.sync.device_fields.Device", mock_device_cls),
             patch("netbox_librenms_plugin.views.sync.device_fields.messages") as mock_msg,
             patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
@@ -1527,7 +1697,10 @@ class TestAssignVCSerialView:
 
         req = _make_request({"serial_1": "SN100", "member_id_1": "5"})
         with (
-            patch("netbox_librenms_plugin.views.sync.device_fields.get_object_or_404", return_value=mock_device),
+            patch(
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+                return_value=mock_device,
+            ),
             patch("netbox_librenms_plugin.views.sync.device_fields.Device", mock_device_cls),
             patch("netbox_librenms_plugin.views.sync.device_fields.messages") as mock_msg,
             patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
@@ -1556,7 +1729,10 @@ class TestAssignVCSerialView:
 
         req = _make_request({"serial_1": "SN100", "member_id_1": "5"})
         with (
-            patch("netbox_librenms_plugin.views.sync.device_fields.get_object_or_404", return_value=mock_device),
+            patch(
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+                return_value=mock_device,
+            ),
             patch("netbox_librenms_plugin.views.sync.device_fields.Device", mock_device_cls),
             patch("netbox_librenms_plugin.views.sync.device_fields.messages") as mock_msg,
             patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
@@ -1598,7 +1774,10 @@ class TestAssignVCSerialView:
             }
         )
         with (
-            patch("netbox_librenms_plugin.views.sync.device_fields.get_object_or_404", return_value=mock_device),
+            patch(
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+                return_value=mock_device,
+            ),
             patch("netbox_librenms_plugin.views.sync.device_fields.Device", mock_device_cls),
             patch("netbox_librenms_plugin.views.sync.device_fields.messages") as mock_msg,
             patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
@@ -1627,14 +1806,20 @@ class TestRemoveServerMappingViewHelpers:
         view = self._view()
         mock_device = MagicMock()
 
-        with patch("netbox_librenms_plugin.views.sync.device_fields.get_object_or_404", return_value=mock_device):
+        with patch(
+            "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+            return_value=mock_device,
+        ):
             obj, model = view._get_object("device", 1)
         assert obj is mock_device
 
     def test_get_object_vm(self):
         view = self._view()
         mock_vm = MagicMock()
-        with patch("netbox_librenms_plugin.views.sync.device_fields.get_object_or_404", return_value=mock_vm):
+        with patch(
+            "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+            return_value=mock_vm,
+        ):
             obj, model = view._get_object("vm", 1)
         assert obj is mock_vm
 
@@ -1711,7 +1896,10 @@ class TestRemoveServerMappingViewPost:
         mock_cfg = {"netbox_librenms_plugin": {"servers": {}, "librenms_url": ""}}
 
         with (
-            patch("netbox_librenms_plugin.views.sync.device_fields.get_object_or_404", return_value=mock_obj),
+            patch(
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+                return_value=mock_obj,
+            ),
             patch("netbox_librenms_plugin.views.sync.device_fields.VirtualMachine", mock_vm_cls),
             patch("netbox_librenms_plugin.views.sync.device_fields.transaction"),
             patch("netbox_librenms_plugin.views.sync.device_fields.messages") as mock_msg,
@@ -1735,7 +1923,10 @@ class TestRemoveServerMappingViewPost:
         req = _make_request({"object_type": "device", "server_key": ""})
 
         with (
-            patch("netbox_librenms_plugin.views.sync.device_fields.get_object_or_404", return_value=MagicMock()),
+            patch(
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+                return_value=MagicMock(),
+            ),
             patch("netbox_librenms_plugin.views.sync.device_fields.messages") as mock_msg,
             patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
         ):
@@ -1751,7 +1942,10 @@ class TestRemoveServerMappingViewPost:
         req = _make_request({"object_type": "device", "server_key": "default"})
 
         with (
-            patch("netbox_librenms_plugin.views.sync.device_fields.get_object_or_404", return_value=mock_obj),
+            patch(
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+                return_value=mock_obj,
+            ),
             patch("netbox_librenms_plugin.views.sync.device_fields.messages") as mock_msg,
             patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
         ):
@@ -1767,7 +1961,10 @@ class TestRemoveServerMappingViewPost:
         req = _make_request({"object_type": "device", "server_key": "default"})
 
         with (
-            patch("netbox_librenms_plugin.views.sync.device_fields.get_object_or_404", return_value=mock_obj),
+            patch(
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+                return_value=mock_obj,
+            ),
             patch("netbox_librenms_plugin.views.sync.device_fields.messages") as mock_msg,
             patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
         ):
@@ -1794,7 +1991,10 @@ class TestRemoveServerMappingViewPost:
         # servers is a list (non-dict) → line 496 normalises it to {}
         mock_cfg = {"netbox_librenms_plugin": {"servers": ["not", "a", "dict"], "librenms_url": ""}}
         with (
-            patch("netbox_librenms_plugin.views.sync.device_fields.get_object_or_404", return_value=mock_obj),
+            patch(
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+                return_value=mock_obj,
+            ),
             patch("netbox_librenms_plugin.views.sync.device_fields.Device", mock_device_cls),
             patch("netbox_librenms_plugin.views.sync.device_fields.transaction"),
             patch("netbox_librenms_plugin.views.sync.device_fields.messages") as mock_msg,
@@ -1815,7 +2015,10 @@ class TestRemoveServerMappingViewPost:
 
         mock_cfg = {"netbox_librenms_plugin": {"servers": {"production": {}}, "librenms_url": ""}}
         with (
-            patch("netbox_librenms_plugin.views.sync.device_fields.get_object_or_404", return_value=mock_obj),
+            patch(
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+                return_value=mock_obj,
+            ),
             patch("netbox_librenms_plugin.views.sync.device_fields.messages") as mock_msg,
             patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
             patch("django.conf.settings") as mock_settings,
@@ -1835,7 +2038,10 @@ class TestRemoveServerMappingViewPost:
 
         mock_cfg = {"netbox_librenms_plugin": {"servers": {}, "librenms_url": "https://librenms.example.com"}}
         with (
-            patch("netbox_librenms_plugin.views.sync.device_fields.get_object_or_404", return_value=mock_obj),
+            patch(
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+                return_value=mock_obj,
+            ),
             patch("netbox_librenms_plugin.views.sync.device_fields.messages") as mock_msg,
             patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
             patch("django.conf.settings") as mock_settings,
@@ -1859,7 +2065,10 @@ class TestRemoveServerMappingViewPost:
 
         mock_cfg = {"netbox_librenms_plugin": {"servers": {}, "librenms_url": ""}}
         with (
-            patch("netbox_librenms_plugin.views.sync.device_fields.get_object_or_404", return_value=mock_obj),
+            patch(
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+                return_value=mock_obj,
+            ),
             patch("netbox_librenms_plugin.views.sync.device_fields.Device", mock_device_cls),
             patch("netbox_librenms_plugin.views.sync.device_fields.transaction"),
             patch("netbox_librenms_plugin.views.sync.device_fields.messages") as mock_msg,
@@ -1889,7 +2098,10 @@ class TestRemoveServerMappingViewPost:
 
         mock_cfg = {"netbox_librenms_plugin": {"servers": {}, "librenms_url": ""}}
         with (
-            patch("netbox_librenms_plugin.views.sync.device_fields.get_object_or_404", return_value=mock_obj),
+            patch(
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+                return_value=mock_obj,
+            ),
             patch("netbox_librenms_plugin.views.sync.device_fields.Device", mock_device_cls),
             patch("netbox_librenms_plugin.views.sync.device_fields.transaction"),
             patch("netbox_librenms_plugin.views.sync.device_fields.messages") as mock_msg,
@@ -1923,7 +2135,10 @@ class TestRemoveServerMappingViewPost:
 
         mock_cfg = {"netbox_librenms_plugin": {"servers": {}, "librenms_url": ""}}
         with (
-            patch("netbox_librenms_plugin.views.sync.device_fields.get_object_or_404", return_value=mock_obj),
+            patch(
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+                return_value=mock_obj,
+            ),
             patch("netbox_librenms_plugin.views.sync.device_fields.Device", mock_device_cls),
             patch("netbox_librenms_plugin.views.sync.device_fields.transaction", mock_txn),
             patch("netbox_librenms_plugin.views.sync.device_fields.messages") as mock_msg,
@@ -1956,7 +2171,10 @@ class TestRemoveServerMappingViewPost:
 
         mock_cfg = {"netbox_librenms_plugin": {"servers": {}, "librenms_url": ""}}
         with (
-            patch("netbox_librenms_plugin.views.sync.device_fields.get_object_or_404", return_value=mock_obj),
+            patch(
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+                return_value=mock_obj,
+            ),
             patch("netbox_librenms_plugin.views.sync.device_fields.Device", mock_device_cls),
             patch("netbox_librenms_plugin.views.sync.device_fields.transaction", mock_txn),
             patch("netbox_librenms_plugin.views.sync.device_fields.messages") as mock_msg,
@@ -1980,7 +2198,7 @@ class TestRemoveServerMappingViewPost:
             patch("netbox_librenms_plugin.views.sync.device_fields.messages") as mock_msg,
             patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
         ):
-            view.post(req, pk=dev.pk)
+            _post(view, req, pk=dev.pk)
         mock_msg.success.assert_called_once()
         # Last key removed → cf librenms_id collapses to None.
         assert Device.objects.get(pk=dev.pk).custom_field_data["librenms_id"] is None
@@ -1997,7 +2215,7 @@ class TestRemoveServerMappingViewPost:
             patch("netbox_librenms_plugin.views.sync.device_fields.messages") as mock_msg,
             patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
         ):
-            view.post(req, pk=dev.pk)
+            _post(view, req, pk=dev.pk)
         mock_msg.success.assert_called_once()
         assert Device.objects.get(pk=dev.pk).custom_field_data["librenms_id"] == {"other": 6}
 
@@ -2020,14 +2238,20 @@ class TestConvertLegacyLibreNMSIdViewHelpers:
     def test_get_model_and_object_device(self):
         view = self._view()
         mock_device = MagicMock()
-        with patch("netbox_librenms_plugin.views.sync.device_fields.get_object_or_404", return_value=mock_device):
+        with patch(
+            "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+            return_value=mock_device,
+        ):
             model, obj = view._get_model_and_object("device", 1)
         assert obj is mock_device
 
     def test_get_model_and_object_vm(self):
         view = self._view()
         mock_vm = MagicMock()
-        with patch("netbox_librenms_plugin.views.sync.device_fields.get_object_or_404", return_value=mock_vm):
+        with patch(
+            "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+            return_value=mock_vm,
+        ):
             model, obj = view._get_model_and_object("vm", 1)
         assert obj is mock_vm
 
@@ -2148,7 +2372,7 @@ class TestConvertLegacyLibreNMSIdViewPost:
     def test_invalid_object_type_returns_400(self):
         view = self._view()
         req = _make_request({"object_type": "badtype"})
-        with patch("netbox_librenms_plugin.views.sync.device_fields.get_object_or_404"):
+        with patch("netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404"):
             result = view.post(req, pk=1)
         assert result.status_code == 400
 
@@ -2173,7 +2397,10 @@ class TestConvertLegacyLibreNMSIdViewPost:
         mock_vm_cls.objects.select_for_update.return_value.get.return_value = mock_locked
 
         with (
-            patch("netbox_librenms_plugin.views.sync.device_fields.get_object_or_404", return_value=mock_obj),
+            patch(
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+                return_value=mock_obj,
+            ),
             patch("netbox_librenms_plugin.views.sync.device_fields.VirtualMachine", mock_vm_cls),
             patch("netbox_librenms_plugin.views.sync.device_fields.find_by_librenms_id", return_value=None),
             patch(
@@ -2206,7 +2433,10 @@ class TestConvertLegacyLibreNMSIdViewPost:
         mock_dev_cls.objects.select_for_update.return_value.get.return_value = mock_locked
 
         with (
-            patch("netbox_librenms_plugin.views.sync.device_fields.get_object_or_404", return_value=mock_obj),
+            patch(
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+                return_value=mock_obj,
+            ),
             patch("netbox_librenms_plugin.views.sync.device_fields.Device", mock_dev_cls),
             patch("netbox_librenms_plugin.views.sync.device_fields.find_by_librenms_id", return_value=None),
             patch(
@@ -2240,7 +2470,10 @@ class TestConvertLegacyLibreNMSIdViewPost:
         mock_dev_cls.objects.select_for_update.return_value.get.return_value = mock_locked
 
         with (
-            patch("netbox_librenms_plugin.views.sync.device_fields.get_object_or_404", return_value=mock_obj),
+            patch(
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+                return_value=mock_obj,
+            ),
             patch("netbox_librenms_plugin.views.sync.device_fields.Device", mock_dev_cls),
             patch("netbox_librenms_plugin.views.sync.device_fields.find_by_librenms_id", return_value=None),
             patch(
@@ -2260,7 +2493,7 @@ class TestConvertLegacyLibreNMSIdViewPost:
         err = MagicMock()
         view.require_all_permissions = MagicMock(return_value=err)
         req = _make_request({"object_type": "device"})
-        with patch("netbox_librenms_plugin.views.sync.device_fields.get_object_or_404"):
+        with patch("netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404"):
             result = view.post(req, pk=1)
         assert result is err
 
@@ -2270,7 +2503,10 @@ class TestConvertLegacyLibreNMSIdViewPost:
         mock_obj.custom_field_data = {"librenms_id": {"default": 5}}
 
         with (
-            patch("netbox_librenms_plugin.views.sync.device_fields.get_object_or_404", return_value=mock_obj),
+            patch(
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+                return_value=mock_obj,
+            ),
             patch("netbox_librenms_plugin.views.sync.device_fields.messages") as mock_msg,
             patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
         ):
@@ -2284,7 +2520,10 @@ class TestConvertLegacyLibreNMSIdViewPost:
         mock_obj.custom_field_data = {"librenms_id": True}
 
         with (
-            patch("netbox_librenms_plugin.views.sync.device_fields.get_object_or_404", return_value=mock_obj),
+            patch(
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+                return_value=mock_obj,
+            ),
             patch("netbox_librenms_plugin.views.sync.device_fields.messages") as mock_msg,
             patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
         ):
@@ -2297,7 +2536,10 @@ class TestConvertLegacyLibreNMSIdViewPost:
         mock_obj.custom_field_data = {"librenms_id": "not-a-number"}
 
         with (
-            patch("netbox_librenms_plugin.views.sync.device_fields.get_object_or_404", return_value=mock_obj),
+            patch(
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+                return_value=mock_obj,
+            ),
             patch("netbox_librenms_plugin.views.sync.device_fields.messages") as mock_msg,
             patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
         ):
@@ -2322,7 +2564,10 @@ class TestConvertLegacyLibreNMSIdViewPost:
         make_device("convert-b", librenms_cf={"default": {"id": 99, "oob": {"id": 42}}})
 
         with (
-            patch("netbox_librenms_plugin.views.sync.device_fields.get_object_or_404", return_value=dev_a),
+            patch(
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+                return_value=dev_a,
+            ),
             patch("netbox_librenms_plugin.views.sync.device_fields.messages") as mock_msg,
             patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
         ):
@@ -2343,11 +2588,14 @@ class TestConvertLegacyLibreNMSIdViewPost:
         view._librenms_api.get_device_info.return_value = (False, None)
 
         with (
-            patch("netbox_librenms_plugin.views.sync.device_fields.get_object_or_404", return_value=mock_obj),
+            patch(
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+                return_value=mock_obj,
+            ),
             patch("netbox_librenms_plugin.views.sync.device_fields.messages") as mock_msg,
             patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
         ):
-            view.post(_make_request({"object_type": "device"}), pk=1)
+            _post(view, _make_request({"object_type": "device"}), pk=1)
         mock_msg.error.assert_called_once()
 
     def test_serial_mismatch_empty_netbox_serial(self):
@@ -2358,7 +2606,10 @@ class TestConvertLegacyLibreNMSIdViewPost:
         view._librenms_api.get_device_info.return_value = (True, {"serial": "SN-ABC"})
 
         with (
-            patch("netbox_librenms_plugin.views.sync.device_fields.get_object_or_404", return_value=mock_obj),
+            patch(
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+                return_value=mock_obj,
+            ),
             patch("netbox_librenms_plugin.views.sync.device_fields.messages") as mock_msg,
             patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
         ):
@@ -2374,7 +2625,10 @@ class TestConvertLegacyLibreNMSIdViewPost:
         view._librenms_api.get_device_info.return_value = (True, {"serial": "SN-ABC"})
 
         with (
-            patch("netbox_librenms_plugin.views.sync.device_fields.get_object_or_404", return_value=mock_obj),
+            patch(
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+                return_value=mock_obj,
+            ),
             patch("netbox_librenms_plugin.views.sync.device_fields.messages") as mock_msg,
             patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
         ):
@@ -2395,7 +2649,10 @@ class TestConvertLegacyLibreNMSIdViewPost:
         mock_device_cls.objects.select_for_update.return_value.get.side_effect = DoesNotExist()
 
         with (
-            patch("netbox_librenms_plugin.views.sync.device_fields.get_object_or_404", return_value=mock_obj),
+            patch(
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+                return_value=mock_obj,
+            ),
             patch("netbox_librenms_plugin.views.sync.device_fields.Device", mock_device_cls),
             patch("netbox_librenms_plugin.views.sync.device_fields.transaction"),
             patch("netbox_librenms_plugin.views.sync.device_fields.messages") as mock_msg,
@@ -2421,7 +2678,10 @@ class TestConvertLegacyLibreNMSIdViewPost:
         mock_device_cls.objects.select_for_update.return_value.get.return_value = mock_locked
 
         with (
-            patch("netbox_librenms_plugin.views.sync.device_fields.get_object_or_404", return_value=mock_obj),
+            patch(
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+                return_value=mock_obj,
+            ),
             patch("netbox_librenms_plugin.views.sync.device_fields.Device", mock_device_cls),
             patch("netbox_librenms_plugin.views.sync.device_fields.transaction"),
             patch("netbox_librenms_plugin.views.sync.device_fields.messages") as mock_msg,
@@ -2447,7 +2707,10 @@ class TestConvertLegacyLibreNMSIdViewPost:
         mock_device_cls.objects.select_for_update.return_value.get.return_value = mock_locked
 
         with (
-            patch("netbox_librenms_plugin.views.sync.device_fields.get_object_or_404", return_value=mock_obj),
+            patch(
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+                return_value=mock_obj,
+            ),
             patch("netbox_librenms_plugin.views.sync.device_fields.Device", mock_device_cls),
             patch("netbox_librenms_plugin.views.sync.device_fields.transaction"),
             patch("netbox_librenms_plugin.views.sync.device_fields.messages") as mock_msg,
@@ -2474,7 +2737,10 @@ class TestConvertLegacyLibreNMSIdViewPost:
         mock_device_cls.objects.select_for_update.return_value.get.return_value = mock_locked
 
         with (
-            patch("netbox_librenms_plugin.views.sync.device_fields.get_object_or_404", return_value=mock_obj),
+            patch(
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+                return_value=mock_obj,
+            ),
             patch("netbox_librenms_plugin.views.sync.device_fields.Device", mock_device_cls),
             patch("netbox_librenms_plugin.views.sync.device_fields.transaction"),
             patch("netbox_librenms_plugin.views.sync.device_fields.messages") as mock_msg,
@@ -2510,7 +2776,10 @@ class TestConvertLegacyLibreNMSIdViewPost:
         mock_txn.set_rollback = MagicMock()
 
         with (
-            patch("netbox_librenms_plugin.views.sync.device_fields.get_object_or_404", return_value=mock_obj),
+            patch(
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+                return_value=mock_obj,
+            ),
             patch("netbox_librenms_plugin.views.sync.device_fields.Device", mock_device_cls),
             patch("netbox_librenms_plugin.views.sync.device_fields.find_by_librenms_id", return_value=other_obj),
             patch("netbox_librenms_plugin.views.sync.device_fields.transaction", mock_txn),
@@ -2541,7 +2810,10 @@ class TestConvertLegacyLibreNMSIdViewPost:
         mock_device_cls.objects.select_for_update.return_value.get.return_value = mock_locked
 
         with (
-            patch("netbox_librenms_plugin.views.sync.device_fields.get_object_or_404", return_value=mock_obj),
+            patch(
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+                return_value=mock_obj,
+            ),
             patch("netbox_librenms_plugin.views.sync.device_fields.Device", mock_device_cls),
             patch("netbox_librenms_plugin.views.sync.device_fields.find_by_librenms_id", return_value=None),
             patch("netbox_librenms_plugin.views.sync.device_fields.migrate_legacy_librenms_id", return_value=False),
@@ -2577,7 +2849,10 @@ class TestConvertLegacyLibreNMSIdViewPost:
         mock_txn.set_rollback = MagicMock()
 
         with (
-            patch("netbox_librenms_plugin.views.sync.device_fields.get_object_or_404", return_value=mock_obj),
+            patch(
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+                return_value=mock_obj,
+            ),
             patch("netbox_librenms_plugin.views.sync.device_fields.Device", mock_device_cls),
             patch("netbox_librenms_plugin.views.sync.device_fields.find_by_librenms_id", return_value=None),
             patch("netbox_librenms_plugin.views.sync.device_fields.migrate_legacy_librenms_id", return_value=True),
@@ -2612,7 +2887,10 @@ class TestConvertLegacyLibreNMSIdViewPost:
         mock_txn.set_rollback = MagicMock()
 
         with (
-            patch("netbox_librenms_plugin.views.sync.device_fields.get_object_or_404", return_value=mock_obj),
+            patch(
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+                return_value=mock_obj,
+            ),
             patch("netbox_librenms_plugin.views.sync.device_fields.Device", mock_device_cls),
             patch("netbox_librenms_plugin.views.sync.device_fields.find_by_librenms_id", return_value=None),
             patch("netbox_librenms_plugin.views.sync.device_fields.migrate_legacy_librenms_id", return_value=True),
@@ -2636,7 +2914,7 @@ class TestConvertLegacyLibreNMSIdViewPost:
             patch("netbox_librenms_plugin.views.sync.device_fields.messages") as mock_msg,
             patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
         ):
-            view.post(_make_request({"object_type": "device"}), pk=dev.pk)
+            _post(view, _make_request({"object_type": "device"}), pk=dev.pk)
         mock_msg.success.assert_called_once()
         assert "42" in mock_msg.success.call_args[0][1]
         assert Device.objects.get(pk=dev.pk).custom_field_data["librenms_id"] == {"default": 42}
@@ -2653,7 +2931,7 @@ class TestConvertLegacyLibreNMSIdViewPost:
             patch("netbox_librenms_plugin.views.sync.device_fields.messages") as mock_msg,
             patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
         ):
-            view.post(_make_request({"object_type": "device"}), pk=dev.pk)
+            _post(view, _make_request({"object_type": "device"}), pk=dev.pk)
         mock_msg.success.assert_called_once()
         assert Device.objects.get(pk=dev.pk).custom_field_data["librenms_id"] == {"default": 42}
 
@@ -2681,7 +2959,10 @@ class TestConvertLegacyLibreNMSIdViewPost:
         mock_device_cls.objects.select_for_update.return_value.get.return_value = mock_locked
 
         with (
-            patch("netbox_librenms_plugin.views.sync.device_fields.get_object_or_404", return_value=mock_obj),
+            patch(
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+                return_value=mock_obj,
+            ),
             patch("netbox_librenms_plugin.views.sync.device_fields.Device", mock_device_cls),
             patch("netbox_librenms_plugin.views.sync.device_fields.find_by_librenms_id", return_value=same_obj),
             patch("netbox_librenms_plugin.views.sync.device_fields.migrate_legacy_librenms_id", return_value=True),
@@ -2910,6 +3191,12 @@ class TestUpdateDeviceFieldsServerRebind:
         from netbox_librenms_plugin.librenms_api import LibreNMSAPI
 
         request = RequestFactory().post(f"/sync/{pk}/", {"server_key": "production"})
+        # RequestFactory skips AuthenticationMiddleware; the object-scoped device lookup reads
+        # request.user, and dispatch() is what binds the request in production.
+        from netbox_librenms_plugin.tests.conftest import make_superuser
+
+        request.user = make_superuser("devfield-rebind-su")
+        view.setup(request)
         global_settings = MagicMock()
         global_settings.first.return_value = None  # no selected server -> default -> first config key
         with (

--- a/netbox_librenms_plugin/tests/test_coverage_device_fields.py
+++ b/netbox_librenms_plugin/tests/test_coverage_device_fields.py
@@ -1319,6 +1319,8 @@ class TestCreateAndAssignPlatformView:
         # the DB's unique constraint, and the re-query that follows is entirely real.
         with (
             _before_restricted_read(view, _rival_commits_first, on_call=1),
+            # Skip validation only for the simulated rival insert. The view's candidate still
+            # reaches the unique constraint and exercises its IntegrityError recovery path.
             patch.object(Platform, "full_clean", _skip_once(Platform.full_clean)),
         ):
             _post(view, req, pk=dev.pk)

--- a/netbox_librenms_plugin/tests/test_coverage_device_fields.py
+++ b/netbox_librenms_plugin/tests/test_coverage_device_fields.py
@@ -14,24 +14,7 @@ import pytest
 from netbox_librenms_plugin.tests.conftest import make_device
 
 
-def _bind_and_call(view, request, method, **kwargs):
-    """Call *view*.<method>, binding the request the way ``View.setup()`` does under dispatch().
-
-    A direct ``view.post(request, ...)`` leaves ``self.request`` unset, which the object-scoped
-    lookups read — production always goes through dispatch(), so bind it here too.
-    """
-    view.setup(request)
-    return getattr(view, method)(request, **kwargs)
-
-
-def _post(view, request, **kwargs):
-    """POST into *view* with the request bound (see :func:`_bind_and_call`)."""
-    return _bind_and_call(view, request, "post", **kwargs)
-
-
-def _get(view, request, **kwargs):
-    """GET into *view* with the request bound (see :func:`_bind_and_call`)."""
-    return _bind_and_call(view, request, "get", **kwargs)
+from netbox_librenms_plugin.tests.view_test_helpers import post as _post
 
 
 @pytest.mark.parametrize(
@@ -283,7 +266,7 @@ class TestUpdateDeviceSerialView:
             patch("netbox_librenms_plugin.views.sync.device_fields.messages") as mock_msg,
             patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
         ):
-            view.post(_make_request(), pk=1)
+            _post(view, _make_request(), pk=1)
         mock_msg.error.assert_called_once()
 
     def test_get_device_info_failure(self):
@@ -315,7 +298,7 @@ class TestUpdateDeviceSerialView:
             patch("netbox_librenms_plugin.views.sync.device_fields.messages") as mock_msg,
             patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
         ):
-            view.post(_make_request(), pk=1)
+            _post(view, _make_request(), pk=1)
         mock_msg.warning.assert_called_once()
 
     def test_serial_is_dash(self):
@@ -331,7 +314,7 @@ class TestUpdateDeviceSerialView:
             patch("netbox_librenms_plugin.views.sync.device_fields.messages") as mock_msg,
             patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
         ):
-            view.post(_make_request(), pk=1)
+            _post(view, _make_request(), pk=1)
         mock_msg.warning.assert_called_once()
 
     def test_save_success_with_old_serial(self):
@@ -491,7 +474,7 @@ class TestUpdateDeviceTypeView:
             patch("netbox_librenms_plugin.views.sync.device_fields.messages") as mock_msg,
             patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
         ):
-            view.post(_make_request(), pk=1)
+            _post(view, _make_request(), pk=1)
         mock_msg.error.assert_called_once()
 
     def test_get_device_info_failure(self):
@@ -521,7 +504,7 @@ class TestUpdateDeviceTypeView:
             patch("netbox_librenms_plugin.views.sync.device_fields.messages") as mock_msg,
             patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
         ):
-            view.post(_make_request(), pk=1)
+            _post(view, _make_request(), pk=1)
         mock_msg.warning.assert_called_once()
 
     def test_no_match_result(self):
@@ -540,7 +523,7 @@ class TestUpdateDeviceTypeView:
             patch("netbox_librenms_plugin.views.sync.device_fields.messages") as mock_msg,
             patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
         ):
-            view.post(_make_request(), pk=1)
+            _post(view, _make_request(), pk=1)
         mock_msg.error.assert_called_once()
 
     def test_match_none_returns_ambiguous_error(self):
@@ -561,7 +544,7 @@ class TestUpdateDeviceTypeView:
             patch("netbox_librenms_plugin.views.sync.device_fields.messages") as mock_msg,
             patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
         ):
-            view.post(_make_request(), pk=1)
+            _post(view, _make_request(), pk=1)
         mock_msg.error.assert_called_once()
         assert "Ambiguous" in mock_msg.error.call_args[0][1]
         mock_device.full_clean.assert_not_called()
@@ -680,7 +663,7 @@ class TestUpdateDevicePlatformView:
             patch("netbox_librenms_plugin.views.sync.device_fields.messages") as mock_msg,
             patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
         ):
-            view.post(_make_request(), pk=1)
+            _post(view, _make_request(), pk=1)
         mock_msg.error.assert_called_once()
 
     def test_get_device_info_failure(self):
@@ -710,7 +693,7 @@ class TestUpdateDevicePlatformView:
             patch("netbox_librenms_plugin.views.sync.device_fields.messages") as mock_msg,
             patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
         ):
-            view.post(_make_request(), pk=1)
+            _post(view, _make_request(), pk=1)
         mock_msg.warning.assert_called_once()
 
     def test_platform_does_not_exist(self):
@@ -731,7 +714,7 @@ class TestUpdateDevicePlatformView:
             patch("netbox_librenms_plugin.views.sync.device_fields.messages") as mock_msg,
             patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
         ):
-            view.post(_make_request(), pk=1)
+            _post(view, _make_request(), pk=1)
         mock_msg.error.assert_called_once()
 
     def test_save_success_with_old_platform(self):
@@ -831,7 +814,7 @@ class TestUpdateDevicePlatformView:
             patch("netbox_librenms_plugin.views.sync.device_fields.messages") as mock_msg,
             patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
         ):
-            view.post(_make_request(), pk=1)
+            _post(view, _make_request(), pk=1)
         mock_msg.error.assert_called_once()
         assert "ambiguity" in mock_msg.error.call_args[0][1].lower()
 
@@ -1619,7 +1602,7 @@ class TestAssignVCSerialView:
             patch("netbox_librenms_plugin.views.sync.device_fields.messages") as mock_msg,
             patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
         ):
-            view.post(_make_request(), pk=1)
+            _post(view, _make_request(), pk=1)
         mock_msg.error.assert_called_once()
 
     def test_no_serial_assignments_no_errors(self):
@@ -1673,10 +1656,13 @@ class TestAssignVCSerialView:
                 return_value=mock_device,
             ),
             patch("netbox_librenms_plugin.views.sync.device_fields.Device", mock_device_cls),
+            # Members are resolved through the SCOPED queryset (their serial is overwritten),
+            # so that is the seam this test stubs.
+            patch.object(view, "restricted_queryset", return_value=mock_device_cls.objects),
             patch("netbox_librenms_plugin.views.sync.device_fields.messages") as mock_msg,
             patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
         ):
-            view.post(req, pk=1)
+            _post(view, req, pk=1)
         # Should call error for the missing device
         mock_msg.error.assert_called()
 
@@ -1702,10 +1688,13 @@ class TestAssignVCSerialView:
                 return_value=mock_device,
             ),
             patch("netbox_librenms_plugin.views.sync.device_fields.Device", mock_device_cls),
+            # Members are resolved through the SCOPED queryset (their serial is overwritten),
+            # so that is the seam this test stubs.
+            patch.object(view, "restricted_queryset", return_value=mock_device_cls.objects),
             patch("netbox_librenms_plugin.views.sync.device_fields.messages") as mock_msg,
             patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
         ):
-            view.post(req, pk=1)
+            _post(view, req, pk=1)
         mock_msg.error.assert_called()
 
     def test_member_save_validation_error(self):
@@ -1734,10 +1723,13 @@ class TestAssignVCSerialView:
                 return_value=mock_device,
             ),
             patch("netbox_librenms_plugin.views.sync.device_fields.Device", mock_device_cls),
+            # Members are resolved through the SCOPED queryset (their serial is overwritten),
+            # so that is the seam this test stubs.
+            patch.object(view, "restricted_queryset", return_value=mock_device_cls.objects),
             patch("netbox_librenms_plugin.views.sync.device_fields.messages") as mock_msg,
             patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
         ):
-            view.post(req, pk=1)
+            _post(view, req, pk=1)
         mock_msg.error.assert_called()
 
     def test_assignments_and_errors_both_reported(self):
@@ -1779,10 +1771,13 @@ class TestAssignVCSerialView:
                 return_value=mock_device,
             ),
             patch("netbox_librenms_plugin.views.sync.device_fields.Device", mock_device_cls),
+            # Members are resolved through the SCOPED queryset (their serial is overwritten),
+            # so that is the seam this test stubs.
+            patch.object(view, "restricted_queryset", return_value=mock_device_cls.objects),
             patch("netbox_librenms_plugin.views.sync.device_fields.messages") as mock_msg,
             patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
         ):
-            view.post(req, pk=1)
+            _post(view, req, pk=1)
         mock_msg.success.assert_called()
         mock_msg.error.assert_called()
         assert good_member.serial == "SN001"

--- a/netbox_librenms_plugin/tests/test_coverage_device_fields.py
+++ b/netbox_librenms_plugin/tests/test_coverage_device_fields.py
@@ -38,7 +38,9 @@ def test_write_views_fetch_device_info_live_not_cached(view_name):
         patch("netbox_librenms_plugin.views.sync.device_fields.messages"),
         patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
     ):
-        view.post(_make_request(), pk=1)
+        _r = _make_request()
+        view.request = _r
+        view.post(_r, pk=1)
     # Unfixed: called as get_device_info(42) → use_cache defaults True → reads the stale render cache.
     assert view._librenms_api.get_device_info.call_args.kwargs.get("use_cache") is False
 
@@ -83,7 +85,9 @@ class TestUpdateDeviceNameView:
         with patch(
             "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404"
         ) as mock_get:
-            result = view.post(_make_request(), pk=1)
+            _r = _make_request()
+            view.request = _r
+            result = view.post(_r, pk=1)
 
         assert result is error_response
         mock_get.assert_not_called()
@@ -224,7 +228,9 @@ class TestUpdateDeviceNameView:
             patch("netbox_librenms_plugin.views.sync.device_fields.messages") as mock_msg,
             patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
         ):
-            view.post(_make_request(), pk=dev.pk)
+            _r = _make_request()
+            view.request = _r
+            view.post(_r, pk=dev.pk)
 
         mock_msg.error.assert_called_once()
         assert dev.name == "orig-int"  # restored after the failed save
@@ -250,7 +256,9 @@ class TestUpdateDeviceSerialView:
         with patch(
             "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404"
         ) as mock_get:
-            result = view.post(_make_request(), pk=1)
+            _r = _make_request()
+            view.request = _r
+            result = view.post(_r, pk=1)
         assert result is err
         mock_get.assert_not_called()
 
@@ -403,7 +411,9 @@ class TestUpdateDeviceSerialView:
             patch("netbox_librenms_plugin.views.sync.device_fields.messages") as mock_msg,
             patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
         ):
-            view.post(_make_request(), pk=dev.pk)
+            _r = _make_request()
+            view.request = _r
+            view.post(_r, pk=dev.pk)
         mock_msg.error.assert_called_once()
         assert dev.serial == "OLD"  # restored in memory
         from dcim.models import Device
@@ -429,7 +439,9 @@ class TestUpdateDeviceSerialView:
             patch("netbox_librenms_plugin.views.sync.device_fields.messages") as mock_msg,
             patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
         ):
-            view.post(_make_request(), pk=dev.pk)
+            _r = _make_request()
+            view.request = _r
+            view.post(_r, pk=dev.pk)
         mock_msg.error.assert_called_once()
 
 
@@ -459,7 +471,9 @@ class TestUpdateDeviceTypeView:
         with patch(
             "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404"
         ) as mock_get:
-            result = view.post(_make_request(), pk=1)
+            _r = _make_request()
+            view.request = _r
+            result = view.post(_r, pk=1)
         assert result is err
         mock_get.assert_not_called()
 
@@ -594,7 +608,9 @@ class TestUpdateDeviceTypeView:
             patch("netbox_librenms_plugin.views.sync.device_fields.messages") as mock_msg,
             patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
         ):
-            view.post(_make_request(), pk=dev.pk)
+            _r = _make_request()
+            view.request = _r
+            view.post(_r, pk=dev.pk)
         mock_msg.error.assert_called_once()
         assert Device.objects.get(pk=dev.pk).device_type_id == original_dt  # nothing persisted
 
@@ -622,7 +638,9 @@ class TestUpdateDeviceTypeView:
             patch("netbox_librenms_plugin.views.sync.device_fields.messages") as mock_msg,
             patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
         ):
-            view.post(_make_request(), pk=dev.pk)
+            _r = _make_request()
+            view.request = _r
+            view.post(_r, pk=dev.pk)
         mock_msg.error.assert_called_once()
 
 
@@ -649,7 +667,9 @@ class TestUpdateDevicePlatformView:
         err = MagicMock()
         view.require_all_permissions = MagicMock(return_value=err)
         with patch("netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404"):
-            result = view.post(_make_request(), pk=1)
+            _r = _make_request()
+            view.request = _r
+            result = view.post(_r, pk=1)
         assert result is err
 
     def test_no_librenms_id(self):
@@ -740,7 +760,9 @@ class TestUpdateDevicePlatformView:
             patch("netbox_librenms_plugin.views.sync.device_fields.messages") as mock_msg,
             patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
         ):
-            view.post(_make_request(), pk=dev.pk)
+            _r = _make_request()
+            view.request = _r
+            view.post(_r, pk=dev.pk)
         mock_msg.success.assert_called_once()
         assert "updated from" in mock_msg.success.call_args[0][1]
         assert Device.objects.get(pk=dev.pk).platform_id == new_platform.pk
@@ -766,7 +788,9 @@ class TestUpdateDevicePlatformView:
             patch("netbox_librenms_plugin.views.sync.device_fields.messages") as mock_msg,
             patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
         ):
-            view.post(_make_request(), pk=dev.pk)
+            _r = _make_request()
+            view.request = _r
+            view.post(_r, pk=dev.pk)
         mock_msg.success.assert_called_once()
         assert "set to" in mock_msg.success.call_args[0][1]
         assert Device.objects.get(pk=dev.pk).platform_id == new_platform.pk
@@ -793,7 +817,9 @@ class TestUpdateDevicePlatformView:
             patch("netbox_librenms_plugin.views.sync.device_fields.messages") as mock_msg,
             patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
         ):
-            view.post(_make_request(), pk=dev.pk)
+            _r = _make_request()
+            view.request = _r
+            view.post(_r, pk=dev.pk)
         mock_msg.success.assert_called_once()
         assert Device.objects.get(pk=dev.pk).platform_id == new_platform.pk
 
@@ -843,7 +869,9 @@ class TestUpdateDevicePlatformView:
             patch("netbox_librenms_plugin.views.sync.device_fields.messages") as mock_msg,
             patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
         ):
-            view.post(_make_request(), pk=dev.pk)
+            _r = _make_request()
+            view.request = _r
+            view.post(_r, pk=dev.pk)
         mock_msg.error.assert_called_once()
         assert Device.objects.get(pk=dev.pk).platform_id is None  # nothing persisted
 
@@ -865,7 +893,9 @@ class TestCreateAndAssignPlatformView:
         err = MagicMock()
         view.require_all_permissions = MagicMock(return_value=err)
         with patch("netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404"):
-            result = view.post(_make_request(), pk=1)
+            _r = _make_request()
+            view.request = _r
+            result = view.post(_r, pk=1)
         assert result is err
 
     def test_no_platform_name(self):
@@ -880,6 +910,7 @@ class TestCreateAndAssignPlatformView:
             patch("netbox_librenms_plugin.views.sync.device_fields.messages") as mock_msg,
             patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
         ):
+            view.request = req
             view.post(req, pk=1)
         mock_msg.error.assert_called_once()
         assert "required" in mock_msg.error.call_args[0][1].lower()
@@ -907,6 +938,7 @@ class TestCreateAndAssignPlatformView:
             patch("netbox_librenms_plugin.views.sync.device_fields.messages"),
             patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
         ):
+            view.request = req
             view.post(req, pk=dev.pk)
 
         # Rebound to the POSTed server (not left on the initial/global client), so the
@@ -931,6 +963,7 @@ class TestCreateAndAssignPlatformView:
             patch("netbox_librenms_plugin.views.sync.device_fields.messages") as mock_msg,
             patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
         ):
+            view.request = req
             view.post(req, pk=dev.pk)
         # Reused — not duplicated.
         assert Platform.objects.filter(name__iexact="ios").count() == 1
@@ -960,6 +993,7 @@ class TestCreateAndAssignPlatformView:
             patch("netbox_librenms_plugin.views.sync.device_fields.messages") as mock_msg,
             patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
         ):
+            view.request = req
             view.post(req, pk=dev.pk)
         assert Platform.objects.filter(name__iexact="ios").count() == 1  # reused
         # A real mapping now points the posted OS at the reused platform.
@@ -975,16 +1009,19 @@ class TestCreateAndAssignPlatformView:
 
         found_platform = MagicMock(pk=5)
         mock_platform_cls = MagicMock()
+        mock_platform_cls.objects.restrict.return_value = mock_platform_cls.objects
         mock_platform_cls.objects.filter.return_value.first.return_value = found_platform
 
         mock_device_cls = MagicMock()
         mock_device_cls.DoesNotExist = type("DoesNotExist", (Exception,), {})
         mock_locked = MagicMock()
+        mock_device_cls.objects.restrict.return_value = mock_device_cls.objects
         mock_device_cls.objects.select_for_update.return_value.get.return_value = mock_locked
 
         # Existing mapping for "ios" points at a different platform (id 999, not 5).
         other_mapping = MagicMock(netbox_platform_id=999)
         mock_mapping_cls = MagicMock()
+        mock_mapping_cls.objects.restrict.return_value = mock_mapping_cls.objects
         mock_mapping_cls.objects.filter.return_value.first.return_value = other_mapping
 
         with (
@@ -999,6 +1036,7 @@ class TestCreateAndAssignPlatformView:
             patch("netbox_librenms_plugin.views.sync.device_fields.messages") as mock_msg,
             patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
         ):
+            view.request = req
             view.post(req, pk=1)
 
         # No new mapping created (PlatformMapping class never instantiated for a create), and
@@ -1016,17 +1054,20 @@ class TestCreateAndAssignPlatformView:
         req = _make_request({"platform_name": "ios", "manufacturer": "99"})
 
         mock_platform_cls = MagicMock()
+        mock_platform_cls.objects.restrict.return_value = mock_platform_cls.objects
         mock_platform_cls.objects.filter.return_value.first.return_value = None
         mock_platform_instance = MagicMock()
         mock_platform_cls.return_value = mock_platform_instance
 
         mock_manuf_cls = MagicMock()
         mock_manuf_cls.DoesNotExist = type("DoesNotExist", (Exception,), {})
+        mock_manuf_cls.objects.restrict.return_value = mock_manuf_cls.objects
         mock_manuf_cls.objects.get.side_effect = mock_manuf_cls.DoesNotExist()
 
         mock_device_cls = MagicMock()
         mock_device_cls.DoesNotExist = type("DoesNotExist", (Exception,), {})
         mock_locked = MagicMock()
+        mock_device_cls.objects.restrict.return_value = mock_device_cls.objects
         mock_device_cls.objects.select_for_update.return_value.get.return_value = mock_locked
 
         with (
@@ -1041,6 +1082,7 @@ class TestCreateAndAssignPlatformView:
             patch("netbox_librenms_plugin.views.sync.device_fields.messages") as mock_msg,
             patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
         ):
+            view.request = req
             view.post(req, pk=1)
         # Should succeed (manufacturer silently ignored)
         mock_msg.success.assert_called_once()
@@ -1063,6 +1105,7 @@ class TestCreateAndAssignPlatformView:
             patch("netbox_librenms_plugin.views.sync.device_fields.messages") as mock_msg,
             patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
         ):
+            view.request = req
             view.post(req, pk=dev.pk)
         mock_msg.success.assert_called_once()
         platform = Platform.objects.get(name="ios-new")
@@ -1088,6 +1131,7 @@ class TestCreateAndAssignPlatformView:
             patch("netbox_librenms_plugin.views.sync.device_fields.messages"),
             patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
         ):
+            view.request = req
             view.post(req, pk=dev.pk)
 
         assert Platform.objects.get(name=platform_name).slug == slugify(platform_name)
@@ -1099,6 +1143,7 @@ class TestCreateAndAssignPlatformView:
         req = _make_request({"platform_name": "ios", "manufacturer": ""})
 
         mock_platform_cls = MagicMock()
+        mock_platform_cls.objects.restrict.return_value = mock_platform_cls.objects
         mock_platform_cls.objects.filter.return_value.first.return_value = None
         mock_platform_instance = MagicMock()
         mock_platform_instance.full_clean.side_effect = ValidationError({"name": ["err"]})
@@ -1117,6 +1162,7 @@ class TestCreateAndAssignPlatformView:
             patch("netbox_librenms_plugin.views.sync.device_fields.messages") as mock_msg,
             patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
         ):
+            view.request = req
             view.post(req, pk=1)
         mock_msg.error.assert_called_once()
         mock_txn.set_rollback.assert_called_once_with(True)
@@ -1126,6 +1172,7 @@ class TestCreateAndAssignPlatformView:
         req = _make_request({"platform_name": "ios", "manufacturer": ""})
 
         mock_platform_cls = MagicMock()
+        mock_platform_cls.objects.restrict.return_value = mock_platform_cls.objects
         mock_platform_cls.objects.filter.return_value.first.return_value = None
         mock_platform_instance = MagicMock()
         mock_platform_cls.return_value = mock_platform_instance
@@ -1133,6 +1180,7 @@ class TestCreateAndAssignPlatformView:
         DoesNotExist = type("DoesNotExist", (Exception,), {})
         mock_device_cls = MagicMock()
         mock_device_cls.DoesNotExist = DoesNotExist
+        mock_device_cls.objects.restrict.return_value = mock_device_cls.objects
         mock_device_cls.objects.select_for_update.return_value.get.side_effect = DoesNotExist()
 
         mock_txn = MagicMock()
@@ -1149,6 +1197,7 @@ class TestCreateAndAssignPlatformView:
             patch("netbox_librenms_plugin.views.sync.device_fields.messages") as mock_msg,
             patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
         ):
+            view.request = req
             view.post(req, pk=1)
         mock_msg.error.assert_called_once()
         mock_txn.set_rollback.assert_called_once_with(True)
@@ -1160,6 +1209,7 @@ class TestCreateAndAssignPlatformView:
         req = _make_request({"platform_name": "ios", "manufacturer": ""})
 
         mock_platform_cls = MagicMock()
+        mock_platform_cls.objects.restrict.return_value = mock_platform_cls.objects
         mock_platform_cls.objects.filter.return_value.first.return_value = None
         mock_platform_instance = MagicMock()
         mock_platform_cls.return_value = mock_platform_instance
@@ -1170,6 +1220,7 @@ class TestCreateAndAssignPlatformView:
 
         mock_device_cls = MagicMock()
         mock_device_cls.DoesNotExist = DoesNotExist
+        mock_device_cls.objects.restrict.return_value = mock_device_cls.objects
         mock_device_cls.objects.select_for_update.return_value.get.return_value = mock_locked
 
         mock_txn = MagicMock()
@@ -1186,6 +1237,7 @@ class TestCreateAndAssignPlatformView:
             patch("netbox_librenms_plugin.views.sync.device_fields.messages") as mock_msg,
             patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
         ):
+            view.request = req
             view.post(req, pk=1)
         mock_msg.error.assert_called_once()
         mock_txn.set_rollback.assert_called_once_with(True)
@@ -1197,6 +1249,7 @@ class TestCreateAndAssignPlatformView:
         req = _make_request({"platform_name": "ios", "manufacturer": ""})
 
         mock_platform_cls = MagicMock()
+        mock_platform_cls.objects.restrict.return_value = mock_platform_cls.objects
         mock_platform_cls.objects.filter.return_value.first.return_value = None
         mock_platform_instance = MagicMock()
         # Make save raise IntegrityError
@@ -1221,6 +1274,7 @@ class TestCreateAndAssignPlatformView:
             patch("netbox_librenms_plugin.views.sync.device_fields.messages") as mock_msg,
             patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
         ):
+            view.request = req
             view.post(req, pk=1)
         mock_msg.error.assert_called_once()
         mock_txn.set_rollback.assert_called_once_with(True)
@@ -1236,6 +1290,7 @@ class TestCreateAndAssignPlatformView:
         mock_platform_cls = MagicMock()
         # First .first() is the up-front existence check (None → take the create path);
         # the second is the post-IntegrityError re-query (the concurrently-created row).
+        mock_platform_cls.objects.restrict.return_value = mock_platform_cls.objects
         mock_platform_cls.objects.filter.return_value.first.side_effect = [None, reused_platform]
         mock_platform_instance = MagicMock()
         mock_platform_instance.save.side_effect = IntegrityError("duplicate")
@@ -1244,6 +1299,7 @@ class TestCreateAndAssignPlatformView:
         mock_device_cls = MagicMock()
         mock_device_cls.DoesNotExist = type("DoesNotExist", (Exception,), {})
         mock_locked = MagicMock()
+        mock_device_cls.objects.restrict.return_value = mock_device_cls.objects
         mock_device_cls.objects.select_for_update.return_value.get.return_value = mock_locked
 
         # __exit__ must return False so the IntegrityError propagates out of the nested atomic.
@@ -1265,6 +1321,7 @@ class TestCreateAndAssignPlatformView:
             patch("netbox_librenms_plugin.views.sync.device_fields.messages") as mock_msg,
             patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
         ):
+            view.request = req
             view.post(req, pk=1)
 
         # Reuse path: the concurrently-created platform is assigned and persisted, with
@@ -1292,13 +1349,17 @@ class TestCreateAndAssignPlatformView:
             }
         )
         mock_platform_cls = MagicMock()
+        mock_platform_cls.objects.restrict.return_value = mock_platform_cls.objects
         mock_platform_cls.objects.filter.return_value.first.return_value = None
+        mock_platform_cls.objects.restrict.return_value = mock_platform_cls.objects
         mock_platform_instance = MagicMock()
         mock_platform_cls.return_value = mock_platform_instance
         mock_device_cls = MagicMock()
         mock_device_cls.DoesNotExist = type("DoesNotExist", (Exception,), {})
         mock_locked = MagicMock()
+        mock_device_cls.objects.restrict.return_value = mock_device_cls.objects
         mock_device_cls.objects.select_for_update.return_value.get.return_value = mock_locked
+        mock_device_cls.objects.restrict.return_value = mock_device_cls.objects
         return view, req, mock_platform_cls, mock_platform_instance, mock_device_cls, mock_locked
 
     def test_mapping_created_when_name_differs(self):
@@ -1309,6 +1370,7 @@ class TestCreateAndAssignPlatformView:
         mock_mapping_cls = MagicMock()
         mock_mapping_instance = MagicMock()
         mock_mapping_cls.return_value = mock_mapping_instance
+        mock_mapping_cls.objects.restrict.return_value = mock_mapping_cls.objects
         mock_mapping_cls.objects.filter.return_value.first.return_value = None
 
         with (
@@ -1323,6 +1385,7 @@ class TestCreateAndAssignPlatformView:
             patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
             patch("netbox_librenms_plugin.views.sync.device_fields.PlatformMapping", mock_mapping_cls),
         ):
+            view.request = req
             view.post(req, pk=1)
 
         mock_mapping_cls.assert_called_once_with(librenms_os="ios", netbox_platform=mock_platform_instance)
@@ -1350,6 +1413,7 @@ class TestCreateAndAssignPlatformView:
             patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
             patch("netbox_librenms_plugin.views.sync.device_fields.PlatformMapping", mock_mapping_cls),
         ):
+            view.request = req
             view.post(req, pk=1)
 
         mock_mapping_cls.assert_not_called()
@@ -1360,6 +1424,7 @@ class TestCreateAndAssignPlatformView:
             platform_name="Cisco IOS", librenms_os="ios", create_mapping="1"
         )
         mock_mapping_cls = MagicMock()
+        mock_mapping_cls.objects.restrict.return_value = mock_mapping_cls.objects
         mock_mapping_cls.objects.filter.return_value.first.return_value = MagicMock()  # existing mapping
 
         with (
@@ -1374,6 +1439,7 @@ class TestCreateAndAssignPlatformView:
             patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
             patch("netbox_librenms_plugin.views.sync.device_fields.PlatformMapping", mock_mapping_cls),
         ):
+            view.request = req
             view.post(req, pk=1)
 
         mock_mapping_cls.assert_not_called()
@@ -1391,6 +1457,7 @@ class TestCreateAndAssignPlatformView:
         mapping_add_perm = "netbox_librenms_plugin.add_platformmapping"
         req.user.has_perm = MagicMock(side_effect=lambda perm: perm != mapping_add_perm)
         mock_mapping_cls = MagicMock()
+        mock_mapping_cls.objects.restrict.return_value = mock_mapping_cls.objects
         mock_mapping_cls.objects.filter.return_value.first.return_value = None  # deleted since preflight
 
         with (
@@ -1406,6 +1473,7 @@ class TestCreateAndAssignPlatformView:
             patch("netbox_librenms_plugin.views.sync.device_fields.PlatformMapping", mock_mapping_cls),
             patch("utilities.permissions.get_permission_for_model", return_value=mapping_add_perm),
         ):
+            view.request = req
             view.post(req, pk=1)
 
         # Prove the write-site permission check actually ran (so the skip is due to the TOCTOU
@@ -1449,6 +1517,7 @@ class TestCreateAndAssignPlatformView:
             patch("netbox_librenms_plugin.views.sync.device_fields.Device", mock_device_cls),
             patch("netbox_librenms_plugin.views.sync.device_fields.PlatformMapping", RealPlatformMapping),
         ):
+            view.request = req
             view.post(req, pk=1)
 
         assert ("add", RealPlatformMapping) not in captured["perms"], (
@@ -1483,6 +1552,7 @@ class TestCreateAndAssignPlatformView:
             patch("netbox_librenms_plugin.views.sync.device_fields.Device", mock_device_cls),
             patch("netbox_librenms_plugin.views.sync.device_fields.PlatformMapping", RealPlatformMapping),
         ):
+            view.request = req
             view.post(req, pk=1)
 
         assert ("add", RealPlatformMapping) not in captured["perms"], (
@@ -1514,6 +1584,7 @@ class TestCreateAndAssignPlatformView:
             patch("netbox_librenms_plugin.views.sync.device_fields.Device", mock_device_cls),
             patch("netbox_librenms_plugin.views.sync.device_fields.PlatformMapping", RealPlatformMapping),
         ):
+            view.request = req
             view.post(req, pk=1)
 
         assert ("add", RealPlatformMapping) not in captured["perms"], (
@@ -1587,7 +1658,9 @@ class TestAssignVCSerialView:
         err = MagicMock()
         view.require_all_permissions = MagicMock(return_value=err)
         with patch("netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404"):
-            result = view.post(_make_request(), pk=1)
+            _r = _make_request()
+            view.request = _r
+            result = view.post(_r, pk=1)
         assert result is err
 
     def test_not_virtual_chassis(self):
@@ -1618,7 +1691,9 @@ class TestAssignVCSerialView:
             patch("netbox_librenms_plugin.views.sync.device_fields.messages") as mock_msg,
             patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
         ):
-            view.post(_make_request({}), pk=1)
+            _r = _make_request({})
+            view.request = _r
+            view.post(_r, pk=1)
         mock_msg.info.assert_called_once()
 
     def test_member_id_missing(self):
@@ -1636,6 +1711,7 @@ class TestAssignVCSerialView:
             patch("netbox_librenms_plugin.views.sync.device_fields.messages") as mock_msg,
             patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
         ):
+            view.request = req
             view.post(req, pk=1)
         mock_msg.info.assert_called_once()
 
@@ -1647,6 +1723,7 @@ class TestAssignVCSerialView:
         DoesNotExist = type("DoesNotExist", (Exception,), {})
         mock_device_cls = MagicMock()
         mock_device_cls.DoesNotExist = DoesNotExist
+        mock_device_cls.objects.restrict.return_value = mock_device_cls.objects
         mock_device_cls.objects.get.side_effect = DoesNotExist()
 
         req = _make_request({"serial_1": "SN100", "member_id_1": "99"})
@@ -1679,6 +1756,7 @@ class TestAssignVCSerialView:
         DoesNotExist = type("DoesNotExist", (Exception,), {})
         mock_device_cls = MagicMock()
         mock_device_cls.DoesNotExist = DoesNotExist
+        mock_device_cls.objects.restrict.return_value = mock_device_cls.objects
         mock_device_cls.objects.get.return_value = member
 
         req = _make_request({"serial_1": "SN100", "member_id_1": "5"})
@@ -1714,6 +1792,7 @@ class TestAssignVCSerialView:
         DoesNotExist = type("DoesNotExist", (Exception,), {})
         mock_device_cls = MagicMock()
         mock_device_cls.DoesNotExist = DoesNotExist
+        mock_device_cls.objects.restrict.return_value = mock_device_cls.objects
         mock_device_cls.objects.get.return_value = member
 
         req = _make_request({"serial_1": "SN100", "member_id_1": "5"})
@@ -1755,6 +1834,7 @@ class TestAssignVCSerialView:
         DoesNotExist = type("DoesNotExist", (Exception,), {})
         mock_device_cls = MagicMock()
         mock_device_cls.DoesNotExist = DoesNotExist
+        mock_device_cls.objects.restrict.return_value = mock_device_cls.objects
         mock_device_cls.objects.get.side_effect = [good_member, bad_member]
 
         req = _make_request(
@@ -1870,6 +1950,7 @@ class TestRemoveServerMappingViewPost:
     def test_invalid_object_type_returns_400(self):
         view = self._view()
         req = _make_request({"object_type": "badtype"})
+        view.request = req
         result = view.post(req, pk=1)
         assert result.status_code == 400
 
@@ -1886,6 +1967,7 @@ class TestRemoveServerMappingViewPost:
         mock_vm_cls.DoesNotExist = DoesNotExist
         mock_locked = MagicMock()
         mock_locked.custom_field_data = {"librenms_id": {"orphan": 5}}
+        mock_vm_cls.objects.restrict.return_value = mock_vm_cls.objects
         mock_vm_cls.objects.select_for_update.return_value.get.return_value = mock_locked
 
         mock_cfg = {"netbox_librenms_plugin": {"servers": {}, "librenms_url": ""}}
@@ -1902,6 +1984,7 @@ class TestRemoveServerMappingViewPost:
             patch("django.conf.settings") as mock_settings,
         ):
             mock_settings.PLUGINS_CONFIG = mock_cfg
+            view.request = req
             view.post(req, pk=1)
         mock_msg.success.assert_called_once()
 
@@ -1910,6 +1993,7 @@ class TestRemoveServerMappingViewPost:
         err = MagicMock()
         view.require_all_permissions = MagicMock(return_value=err)
         req = _make_request({"object_type": "device", "server_key": "x"})
+        view.request = req
         result = view.post(req, pk=1)
         assert result is err
 
@@ -1925,6 +2009,7 @@ class TestRemoveServerMappingViewPost:
             patch("netbox_librenms_plugin.views.sync.device_fields.messages") as mock_msg,
             patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
         ):
+            view.request = req
             view.post(req, pk=1)
         mock_msg.error.assert_called_once()
 
@@ -1944,6 +2029,7 @@ class TestRemoveServerMappingViewPost:
             patch("netbox_librenms_plugin.views.sync.device_fields.messages") as mock_msg,
             patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
         ):
+            view.request = req
             view.post(req, pk=1)
         mock_msg.warning.assert_called_once()
 
@@ -1963,6 +2049,7 @@ class TestRemoveServerMappingViewPost:
             patch("netbox_librenms_plugin.views.sync.device_fields.messages") as mock_msg,
             patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
         ):
+            view.request = req
             view.post(req, pk=1)
         mock_msg.warning.assert_called_once()
 
@@ -1981,6 +2068,7 @@ class TestRemoveServerMappingViewPost:
         mock_device_cls = MagicMock()
         mock_device_cls.__name__ = "Device"
         mock_device_cls.DoesNotExist = DoesNotExist
+        mock_device_cls.objects.restrict.return_value = mock_device_cls.objects
         mock_device_cls.objects.select_for_update.return_value.get.return_value = mock_locked
 
         # servers is a list (non-dict) → line 496 normalises it to {}
@@ -1997,6 +2085,7 @@ class TestRemoveServerMappingViewPost:
             patch("django.conf.settings") as mock_settings,
         ):
             mock_settings.PLUGINS_CONFIG = mock_cfg
+            view.request = req
             view.post(req, pk=1)
         mock_msg.success.assert_called_once()
 
@@ -2019,6 +2108,7 @@ class TestRemoveServerMappingViewPost:
             patch("django.conf.settings") as mock_settings,
         ):
             mock_settings.PLUGINS_CONFIG = mock_cfg
+            view.request = req
             view.post(req, pk=1)
         mock_msg.error.assert_called_once()
         assert "Cannot remove" in mock_msg.error.call_args[0][1]
@@ -2042,6 +2132,7 @@ class TestRemoveServerMappingViewPost:
             patch("django.conf.settings") as mock_settings,
         ):
             mock_settings.PLUGINS_CONFIG = mock_cfg
+            view.request = req
             view.post(req, pk=1)
         mock_msg.error.assert_called_once()
 
@@ -2056,6 +2147,7 @@ class TestRemoveServerMappingViewPost:
         mock_device_cls = MagicMock()
         mock_device_cls.__name__ = "Device"
         mock_device_cls.DoesNotExist = DoesNotExist
+        mock_device_cls.objects.restrict.return_value = mock_device_cls.objects
         mock_device_cls.objects.select_for_update.return_value.get.side_effect = DoesNotExist()
 
         mock_cfg = {"netbox_librenms_plugin": {"servers": {}, "librenms_url": ""}}
@@ -2071,6 +2163,7 @@ class TestRemoveServerMappingViewPost:
             patch("django.conf.settings") as mock_settings,
         ):
             mock_settings.PLUGINS_CONFIG = mock_cfg
+            view.request = req
             view.post(req, pk=1)
         mock_msg.error.assert_called_once()
 
@@ -2089,6 +2182,7 @@ class TestRemoveServerMappingViewPost:
 
         mock_device_cls = MagicMock()
         mock_device_cls.DoesNotExist = DoesNotExist
+        mock_device_cls.objects.restrict.return_value = mock_device_cls.objects
         mock_device_cls.objects.select_for_update.return_value.get.return_value = mock_locked
 
         mock_cfg = {"netbox_librenms_plugin": {"servers": {}, "librenms_url": ""}}
@@ -2104,6 +2198,7 @@ class TestRemoveServerMappingViewPost:
             patch("django.conf.settings") as mock_settings,
         ):
             mock_settings.PLUGINS_CONFIG = mock_cfg
+            view.request = req
             view.post(req, pk=1)
         mock_msg.warning.assert_called_once()
 
@@ -2123,6 +2218,7 @@ class TestRemoveServerMappingViewPost:
 
         mock_device_cls = MagicMock()
         mock_device_cls.DoesNotExist = DoesNotExist
+        mock_device_cls.objects.restrict.return_value = mock_device_cls.objects
         mock_device_cls.objects.select_for_update.return_value.get.return_value = mock_locked
 
         mock_txn = MagicMock()
@@ -2141,6 +2237,7 @@ class TestRemoveServerMappingViewPost:
             patch("django.conf.settings") as mock_settings,
         ):
             mock_settings.PLUGINS_CONFIG = mock_cfg
+            view.request = req
             view.post(req, pk=1)
         mock_msg.error.assert_called_once()
         mock_txn.set_rollback.assert_called_once_with(True)
@@ -2159,6 +2256,7 @@ class TestRemoveServerMappingViewPost:
 
         mock_device_cls = MagicMock()
         mock_device_cls.DoesNotExist = DoesNotExist
+        mock_device_cls.objects.restrict.return_value = mock_device_cls.objects
         mock_device_cls.objects.select_for_update.return_value.get.return_value = mock_locked
 
         mock_txn = MagicMock()
@@ -2177,6 +2275,7 @@ class TestRemoveServerMappingViewPost:
             patch("django.conf.settings") as mock_settings,
         ):
             mock_settings.PLUGINS_CONFIG = mock_cfg
+            view.request = req
             view.post(req, pk=1)
         mock_msg.error.assert_called_once()
         mock_txn.set_rollback.assert_called_once_with(True)
@@ -2368,6 +2467,7 @@ class TestConvertLegacyLibreNMSIdViewPost:
         view = self._view()
         req = _make_request({"object_type": "badtype"})
         with patch("netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404"):
+            view.request = req
             result = view.post(req, pk=1)
         assert result.status_code == 400
 
@@ -2389,6 +2489,7 @@ class TestConvertLegacyLibreNMSIdViewPost:
 
         mock_vm_cls = MagicMock()
         mock_vm_cls.DoesNotExist = DoesNotExist
+        mock_vm_cls.objects.restrict.return_value = mock_vm_cls.objects
         mock_vm_cls.objects.select_for_update.return_value.get.return_value = mock_locked
 
         with (
@@ -2405,7 +2506,9 @@ class TestConvertLegacyLibreNMSIdViewPost:
             patch("netbox_librenms_plugin.views.sync.device_fields.messages") as mock_msg,
             patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
         ):
-            view.post(_make_request({"object_type": "virtualmachine"}), pk=1)
+            _r = _make_request({"object_type": "virtualmachine"})
+            view.request = _r
+            view.post(_r, pk=1)
         mock_msg.success.assert_called_once()
         mock_migrate.assert_called_once()
         mock_locked.full_clean.assert_called_once()
@@ -2425,6 +2528,7 @@ class TestConvertLegacyLibreNMSIdViewPost:
         mock_locked.serial = "SN-MATCH"
         mock_dev_cls = MagicMock()
         mock_dev_cls.DoesNotExist = DoesNotExist
+        mock_dev_cls.objects.restrict.return_value = mock_dev_cls.objects
         mock_dev_cls.objects.select_for_update.return_value.get.return_value = mock_locked
 
         with (
@@ -2441,7 +2545,9 @@ class TestConvertLegacyLibreNMSIdViewPost:
             patch("netbox_librenms_plugin.views.sync.device_fields.messages") as mock_msg,
             patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
         ):
-            view.post(_make_request({"object_type": "device"}), pk=1)
+            _r = _make_request({"object_type": "device"})
+            view.request = _r
+            view.post(_r, pk=1)
         # Unfixed: ' 42 '.isdigit() is False → error "not a valid integer" and migrate NOT called.
         mock_migrate.assert_called_once()
         assert not any("not a valid integer" in str(c) for c in mock_msg.error.call_args_list)
@@ -2462,6 +2568,7 @@ class TestConvertLegacyLibreNMSIdViewPost:
         mock_locked.serial = "987654"
         mock_dev_cls = MagicMock()
         mock_dev_cls.DoesNotExist = DoesNotExist
+        mock_dev_cls.objects.restrict.return_value = mock_dev_cls.objects
         mock_dev_cls.objects.select_for_update.return_value.get.return_value = mock_locked
 
         with (
@@ -2478,7 +2585,9 @@ class TestConvertLegacyLibreNMSIdViewPost:
             patch("netbox_librenms_plugin.views.sync.device_fields.messages") as mock_msg,
             patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
         ):
-            view.post(_make_request({"object_type": "device"}), pk=1)
+            _r = _make_request({"object_type": "device"})
+            view.request = _r
+            view.post(_r, pk=1)
 
         mock_migrate.assert_called_once()
         assert not any("Serial number mismatch" in str(c) for c in mock_msg.error.call_args_list)
@@ -2489,6 +2598,7 @@ class TestConvertLegacyLibreNMSIdViewPost:
         view.require_all_permissions = MagicMock(return_value=err)
         req = _make_request({"object_type": "device"})
         with patch("netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404"):
+            view.request = req
             result = view.post(req, pk=1)
         assert result is err
 
@@ -2505,7 +2615,9 @@ class TestConvertLegacyLibreNMSIdViewPost:
             patch("netbox_librenms_plugin.views.sync.device_fields.messages") as mock_msg,
             patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
         ):
-            view.post(_make_request({"object_type": "device"}), pk=1)
+            _r = _make_request({"object_type": "device"})
+            view.request = _r
+            view.post(_r, pk=1)
         mock_msg.warning.assert_called_once()
         assert "already" in mock_msg.warning.call_args[0][1].lower()
 
@@ -2522,7 +2634,9 @@ class TestConvertLegacyLibreNMSIdViewPost:
             patch("netbox_librenms_plugin.views.sync.device_fields.messages") as mock_msg,
             patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
         ):
-            view.post(_make_request({"object_type": "device"}), pk=1)
+            _r = _make_request({"object_type": "device"})
+            view.request = _r
+            view.post(_r, pk=1)
         mock_msg.error.assert_called_once()
 
     def test_non_digit_string_cf_value(self):
@@ -2538,7 +2652,9 @@ class TestConvertLegacyLibreNMSIdViewPost:
             patch("netbox_librenms_plugin.views.sync.device_fields.messages") as mock_msg,
             patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
         ):
-            view.post(_make_request({"object_type": "device"}), pk=1)
+            _r = _make_request({"object_type": "device"})
+            view.request = _r
+            view.post(_r, pk=1)
         mock_msg.error.assert_called_once()
 
     @pytest.mark.django_db
@@ -2566,7 +2682,9 @@ class TestConvertLegacyLibreNMSIdViewPost:
             patch("netbox_librenms_plugin.views.sync.device_fields.messages") as mock_msg,
             patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
         ):
-            view.post(_make_request({"object_type": "device"}), pk=dev_a.pk)
+            _r = _make_request({"object_type": "device"})
+            view.request = _r
+            view.post(_r, pk=dev_a.pk)
 
         # Refused (fail closed): an error, never a success, and the legacy id is left untouched
         # (NOT silently converted to the JSON dict form).
@@ -2608,7 +2726,9 @@ class TestConvertLegacyLibreNMSIdViewPost:
             patch("netbox_librenms_plugin.views.sync.device_fields.messages") as mock_msg,
             patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
         ):
-            view.post(_make_request({"object_type": "device"}), pk=1)
+            _r = _make_request({"object_type": "device"})
+            view.request = _r
+            view.post(_r, pk=1)
         mock_msg.error.assert_called_once()
         assert "Serial" in mock_msg.error.call_args[0][1]
 
@@ -2627,7 +2747,9 @@ class TestConvertLegacyLibreNMSIdViewPost:
             patch("netbox_librenms_plugin.views.sync.device_fields.messages") as mock_msg,
             patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
         ):
-            view.post(_make_request({"object_type": "device"}), pk=1)
+            _r = _make_request({"object_type": "device"})
+            view.request = _r
+            view.post(_r, pk=1)
         mock_msg.error.assert_called_once()
 
     def test_object_no_longer_exists_in_lock(self):
@@ -2641,6 +2763,7 @@ class TestConvertLegacyLibreNMSIdViewPost:
         mock_device_cls = MagicMock()
         mock_device_cls.__name__ = "Device"
         mock_device_cls.DoesNotExist = DoesNotExist
+        mock_device_cls.objects.restrict.return_value = mock_device_cls.objects
         mock_device_cls.objects.select_for_update.return_value.get.side_effect = DoesNotExist()
 
         with (
@@ -2653,7 +2776,9 @@ class TestConvertLegacyLibreNMSIdViewPost:
             patch("netbox_librenms_plugin.views.sync.device_fields.messages") as mock_msg,
             patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
         ):
-            view.post(_make_request({"object_type": "device"}), pk=1)
+            _r = _make_request({"object_type": "device"})
+            view.request = _r
+            view.post(_r, pk=1)
         mock_msg.error.assert_called_once()
 
     def test_cf_value_changed_to_json_after_lock(self):
@@ -2670,6 +2795,7 @@ class TestConvertLegacyLibreNMSIdViewPost:
 
         mock_device_cls = MagicMock()
         mock_device_cls.DoesNotExist = DoesNotExist
+        mock_device_cls.objects.restrict.return_value = mock_device_cls.objects
         mock_device_cls.objects.select_for_update.return_value.get.return_value = mock_locked
 
         with (
@@ -2682,7 +2808,9 @@ class TestConvertLegacyLibreNMSIdViewPost:
             patch("netbox_librenms_plugin.views.sync.device_fields.messages") as mock_msg,
             patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
         ):
-            view.post(_make_request({"object_type": "device"}), pk=1)
+            _r = _make_request({"object_type": "device"})
+            view.request = _r
+            view.post(_r, pk=1)
         mock_msg.warning.assert_called_once()
 
     def test_cf_value_not_int_after_lock(self):
@@ -2699,6 +2827,7 @@ class TestConvertLegacyLibreNMSIdViewPost:
 
         mock_device_cls = MagicMock()
         mock_device_cls.DoesNotExist = DoesNotExist
+        mock_device_cls.objects.restrict.return_value = mock_device_cls.objects
         mock_device_cls.objects.select_for_update.return_value.get.return_value = mock_locked
 
         with (
@@ -2711,7 +2840,9 @@ class TestConvertLegacyLibreNMSIdViewPost:
             patch("netbox_librenms_plugin.views.sync.device_fields.messages") as mock_msg,
             patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
         ):
-            view.post(_make_request({"object_type": "device"}), pk=1)
+            _r = _make_request({"object_type": "device"})
+            view.request = _r
+            view.post(_r, pk=1)
         mock_msg.error.assert_called_once()
 
     def test_data_changed_before_lock(self):
@@ -2729,6 +2860,7 @@ class TestConvertLegacyLibreNMSIdViewPost:
 
         mock_device_cls = MagicMock()
         mock_device_cls.DoesNotExist = DoesNotExist
+        mock_device_cls.objects.restrict.return_value = mock_device_cls.objects
         mock_device_cls.objects.select_for_update.return_value.get.return_value = mock_locked
 
         with (
@@ -2741,7 +2873,9 @@ class TestConvertLegacyLibreNMSIdViewPost:
             patch("netbox_librenms_plugin.views.sync.device_fields.messages") as mock_msg,
             patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
         ):
-            view.post(_make_request({"object_type": "device"}), pk=1)
+            _r = _make_request({"object_type": "device"})
+            view.request = _r
+            view.post(_r, pk=1)
         mock_msg.error.assert_called_once()
 
     def test_conflict_with_another_object(self):
@@ -2765,6 +2899,7 @@ class TestConvertLegacyLibreNMSIdViewPost:
         mock_device_cls = MagicMock()
         mock_device_cls.__name__ = "Device"
         mock_device_cls.DoesNotExist = DoesNotExist
+        mock_device_cls.objects.restrict.return_value = mock_device_cls.objects
         mock_device_cls.objects.select_for_update.return_value.get.return_value = mock_locked
 
         mock_txn = MagicMock()
@@ -2781,7 +2916,9 @@ class TestConvertLegacyLibreNMSIdViewPost:
             patch("netbox_librenms_plugin.views.sync.device_fields.messages") as mock_msg,
             patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
         ):
-            view.post(_make_request({"object_type": "device"}), pk=1)
+            _r = _make_request({"object_type": "device"})
+            view.request = _r
+            view.post(_r, pk=1)
         mock_msg.error.assert_called_once()
         mock_txn.set_rollback.assert_called_once_with(True)
 
@@ -2802,6 +2939,7 @@ class TestConvertLegacyLibreNMSIdViewPost:
 
         mock_device_cls = MagicMock()
         mock_device_cls.DoesNotExist = DoesNotExist
+        mock_device_cls.objects.restrict.return_value = mock_device_cls.objects
         mock_device_cls.objects.select_for_update.return_value.get.return_value = mock_locked
 
         with (
@@ -2816,7 +2954,9 @@ class TestConvertLegacyLibreNMSIdViewPost:
             patch("netbox_librenms_plugin.views.sync.device_fields.messages") as mock_msg,
             patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
         ):
-            view.post(_make_request({"object_type": "device"}), pk=1)
+            _r = _make_request({"object_type": "device"})
+            view.request = _r
+            view.post(_r, pk=1)
         mock_msg.warning.assert_called_once()
 
     def test_validation_error_on_save(self):
@@ -2838,6 +2978,7 @@ class TestConvertLegacyLibreNMSIdViewPost:
 
         mock_device_cls = MagicMock()
         mock_device_cls.DoesNotExist = DoesNotExist
+        mock_device_cls.objects.restrict.return_value = mock_device_cls.objects
         mock_device_cls.objects.select_for_update.return_value.get.return_value = mock_locked
 
         mock_txn = MagicMock()
@@ -2855,7 +2996,9 @@ class TestConvertLegacyLibreNMSIdViewPost:
             patch("netbox_librenms_plugin.views.sync.device_fields.messages") as mock_msg,
             patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
         ):
-            view.post(_make_request({"object_type": "device"}), pk=1)
+            _r = _make_request({"object_type": "device"})
+            view.request = _r
+            view.post(_r, pk=1)
         mock_msg.error.assert_called_once()
         mock_txn.set_rollback.assert_called_once_with(True)
 
@@ -2876,6 +3019,7 @@ class TestConvertLegacyLibreNMSIdViewPost:
 
         mock_device_cls = MagicMock()
         mock_device_cls.DoesNotExist = DoesNotExist
+        mock_device_cls.objects.restrict.return_value = mock_device_cls.objects
         mock_device_cls.objects.select_for_update.return_value.get.return_value = mock_locked
 
         mock_txn = MagicMock()
@@ -2893,7 +3037,9 @@ class TestConvertLegacyLibreNMSIdViewPost:
             patch("netbox_librenms_plugin.views.sync.device_fields.messages") as mock_msg,
             patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
         ):
-            view.post(_make_request({"object_type": "device"}), pk=1)
+            _r = _make_request({"object_type": "device"})
+            view.request = _r
+            view.post(_r, pk=1)
         mock_msg.error.assert_called_once()
         mock_txn.set_rollback.assert_called_once_with(True)
 
@@ -2951,6 +3097,7 @@ class TestConvertLegacyLibreNMSIdViewPost:
 
         mock_device_cls = MagicMock()
         mock_device_cls.DoesNotExist = DoesNotExist
+        mock_device_cls.objects.restrict.return_value = mock_device_cls.objects
         mock_device_cls.objects.select_for_update.return_value.get.return_value = mock_locked
 
         with (
@@ -2965,7 +3112,9 @@ class TestConvertLegacyLibreNMSIdViewPost:
             patch("netbox_librenms_plugin.views.sync.device_fields.messages") as mock_msg,
             patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
         ):
-            view.post(_make_request({"object_type": "device"}), pk=1)
+            _r = _make_request({"object_type": "device"})
+            view.request = _r
+            view.post(_r, pk=1)
         mock_msg.success.assert_called_once()
         mock_locked.full_clean.assert_called_once()
         mock_locked.save.assert_called_once()
@@ -3201,6 +3350,7 @@ class TestUpdateDeviceFieldsServerRebind:
             patch("netbox_librenms_plugin.views.sync.device_fields.messages"),
             patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
         ):
+            view.request = request
             view.post(request, pk=pk)
 
     def test_update_name_rebinds_and_renames_from_posted_server(self):

--- a/netbox_librenms_plugin/tests/test_coverage_device_operations.py
+++ b/netbox_librenms_plugin/tests/test_coverage_device_operations.py
@@ -322,6 +322,31 @@ class TestValidateDeviceStateMachine:
         assert "role" not in joined
         assert "cluster" not in joined
 
+    def test_ambiguous_primary_ip_is_terminal_no_new_import_blockers(self):
+        """A duplicate primary-IP match (resolve_device_by_host_ip ambiguous) is terminal too — validation must NOT fall through into the new-import site/role/device-type checks and pile unrelated blockers onto the row (mirrors the ambiguous_librenms_id handling)."""
+        from unittest.mock import patch
+
+        device = self._base_device()
+        device["ip"] = "10.1.2.3"  # drives the primary-IP resolution path
+        result = self._run_validate(
+            device,
+            patches_overrides=[
+                patch(
+                    "netbox_librenms_plugin.import_utils.device_operations.resolve_device_by_host_ip",
+                    return_value=(None, True, set()),  # ip_ambiguous
+                ),
+            ],
+        )
+        assert result["existing_match_type"] == "ambiguous_hostname_or_serial"
+        assert result["can_import"] is False
+        assert result["is_ready"] is False
+        # The duplicate-IP ambiguity is the only blocker — no new-import blockers appended.
+        joined = " ".join(result["issues"]).lower()
+        assert "site" not in joined
+        assert "role" not in joined
+        assert "cluster" not in joined
+        assert any("serial or management IP" in i for i in result["issues"])
+
     def test_flag_ambiguous_is_a_durable_blocker(self):
         """The ambiguity must land in issues (not only warnings) so the readiness step's `can_import = len(issues) == 0` recompute cannot silently re-enable the import."""
         from netbox_librenms_plugin.import_utils.device_operations import _flag_ambiguous_librenms_id

--- a/netbox_librenms_plugin/tests/test_coverage_device_operations.py
+++ b/netbox_librenms_plugin/tests/test_coverage_device_operations.py
@@ -1625,10 +1625,8 @@ class TestValidateDeviceForImportEdgeCases:
         assert validation.get("existing_match_type") == "ambiguous_hostname_or_serial"
         assert any("serial or management IP" in i for i in validation.get("issues", []))
 
-        # Resolve the duplicate: dev_b no longer carries the shared host address. Refresh first so
-        # `address` is an IPNetwork, not the str it was constructed with — NetBox 4.4's pre_delete
-        # `clear_primary_ip` reads `instance.family`, which dereferences `.version` unguarded there.
-        ip_b.refresh_from_db()
+        # Resolve the duplicate: dev_b no longer carries the shared host address. The shared
+        # builder must return a DB-coerced address so NetBox's pre-delete receiver can inspect it.
         ip_b.delete()
 
         _refresh_existing_device(validation, libre_device=libre_device, server_key="default")
@@ -3538,7 +3536,10 @@ class TestValidateDedupsSerialDuplicateQuery:
         serial_dup_queries = [
             q["sql"]
             for q in ctx.captured_queries
-            if '."serial" =' in q["sql"].lower() and "limit 2" in q["sql"].lower() and "not" not in q["sql"].lower()
+            if '."serial" =' in (sql := q["sql"].lower())
+            and "limit 2" in sql
+            # Cross-side lookups exclude a peer ID; the duplicate lookup's WHERE clause does not.
+            and '."id"' not in sql.partition(" where ")[2].partition(" order by ")[0]
         ]
         assert len(serial_dup_queries) == 1
         # A TRIM-wrapped comparison would not match the exact-serial filter above, so check

--- a/netbox_librenms_plugin/tests/test_coverage_device_operations.py
+++ b/netbox_librenms_plugin/tests/test_coverage_device_operations.py
@@ -575,6 +575,23 @@ class TestFetchDeviceWithCache:
         mock_cache.get.assert_not_called()
 
     @patch("netbox_librenms_plugin.import_utils.device_operations.cache")
+    def test_mis_keyed_cache_dict_row_is_not_returned(self, mock_cache):
+        """A pre-fetched cache row whose device_id contradicts the requested id (mis-keyed/stale) is NOT served as this device — resolution falls through to the Django cache / API."""
+        from netbox_librenms_plugin.import_utils.device_operations import fetch_device_with_cache
+
+        api = MagicMock()
+        api.server_key = "default"
+        # The dict maps id 1 -> device 99's row (mis-keyed); the Django cache holds the REAL id-1 row.
+        real_row = {"device_id": 1, "hostname": "real-1"}
+        mock_cache.get.return_value = real_row
+
+        result = fetch_device_with_cache(1, api, libre_devices_cache={1: {"device_id": 99}})
+
+        # The mis-keyed dict row is rejected → the Django cache's real row is returned instead.
+        assert result is real_row
+        mock_cache.get.assert_called_once()
+
+    @patch("netbox_librenms_plugin.import_utils.device_operations.cache")
     def test_from_django_cache(self, mock_cache):
         from netbox_librenms_plugin.import_utils.device_operations import fetch_device_with_cache
 

--- a/netbox_librenms_plugin/tests/test_coverage_device_operations.py
+++ b/netbox_librenms_plugin/tests/test_coverage_device_operations.py
@@ -343,6 +343,7 @@ class TestValidateDeviceStateMachine:
         # The duplicate-IP ambiguity is the only blocker — no new-import blockers appended.
         joined = " ".join(result["issues"]).lower()
         assert "site" not in joined
+        assert "device type" not in joined
         assert "role" not in joined
         assert "cluster" not in joined
         assert any("serial or management IP" in i for i in result["issues"])

--- a/netbox_librenms_plugin/tests/test_coverage_device_operations.py
+++ b/netbox_librenms_plugin/tests/test_coverage_device_operations.py
@@ -3541,4 +3541,6 @@ class TestValidateDedupsSerialDuplicateQuery:
             if '."serial" =' in q["sql"].lower() and "limit 2" in q["sql"].lower() and "not" not in q["sql"].lower()
         ]
         assert len(serial_dup_queries) == 1
-        assert all("trim(" not in sql.lower() for sql in serial_dup_queries)
+        # A TRIM-wrapped comparison would not match the exact-serial filter above, so check
+        # every captured query rather than only the already-filtered exact-match subset.
+        assert all("trim(" not in query["sql"].lower() for query in ctx.captured_queries)

--- a/netbox_librenms_plugin/tests/test_coverage_devices.py
+++ b/netbox_librenms_plugin/tests/test_coverage_devices.py
@@ -1468,17 +1468,24 @@ class TestIpCachedSnapshotMgmtIpBackfill:
         # Pre-upgrade snapshot: NO "mgmt_ip" key.
         real_cache.set(key, {"ip_addresses": [], "ports_by_id": {"7": {}}}, timeout=300)
         try:
-            view._prepare_context(request, device, "ifName", fetch_fresh=False, server_key="default")
-            # The missing key triggered a one-time live resolve of the management IP...
-            api.get_device_info.assert_called_once_with(7)
-            # ...and the resolved VALUE was backfilled into the re-cached snapshot...
-            assert real_cache.get(key)["mgmt_ip"] == "10.0.0.9"
-            # ...so the next cached render reads it WITHOUT a second LibreNMS round-trip. Proving
-            # the backfill is consumed is the point of storing it; asserting only the stored value
-            # would still pass if every render re-resolved.
-            api.get_device_info.reset_mock()
-            view._prepare_context(request, device, "ifName", fetch_fresh=False, server_key="default")
-            api.get_device_info.assert_not_called()
+            # This test exercises the django-redis-style positive-TTL path explicitly. Other
+            # backends intentionally skip the backfill because Django's core cache API has no TTL
+            # introspection.
+            with patch(
+                "netbox_librenms_plugin.views.base.ip_addresses_view.cache_remaining_ttl",
+                return_value=300,
+            ):
+                view._prepare_context(request, device, "ifName", fetch_fresh=False, server_key="default")
+                # The missing key triggered a one-time live resolve of the management IP...
+                api.get_device_info.assert_called_once_with(7)
+                # ...and the resolved VALUE was backfilled into the re-cached snapshot...
+                assert real_cache.get(key)["mgmt_ip"] == "10.0.0.9"
+                # ...so the next cached render reads it WITHOUT a second LibreNMS round-trip. Proving
+                # the backfill is consumed is the point of storing it; asserting only the stored value
+                # would still pass if every render re-resolved.
+                api.get_device_info.reset_mock()
+                view._prepare_context(request, device, "ifName", fetch_fresh=False, server_key="default")
+                api.get_device_info.assert_not_called()
         finally:
             real_cache.delete(key)
 

--- a/netbox_librenms_plugin/tests/test_coverage_devices.py
+++ b/netbox_librenms_plugin/tests/test_coverage_devices.py
@@ -5,24 +5,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 
-def _bind_and_call(view, request, method, **kwargs):
-    """Call *view*.<method>, binding the request the way ``View.setup()`` does under dispatch().
-
-    A direct ``view.post(request, ...)`` leaves ``self.request`` unset, which the object-scoped
-    lookups read — production always goes through dispatch(), so bind it here too.
-    """
-    view.setup(request)
-    return getattr(view, method)(request, **kwargs)
-
-
-def _post(view, request, **kwargs):
-    """POST into *view* with the request bound (see :func:`_bind_and_call`)."""
-    return _bind_and_call(view, request, "post", **kwargs)
-
-
-def _get(view, request, **kwargs):
-    """GET into *view* with the request bound (see :func:`_bind_and_call`)."""
-    return _bind_and_call(view, request, "get", **kwargs)
+from netbox_librenms_plugin.tests.view_test_helpers import post as _post
 
 
 def _make_real_device(tag):

--- a/netbox_librenms_plugin/tests/test_coverage_devices.py
+++ b/netbox_librenms_plugin/tests/test_coverage_devices.py
@@ -734,6 +734,37 @@ class TestSingleVlanGroupVerifyView:
 
         assert ("view", VLANGroup) in SingleVlanGroupVerifyView.required_object_permissions["POST"]
 
+    @pytest.mark.django_db
+    def test_denies_a_user_without_vlan_read_permission(self):
+        """The verify endpoint must gate its VLAN membership reads."""
+        from dcim.models import Device
+        from ipam.models import VLAN, VLANGroup
+
+        from netbox_librenms_plugin.views.object_sync.devices import SingleVlanGroupVerifyView
+
+        device = _make_real_device("vg-no-vlan-perm")
+        user = _user_with_perms(
+            "vg-no-vlan-perm",
+            [("view", Device), ("view", VLANGroup)],
+        )
+        request = _real_verify_request(
+            {"device_id": device.pk, "vid": "100", "server_key": "default"},
+            "vg-no-vlan-request",
+        )
+        request.user = user
+        view = SingleVlanGroupVerifyView()
+        view.setup(request)
+
+        assert user.has_perm("dcim.view_device") is True
+        assert user.has_perm("ipam.view_vlangroup") is True
+        assert user.has_perm("ipam.view_vlan") is False
+        assert ("view", VLAN) in view.required_object_permissions["POST"]
+        assert view.check_object_permissions("POST")[0] is False
+
+        response = view.post(request)
+
+        assert response.status_code == 403
+
     def test_returns_400_when_no_device_id(self):
         """Returns 400 when no device_id provided."""
         import json

--- a/netbox_librenms_plugin/tests/test_coverage_devices.py
+++ b/netbox_librenms_plugin/tests/test_coverage_devices.py
@@ -5,6 +5,26 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 
+def _bind_and_call(view, request, method, **kwargs):
+    """Call *view*.<method>, binding the request the way ``View.setup()`` does under dispatch().
+
+    A direct ``view.post(request, ...)`` leaves ``self.request`` unset, which the object-scoped
+    lookups read — production always goes through dispatch(), so bind it here too.
+    """
+    view.setup(request)
+    return getattr(view, method)(request, **kwargs)
+
+
+def _post(view, request, **kwargs):
+    """POST into *view* with the request bound (see :func:`_bind_and_call`)."""
+    return _bind_and_call(view, request, "post", **kwargs)
+
+
+def _get(view, request, **kwargs):
+    """GET into *view* with the request bound (see :func:`_bind_and_call`)."""
+    return _bind_and_call(view, request, "get", **kwargs)
+
+
 def _make_real_device(tag):
     """Create and return a real NetBox Device (with its required FKs) for DB-backed tests."""
     from dcim.models import Device, DeviceRole, DeviceType, Manufacturer, Site
@@ -716,7 +736,9 @@ class TestSingleVlanGroupVerifyView:
         request.user.has_perm.return_value = False  # unauthorized → real gate returns 403
         view.request = request
 
-        with patch("netbox_librenms_plugin.views.object_sync.devices.get_object_or_404") as mock_get_obj:
+        with patch(
+            "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404"
+        ) as mock_get_obj:
             response = view.post(request)
 
         assert response.status_code == 403
@@ -791,7 +813,7 @@ class TestSingleVlanGroupVerifyView:
         ).encode()
         request.user = _make_verify_superuser("vg-with")
         view.request = request
-        response = view.post(request)
+        response = _post(view, request)
 
         assert isinstance(response, JsonResponse)
         assert response.status_code == 200
@@ -890,7 +912,9 @@ class TestVerifyVlanSyncGroupView:
         request.user.has_perm.return_value = False  # unauthorized → real gate returns 403
         view.request = request
 
-        with patch("netbox_librenms_plugin.views.object_sync.devices.get_object_or_404") as mock_get_obj:
+        with patch(
+            "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404"
+        ) as mock_get_obj:
             response = view.post(request)
 
         assert response.status_code == 403
@@ -938,7 +962,7 @@ class TestVerifyVlanSyncGroupView:
         view = self._make_view()
         request = MagicMock()
         request.body = json.dumps({"vid": "10", "vlan_group_id": group.pk, "name": "vlan10"}).encode()
-        response = view.post(request)
+        response = _post(view, request)
 
         assert isinstance(response, JsonResponse)
         data = json.loads(response.content)

--- a/netbox_librenms_plugin/tests/test_coverage_devices.py
+++ b/netbox_librenms_plugin/tests/test_coverage_devices.py
@@ -330,7 +330,7 @@ class TestSingleInterfaceVerifyView:
         assert response.status_code == 400
 
     def test_checks_permission_before_resolving_device(self):
-        """The object-view gate must run BEFORE get_object_or_404 so an unauthorized caller can't probe arbitrary device IDs (existence via 404). Exercises the REAL require_object_permissions_json (only request.user.has_perm is mocked) — mocking the gate itself would mask a missing NetBoxObjectPermissionMixin base (AttributeError/500 in production)."""
+        """The object-view gate must run BEFORE restrict_object_or_404 so an unauthorized caller can't probe arbitrary device IDs (existence via 404). Exercises the REAL require_object_permissions_json (only request.user.has_perm is mocked) — mocking the gate itself would mask a missing NetBoxObjectPermissionMixin base (AttributeError/500 in production)."""
         import json
         from netbox_librenms_plugin.views.object_sync.devices import SingleInterfaceVerifyView
 
@@ -495,7 +495,7 @@ class TestSingleModuleVerifyView:
         return view
 
     def test_checks_permission_before_resolving_device(self):
-        """The object-view gate must run BEFORE get_object_or_404 so an unauthorized caller can't probe arbitrary device IDs (existence via 404). Exercises the real require_object_permissions_json (only request.user.has_perm is mocked)."""
+        """The object-view gate must run BEFORE restrict_object_or_404 so an unauthorized caller can't probe arbitrary device IDs (existence via 404). Exercises the real require_object_permissions_json (only request.user.has_perm is mocked)."""
         import json
         from netbox_librenms_plugin.views.object_sync.devices import SingleModuleVerifyView
 

--- a/netbox_librenms_plugin/tests/test_coverage_devices.py
+++ b/netbox_librenms_plugin/tests/test_coverage_devices.py
@@ -719,9 +719,7 @@ class TestSingleVlanGroupVerifyView:
         request.user.has_perm.return_value = False  # unauthorized → real gate returns 403
         view.request = request
 
-        with patch(
-            "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404"
-        ) as mock_get_obj:
+        with patch.object(view, "restrict_object_or_404") as mock_get_obj:
             response = view.post(request)
 
         assert response.status_code == 403

--- a/netbox_librenms_plugin/tests/test_coverage_devices.py
+++ b/netbox_librenms_plugin/tests/test_coverage_devices.py
@@ -765,6 +765,44 @@ class TestSingleVlanGroupVerifyView:
 
         assert response.status_code == 403
 
+    @pytest.mark.django_db
+    def test_a_hidden_vlan_is_not_reported_as_available(self):
+        """A constrained VLAN grant must not disclose another VLAN through its VID."""
+        import json
+
+        from dcim.models import Device
+        from ipam.models import VLAN, VLANGroup
+
+        from netbox_librenms_plugin.tests.view_test_helpers import grant
+        from netbox_librenms_plugin.views.object_sync.devices import SingleVlanGroupVerifyView
+
+        device = _make_real_device("vg-hidden")
+        group = VLANGroup.objects.create(name="Grp-vg-hidden", slug="grp-vg-hidden")
+        visible = VLAN.objects.create(vid=10, name="visible", group=group)
+        hidden = VLAN.objects.create(vid=20, name="hidden", group=group)
+        user = _user_with_perms(
+            "vg-hidden",
+            [("view", Device), ("view", VLANGroup)],
+        )
+        user = grant(user, "view", VLAN, constraints={"pk": visible.pk})
+        request = _real_verify_request(
+            {
+                "device_id": device.pk,
+                "vid": str(hidden.vid),
+                "vlan_group_id": group.pk,
+                "vlan_type": "U",
+            },
+            "vg-hidden-request",
+        )
+        request.user = user
+        view = SingleVlanGroupVerifyView()
+        view.setup(request)
+
+        response = view.post(request)
+
+        assert response.status_code == 200
+        assert json.loads(response.content)["is_missing"] is True
+
     def test_returns_400_when_no_device_id(self):
         """Returns 400 when no device_id provided."""
         import json
@@ -1010,7 +1048,7 @@ class TestVerifyVlanSyncGroupView:
         view = self._make_view()
         request = MagicMock()
         request.body = json.dumps({"vid": "20", "name": "vlan20"}).encode()
-        response = view.post(request)
+        response = _post(view, request)
 
         assert isinstance(response, JsonResponse)
         data = json.loads(response.content)
@@ -1018,6 +1056,36 @@ class TestVerifyVlanSyncGroupView:
         assert data["status"] == "success"
         assert data["exists_in_netbox"] is False
         assert data["css_class"]  # a real CSS class was computed
+
+    @pytest.mark.django_db
+    def test_a_hidden_vlan_is_not_returned_from_the_group_lookup(self):
+        """The standalone VLAN verifier must apply the constrained VLAN grant too."""
+        import json
+
+        from ipam.models import VLAN, VLANGroup
+
+        from netbox_librenms_plugin.tests.view_test_helpers import grant
+        from netbox_librenms_plugin.views.object_sync.devices import VerifyVlanSyncGroupView
+
+        group = VLANGroup.objects.create(name="Grp-sync-hidden", slug="grp-sync-hidden")
+        visible = VLAN.objects.create(vid=10, name="visible", group=group)
+        hidden = VLAN.objects.create(vid=20, name="hidden", group=group)
+        user = _user_with_perms("sync-hidden", [("view", VLANGroup)])
+        user = grant(user, "view", VLAN, constraints={"pk": visible.pk})
+        request = _real_verify_request(
+            {"vid": str(hidden.vid), "vlan_group_id": group.pk, "name": hidden.name},
+            "sync-hidden-request",
+        )
+        request.user = user
+        view = VerifyVlanSyncGroupView()
+        view.setup(request)
+
+        response = view.post(request)
+
+        data = json.loads(response.content)
+        assert response.status_code == 200
+        assert data["exists_in_netbox"] is False
+        assert data["name_matches"] is False
 
 
 class TestSaveVlanGroupOverridesView:

--- a/netbox_librenms_plugin/tests/test_coverage_devices.py
+++ b/netbox_librenms_plugin/tests/test_coverage_devices.py
@@ -727,6 +727,13 @@ class TestSingleVlanGroupVerifyView:
         assert response.status_code == 403
         mock_get_obj.assert_not_called()  # device never resolved → no arbitrary-ID probing
 
+    def test_declares_vlan_group_read_permission(self):
+        from ipam.models import VLANGroup
+
+        from netbox_librenms_plugin.views.object_sync.devices import SingleVlanGroupVerifyView
+
+        assert ("view", VLANGroup) in SingleVlanGroupVerifyView.required_object_permissions["POST"]
+
     def test_returns_400_when_no_device_id(self):
         """Returns 400 when no device_id provided."""
         import json
@@ -879,6 +886,13 @@ class TestVerifyVlanSyncGroupView:
         # gate here; the dedicated perm test exercises the real gate. Mirrors the other harnesses.
         view.require_object_permissions_json = MagicMock(return_value=None)
         return view
+
+    def test_declares_vlan_group_read_permission(self):
+        from ipam.models import VLANGroup
+
+        from netbox_librenms_plugin.views.object_sync.devices import VerifyVlanSyncGroupView
+
+        assert ("view", VLANGroup) in VerifyVlanSyncGroupView.required_object_permissions["POST"]
 
     def test_checks_permission_before_resolving_group(self):
         """The object-view gate (on VLAN — no device here) must run BEFORE get_object_or_404 so an unauthorized caller can't enumerate VLANs/groups (existence via 404). Exercises the real require_object_permissions_json (only request.user.has_perm is mocked)."""

--- a/netbox_librenms_plugin/tests/test_coverage_devices.py
+++ b/netbox_librenms_plugin/tests/test_coverage_devices.py
@@ -1471,9 +1471,14 @@ class TestIpCachedSnapshotMgmtIpBackfill:
             view._prepare_context(request, device, "ifName", fetch_fresh=False, server_key="default")
             # The missing key triggered a one-time live resolve of the management IP...
             api.get_device_info.assert_called_once_with(7)
-            # ...and the resolved VALUE was backfilled into the re-cached snapshot, so
-            # subsequent cached renders read it without another live call.
+            # ...and the resolved VALUE was backfilled into the re-cached snapshot...
             assert real_cache.get(key)["mgmt_ip"] == "10.0.0.9"
+            # ...so the next cached render reads it WITHOUT a second LibreNMS round-trip. Proving
+            # the backfill is consumed is the point of storing it; asserting only the stored value
+            # would still pass if every render re-resolved.
+            api.get_device_info.reset_mock()
+            view._prepare_context(request, device, "ifName", fetch_fresh=False, server_key="default")
+            api.get_device_info.assert_not_called()
         finally:
             real_cache.delete(key)
 

--- a/netbox_librenms_plugin/tests/test_coverage_devices.py
+++ b/netbox_librenms_plugin/tests/test_coverage_devices.py
@@ -1026,8 +1026,7 @@ class TestVerifyVlanSyncGroupView:
         VLAN.objects.create(vid=10, name="vlan10", group=group)
 
         view = self._make_view()
-        request = MagicMock()
-        request.body = json.dumps({"vid": "10", "vlan_group_id": group.pk, "name": "vlan10"}).encode()
+        request = _real_verify_request({"vid": "10", "vlan_group_id": group.pk, "name": "vlan10"}, "sync-group-with")
         response = _post(view, request)
 
         assert isinstance(response, JsonResponse)
@@ -1046,8 +1045,7 @@ class TestVerifyVlanSyncGroupView:
         from django.http import JsonResponse
 
         view = self._make_view()
-        request = MagicMock()
-        request.body = json.dumps({"vid": "20", "name": "vlan20"}).encode()
+        request = _real_verify_request({"vid": "20", "name": "vlan20"}, "sync-group-without")
         response = _post(view, request)
 
         assert isinstance(response, JsonResponse)

--- a/netbox_librenms_plugin/tests/test_coverage_devices.py
+++ b/netbox_librenms_plugin/tests/test_coverage_devices.py
@@ -801,6 +801,23 @@ class TestSingleVlanGroupVerifyView:
         assert response.status_code == 200
         assert json.loads(response.content)["is_missing"] is True
 
+        visible_request = _real_verify_request(
+            {
+                "device_id": device.pk,
+                "vid": str(visible.vid),
+                "vlan_group_id": group.pk,
+                "vlan_type": "U",
+            },
+            "vg-visible-request",
+        )
+        visible_request.user = user
+        visible_view = SingleVlanGroupVerifyView()
+        visible_view.setup(visible_request)
+
+        visible_response = visible_view.post(visible_request)
+
+        assert json.loads(visible_response.content)["is_missing"] is False
+
     def test_returns_400_when_no_device_id(self):
         """Returns 400 when no device_id provided."""
         import json
@@ -1082,6 +1099,18 @@ class TestVerifyVlanSyncGroupView:
         assert response.status_code == 200
         assert data["exists_in_netbox"] is False
         assert data["name_matches"] is False
+
+        visible_request = _real_verify_request(
+            {"vid": str(visible.vid), "vlan_group_id": group.pk, "name": visible.name},
+            "sync-visible-request",
+        )
+        visible_request.user = user
+        visible_view = VerifyVlanSyncGroupView()
+        visible_view.setup(visible_request)
+
+        visible_response = visible_view.post(visible_request)
+
+        assert json.loads(visible_response.content)["exists_in_netbox"] is True
 
 
 class TestSaveVlanGroupOverridesView:

--- a/netbox_librenms_plugin/tests/test_coverage_sync_interfaces.py
+++ b/netbox_librenms_plugin/tests/test_coverage_sync_interfaces.py
@@ -1364,6 +1364,7 @@ class TestDeleteNetBoxInterfacesViewPost:
         view.require_all_permissions_json = MagicMock(return_value=_denied_response())
 
         req = _make_request(post_data={"interface_ids": ["1"]})
+        view.request = req
         result = view.post(req, "device", 1)
         assert result.status_code == 403
 
@@ -1377,6 +1378,7 @@ class TestDeleteNetBoxInterfacesViewPost:
 
         mock_device = MagicMock(pk=1)
         req = _make_request(post_data={})  # No interface_ids
+        view.request = req
 
         with patch(
             "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
@@ -1396,6 +1398,7 @@ class TestDeleteNetBoxInterfacesViewPost:
         view.require_all_permissions_json = MagicMock(return_value=None)
 
         req = _make_request(post_data={"interface_ids": ["1"]})
+        view.request = req
         with pytest.raises(Http404):
             view.post(req, "badtype", 1)
 
@@ -1417,6 +1420,7 @@ class TestDeleteNetBoxInterfacesViewPost:
         mock_interface.device_id = 1
 
         req = _make_request(post_data={"interface_ids": ["5"]})
+        view.request = req
 
         with (
             patch(
@@ -1426,6 +1430,7 @@ class TestDeleteNetBoxInterfacesViewPost:
             patch("netbox_librenms_plugin.views.sync.interfaces.Interface") as mock_intf_cls,
             patch("netbox_librenms_plugin.views.sync.interfaces.transaction"),
         ):
+            mock_intf_cls.objects.restrict.return_value = mock_intf_cls.objects
             mock_intf_cls.objects.get.return_value = mock_interface
 
             class _DNE(Exception):
@@ -1458,6 +1463,7 @@ class TestDeleteNetBoxInterfacesViewPost:
         mock_interface.virtual_machine_id = 2
 
         req = _make_request(post_data={"interface_ids": ["7"]})
+        view.request = req
 
         with (
             patch(
@@ -1467,6 +1473,7 @@ class TestDeleteNetBoxInterfacesViewPost:
             patch("netbox_librenms_plugin.views.sync.interfaces.VMInterface") as mock_vmintf_cls,
             patch("netbox_librenms_plugin.views.sync.interfaces.transaction"),
         ):
+            mock_vmintf_cls.objects.restrict.return_value = mock_vmintf_cls.objects
             mock_vmintf_cls.objects.get.return_value = mock_interface
 
             class _DNE(Exception):
@@ -1498,6 +1505,7 @@ class TestDeleteNetBoxInterfacesViewPost:
         mock_interface.device_id = 99  # Wrong device
 
         req = _make_request(post_data={"interface_ids": ["5"]})
+        view.request = req
 
         with (
             patch(
@@ -1507,6 +1515,7 @@ class TestDeleteNetBoxInterfacesViewPost:
             patch("netbox_librenms_plugin.views.sync.interfaces.Interface") as mock_intf_cls,
             patch("netbox_librenms_plugin.views.sync.interfaces.transaction"),
         ):
+            mock_intf_cls.objects.restrict.return_value = mock_intf_cls.objects
             mock_intf_cls.objects.get.return_value = mock_interface
 
             class _DNE(Exception):
@@ -1541,6 +1550,7 @@ class TestDeleteNetBoxInterfacesViewPost:
         mock_interface.device_id = 999  # Not in VC
 
         req = _make_request(post_data={"interface_ids": ["5"]})
+        view.request = req
 
         with (
             patch(
@@ -1550,6 +1560,7 @@ class TestDeleteNetBoxInterfacesViewPost:
             patch("netbox_librenms_plugin.views.sync.interfaces.Interface") as mock_intf_cls,
             patch("netbox_librenms_plugin.views.sync.interfaces.transaction"),
         ):
+            mock_intf_cls.objects.restrict.return_value = mock_intf_cls.objects
             mock_intf_cls.objects.get.return_value = mock_interface
 
             class _DNE(Exception):
@@ -1576,6 +1587,7 @@ class TestDeleteNetBoxInterfacesViewPost:
         mock_device.virtual_chassis = None
 
         req = _make_request(post_data={"interface_ids": ["999"]})
+        view.request = req
 
         class _DNE(Exception):
             pass
@@ -1589,6 +1601,7 @@ class TestDeleteNetBoxInterfacesViewPost:
             patch("netbox_librenms_plugin.views.sync.interfaces.transaction"),
         ):
             mock_intf_cls.DoesNotExist = _DNE
+            mock_intf_cls.objects.restrict.return_value = mock_intf_cls.objects
             mock_intf_cls.objects.get.side_effect = _DNE()
 
             result = view.post(req, "device", 1)
@@ -1614,6 +1627,7 @@ class TestDeleteNetBoxInterfacesViewPost:
         mock_interface.virtual_machine_id = 99  # Wrong VM
 
         req = _make_request(post_data={"interface_ids": ["7"]})
+        view.request = req
 
         with (
             patch(
@@ -1623,6 +1637,7 @@ class TestDeleteNetBoxInterfacesViewPost:
             patch("netbox_librenms_plugin.views.sync.interfaces.VMInterface") as mock_vmintf_cls,
             patch("netbox_librenms_plugin.views.sync.interfaces.transaction"),
         ):
+            mock_vmintf_cls.objects.restrict.return_value = mock_vmintf_cls.objects
             mock_vmintf_cls.objects.get.return_value = mock_interface
 
             class _DNE(Exception):
@@ -1660,6 +1675,7 @@ class TestDeleteNetBoxInterfacesViewPost:
         mock_interface_bad.device_id = 99  # Wrong device
 
         req = _make_request(post_data={"interface_ids": ["5", "6"]})
+        view.request = req
 
         call_count = [0]
 
@@ -1681,6 +1697,7 @@ class TestDeleteNetBoxInterfacesViewPost:
             patch("netbox_librenms_plugin.views.sync.interfaces.transaction"),
         ):
             mock_intf_cls.DoesNotExist = _DNE
+            mock_intf_cls.objects.restrict.return_value = mock_intf_cls.objects
             mock_intf_cls.objects.get.side_effect = get_side_effect
             result = view.post(req, "device", 1)
 

--- a/netbox_librenms_plugin/tests/test_coverage_sync_interfaces.py
+++ b/netbox_librenms_plugin/tests/test_coverage_sync_interfaces.py
@@ -9,7 +9,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from netbox_librenms_plugin.tests.conftest import make_device, make_interface, make_virtual_chassis, make_vm
+from netbox_librenms_plugin.tests.conftest import make_device, make_interface, make_virtual_chassis_members, make_vm
 from netbox_librenms_plugin.tests.view_test_helpers import make_request, make_user_with_perms, make_view, missing_pk
 
 # The views here are built with real requests and real users, so the whole file needs the DB.
@@ -725,7 +725,7 @@ class TestSyncInterfacesViewSyncInterfaceDevice:
         """A posted sibling of the same chassis receives the interface."""
         from dcim.models import Interface
 
-        _vc, (host, sibling) = make_virtual_chassis("selvalid")
+        _vc, (host, sibling) = make_virtual_chassis_members("selvalid")
         view = self._make_view(_make_request(post_data={"device_selection_Gi0/1": str(sibling.pk)}))
 
         view.sync_interface(host, {"ifName": "Gi0/1", "port_id": None}, [], "ifName")
@@ -763,7 +763,7 @@ class TestSyncInterfacesViewSyncInterfaceDevice:
         """A hidden posted target must not silently sync the row onto the page device."""
         from dcim.models import Device, Interface
 
-        _vc, (host, sibling) = make_virtual_chassis("selhidden")
+        _vc, (host, sibling) = make_virtual_chassis_members("selhidden")
         user = make_user_with_perms(
             "selhidden-user",
             [("view", Device)],

--- a/netbox_librenms_plugin/tests/test_coverage_sync_interfaces.py
+++ b/netbox_librenms_plugin/tests/test_coverage_sync_interfaces.py
@@ -78,7 +78,10 @@ class TestSyncInterfacesViewGetObject:
         view = object.__new__(SyncInterfacesView)
         mock_device = MagicMock()
 
-        with patch("netbox_librenms_plugin.views.sync.interfaces.get_object_or_404", return_value=mock_device):
+        with patch(
+            "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+            return_value=mock_device,
+        ):
             result = view.get_object("device", 1)
         assert result is mock_device
 
@@ -88,7 +91,10 @@ class TestSyncInterfacesViewGetObject:
         view = object.__new__(SyncInterfacesView)
         mock_vm = MagicMock()
 
-        with patch("netbox_librenms_plugin.views.sync.interfaces.get_object_or_404", return_value=mock_vm):
+        with patch(
+            "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+            return_value=mock_vm,
+        ):
             result = view.get_object("virtualmachine", 2)
         assert result is mock_vm
 
@@ -373,7 +379,10 @@ class TestSyncInterfacesViewPost:
         req = _make_request(post_data={})  # No selection
 
         with (
-            patch("netbox_librenms_plugin.views.sync.interfaces.get_object_or_404", return_value=mock_device),
+            patch(
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+                return_value=mock_device,
+            ),
             patch("netbox_librenms_plugin.views.sync.interfaces.get_interface_name_field", return_value="ifName"),
             patch("netbox_librenms_plugin.views.sync.interfaces.messages") as mock_msgs,
             patch("netbox_librenms_plugin.views.sync.interfaces.redirect") as mock_redirect,
@@ -418,7 +427,10 @@ class TestSyncInterfacesViewPost:
         req = _make_request(post_data={"select": ["Gi0/1"]})
 
         with (
-            patch("netbox_librenms_plugin.views.sync.interfaces.get_object_or_404", return_value=mock_device),
+            patch(
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+                return_value=mock_device,
+            ),
             patch("netbox_librenms_plugin.views.sync.interfaces.get_interface_name_field", return_value="ifName"),
             patch("netbox_librenms_plugin.views.sync.interfaces.cache") as mock_cache,
             patch("netbox_librenms_plugin.views.sync.interfaces.messages"),
@@ -446,7 +458,10 @@ class TestSyncInterfacesViewPost:
         req = _make_request(post_data={"select": ["Gi0/1"], "server_key": "default"})
 
         with (
-            patch("netbox_librenms_plugin.views.sync.interfaces.get_object_or_404", return_value=mock_device),
+            patch(
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+                return_value=mock_device,
+            ),
             patch("netbox_librenms_plugin.views.sync.interfaces.get_interface_name_field", return_value="ifName"),
             patch("netbox_librenms_plugin.views.sync.interfaces.cache") as mock_cache,
             patch("netbox_librenms_plugin.views.sync.interfaces.messages") as mock_msgs,
@@ -478,7 +493,10 @@ class TestSyncInterfacesViewPost:
         req = _make_request(post_data={"select": ["eth0"], "server_key": "default"})
 
         with (
-            patch("netbox_librenms_plugin.views.sync.interfaces.get_object_or_404", return_value=mock_vm),
+            patch(
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+                return_value=mock_vm,
+            ),
             patch("netbox_librenms_plugin.views.sync.interfaces.get_interface_name_field", return_value="ifName"),
             patch("netbox_librenms_plugin.views.sync.interfaces.cache") as mock_cache,
             patch("netbox_librenms_plugin.views.sync.interfaces.messages") as mock_msgs,
@@ -514,7 +532,10 @@ class TestSyncInterfacesViewPost:
             view._skipped_conflicts.append("Gi0/1")
 
         with (
-            patch("netbox_librenms_plugin.views.sync.interfaces.get_object_or_404", return_value=mock_device),
+            patch(
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+                return_value=mock_device,
+            ),
             patch("netbox_librenms_plugin.views.sync.interfaces.get_interface_name_field", return_value="ifName"),
             patch("netbox_librenms_plugin.views.sync.interfaces.cache") as mock_cache,
             patch("netbox_librenms_plugin.views.sync.interfaces.messages") as mock_msgs,
@@ -557,7 +578,10 @@ class TestSyncInterfacesViewServerKeyAndRedirect:
     def _run_no_selection(self, view, mock_api, post_data, name_field="ifName"):
         """Drive post() down the no-selection redirect path (server_key + redirect_url are set before that), returning the redirect call mock."""
         with (
-            patch("netbox_librenms_plugin.views.sync.interfaces.get_object_or_404", return_value=MagicMock(pk=1)),
+            patch(
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+                return_value=MagicMock(pk=1),
+            ),
             patch("netbox_librenms_plugin.views.sync.interfaces.get_interface_name_field", return_value=name_field),
             patch("netbox_librenms_plugin.views.sync.interfaces.messages"),
             patch("netbox_librenms_plugin.views.sync.interfaces.redirect") as mock_redirect,
@@ -1354,7 +1378,10 @@ class TestDeleteNetBoxInterfacesViewPost:
         mock_device = MagicMock(pk=1)
         req = _make_request(post_data={})  # No interface_ids
 
-        with patch("netbox_librenms_plugin.views.sync.interfaces.get_object_or_404", return_value=mock_device):
+        with patch(
+            "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+            return_value=mock_device,
+        ):
             result = view.post(req, "device", 1)
 
         assert isinstance(result, JsonResponse)
@@ -1392,7 +1419,10 @@ class TestDeleteNetBoxInterfacesViewPost:
         req = _make_request(post_data={"interface_ids": ["5"]})
 
         with (
-            patch("netbox_librenms_plugin.views.sync.interfaces.get_object_or_404", return_value=mock_device),
+            patch(
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+                return_value=mock_device,
+            ),
             patch("netbox_librenms_plugin.views.sync.interfaces.Interface") as mock_intf_cls,
             patch("netbox_librenms_plugin.views.sync.interfaces.transaction"),
         ):
@@ -1430,7 +1460,10 @@ class TestDeleteNetBoxInterfacesViewPost:
         req = _make_request(post_data={"interface_ids": ["7"]})
 
         with (
-            patch("netbox_librenms_plugin.views.sync.interfaces.get_object_or_404", return_value=mock_vm),
+            patch(
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+                return_value=mock_vm,
+            ),
             patch("netbox_librenms_plugin.views.sync.interfaces.VMInterface") as mock_vmintf_cls,
             patch("netbox_librenms_plugin.views.sync.interfaces.transaction"),
         ):
@@ -1467,7 +1500,10 @@ class TestDeleteNetBoxInterfacesViewPost:
         req = _make_request(post_data={"interface_ids": ["5"]})
 
         with (
-            patch("netbox_librenms_plugin.views.sync.interfaces.get_object_or_404", return_value=mock_device),
+            patch(
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+                return_value=mock_device,
+            ),
             patch("netbox_librenms_plugin.views.sync.interfaces.Interface") as mock_intf_cls,
             patch("netbox_librenms_plugin.views.sync.interfaces.transaction"),
         ):
@@ -1507,7 +1543,10 @@ class TestDeleteNetBoxInterfacesViewPost:
         req = _make_request(post_data={"interface_ids": ["5"]})
 
         with (
-            patch("netbox_librenms_plugin.views.sync.interfaces.get_object_or_404", return_value=mock_device),
+            patch(
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+                return_value=mock_device,
+            ),
             patch("netbox_librenms_plugin.views.sync.interfaces.Interface") as mock_intf_cls,
             patch("netbox_librenms_plugin.views.sync.interfaces.transaction"),
         ):
@@ -1542,7 +1581,10 @@ class TestDeleteNetBoxInterfacesViewPost:
             pass
 
         with (
-            patch("netbox_librenms_plugin.views.sync.interfaces.get_object_or_404", return_value=mock_device),
+            patch(
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+                return_value=mock_device,
+            ),
             patch("netbox_librenms_plugin.views.sync.interfaces.Interface") as mock_intf_cls,
             patch("netbox_librenms_plugin.views.sync.interfaces.transaction"),
         ):
@@ -1574,7 +1616,10 @@ class TestDeleteNetBoxInterfacesViewPost:
         req = _make_request(post_data={"interface_ids": ["7"]})
 
         with (
-            patch("netbox_librenms_plugin.views.sync.interfaces.get_object_or_404", return_value=mock_vm),
+            patch(
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+                return_value=mock_vm,
+            ),
             patch("netbox_librenms_plugin.views.sync.interfaces.VMInterface") as mock_vmintf_cls,
             patch("netbox_librenms_plugin.views.sync.interfaces.transaction"),
         ):
@@ -1628,7 +1673,10 @@ class TestDeleteNetBoxInterfacesViewPost:
             pass
 
         with (
-            patch("netbox_librenms_plugin.views.sync.interfaces.get_object_or_404", return_value=mock_device),
+            patch(
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+                return_value=mock_device,
+            ),
             patch("netbox_librenms_plugin.views.sync.interfaces.Interface") as mock_intf_cls,
             patch("netbox_librenms_plugin.views.sync.interfaces.transaction"),
         ):

--- a/netbox_librenms_plugin/tests/test_coverage_sync_interfaces.py
+++ b/netbox_librenms_plugin/tests/test_coverage_sync_interfaces.py
@@ -754,10 +754,12 @@ class TestSyncInterfacesViewSyncInterfaceDevice:
         dev = make_device("selgone-page")
         absent_pk = missing_pk(Device)
         view = self._make_view(_make_request(post_data={"device_selection_Gi0/1": str(absent_pk)}))
+        view._skipped_conflicts = []
 
         view.sync_interface(dev, {"ifName": "Gi0/1", "port_id": None}, [], "ifName")
 
         assert not Interface.objects.filter(device=dev, name="Gi0/1").exists()
+        assert view._skipped_conflicts == ["Gi0/1 (selected target unavailable)"]
 
     def test_explicit_vc_member_outside_grant_is_skipped(self):
         """A hidden posted target must not silently sync the row onto the page device."""

--- a/netbox_librenms_plugin/tests/test_coverage_sync_interfaces.py
+++ b/netbox_librenms_plugin/tests/test_coverage_sync_interfaces.py
@@ -908,17 +908,21 @@ class TestSyncInterfacesViewHandleMacAddress:
         assert list(iface.mac_addresses.all()) == [mac]
 
     def test_existing_mac_added_without_create(self):
-        """A MAC already on this interface is reused, not duplicated."""
-        from dcim.models import MACAddress
+        """A MAC already on this interface is reused, not duplicated, and becomes primary."""
+        from dcim.models import Interface, MACAddress
 
         iface = make_interface(make_device("mac-existing"), "Gi0/1")
         existing = MACAddress.objects.create(mac_address="aa:bb:cc:dd:ee:ff")
         iface.mac_addresses.add(existing)
+        assert iface.primary_mac_address is None  # the branch has done nothing yet
 
         _sync_view().handle_mac_address(iface, "aa:bb:cc:dd:ee:ff")
+        iface.save()
 
         assert MACAddress.objects.filter(mac_address="aa:bb:cc:dd:ee:ff").count() == 1
         assert list(iface.mac_addresses.all()) == [existing]
+        # Without this the test would pass on an early return: the m2m link predates the call.
+        assert Interface.objects.get(pk=iface.pk).primary_mac_address == existing
 
     def test_primary_mac_assigned_if_attribute_exists(self):
         from dcim.models import Interface, MACAddress

--- a/netbox_librenms_plugin/tests/test_coverage_sync_interfaces.py
+++ b/netbox_librenms_plugin/tests/test_coverage_sync_interfaces.py
@@ -10,7 +10,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from netbox_librenms_plugin.tests.conftest import make_device, make_interface, make_vm
-from netbox_librenms_plugin.tests.view_test_helpers import make_request, make_view
+from netbox_librenms_plugin.tests.view_test_helpers import make_request, make_view, missing_pk
 
 # The views here are built with real requests and real users, so the whole file needs the DB.
 pytestmark = pytest.mark.django_db
@@ -765,8 +765,8 @@ class TestSyncInterfacesViewSyncInterfaceDevice:
         from dcim.models import Device, Interface
 
         dev = make_device("selgone-page")
-        missing_pk = Device.objects.order_by("-pk").first().pk + 1000
-        view = self._make_view(_make_request(post_data={"device_selection_Gi0/1": str(missing_pk)}))
+        absent_pk = missing_pk(Device)
+        view = self._make_view(_make_request(post_data={"device_selection_Gi0/1": str(absent_pk)}))
 
         view.sync_interface(dev, {"ifName": "Gi0/1", "port_id": None}, [], "ifName")
 
@@ -880,61 +880,6 @@ class TestSyncInterfacesViewSyncInterfaceVM:
 
         with pytest.raises(ValueError):
             view.sync_interface(MagicMock(), librenms_port, [], "ifName")
-
-
-# ===========================================================================
-# SyncInterfacesView.handle_mac_address
-# ===========================================================================
-
-
-class TestSyncInterfacesViewHandleMacAddress:
-    """Real Interfaces and real MACAddress rows: the m2m and the primary pointer both land."""
-
-    def test_no_mac_address_does_nothing(self):
-        iface = make_interface(make_device("mac-none"), "Gi0/1")
-
-        _sync_view().handle_mac_address(iface, None)
-
-        assert not iface.mac_addresses.exists()
-
-    def test_new_mac_created_and_added(self):
-        from dcim.models import MACAddress
-
-        iface = make_interface(make_device("mac-new"), "Gi0/1")
-
-        _sync_view().handle_mac_address(iface, "aa:bb:cc:dd:ee:ff")
-
-        mac = MACAddress.objects.get(mac_address="aa:bb:cc:dd:ee:ff")
-        assert list(iface.mac_addresses.all()) == [mac]
-
-    def test_existing_mac_added_without_create(self):
-        """A MAC already on this interface is reused, not duplicated, and becomes primary."""
-        from dcim.models import Interface, MACAddress
-
-        iface = make_interface(make_device("mac-existing"), "Gi0/1")
-        existing = MACAddress.objects.create(mac_address="aa:bb:cc:dd:ee:ff")
-        iface.mac_addresses.add(existing)
-        assert iface.primary_mac_address is None  # the branch has done nothing yet
-
-        _sync_view().handle_mac_address(iface, "aa:bb:cc:dd:ee:ff")
-        iface.save()
-
-        assert MACAddress.objects.filter(mac_address="aa:bb:cc:dd:ee:ff").count() == 1
-        assert list(iface.mac_addresses.all()) == [existing]
-        # Without this the test would pass on an early return: the m2m link predates the call.
-        assert Interface.objects.get(pk=iface.pk).primary_mac_address == existing
-
-    def test_primary_mac_assigned_if_attribute_exists(self):
-        from dcim.models import Interface, MACAddress
-
-        iface = make_interface(make_device("mac-primary"), "Gi0/1")
-
-        view = _sync_view()
-        view.handle_mac_address(iface, "aa:bb:cc:dd:ee:ff")
-        iface.save()
-
-        mac = MACAddress.objects.get(mac_address="aa:bb:cc:dd:ee:ff")
-        assert Interface.objects.get(pk=iface.pk).primary_mac_address == mac
 
 
 class TestSyncInterfacesViewUpdateInterfaceAttributes:

--- a/netbox_librenms_plugin/tests/test_coverage_sync_interfaces.py
+++ b/netbox_librenms_plugin/tests/test_coverage_sync_interfaces.py
@@ -10,7 +10,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from netbox_librenms_plugin.tests.conftest import make_device, make_interface, make_vm
-from netbox_librenms_plugin.tests.view_test_helpers import make_request, make_view, missing_pk
+from netbox_librenms_plugin.tests.view_test_helpers import make_request, make_user_with_perms, make_view, missing_pk
 
 # The views here are built with real requests and real users, so the whole file needs the DB.
 pytestmark = pytest.mark.django_db
@@ -748,7 +748,7 @@ class TestSyncInterfacesViewSyncInterfaceDevice:
         assert Interface.objects.filter(device=sibling, name="Gi0/1").exists()
         assert not Interface.objects.filter(device=host, name="Gi0/1").exists()
 
-    def test_device_selection_invalid_defaults_to_obj(self):
+    def test_device_selection_invalid_is_skipped(self):
         """A device that is neither the page device nor a VC sibling is refused."""
         from dcim.models import Interface
 
@@ -758,10 +758,10 @@ class TestSyncInterfacesViewSyncInterfaceDevice:
 
         view.sync_interface(dev, {"ifName": "Gi0/1", "port_id": None}, [], "ifName")
 
-        assert Interface.objects.filter(device=dev, name="Gi0/1").exists()
+        assert not Interface.objects.filter(device=dev, name="Gi0/1").exists()
         assert not Interface.objects.filter(device=other, name="Gi0/1").exists()
 
-    def test_device_selection_does_not_exist_defaults_to_obj(self):
+    def test_device_selection_does_not_exist_is_skipped(self):
         from dcim.models import Device, Interface
 
         dev = make_device("selgone-page")
@@ -770,7 +770,29 @@ class TestSyncInterfacesViewSyncInterfaceDevice:
 
         view.sync_interface(dev, {"ifName": "Gi0/1", "port_id": None}, [], "ifName")
 
-        assert Interface.objects.filter(device=dev, name="Gi0/1").exists()
+        assert not Interface.objects.filter(device=dev, name="Gi0/1").exists()
+
+    def test_explicit_vc_member_outside_grant_is_skipped(self):
+        """A hidden posted target must not silently sync the row onto the page device."""
+        from dcim.models import Device, Interface
+
+        _vc, (host, sibling) = self._vc("selhidden")
+        user = make_user_with_perms(
+            "selhidden-user",
+            [("view", Device)],
+            constraints={"pk": host.pk},
+        )
+        request = _make_request(
+            post_data={"device_selection_Gi0/1": str(sibling.pk)},
+            user=user,
+        )
+        view = self._make_view(request)
+        view._skipped_conflicts = []
+
+        view.sync_interface(host, {"ifName": "Gi0/1", "port_id": None}, [], "ifName")
+
+        assert not Interface.objects.filter(name="Gi0/1").exists()
+        assert view._skipped_conflicts == ["Gi0/1"]
 
     @pytest.mark.django_db
     def test_device_port_id_prefers_existing_librenms_id_match(self):

--- a/netbox_librenms_plugin/tests/test_coverage_sync_interfaces.py
+++ b/netbox_librenms_plugin/tests/test_coverage_sync_interfaces.py
@@ -9,7 +9,11 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from netbox_librenms_plugin.tests.conftest import make_device, make_interface
+from netbox_librenms_plugin.tests.conftest import make_device, make_interface, make_vm
+from netbox_librenms_plugin.tests.view_test_helpers import make_request, make_view
+
+# The views here are built with real requests and real users, so the whole file needs the DB.
+pytestmark = pytest.mark.django_db
 
 
 # ---------------------------------------------------------------------------
@@ -17,16 +21,22 @@ from netbox_librenms_plugin.tests.conftest import make_device, make_interface
 # ---------------------------------------------------------------------------
 
 
-def _make_request(post_data=None, get_data=None):
-    """Build a mock request with proper POST / GET dicts."""
-    req = MagicMock()
-    _post = post_data or {}
-    post_mock = MagicMock()
-    post_mock.get = lambda k, d=None: _post.get(k, d)
-    post_mock.getlist = lambda k: _post[k] if isinstance(_post.get(k), list) else ([] if k not in _post else [_post[k]])
-    req.POST = post_mock
-    req.GET = get_data or {}
-    return req
+def _make_request(post_data=None, get_data=None, user=None):
+    """A real request. POST wins when both are given; a GET-only call builds a GET request."""
+    if post_data is None and get_data:
+        return make_request("get", get_data, user=user)
+    request = make_request("post", post_data or {}, user=user)
+    request.GET = get_data or request.GET
+    return request
+
+
+def _sync_view(request=None):
+    """The real SyncInterfacesView; only the LibreNMS client is stubbed."""
+    from netbox_librenms_plugin.views.sync.interfaces import SyncInterfacesView
+
+    view = make_view(SyncInterfacesView, request)
+    view._post_server_key = "default"
+    return view
 
 
 def _denied_response():
@@ -614,12 +624,9 @@ class TestSyncInterfacesViewServerKeyAndRedirect:
 
 
 class TestSyncInterfacesViewSyncInterfaceDevice:
-    def _make_view(self):
-        from netbox_librenms_plugin.views.sync.interfaces import SyncInterfacesView
-
-        view = object.__new__(SyncInterfacesView)
-        view.request = _make_request()
-        view._post_server_key = "default"
+    def _make_view(self, request=None):
+        """The real view; only its own next steps (attribute copy, VLAN sync) are stubbed."""
+        view = _sync_view(request)
         view._lookup_maps = {}
         view.interface_name_field = "ifName"
         view.update_interface_attributes = MagicMock()
@@ -714,99 +721,56 @@ class TestSyncInterfacesViewSyncInterfaceDevice:
         assert view._skipped_conflicts == ["Gi0/1"]
         view.update_interface_attributes.assert_not_called()
 
+    @staticmethod
+    def _vc(tag, count=2):
+        """A real VirtualChassis with *count* members at consecutive positions."""
+        from dcim.models import VirtualChassis
+
+        vc = VirtualChassis.objects.create(name=f"vc-{tag}")
+        members = []
+        for position in range(1, count + 1):
+            member = make_device(f"{tag}-m{position}")
+            member.virtual_chassis = vc
+            member.vc_position = position
+            member.save()
+            members.append(member)
+        return vc, members
+
     def test_device_selection_with_vc_valid(self):
-        from dcim.models import Device
+        """A posted sibling of the same chassis receives the interface."""
+        from dcim.models import Interface
 
-        view = self._make_view()
-        view.request = _make_request(post_data={"device_selection_Gi0/1": "2"})
+        _vc, (host, sibling) = self._vc("selvalid")
+        view = self._make_view(_make_request(post_data={"device_selection_Gi0/1": str(sibling.pk)}))
 
-        mock_device = MagicMock()
-        mock_device.__class__ = Device
-        mock_device.id = 1
-        mock_vc = MagicMock()
-        mock_vc.members.values_list.return_value = [1, 2]
-        mock_device.virtual_chassis = mock_vc
+        view.sync_interface(host, {"ifName": "Gi0/1", "port_id": None}, [], "ifName")
 
-        mock_target_device = MagicMock()
-        mock_target_device.__class__ = Device
-        mock_target_device.id = 2
-
-        mock_interface = MagicMock()
-        librenms_port = {"ifName": "Gi0/1", "port_id": None}
-
-        with (
-            patch("netbox_librenms_plugin.views.sync.interfaces.Interface") as mock_intf_cls,
-            patch.object(Device, "objects") as mock_device_objects,
-        ):
-            mock_device_objects.restrict.return_value = mock_device_objects
-            mock_device_objects.get.return_value = mock_target_device
-            mock_intf_cls.objects.restrict.return_value = mock_intf_cls.objects
-            mock_intf_cls.objects.get_or_create.return_value = (mock_interface, True)
-            view.get_netbox_interface_type = MagicMock(return_value="other")
-            view.sync_interface(mock_device, librenms_port, [], "ifName")
-
-        mock_intf_cls.objects.get_or_create.assert_called_once_with(device=mock_target_device, name="Gi0/1")
+        assert Interface.objects.filter(device=sibling, name="Gi0/1").exists()
+        assert not Interface.objects.filter(device=host, name="Gi0/1").exists()
 
     def test_device_selection_invalid_defaults_to_obj(self):
-        from dcim.models import Device
+        """A device that is neither the page device nor a VC sibling is refused."""
+        from dcim.models import Interface
 
-        view = self._make_view()
-        view.request = _make_request(post_data={"device_selection_Gi0/1": "99"})
+        dev = make_device("selinvalid-page")
+        other = make_device("selinvalid-other")
+        view = self._make_view(_make_request(post_data={"device_selection_Gi0/1": str(other.pk)}))
 
-        mock_device = MagicMock()
-        mock_device.__class__ = Device
-        mock_device.id = 1
-        mock_device.virtual_chassis = None
+        view.sync_interface(dev, {"ifName": "Gi0/1", "port_id": None}, [], "ifName")
 
-        mock_other_device = MagicMock()
-        mock_other_device.__class__ = Device
-        mock_other_device.id = 99  # Different id, no VC → falls back to obj
-
-        mock_interface = MagicMock()
-        librenms_port = {"ifName": "Gi0/1", "port_id": None}
-
-        with (
-            patch("netbox_librenms_plugin.views.sync.interfaces.Interface") as mock_intf_cls,
-            patch.object(Device, "objects") as mock_device_objects,
-        ):
-            mock_device_objects.restrict.return_value = mock_device_objects
-            mock_device_objects.get.return_value = mock_other_device
-            mock_intf_cls.objects.restrict.return_value = mock_intf_cls.objects
-            mock_intf_cls.objects.get_or_create.return_value = (mock_interface, True)
-            view.get_netbox_interface_type = MagicMock(return_value="other")
-            view.sync_interface(mock_device, librenms_port, [], "ifName")
-
-        # Should use mock_device (obj), not mock_other_device
-        call_kwargs = mock_intf_cls.objects.get_or_create.call_args[1]
-        assert call_kwargs["device"] is mock_device
+        assert Interface.objects.filter(device=dev, name="Gi0/1").exists()
+        assert not Interface.objects.filter(device=other, name="Gi0/1").exists()
 
     def test_device_selection_does_not_exist_defaults_to_obj(self):
-        from dcim.models import Device
+        from dcim.models import Device, Interface
 
-        view = self._make_view()
-        view.request = _make_request(post_data={"device_selection_Gi0/1": "999"})
+        dev = make_device("selgone-page")
+        missing_pk = Device.objects.order_by("-pk").first().pk + 1000
+        view = self._make_view(_make_request(post_data={"device_selection_Gi0/1": str(missing_pk)}))
 
-        mock_device = MagicMock()
-        mock_device.__class__ = Device
-        mock_device.id = 1
-        mock_device.virtual_chassis = None
+        view.sync_interface(dev, {"ifName": "Gi0/1", "port_id": None}, [], "ifName")
 
-        mock_interface = MagicMock()
-        librenms_port = {"ifName": "Gi0/1", "port_id": None}
-
-        with (
-            patch("netbox_librenms_plugin.views.sync.interfaces.Interface") as mock_intf_cls,
-            patch.object(Device, "objects") as mock_device_objects,
-        ):
-            mock_device_objects.restrict.return_value = mock_device_objects
-            mock_device_objects.get.side_effect = Device.DoesNotExist()
-            mock_intf_cls.objects.restrict.return_value = mock_intf_cls.objects
-            mock_intf_cls.objects.get_or_create.return_value = (mock_interface, True)
-            view.get_netbox_interface_type = MagicMock(return_value="other")
-            view.sync_interface(mock_device, librenms_port, [], "ifName")
-
-        call_kwargs = mock_intf_cls.objects.get_or_create.call_args[1]
-        assert call_kwargs["device"] is mock_device
+        assert Interface.objects.filter(device=dev, name="Gi0/1").exists()
 
     @pytest.mark.django_db
     def test_device_port_id_prefers_existing_librenms_id_match(self):
@@ -875,63 +839,37 @@ class TestSyncInterfacesViewSyncInterfaceDevice:
 
 class TestSyncInterfacesViewSyncInterfaceVM:
     def test_vm_interface_created(self):
-        from netbox_librenms_plugin.views.sync.interfaces import SyncInterfacesView
-        from virtualization.models import VirtualMachine
+        from virtualization.models import VMInterface
 
-        view = object.__new__(SyncInterfacesView)
-        view.request = _make_request()
-        view._post_server_key = "default"
+        vm = make_vm("vmsync-created")
+        view = _sync_view()
         view._lookup_maps = {}
-        view.interface_name_field = "ifName"
         view.update_interface_attributes = MagicMock()
         view._sync_interface_vlans = MagicMock()
 
-        mock_vm = MagicMock()
-        mock_vm.__class__ = VirtualMachine
-        mock_vm_interface = MagicMock()
-        librenms_port = {"ifName": "eth0", "port_id": None}
+        view.sync_interface(vm, {"ifName": "eth0", "port_id": None}, [], "ifName")
 
-        with patch("netbox_librenms_plugin.views.sync.interfaces.VMInterface") as mock_vmintf_cls:
-            mock_vmintf_cls.objects.restrict.return_value = mock_vmintf_cls.objects
-            mock_vmintf_cls.objects.get_or_create.return_value = (mock_vm_interface, True)
-            view.sync_interface(mock_vm, librenms_port, [], "ifName")
-
-        mock_vmintf_cls.objects.get_or_create.assert_called_once()
+        assert VMInterface.objects.filter(virtual_machine=vm, name="eth0").exists()
         view.update_interface_attributes.assert_called_once()
 
     def test_vm_port_id_prefers_existing_librenms_id_match(self):
-        from netbox_librenms_plugin.views.sync.interfaces import SyncInterfacesView
-        from virtualization.models import VirtualMachine
+        """A port_id already stored on this VM's interface updates it; no second interface."""
+        from virtualization.models import VMInterface
 
-        view = object.__new__(SyncInterfacesView)
-        view.request = _make_request()
-        view._post_server_key = "default"
+        vm = make_vm("vmsync-portid")
+        matched = VMInterface.objects.create(virtual_machine=vm, name="eth0")
+        matched.custom_field_data["librenms_id"] = {"default": 55}
+        matched.save()
+        view = _sync_view()
         view._lookup_maps = {}
-        view.interface_name_field = "ifName"
         view.update_interface_attributes = MagicMock()
         view._sync_interface_vlans = MagicMock()
+        librenms_port = {"ifName": "renamed-in-librenms", "port_id": 55}
 
-        mock_vm = MagicMock()
-        mock_vm.__class__ = VirtualMachine
-        mock_vm.id = 5
-        matched_interface = MagicMock()
-        matched_interface.virtual_machine_id = 5
-        librenms_port = {"ifName": "eth0", "port_id": 55}
+        view.sync_interface(vm, librenms_port, [], "ifName")
 
-        with (
-            patch("netbox_librenms_plugin.views.sync.interfaces.VMInterface") as mock_vmintf_cls,
-            patch("netbox_librenms_plugin.views.sync.interfaces.find_by_librenms_id", return_value=matched_interface),
-        ):
-            view.sync_interface(mock_vm, librenms_port, [], "ifName")
-
-        mock_vmintf_cls.objects.get_or_create.assert_not_called()
-        view.update_interface_attributes.assert_called_once_with(
-            matched_interface,
-            librenms_port,
-            None,
-            [],
-            "ifName",
-        )
+        assert VMInterface.objects.filter(virtual_machine=vm).count() == 1
+        view.update_interface_attributes.assert_called_once_with(matched, librenms_port, None, [], "ifName")
 
     def test_invalid_obj_raises_value_error(self):
         from netbox_librenms_plugin.views.sync.interfaces import SyncInterfacesView
@@ -945,162 +883,56 @@ class TestSyncInterfacesViewSyncInterfaceVM:
 
 
 # ===========================================================================
-# SyncInterfacesView.get_netbox_interface_type
-# ===========================================================================
-
-
-class TestSyncInterfacesViewGetNetboxInterfaceType:
-    def test_with_speed_uses_speed_mapping(self):
-        from netbox_librenms_plugin.views.sync.interfaces import SyncInterfacesView
-
-        view = object.__new__(SyncInterfacesView)
-        mock_mapping = MagicMock()
-        mock_mapping.netbox_type = "1000base-t"
-
-        with (
-            patch("netbox_librenms_plugin.views.sync.interfaces.convert_speed_to_kbps", return_value=1000),
-            patch("netbox_librenms_plugin.views.sync.interfaces.InterfaceTypeMapping") as mock_cls,
-        ):
-            # mappings = objects.filter(...); speed_mapping = mappings.filter(...).order_by(...).first()
-            mock_cls.objects.restrict.return_value = mock_cls.objects
-            mock_cls.objects.filter.return_value.filter.return_value.order_by.return_value.first.return_value = (
-                mock_mapping
-            )
-            result = view.get_netbox_interface_type({"ifType": "ethernetCsmacd", "ifSpeed": 1000000000})
-
-        assert result == "1000base-t"
-
-    def test_no_speed_uses_null_mapping(self):
-        from netbox_librenms_plugin.views.sync.interfaces import SyncInterfacesView
-
-        view = object.__new__(SyncInterfacesView)
-        mock_mapping = MagicMock()
-        mock_mapping.netbox_type = "virtual"
-
-        with (
-            patch("netbox_librenms_plugin.views.sync.interfaces.convert_speed_to_kbps", return_value=None),
-            patch("netbox_librenms_plugin.views.sync.interfaces.InterfaceTypeMapping") as mock_cls,
-        ):
-            mock_qs = MagicMock()
-            mock_qs.filter.return_value.first.return_value = mock_mapping
-            mock_cls.objects.restrict.return_value = mock_cls.objects
-            mock_cls.objects.filter.return_value = mock_qs
-            result = view.get_netbox_interface_type({"ifType": "softwareLoopback", "ifSpeed": None})
-
-        assert result == "virtual"
-
-    def test_no_mapping_returns_other(self):
-        from netbox_librenms_plugin.views.sync.interfaces import SyncInterfacesView
-
-        view = object.__new__(SyncInterfacesView)
-        with (
-            patch("netbox_librenms_plugin.views.sync.interfaces.convert_speed_to_kbps", return_value=None),
-            patch("netbox_librenms_plugin.views.sync.interfaces.InterfaceTypeMapping") as mock_cls,
-        ):
-            mock_qs = MagicMock()
-            mock_qs.filter.return_value.first.return_value = None
-            mock_cls.objects.restrict.return_value = mock_cls.objects
-            mock_cls.objects.filter.return_value = mock_qs
-            result = view.get_netbox_interface_type({"ifType": "unknown", "ifSpeed": None})
-
-        assert result == "other"
-
-    def test_speed_mapping_falls_back_to_null(self):
-        """When speed mapping returns None, falls back to null-speed mapping."""
-        from netbox_librenms_plugin.views.sync.interfaces import SyncInterfacesView
-
-        view = object.__new__(SyncInterfacesView)
-        mock_null_mapping = MagicMock()
-        mock_null_mapping.netbox_type = "other"
-
-        with (
-            patch("netbox_librenms_plugin.views.sync.interfaces.convert_speed_to_kbps", return_value=1000),
-            patch("netbox_librenms_plugin.views.sync.interfaces.InterfaceTypeMapping") as mock_cls,
-        ):
-            mock_speed_qs = MagicMock()
-            mock_speed_qs.order_by.return_value.first.return_value = None  # No speed match
-            mock_null_qs = MagicMock()
-            mock_null_qs.first.return_value = mock_null_mapping
-            mock_qs = MagicMock()
-            mock_qs.filter.side_effect = [mock_speed_qs, mock_null_qs]
-            mock_cls.objects.restrict.return_value = mock_cls.objects
-            mock_cls.objects.filter.return_value = mock_qs
-            result = view.get_netbox_interface_type({"ifType": "ethernetCsmacd", "ifSpeed": 1000})
-
-        assert result == "other"
-
-
-# ===========================================================================
 # SyncInterfacesView.handle_mac_address
 # ===========================================================================
 
 
 class TestSyncInterfacesViewHandleMacAddress:
-    def test_no_mac_address_does_nothing(self):
-        from netbox_librenms_plugin.views.sync.interfaces import SyncInterfacesView
+    """Real Interfaces and real MACAddress rows: the m2m and the primary pointer both land."""
 
-        view = object.__new__(SyncInterfacesView)
-        interface = MagicMock()
-        view.handle_mac_address(interface, None)
-        interface.mac_addresses.add.assert_not_called()
+    def test_no_mac_address_does_nothing(self):
+        iface = make_interface(make_device("mac-none"), "Gi0/1")
+
+        _sync_view().handle_mac_address(iface, None)
+
+        assert not iface.mac_addresses.exists()
 
     def test_new_mac_created_and_added(self):
-        from netbox_librenms_plugin.views.sync.interfaces import SyncInterfacesView
+        from dcim.models import MACAddress
 
-        view = object.__new__(SyncInterfacesView)
-        interface = MagicMock()
-        interface.mac_addresses.filter.return_value.first.return_value = None
-        mock_mac = MagicMock()
+        iface = make_interface(make_device("mac-new"), "Gi0/1")
 
-        with patch("netbox_librenms_plugin.views.sync.interfaces.MACAddress") as mock_mac_cls:
-            mock_mac_cls.objects.create.return_value = mock_mac
-            view.handle_mac_address(interface, "aa:bb:cc:dd:ee:ff")
+        _sync_view().handle_mac_address(iface, "aa:bb:cc:dd:ee:ff")
 
-        interface.mac_addresses.add.assert_called_once_with(mock_mac)
+        mac = MACAddress.objects.get(mac_address="aa:bb:cc:dd:ee:ff")
+        assert list(iface.mac_addresses.all()) == [mac]
 
     def test_existing_mac_added_without_create(self):
-        from netbox_librenms_plugin.views.sync.interfaces import SyncInterfacesView
+        """A MAC already on this interface is reused, not duplicated."""
+        from dcim.models import MACAddress
 
-        view = object.__new__(SyncInterfacesView)
-        existing_mac = MagicMock()
-        interface = MagicMock()
-        interface.mac_addresses.filter.return_value.first.return_value = existing_mac
+        iface = make_interface(make_device("mac-existing"), "Gi0/1")
+        existing = MACAddress.objects.create(mac_address="aa:bb:cc:dd:ee:ff")
+        iface.mac_addresses.add(existing)
 
-        with patch("netbox_librenms_plugin.views.sync.interfaces.MACAddress") as mock_mac_cls:
-            view.handle_mac_address(interface, "aa:bb:cc:dd:ee:ff")
+        _sync_view().handle_mac_address(iface, "aa:bb:cc:dd:ee:ff")
 
-        mock_mac_cls.objects.create.assert_not_called()
-        interface.mac_addresses.add.assert_called_once_with(existing_mac)
+        assert MACAddress.objects.filter(mac_address="aa:bb:cc:dd:ee:ff").count() == 1
+        assert list(iface.mac_addresses.all()) == [existing]
 
     def test_primary_mac_assigned_if_attribute_exists(self):
-        from netbox_librenms_plugin.views.sync.interfaces import SyncInterfacesView
+        from dcim.models import Interface, MACAddress
 
-        view = object.__new__(SyncInterfacesView)
+        iface = make_interface(make_device("mac-primary"), "Gi0/1")
 
-        # Use a stub with explicit attributes to enforce the guard on primary_mac_address
-        class InterfaceStub:
-            primary_mac_address = None
+        view = _sync_view()
+        view.handle_mac_address(iface, "aa:bb:cc:dd:ee:ff")
+        iface.save()
 
-            def __init__(self):
-                self.mac_addresses = MagicMock()
-                self.mac_addresses.filter.return_value.first.return_value = None
-
-        interface = InterfaceStub()
-        mock_mac = MagicMock()
-
-        with patch("netbox_librenms_plugin.views.sync.interfaces.MACAddress") as mock_mac_cls:
-            mock_mac_cls.objects.create.return_value = mock_mac
-            view.handle_mac_address(interface, "aa:bb:cc:dd:ee:ff")
-
-        assert interface.primary_mac_address == mock_mac
+        mac = MACAddress.objects.get(mac_address="aa:bb:cc:dd:ee:ff")
+        assert Interface.objects.get(pk=iface.pk).primary_mac_address == mac
 
 
-# ===========================================================================
-# SyncInterfacesView.update_interface_attributes
-# ===========================================================================
-
-
-@pytest.mark.django_db
 class TestSyncInterfacesViewUpdateInterfaceAttributes:
     def _make_view(self):
         from netbox_librenms_plugin.views.sync.interfaces import SyncInterfacesView
@@ -1339,389 +1171,6 @@ class TestSyncInterfacesViewSyncSelected:
         assert view.sync_interface.call_count == 1
         call_args = view.sync_interface.call_args
         assert call_args[0][1]["ifName"] == "Gi0/1"
-
-
-# ===========================================================================
-# DeleteNetBoxInterfacesView
-# ===========================================================================
-
-
-class TestDeleteNetBoxInterfacesViewPermissions:
-    def test_device_returns_interface_delete_perm(self):
-        from netbox_librenms_plugin.views.sync.interfaces import DeleteNetBoxInterfacesView
-        from dcim.models import Interface
-
-        view = object.__new__(DeleteNetBoxInterfacesView)
-        perms = view.get_required_permissions_for_object_type("device")
-        assert ("delete", Interface) in perms
-
-    def test_vm_returns_vminterface_delete_perm(self):
-        from netbox_librenms_plugin.views.sync.interfaces import DeleteNetBoxInterfacesView
-        from virtualization.models import VMInterface
-
-        view = object.__new__(DeleteNetBoxInterfacesView)
-        perms = view.get_required_permissions_for_object_type("virtualmachine")
-        assert ("delete", VMInterface) in perms
-
-    def test_invalid_type_raises_http404(self):
-        from netbox_librenms_plugin.views.sync.interfaces import DeleteNetBoxInterfacesView
-        from django.http import Http404
-
-        view = object.__new__(DeleteNetBoxInterfacesView)
-        with pytest.raises(Http404):
-            view.get_required_permissions_for_object_type("invalid")
-
-
-class TestDeleteNetBoxInterfacesViewPost:
-    def test_permission_denied_returns_early(self):
-        from netbox_librenms_plugin.views.sync.interfaces import DeleteNetBoxInterfacesView
-
-        view = object.__new__(DeleteNetBoxInterfacesView)
-        view.get_required_permissions_for_object_type = MagicMock(return_value=[])
-        view.require_all_permissions_json = MagicMock(return_value=_denied_response())
-
-        req = _make_request(post_data={"interface_ids": ["1"]})
-        view.request = req
-        result = view.post(req, "device", 1)
-        assert result.status_code == 403
-
-    def test_empty_interface_ids_returns_400(self):
-        from netbox_librenms_plugin.views.sync.interfaces import DeleteNetBoxInterfacesView
-        from django.http import JsonResponse
-
-        view = object.__new__(DeleteNetBoxInterfacesView)
-        view.get_required_permissions_for_object_type = MagicMock(return_value=[])
-        view.require_all_permissions_json = MagicMock(return_value=None)
-
-        mock_device = MagicMock(pk=1)
-        req = _make_request(post_data={})  # No interface_ids
-
-        with patch(
-            "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
-            return_value=mock_device,
-        ):
-            view.request = req
-            result = view.post(req, "device", 1)
-
-        assert isinstance(result, JsonResponse)
-        assert result.status_code == 400
-
-    def test_invalid_object_type_raises_http404(self):
-        """Invalid object_type raises Http404 from get_required_permissions_for_object_type."""
-        from django.http import Http404
-        from netbox_librenms_plugin.views.sync.interfaces import DeleteNetBoxInterfacesView
-
-        view = object.__new__(DeleteNetBoxInterfacesView)
-        view.require_all_permissions_json = MagicMock(return_value=None)
-
-        req = _make_request(post_data={"interface_ids": ["1"]})
-        with pytest.raises(Http404):
-            view.request = req
-            view.post(req, "badtype", 1)
-
-    def test_device_interface_deleted_successfully(self):
-        from netbox_librenms_plugin.views.sync.interfaces import DeleteNetBoxInterfacesView
-        from django.http import JsonResponse
-        import json
-
-        view = object.__new__(DeleteNetBoxInterfacesView)
-        view.get_required_permissions_for_object_type = MagicMock(return_value=[])
-        view.require_all_permissions_json = MagicMock(return_value=None)
-
-        mock_device = MagicMock(pk=1)
-        mock_device.id = 1
-        mock_device.virtual_chassis = None
-
-        mock_interface = MagicMock()
-        mock_interface.name = "Gi0/1"
-        mock_interface.device_id = 1
-
-        req = _make_request(post_data={"interface_ids": ["5"]})
-
-        with (
-            patch(
-                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
-                return_value=mock_device,
-            ),
-            patch("netbox_librenms_plugin.views.sync.interfaces.Interface") as mock_intf_cls,
-            patch("netbox_librenms_plugin.views.sync.interfaces.transaction"),
-        ):
-            mock_intf_cls.objects.restrict.return_value = mock_intf_cls.objects
-            mock_intf_cls.objects.get.return_value = mock_interface
-
-            class _DNE(Exception):
-                pass
-
-            mock_intf_cls.DoesNotExist = _DNE
-
-            view.request = req
-            result = view.post(req, "device", 1)
-
-        assert isinstance(result, JsonResponse)
-        data = json.loads(result.content)
-        assert data["deleted_count"] == 1
-        mock_interface.delete.assert_called_once()
-
-    def test_vm_interface_deleted_successfully(self):
-        from netbox_librenms_plugin.views.sync.interfaces import DeleteNetBoxInterfacesView
-        from virtualization.models import VMInterface
-        from django.http import JsonResponse
-        import json
-
-        view = object.__new__(DeleteNetBoxInterfacesView)
-        view.get_required_permissions_for_object_type = MagicMock(return_value=[])
-        view.require_all_permissions_json = MagicMock(return_value=None)
-
-        mock_vm = MagicMock(pk=2)
-        mock_vm.id = 2
-
-        mock_interface = MagicMock(spec=VMInterface)
-        mock_interface.name = "eth0"
-        mock_interface.virtual_machine_id = 2
-
-        req = _make_request(post_data={"interface_ids": ["7"]})
-
-        with (
-            patch(
-                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
-                return_value=mock_vm,
-            ),
-            patch("netbox_librenms_plugin.views.sync.interfaces.VMInterface") as mock_vmintf_cls,
-            patch("netbox_librenms_plugin.views.sync.interfaces.transaction"),
-        ):
-            mock_vmintf_cls.objects.restrict.return_value = mock_vmintf_cls.objects
-            mock_vmintf_cls.objects.get.return_value = mock_interface
-
-            class _DNE(Exception):
-                pass
-
-            mock_vmintf_cls.DoesNotExist = _DNE
-
-            view.request = req
-            result = view.post(req, "virtualmachine", 2)
-
-        assert isinstance(result, JsonResponse)
-        data = json.loads(result.content)
-        assert data["deleted_count"] == 1
-        mock_interface.delete.assert_called_once()
-
-    def test_device_interface_wrong_device_adds_error(self):
-        from netbox_librenms_plugin.views.sync.interfaces import DeleteNetBoxInterfacesView
-        import json
-
-        view = object.__new__(DeleteNetBoxInterfacesView)
-        view.get_required_permissions_for_object_type = MagicMock(return_value=[])
-        view.require_all_permissions_json = MagicMock(return_value=None)
-
-        mock_device = MagicMock(pk=1)
-        mock_device.id = 1
-        mock_device.virtual_chassis = None
-
-        mock_interface = MagicMock()
-        mock_interface.name = "Gi0/1"
-        mock_interface.device_id = 99  # Wrong device
-
-        req = _make_request(post_data={"interface_ids": ["5"]})
-
-        with (
-            patch(
-                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
-                return_value=mock_device,
-            ),
-            patch("netbox_librenms_plugin.views.sync.interfaces.Interface") as mock_intf_cls,
-            patch("netbox_librenms_plugin.views.sync.interfaces.transaction"),
-        ):
-            mock_intf_cls.objects.restrict.return_value = mock_intf_cls.objects
-            mock_intf_cls.objects.get.return_value = mock_interface
-
-            class _DNE(Exception):
-                pass
-
-            mock_intf_cls.DoesNotExist = _DNE
-
-            view.request = req
-            result = view.post(req, "device", 1)
-
-        data = json.loads(result.content)
-        assert data["deleted_count"] == 0
-        assert len(data["errors"]) == 1
-
-    def test_device_interface_with_vc_wrong_member_adds_error(self):
-        from netbox_librenms_plugin.views.sync.interfaces import DeleteNetBoxInterfacesView
-        import json
-
-        view = object.__new__(DeleteNetBoxInterfacesView)
-        view.get_required_permissions_for_object_type = MagicMock(return_value=[])
-        view.require_all_permissions_json = MagicMock(return_value=None)
-
-        mock_device = MagicMock(pk=1)
-        mock_device.id = 1
-        mock_vc = MagicMock()
-        mock_member = MagicMock()
-        mock_member.id = 1
-        mock_vc.members.all.return_value = [mock_member]
-        mock_device.virtual_chassis = mock_vc
-
-        mock_interface = MagicMock()
-        mock_interface.name = "Gi0/1"
-        mock_interface.device_id = 999  # Not in VC
-
-        req = _make_request(post_data={"interface_ids": ["5"]})
-
-        with (
-            patch(
-                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
-                return_value=mock_device,
-            ),
-            patch("netbox_librenms_plugin.views.sync.interfaces.Interface") as mock_intf_cls,
-            patch("netbox_librenms_plugin.views.sync.interfaces.transaction"),
-        ):
-            mock_intf_cls.objects.restrict.return_value = mock_intf_cls.objects
-            mock_intf_cls.objects.get.return_value = mock_interface
-
-            class _DNE(Exception):
-                pass
-
-            mock_intf_cls.DoesNotExist = _DNE
-
-            view.request = req
-            result = view.post(req, "device", 1)
-
-        data = json.loads(result.content)
-        assert data["deleted_count"] == 0
-        assert len(data["errors"]) == 1
-
-    def test_interface_not_found_adds_error(self):
-        from netbox_librenms_plugin.views.sync.interfaces import DeleteNetBoxInterfacesView
-        import json
-
-        view = object.__new__(DeleteNetBoxInterfacesView)
-        view.get_required_permissions_for_object_type = MagicMock(return_value=[])
-        view.require_all_permissions_json = MagicMock(return_value=None)
-
-        mock_device = MagicMock(pk=1)
-        mock_device.id = 1
-        mock_device.virtual_chassis = None
-
-        req = _make_request(post_data={"interface_ids": ["999"]})
-
-        class _DNE(Exception):
-            pass
-
-        with (
-            patch(
-                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
-                return_value=mock_device,
-            ),
-            patch("netbox_librenms_plugin.views.sync.interfaces.Interface") as mock_intf_cls,
-            patch("netbox_librenms_plugin.views.sync.interfaces.transaction"),
-        ):
-            mock_intf_cls.DoesNotExist = _DNE
-            mock_intf_cls.objects.restrict.return_value = mock_intf_cls.objects
-            mock_intf_cls.objects.get.side_effect = _DNE()
-
-            view.request = req
-            result = view.post(req, "device", 1)
-
-        data = json.loads(result.content)
-        assert data["deleted_count"] == 0
-        assert len(data["errors"]) == 1
-
-    def test_vm_interface_wrong_vm_adds_error(self):
-        from netbox_librenms_plugin.views.sync.interfaces import DeleteNetBoxInterfacesView
-        from virtualization.models import VMInterface
-        import json
-
-        view = object.__new__(DeleteNetBoxInterfacesView)
-        view.get_required_permissions_for_object_type = MagicMock(return_value=[])
-        view.require_all_permissions_json = MagicMock(return_value=None)
-
-        mock_vm = MagicMock(pk=2)
-        mock_vm.id = 2
-
-        mock_interface = MagicMock(spec=VMInterface)
-        mock_interface.name = "eth0"
-        mock_interface.virtual_machine_id = 99  # Wrong VM
-
-        req = _make_request(post_data={"interface_ids": ["7"]})
-
-        with (
-            patch(
-                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
-                return_value=mock_vm,
-            ),
-            patch("netbox_librenms_plugin.views.sync.interfaces.VMInterface") as mock_vmintf_cls,
-            patch("netbox_librenms_plugin.views.sync.interfaces.transaction"),
-        ):
-            mock_vmintf_cls.objects.restrict.return_value = mock_vmintf_cls.objects
-            mock_vmintf_cls.objects.get.return_value = mock_interface
-
-            class _DNE(Exception):
-                pass
-
-            mock_vmintf_cls.DoesNotExist = _DNE
-
-            view.request = req
-            result = view.post(req, "virtualmachine", 2)
-
-        data = json.loads(result.content)
-        assert data["deleted_count"] == 0
-        assert len(data["errors"]) == 1
-
-    def test_response_includes_errors_in_message(self):
-        """When errors exist, message mentions error count."""
-        from netbox_librenms_plugin.views.sync.interfaces import DeleteNetBoxInterfacesView
-        from dcim.models import Interface
-        import json
-
-        view = object.__new__(DeleteNetBoxInterfacesView)
-        view.get_required_permissions_for_object_type = MagicMock(return_value=[])
-        view.require_all_permissions_json = MagicMock(return_value=None)
-
-        mock_device = MagicMock(pk=1)
-        mock_device.id = 1
-        mock_device.virtual_chassis = None
-
-        # Two interfaces: one that belongs, one that doesn't
-        mock_interface_ok = MagicMock(spec=Interface)
-        mock_interface_ok.name = "Gi0/1"
-        mock_interface_ok.device_id = 1
-
-        mock_interface_bad = MagicMock(spec=Interface)
-        mock_interface_bad.name = "Gi0/2"
-        mock_interface_bad.device_id = 99  # Wrong device
-
-        req = _make_request(post_data={"interface_ids": ["5", "6"]})
-
-        call_count = [0]
-
-        def get_side_effect(id):
-            call_count[0] += 1
-            if call_count[0] == 1:
-                return mock_interface_ok
-            return mock_interface_bad
-
-        class _DNE(Exception):
-            pass
-
-        with (
-            patch(
-                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
-                return_value=mock_device,
-            ),
-            patch("netbox_librenms_plugin.views.sync.interfaces.Interface") as mock_intf_cls,
-            patch("netbox_librenms_plugin.views.sync.interfaces.transaction"),
-        ):
-            mock_intf_cls.DoesNotExist = _DNE
-            mock_intf_cls.objects.restrict.return_value = mock_intf_cls.objects
-            mock_intf_cls.objects.get.side_effect = get_side_effect
-            view.request = req
-            result = view.post(req, "device", 1)
-
-        data = json.loads(result.content)
-        assert data["deleted_count"] == 1
-        assert "error" in data["message"]
-        mock_interface_ok.delete.assert_called_once()
 
 
 # A POSTed valid non-default server_key must scope the sync to that server without 500ing on a

--- a/netbox_librenms_plugin/tests/test_coverage_sync_interfaces.py
+++ b/netbox_librenms_plugin/tests/test_coverage_sync_interfaces.py
@@ -9,7 +9,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from netbox_librenms_plugin.tests.conftest import make_device, make_interface, make_vm
+from netbox_librenms_plugin.tests.conftest import make_device, make_interface, make_virtual_chassis, make_vm
 from netbox_librenms_plugin.tests.view_test_helpers import make_request, make_user_with_perms, make_view, missing_pk
 
 # The views here are built with real requests and real users, so the whole file needs the DB.
@@ -544,7 +544,7 @@ class TestSyncInterfacesViewPost:
         req = _make_request(post_data={"select": ["Gi0/1"], "server_key": "default"})
 
         def _record_skip(*args, **kwargs):
-            view._skipped_conflicts.append("Gi0/1")
+            view._skipped_conflicts.append("Gi0/1 (selected target unavailable)")
 
         with (
             patch(
@@ -570,8 +570,8 @@ class TestSyncInterfacesViewPost:
         mock_msgs.warning.assert_called_once()
         warning_msg = mock_msgs.warning.call_args[0][1]
         assert "Gi0/1" in warning_msg
-        # Generic reason covers both "mapped elsewhere" and ambiguous-port_id skips.
-        assert "could not be safely matched" in warning_msg
+        assert "selected target unavailable" in warning_msg
+        assert "could not be safely matched" not in warning_msg
         mock_msgs.success.assert_called_once()
 
 
@@ -718,29 +718,14 @@ class TestSyncInterfacesViewSyncInterfaceDevice:
 
         view.sync_interface(mock_device, librenms_port, [], "ifName")
 
-        assert view._skipped_conflicts == ["Gi0/1"]
+        assert view._skipped_conflicts == ["Gi0/1 (port already mapped elsewhere or ambiguous)"]
         view.update_interface_attributes.assert_not_called()
-
-    @staticmethod
-    def _vc(tag, count=2):
-        """A real VirtualChassis with *count* members at consecutive positions."""
-        from dcim.models import VirtualChassis
-
-        vc = VirtualChassis.objects.create(name=f"vc-{tag}")
-        members = []
-        for position in range(1, count + 1):
-            member = make_device(f"{tag}-m{position}")
-            member.virtual_chassis = vc
-            member.vc_position = position
-            member.save()
-            members.append(member)
-        return vc, members
 
     def test_device_selection_with_vc_valid(self):
         """A posted sibling of the same chassis receives the interface."""
         from dcim.models import Interface
 
-        _vc, (host, sibling) = self._vc("selvalid")
+        _vc, (host, sibling) = make_virtual_chassis("selvalid")
         view = self._make_view(_make_request(post_data={"device_selection_Gi0/1": str(sibling.pk)}))
 
         view.sync_interface(host, {"ifName": "Gi0/1", "port_id": None}, [], "ifName")
@@ -755,11 +740,13 @@ class TestSyncInterfacesViewSyncInterfaceDevice:
         dev = make_device("selinvalid-page")
         other = make_device("selinvalid-other")
         view = self._make_view(_make_request(post_data={"device_selection_Gi0/1": str(other.pk)}))
+        view._skipped_conflicts = []
 
         view.sync_interface(dev, {"ifName": "Gi0/1", "port_id": None}, [], "ifName")
 
         assert not Interface.objects.filter(device=dev, name="Gi0/1").exists()
         assert not Interface.objects.filter(device=other, name="Gi0/1").exists()
+        assert view._skipped_conflicts == ["Gi0/1 (selected target unavailable)"]
 
     def test_device_selection_does_not_exist_is_skipped(self):
         from dcim.models import Device, Interface
@@ -776,7 +763,7 @@ class TestSyncInterfacesViewSyncInterfaceDevice:
         """A hidden posted target must not silently sync the row onto the page device."""
         from dcim.models import Device, Interface
 
-        _vc, (host, sibling) = self._vc("selhidden")
+        _vc, (host, sibling) = make_virtual_chassis("selhidden")
         user = make_user_with_perms(
             "selhidden-user",
             [("view", Device)],
@@ -792,7 +779,7 @@ class TestSyncInterfacesViewSyncInterfaceDevice:
         view.sync_interface(host, {"ifName": "Gi0/1", "port_id": None}, [], "ifName")
 
         assert not Interface.objects.filter(name="Gi0/1").exists()
-        assert view._skipped_conflicts == ["Gi0/1"]
+        assert view._skipped_conflicts == ["Gi0/1 (selected target unavailable)"]
 
     @pytest.mark.django_db
     def test_device_port_id_prefers_existing_librenms_id_match(self):
@@ -855,7 +842,7 @@ class TestSyncInterfacesViewSyncInterfaceDevice:
         view.sync_interface(dev, librenms_port, ["vlans"], "ifName")
 
         # No same-named local interface to fall back to, and we never get_or_create one here.
-        assert view._skipped_conflicts == ["Gi0/1"]
+        assert view._skipped_conflicts == ["Gi0/1 (port already mapped elsewhere or ambiguous)"]
         assert not Interface.objects.filter(device=dev, name="Gi0/1").exists()
 
 

--- a/netbox_librenms_plugin/tests/test_coverage_sync_interfaces.py
+++ b/netbox_librenms_plugin/tests/test_coverage_sync_interfaces.py
@@ -363,6 +363,7 @@ class TestSyncInterfacesViewPost:
         view.require_all_permissions = MagicMock(return_value=_denied_response())
         view.get_required_permissions_for_object_type = MagicMock(return_value=[])
         req = _make_request(post_data={"select": ["Gi0/1"]})
+        view.request = req
         result = view.post(req, "device", 1)
         assert result.status_code == 403
 
@@ -389,6 +390,7 @@ class TestSyncInterfacesViewPost:
             patch("netbox_librenms_plugin.views.sync.interfaces.reverse", return_value="/sync/"),
             patch.object(type(view), "librenms_api", new_callable=lambda: property(lambda s: mock_api)),
         ):
+            view.request = req
             view.post(req, "device", 1)
 
         mock_msgs.error.assert_called_once()
@@ -441,6 +443,7 @@ class TestSyncInterfacesViewPost:
             patch.object(type(view), "librenms_api", new_callable=lambda: property(lambda s: mock_api)),
         ):
             mock_cache.get.return_value = None
+            view.request = req
             view.post(req, "device", 1)
 
         mock_redirect.assert_called()
@@ -475,6 +478,7 @@ class TestSyncInterfacesViewPost:
             patch.object(type(view), "librenms_api", new_callable=lambda: property(lambda s: mock_api)),
         ):
             mock_cache.get.return_value = {"ports": ports}
+            view.request = req
             view.post(req, "device", 1)
 
         mock_msgs.success.assert_called_once()
@@ -510,6 +514,7 @@ class TestSyncInterfacesViewPost:
             patch.object(type(view), "librenms_api", new_callable=lambda: property(lambda s: mock_api)),
         ):
             mock_cache.get.return_value = {"ports": ports}
+            view.request = req
             view.post(req, "virtualmachine", 5)
 
         mock_msgs.success.assert_called_once()
@@ -549,6 +554,7 @@ class TestSyncInterfacesViewPost:
             patch.object(type(view), "librenms_api", new_callable=lambda: property(lambda s: mock_api)),
         ):
             mock_cache.get.return_value = {"ports": ports}
+            view.request = req
             view.post(req, "device", 1)
 
         mock_msgs.warning.assert_called_once()
@@ -732,7 +738,9 @@ class TestSyncInterfacesViewSyncInterfaceDevice:
             patch("netbox_librenms_plugin.views.sync.interfaces.Interface") as mock_intf_cls,
             patch.object(Device, "objects") as mock_device_objects,
         ):
+            mock_device_objects.restrict.return_value = mock_device_objects
             mock_device_objects.get.return_value = mock_target_device
+            mock_intf_cls.objects.restrict.return_value = mock_intf_cls.objects
             mock_intf_cls.objects.get_or_create.return_value = (mock_interface, True)
             view.get_netbox_interface_type = MagicMock(return_value="other")
             view.sync_interface(mock_device, librenms_port, [], "ifName")
@@ -761,7 +769,9 @@ class TestSyncInterfacesViewSyncInterfaceDevice:
             patch("netbox_librenms_plugin.views.sync.interfaces.Interface") as mock_intf_cls,
             patch.object(Device, "objects") as mock_device_objects,
         ):
+            mock_device_objects.restrict.return_value = mock_device_objects
             mock_device_objects.get.return_value = mock_other_device
+            mock_intf_cls.objects.restrict.return_value = mock_intf_cls.objects
             mock_intf_cls.objects.get_or_create.return_value = (mock_interface, True)
             view.get_netbox_interface_type = MagicMock(return_value="other")
             view.sync_interface(mock_device, librenms_port, [], "ifName")
@@ -788,7 +798,9 @@ class TestSyncInterfacesViewSyncInterfaceDevice:
             patch("netbox_librenms_plugin.views.sync.interfaces.Interface") as mock_intf_cls,
             patch.object(Device, "objects") as mock_device_objects,
         ):
+            mock_device_objects.restrict.return_value = mock_device_objects
             mock_device_objects.get.side_effect = Device.DoesNotExist()
+            mock_intf_cls.objects.restrict.return_value = mock_intf_cls.objects
             mock_intf_cls.objects.get_or_create.return_value = (mock_interface, True)
             view.get_netbox_interface_type = MagicMock(return_value="other")
             view.sync_interface(mock_device, librenms_port, [], "ifName")
@@ -880,6 +892,7 @@ class TestSyncInterfacesViewSyncInterfaceVM:
         librenms_port = {"ifName": "eth0", "port_id": None}
 
         with patch("netbox_librenms_plugin.views.sync.interfaces.VMInterface") as mock_vmintf_cls:
+            mock_vmintf_cls.objects.restrict.return_value = mock_vmintf_cls.objects
             mock_vmintf_cls.objects.get_or_create.return_value = (mock_vm_interface, True)
             view.sync_interface(mock_vm, librenms_port, [], "ifName")
 
@@ -949,6 +962,7 @@ class TestSyncInterfacesViewGetNetboxInterfaceType:
             patch("netbox_librenms_plugin.views.sync.interfaces.InterfaceTypeMapping") as mock_cls,
         ):
             # mappings = objects.filter(...); speed_mapping = mappings.filter(...).order_by(...).first()
+            mock_cls.objects.restrict.return_value = mock_cls.objects
             mock_cls.objects.filter.return_value.filter.return_value.order_by.return_value.first.return_value = (
                 mock_mapping
             )
@@ -969,6 +983,7 @@ class TestSyncInterfacesViewGetNetboxInterfaceType:
         ):
             mock_qs = MagicMock()
             mock_qs.filter.return_value.first.return_value = mock_mapping
+            mock_cls.objects.restrict.return_value = mock_cls.objects
             mock_cls.objects.filter.return_value = mock_qs
             result = view.get_netbox_interface_type({"ifType": "softwareLoopback", "ifSpeed": None})
 
@@ -984,6 +999,7 @@ class TestSyncInterfacesViewGetNetboxInterfaceType:
         ):
             mock_qs = MagicMock()
             mock_qs.filter.return_value.first.return_value = None
+            mock_cls.objects.restrict.return_value = mock_cls.objects
             mock_cls.objects.filter.return_value = mock_qs
             result = view.get_netbox_interface_type({"ifType": "unknown", "ifSpeed": None})
 
@@ -1007,6 +1023,7 @@ class TestSyncInterfacesViewGetNetboxInterfaceType:
             mock_null_qs.first.return_value = mock_null_mapping
             mock_qs = MagicMock()
             mock_qs.filter.side_effect = [mock_speed_qs, mock_null_qs]
+            mock_cls.objects.restrict.return_value = mock_cls.objects
             mock_cls.objects.filter.return_value = mock_qs
             result = view.get_netbox_interface_type({"ifType": "ethernetCsmacd", "ifSpeed": 1000})
 
@@ -1378,12 +1395,12 @@ class TestDeleteNetBoxInterfacesViewPost:
 
         mock_device = MagicMock(pk=1)
         req = _make_request(post_data={})  # No interface_ids
-        view.request = req
 
         with patch(
             "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
             return_value=mock_device,
         ):
+            view.request = req
             result = view.post(req, "device", 1)
 
         assert isinstance(result, JsonResponse)
@@ -1398,8 +1415,8 @@ class TestDeleteNetBoxInterfacesViewPost:
         view.require_all_permissions_json = MagicMock(return_value=None)
 
         req = _make_request(post_data={"interface_ids": ["1"]})
-        view.request = req
         with pytest.raises(Http404):
+            view.request = req
             view.post(req, "badtype", 1)
 
     def test_device_interface_deleted_successfully(self):
@@ -1420,7 +1437,6 @@ class TestDeleteNetBoxInterfacesViewPost:
         mock_interface.device_id = 1
 
         req = _make_request(post_data={"interface_ids": ["5"]})
-        view.request = req
 
         with (
             patch(
@@ -1438,6 +1454,7 @@ class TestDeleteNetBoxInterfacesViewPost:
 
             mock_intf_cls.DoesNotExist = _DNE
 
+            view.request = req
             result = view.post(req, "device", 1)
 
         assert isinstance(result, JsonResponse)
@@ -1463,7 +1480,6 @@ class TestDeleteNetBoxInterfacesViewPost:
         mock_interface.virtual_machine_id = 2
 
         req = _make_request(post_data={"interface_ids": ["7"]})
-        view.request = req
 
         with (
             patch(
@@ -1481,6 +1497,7 @@ class TestDeleteNetBoxInterfacesViewPost:
 
             mock_vmintf_cls.DoesNotExist = _DNE
 
+            view.request = req
             result = view.post(req, "virtualmachine", 2)
 
         assert isinstance(result, JsonResponse)
@@ -1505,7 +1522,6 @@ class TestDeleteNetBoxInterfacesViewPost:
         mock_interface.device_id = 99  # Wrong device
 
         req = _make_request(post_data={"interface_ids": ["5"]})
-        view.request = req
 
         with (
             patch(
@@ -1523,6 +1539,7 @@ class TestDeleteNetBoxInterfacesViewPost:
 
             mock_intf_cls.DoesNotExist = _DNE
 
+            view.request = req
             result = view.post(req, "device", 1)
 
         data = json.loads(result.content)
@@ -1550,7 +1567,6 @@ class TestDeleteNetBoxInterfacesViewPost:
         mock_interface.device_id = 999  # Not in VC
 
         req = _make_request(post_data={"interface_ids": ["5"]})
-        view.request = req
 
         with (
             patch(
@@ -1568,6 +1584,7 @@ class TestDeleteNetBoxInterfacesViewPost:
 
             mock_intf_cls.DoesNotExist = _DNE
 
+            view.request = req
             result = view.post(req, "device", 1)
 
         data = json.loads(result.content)
@@ -1587,7 +1604,6 @@ class TestDeleteNetBoxInterfacesViewPost:
         mock_device.virtual_chassis = None
 
         req = _make_request(post_data={"interface_ids": ["999"]})
-        view.request = req
 
         class _DNE(Exception):
             pass
@@ -1604,6 +1620,7 @@ class TestDeleteNetBoxInterfacesViewPost:
             mock_intf_cls.objects.restrict.return_value = mock_intf_cls.objects
             mock_intf_cls.objects.get.side_effect = _DNE()
 
+            view.request = req
             result = view.post(req, "device", 1)
 
         data = json.loads(result.content)
@@ -1627,7 +1644,6 @@ class TestDeleteNetBoxInterfacesViewPost:
         mock_interface.virtual_machine_id = 99  # Wrong VM
 
         req = _make_request(post_data={"interface_ids": ["7"]})
-        view.request = req
 
         with (
             patch(
@@ -1645,6 +1661,7 @@ class TestDeleteNetBoxInterfacesViewPost:
 
             mock_vmintf_cls.DoesNotExist = _DNE
 
+            view.request = req
             result = view.post(req, "virtualmachine", 2)
 
         data = json.loads(result.content)
@@ -1675,7 +1692,6 @@ class TestDeleteNetBoxInterfacesViewPost:
         mock_interface_bad.device_id = 99  # Wrong device
 
         req = _make_request(post_data={"interface_ids": ["5", "6"]})
-        view.request = req
 
         call_count = [0]
 
@@ -1699,6 +1715,7 @@ class TestDeleteNetBoxInterfacesViewPost:
             mock_intf_cls.DoesNotExist = _DNE
             mock_intf_cls.objects.restrict.return_value = mock_intf_cls.objects
             mock_intf_cls.objects.get.side_effect = get_side_effect
+            view.request = req
             result = view.post(req, "device", 1)
 
         data = json.loads(result.content)

--- a/netbox_librenms_plugin/tests/test_coverage_sync_views.py
+++ b/netbox_librenms_plugin/tests/test_coverage_sync_views.py
@@ -5,9 +5,9 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from netbox_librenms_plugin.tests.conftest import make_device, make_interface, make_ip, make_vm
-
-
-from netbox_librenms_plugin.tests.view_test_helpers import make_view, missing_pk
+from netbox_librenms_plugin.tests.view_test_helpers import grant
+from netbox_librenms_plugin.tests.view_test_helpers import make_request as make_real_request
+from netbox_librenms_plugin.tests.view_test_helpers import make_user_with_perms, make_view, missing_pk
 from netbox_librenms_plugin.tests.view_test_helpers import post as _post
 
 
@@ -1312,14 +1312,12 @@ class TestSyncInterfacesViewSyncInterface:
         assert raised
 
 
+@pytest.mark.django_db
 class TestDeleteNetBoxInterfacesViewPost:
-    def _make_view(self):
+    def _make_view(self, request=None):
         from netbox_librenms_plugin.views.sync.interfaces import DeleteNetBoxInterfacesView
 
-        view = object.__new__(DeleteNetBoxInterfacesView)
-        view._librenms_api = MagicMock()
-        view.request = _make_request()
-        return view
+        return make_view(DeleteNetBoxInterfacesView, request or make_real_request("post"))
 
     def test_permission_denied_returns_json_403(self):
         view = self._make_view()
@@ -1343,26 +1341,27 @@ class TestDeleteNetBoxInterfacesViewPost:
 
     @pytest.mark.django_db
     def test_no_interface_ids_returns_400(self):
-        view = self._make_view()
         obj = make_device("del-noids-dev")
-        req = _make_request({"interface_ids": []})
-        with patch.object(view, "require_all_permissions_json", return_value=None):
-            view.request = req
-            result = view.post(req, object_type="device", object_id=obj.pk)
+        req = make_real_request("post", {"interface_ids": []})
+        view = self._make_view(req)
+        result = _post(view, req, object_type="device", object_id=obj.pk)
         assert result.status_code == 400
 
     @pytest.mark.django_db
     def test_device_interface_wrong_device_skipped(self):
         import json
 
-        view = self._make_view()
+        from dcim.models import Device, Interface
+
         obj = make_device("del-wrongdev-target")
         other = make_device("del-wrongdev-other")
         iface = make_interface(other, "eth0")  # belongs to a different device
-        req = _make_request({"interface_ids": [str(iface.pk)]})
-        with patch.object(view, "require_all_permissions_json", return_value=None):
-            view.request = req
-            result = view.post(req, object_type="device", object_id=obj.pk)
+        user = make_user_with_perms("del-wrongdev-user", [])
+        user = grant(user, "view", Device, constraints={"pk": obj.pk})
+        user = grant(user, "delete", Interface, constraints={"pk": iface.pk})
+        req = make_real_request("post", {"interface_ids": [str(iface.pk)]}, user=user)
+        view = self._make_view(req)
+        result = _post(view, req, object_type="device", object_id=obj.pk)
         data = json.loads(result.content)
         assert data["deleted_count"] == 0
         assert other.interfaces.filter(pk=iface.pk).exists()  # not deleted
@@ -1371,16 +1370,17 @@ class TestDeleteNetBoxInterfacesViewPost:
     def test_vm_interface_wrong_vm_skipped(self):
         import json
 
-        from virtualization.models import VMInterface
+        from virtualization.models import VirtualMachine, VMInterface
 
-        view = self._make_view()
         vm = make_vm("del-wrongvm-target")
         other_vm = make_vm("del-wrongvm-other")
         vmiface = VMInterface.objects.create(virtual_machine=other_vm, name="eth0")
-        req = _make_request({"interface_ids": [str(vmiface.pk)]})
-        with patch.object(view, "require_all_permissions_json", return_value=None):
-            view.request = req
-            result = view.post(req, object_type="virtualmachine", object_id=vm.pk)
+        user = make_user_with_perms("del-wrongvm-user", [])
+        user = grant(user, "view", VirtualMachine, constraints={"pk": vm.pk})
+        user = grant(user, "delete", VMInterface, constraints={"pk": vmiface.pk})
+        req = make_real_request("post", {"interface_ids": [str(vmiface.pk)]}, user=user)
+        view = self._make_view(req)
+        result = _post(view, req, object_type="virtualmachine", object_id=vm.pk)
         data = json.loads(result.content)
         assert data["deleted_count"] == 0
         assert VMInterface.objects.filter(pk=vmiface.pk).exists()
@@ -1391,13 +1391,11 @@ class TestDeleteNetBoxInterfacesViewPost:
 
         from dcim.models import Interface
 
-        view = self._make_view()
         obj = make_device("del-ok-dev")
         iface = make_interface(obj, "eth0")
-        req = _make_request({"interface_ids": [str(iface.pk)]})
-        with patch.object(view, "require_all_permissions_json", return_value=None):
-            view.request = req
-            result = view.post(req, object_type="device", object_id=obj.pk)
+        req = make_real_request("post", {"interface_ids": [str(iface.pk)]})
+        view = self._make_view(req)
+        result = _post(view, req, object_type="device", object_id=obj.pk)
         data = json.loads(result.content)
         assert data["deleted_count"] == 1
         assert not Interface.objects.filter(pk=iface.pk).exists()  # actually deleted
@@ -1408,13 +1406,11 @@ class TestDeleteNetBoxInterfacesViewPost:
 
         from virtualization.models import VMInterface
 
-        view = self._make_view()
         vm = make_vm("del-ok-vm")
         vmiface = VMInterface.objects.create(virtual_machine=vm, name="eth0")
-        req = _make_request({"interface_ids": [str(vmiface.pk)]})
-        with patch.object(view, "require_all_permissions_json", return_value=None):
-            view.request = req
-            result = view.post(req, object_type="virtualmachine", object_id=vm.pk)
+        req = make_real_request("post", {"interface_ids": [str(vmiface.pk)]})
+        view = self._make_view(req)
+        result = _post(view, req, object_type="virtualmachine", object_id=vm.pk)
         data = json.loads(result.content)
         assert data["deleted_count"] == 1
         assert not VMInterface.objects.filter(pk=vmiface.pk).exists()
@@ -1423,13 +1419,11 @@ class TestDeleteNetBoxInterfacesViewPost:
     def test_interface_not_found_adds_error(self):
         import json
 
-        view = self._make_view()
         obj = make_device("del-notfound-dev")
         # An interface id that does not exist → real Interface.DoesNotExist → recorded error.
-        req = _make_request({"interface_ids": ["999999"]})
-        with patch.object(view, "require_all_permissions_json", return_value=None):
-            view.request = req
-            result = view.post(req, object_type="device", object_id=obj.pk)
+        req = make_real_request("post", {"interface_ids": ["999999"]})
+        view = self._make_view(req)
+        result = _post(view, req, object_type="device", object_id=obj.pk)
         data = json.loads(result.content)
         assert "errors" in data
         assert data["deleted_count"] == 0
@@ -1440,7 +1434,6 @@ class TestDeleteNetBoxInterfacesViewPost:
 
         from dcim.models import Interface, VirtualChassis
 
-        view = self._make_view()
         vc = VirtualChassis.objects.create(name="vc-del")
         member = make_device("del-vc-member")
         member.virtual_chassis = vc
@@ -1448,10 +1441,9 @@ class TestDeleteNetBoxInterfacesViewPost:
         member.save()
         outsider = make_device("del-vc-outsider")  # not part of the VC
         iface = make_interface(outsider, "eth0")
-        req = _make_request({"interface_ids": [str(iface.pk)]})
-        with patch.object(view, "require_all_permissions_json", return_value=None):
-            view.request = req
-            result = view.post(req, object_type="device", object_id=member.pk)
+        req = make_real_request("post", {"interface_ids": [str(iface.pk)]})
+        view = self._make_view(req)
+        result = _post(view, req, object_type="device", object_id=member.pk)
         data = json.loads(result.content)
         assert data["deleted_count"] == 0
         assert Interface.objects.filter(pk=iface.pk).exists()  # not deleted (not a VC member's)

--- a/netbox_librenms_plugin/tests/test_coverage_sync_views.py
+++ b/netbox_librenms_plugin/tests/test_coverage_sync_views.py
@@ -2386,13 +2386,14 @@ class TestSyncVLANsViewStructure:
         assert CacheMixin in mro
 
     def test_required_object_permissions(self):
-        from ipam.models import VLAN
+        from ipam.models import VLAN, VLANGroup
 
         from netbox_librenms_plugin.views.sync.vlans import SyncVLANsView
 
         perms = SyncVLANsView.required_object_permissions["POST"]
         assert ("add", VLAN) in perms
         assert ("change", VLAN) in perms
+        assert ("view", VLANGroup) in perms
 
 
 class TestSyncVLANsViewGetObject:

--- a/netbox_librenms_plugin/tests/test_coverage_sync_views.py
+++ b/netbox_librenms_plugin/tests/test_coverage_sync_views.py
@@ -7,6 +7,7 @@ import pytest
 from netbox_librenms_plugin.tests.conftest import make_device, make_interface, make_ip, make_vm
 
 
+from netbox_librenms_plugin.tests.view_test_helpers import make_view
 from netbox_librenms_plugin.tests.view_test_helpers import post as _post
 
 
@@ -1309,101 +1310,6 @@ class TestSyncInterfacesViewSyncInterface:
         assert raised
 
 
-class TestSyncInterfacesViewGetNetboxInterfaceType:
-    def test_speed_match_returns_mapped_type(self):
-        from netbox_librenms_plugin.views.sync.interfaces import SyncInterfacesView
-
-        view = _make_view(SyncInterfacesView)
-        librenms_if = {"ifType": "ethernetCsmacd", "ifSpeed": 1000000000}
-        mock_mapping = MagicMock()
-        mock_mapping.netbox_type = "1000base-t"
-        mock_qs = MagicMock()
-        mock_qs.filter.return_value.order_by.return_value.first.return_value = mock_mapping
-        with patch("netbox_librenms_plugin.views.sync.interfaces.InterfaceTypeMapping") as mock_itm:
-            with patch(
-                "netbox_librenms_plugin.views.sync.interfaces.convert_speed_to_kbps",
-                return_value=1000000,
-            ):
-                mock_itm.objects.restrict.return_value = mock_itm.objects
-                mock_itm.objects.filter.return_value = mock_qs
-                result = view.get_netbox_interface_type(librenms_if)
-        assert result is not None
-
-    def test_fallback_no_speed_mapping(self):
-        from netbox_librenms_plugin.views.sync.interfaces import SyncInterfacesView
-
-        view = _make_view(SyncInterfacesView)
-        librenms_if = {"ifType": "ethernetCsmacd", "ifSpeed": None}
-        mock_mapping = MagicMock()
-        mock_mapping.netbox_type = "other"
-        mock_qs = MagicMock()
-        mock_qs.filter.return_value.first.return_value = mock_mapping
-        with patch("netbox_librenms_plugin.views.sync.interfaces.InterfaceTypeMapping") as mock_itm:
-            with patch(
-                "netbox_librenms_plugin.views.sync.interfaces.convert_speed_to_kbps",
-                return_value=None,
-            ):
-                mock_itm.objects.restrict.return_value = mock_itm.objects
-                mock_itm.objects.filter.return_value = mock_qs
-                result = view.get_netbox_interface_type(librenms_if)
-        assert result == "other"
-
-    def test_no_mappings_returns_other(self):
-        from netbox_librenms_plugin.views.sync.interfaces import SyncInterfacesView
-
-        view = _make_view(SyncInterfacesView)
-        librenms_if = {"ifType": "unknown_type", "ifSpeed": None}
-        mock_qs = MagicMock()
-        mock_qs.filter.return_value.first.return_value = None
-        with patch("netbox_librenms_plugin.views.sync.interfaces.InterfaceTypeMapping") as mock_itm:
-            with patch(
-                "netbox_librenms_plugin.views.sync.interfaces.convert_speed_to_kbps",
-                return_value=None,
-            ):
-                mock_itm.objects.restrict.return_value = mock_itm.objects
-                mock_itm.objects.filter.return_value = mock_qs
-                result = view.get_netbox_interface_type(librenms_if)
-        assert result == "other"
-
-
-class TestSyncInterfacesViewHandleMacAddress:
-    def test_no_mac_address_no_op(self):
-        from netbox_librenms_plugin.views.sync.interfaces import SyncInterfacesView
-
-        view = _make_view(SyncInterfacesView)
-        mock_iface = MagicMock()
-        view.handle_mac_address(mock_iface, None)
-        mock_iface.mac_addresses.filter.assert_not_called()
-
-    def test_existing_mac_is_reused(self):
-        from netbox_librenms_plugin.views.sync.interfaces import SyncInterfacesView
-
-        view = _make_view(SyncInterfacesView)
-        mock_iface = MagicMock()
-        existing_mac = MagicMock()
-        mock_iface.mac_addresses.filter.return_value.first.return_value = existing_mac
-        view.handle_mac_address(mock_iface, "aa:bb:cc:dd:ee:ff")
-        mock_iface.mac_addresses.add.assert_called_once_with(existing_mac)
-
-    def test_new_mac_is_created(self):
-        from netbox_librenms_plugin.views.sync.interfaces import SyncInterfacesView
-
-        view = _make_view(SyncInterfacesView)
-        mock_iface = MagicMock()
-        mock_iface.mac_addresses.filter.return_value.first.return_value = None
-        new_mac = MagicMock()
-        with patch("netbox_librenms_plugin.views.sync.interfaces.MACAddress") as mock_mac_cls:
-            mock_mac_cls.objects.create.return_value = new_mac
-            view.handle_mac_address(mock_iface, "aa:bb:cc:dd:ee:ff")
-        mock_mac_cls.objects.create.assert_called_once_with(mac_address="aa:bb:cc:dd:ee:ff")
-        mock_iface.mac_addresses.add.assert_called_once_with(new_mac)
-
-
-# ===========================================================================
-# interfaces.py — DeleteNetBoxInterfacesView
-# ===========================================================================
-
-
 class TestDeleteNetBoxInterfacesViewPost:
     def _make_view(self):
         from netbox_librenms_plugin.views.sync.interfaces import DeleteNetBoxInterfacesView
@@ -1576,42 +1482,6 @@ class TestSyncIPAddressesViewStructure:
         perms = SyncIPAddressesView.required_object_permissions["POST"]
         assert ("add", IPAddress) in perms
         assert ("change", IPAddress) in perms
-
-
-class TestSyncIPAddressesViewGetVrfSelection:
-    def test_no_vrf_id_returns_none(self):
-        from netbox_librenms_plugin.views.sync.ip_addresses import SyncIPAddressesView
-
-        view = _make_view(SyncIPAddressesView)
-        req = _make_request({})
-        result = view.get_vrf_selection(req, "192.168.1.1")
-        assert result is None
-
-    def test_valid_vrf_id_returns_vrf(self):
-        from netbox_librenms_plugin.views.sync.ip_addresses import SyncIPAddressesView
-
-        view = _make_view(SyncIPAddressesView)
-        req = _make_request({"vrf_192.168.1.1": "3"})
-        mock_vrf = MagicMock()
-        with patch("netbox_librenms_plugin.views.sync.ip_addresses.VRF") as mock_vrf_cls:
-            mock_vrf_cls.objects.restrict.return_value = mock_vrf_cls.objects
-            mock_vrf_cls.objects.get.return_value = mock_vrf
-            result = view.get_vrf_selection(req, "192.168.1.1")
-        assert result is mock_vrf
-
-    def test_vrf_does_not_exist_returns_none(self):
-        from ipam.models import VRF
-
-        from netbox_librenms_plugin.views.sync.ip_addresses import SyncIPAddressesView
-
-        view = _make_view(SyncIPAddressesView)
-        req = _make_request({"vrf_192.168.1.1": "999"})
-        with patch("netbox_librenms_plugin.views.sync.ip_addresses.VRF") as mock_vrf_cls:
-            mock_vrf_cls.DoesNotExist = VRF.DoesNotExist
-            mock_vrf_cls.objects.restrict.return_value = mock_vrf_cls.objects
-            mock_vrf_cls.objects.get.side_effect = VRF.DoesNotExist
-            result = view.get_vrf_selection(req, "192.168.1.1")
-        assert result is None
 
 
 class TestSyncIPAddressesViewGetManagementIp:
@@ -2242,33 +2112,26 @@ class TestSyncSiteLocationViewCreateSyncData:
         assert result.is_synced is False
 
 
+@pytest.mark.django_db
 class TestSyncSiteLocationViewGetSiteByPk:
-    def _make_view(self):
+    def _make_view(self, request=None):
         from netbox_librenms_plugin.views.sync.locations import SyncSiteLocationView
 
-        view = object.__new__(SyncSiteLocationView)
-        view._librenms_api = MagicMock()
-        view.request = _make_request()
-        return view
+        return make_view(SyncSiteLocationView, request)
 
     def test_found_returns_site(self):
-        view = self._make_view()
-        mock_site = MagicMock()
-        with patch("netbox_librenms_plugin.views.sync.locations.Site") as mock_site_cls:
-            mock_site_cls.objects.restrict.return_value = mock_site_cls.objects
-            mock_site_cls.objects.get.return_value = mock_site
-            result = view.get_site_by_pk(1)
-        assert result is mock_site
+        from dcim.models import Site
+
+        site = Site.objects.create(name="Bypk Site", slug="bypk-site")
+
+        assert self._make_view().get_site_by_pk(site.pk) == site
 
     def test_not_found_returns_none(self):
-        from django.core.exceptions import ObjectDoesNotExist
+        from dcim.models import Site
 
-        view = self._make_view()
-        with patch("netbox_librenms_plugin.views.sync.locations.Site") as mock_site_cls:
-            mock_site_cls.objects.restrict.return_value = mock_site_cls.objects
-            mock_site_cls.objects.get.side_effect = ObjectDoesNotExist
-            result = view.get_site_by_pk(999)
-        assert result is None
+        missing_pk = (Site.objects.order_by("-pk").first().pk if Site.objects.exists() else 0) + 1000
+
+        assert self._make_view().get_site_by_pk(missing_pk) is None
 
 
 class TestSyncSiteLocationViewPost:

--- a/netbox_librenms_plugin/tests/test_coverage_sync_views.py
+++ b/netbox_librenms_plugin/tests/test_coverage_sync_views.py
@@ -2386,11 +2386,13 @@ class TestSyncVLANsViewStructure:
         assert CacheMixin in mro
 
     def test_required_object_permissions(self):
+        from dcim.models import Device
         from ipam.models import VLAN, VLANGroup
 
         from netbox_librenms_plugin.views.sync.vlans import SyncVLANsView
 
         perms = SyncVLANsView.required_object_permissions["POST"]
+        assert ("view", Device) in perms
         assert ("add", VLAN) in perms
         assert ("change", VLAN) in perms
         assert ("view", VLANGroup) in perms

--- a/netbox_librenms_plugin/tests/test_coverage_sync_views.py
+++ b/netbox_librenms_plugin/tests/test_coverage_sync_views.py
@@ -1419,9 +1419,11 @@ class TestDeleteNetBoxInterfacesViewPost:
     def test_interface_not_found_adds_error(self):
         import json
 
+        from dcim.models import Interface
+
         obj = make_device("del-notfound-dev")
-        # An interface id that does not exist → real Interface.DoesNotExist → recorded error.
-        req = make_real_request("post", {"interface_ids": ["999999"]})
+        absent_pk = missing_pk(Interface)
+        req = make_real_request("post", {"interface_ids": [str(absent_pk)]})
         view = self._make_view(req)
         result = _post(view, req, object_type="device", object_id=obj.pk)
         data = json.loads(result.content)

--- a/netbox_librenms_plugin/tests/test_coverage_sync_views.py
+++ b/netbox_librenms_plugin/tests/test_coverage_sync_views.py
@@ -1648,6 +1648,18 @@ class TestSyncIPAddressesViewGetIpTabUrl:
 
 
 class TestSyncIPAddressesViewPost:
+    def test_invalid_object_type_raises_404_before_permission_check(self):
+        from django.http import Http404
+
+        from netbox_librenms_plugin.views.sync.ip_addresses import SyncIPAddressesView
+
+        view = _make_view(SyncIPAddressesView)
+        with patch.object(view, "require_all_permissions") as permission_check:
+            with pytest.raises(Http404, match="Invalid object type"):
+                view.post(view.request, object_type="rack", pk=1)
+
+        permission_check.assert_not_called()
+
     def test_permission_denied_returns_early(self):
         from netbox_librenms_plugin.views.sync.ip_addresses import SyncIPAddressesView
 

--- a/netbox_librenms_plugin/tests/test_coverage_sync_views.py
+++ b/netbox_librenms_plugin/tests/test_coverage_sync_views.py
@@ -7,7 +7,7 @@ import pytest
 from netbox_librenms_plugin.tests.conftest import make_device, make_interface, make_ip, make_vm
 
 
-from netbox_librenms_plugin.tests.view_test_helpers import make_view
+from netbox_librenms_plugin.tests.view_test_helpers import make_view, missing_pk
 from netbox_librenms_plugin.tests.view_test_helpers import post as _post
 
 
@@ -2129,9 +2129,9 @@ class TestSyncSiteLocationViewGetSiteByPk:
     def test_not_found_returns_none(self):
         from dcim.models import Site
 
-        missing_pk = (Site.objects.order_by("-pk").first().pk if Site.objects.exists() else 0) + 1000
+        absent_pk = missing_pk(Site)
 
-        assert self._make_view().get_site_by_pk(missing_pk) is None
+        assert self._make_view().get_site_by_pk(absent_pk) is None
 
 
 class TestSyncSiteLocationViewPost:

--- a/netbox_librenms_plugin/tests/test_coverage_sync_views.py
+++ b/netbox_librenms_plugin/tests/test_coverage_sync_views.py
@@ -7,24 +7,7 @@ import pytest
 from netbox_librenms_plugin.tests.conftest import make_device, make_interface, make_ip, make_vm
 
 
-def _bind_and_call(view, request, method, **kwargs):
-    """Call *view*.<method>, binding the request the way ``View.setup()`` does under dispatch().
-
-    A direct ``view.post(request, ...)`` leaves ``self.request`` unset, which the object-scoped
-    lookups read — production always goes through dispatch(), so bind it here too.
-    """
-    view.setup(request)
-    return getattr(view, method)(request, **kwargs)
-
-
-def _post(view, request, **kwargs):
-    """POST into *view* with the request bound (see :func:`_bind_and_call`)."""
-    return _bind_and_call(view, request, "post", **kwargs)
-
-
-def _get(view, request, **kwargs):
-    """GET into *view* with the request bound (see :func:`_bind_and_call`)."""
-    return _bind_and_call(view, request, "get", **kwargs)
+from netbox_librenms_plugin.tests.view_test_helpers import post as _post
 
 
 def _make_post(data):
@@ -824,7 +807,7 @@ class TestUpdateDeviceLocationViewPost:
         device.get_absolute_url.return_value = "/dcim/devices/1/"
         with patch.object(view, "require_write_permission", return_value=None):
             with patch(
-                "netbox_librenms_plugin.views.sync.devices.get_object_or_404",
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
                 return_value=device,
             ):
                 with patch("netbox_librenms_plugin.views.sync.devices.redirect"):
@@ -841,7 +824,7 @@ class TestUpdateDeviceLocationViewPost:
         device.pk = 1
         with patch.object(view, "require_write_permission", return_value=None):
             with patch(
-                "netbox_librenms_plugin.views.sync.devices.get_object_or_404",
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
                 return_value=device,
             ):
                 with patch("netbox_librenms_plugin.views.sync.devices.redirect"):
@@ -859,7 +842,7 @@ class TestUpdateDeviceLocationViewPost:
         device.site.name = "Paris"
         with patch.object(view, "require_write_permission", return_value=None):
             with patch(
-                "netbox_librenms_plugin.views.sync.devices.get_object_or_404",
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
                 return_value=device,
             ):
                 with patch("netbox_librenms_plugin.views.sync.devices.redirect"):

--- a/netbox_librenms_plugin/tests/test_coverage_sync_views.py
+++ b/netbox_librenms_plugin/tests/test_coverage_sync_views.py
@@ -7,6 +7,26 @@ import pytest
 from netbox_librenms_plugin.tests.conftest import make_device, make_interface, make_ip, make_vm
 
 
+def _bind_and_call(view, request, method, **kwargs):
+    """Call *view*.<method>, binding the request the way ``View.setup()`` does under dispatch().
+
+    A direct ``view.post(request, ...)`` leaves ``self.request`` unset, which the object-scoped
+    lookups read — production always goes through dispatch(), so bind it here too.
+    """
+    view.setup(request)
+    return getattr(view, method)(request, **kwargs)
+
+
+def _post(view, request, **kwargs):
+    """POST into *view* with the request bound (see :func:`_bind_and_call`)."""
+    return _bind_and_call(view, request, "post", **kwargs)
+
+
+def _get(view, request, **kwargs):
+    """GET into *view* with the request bound (see :func:`_bind_and_call`)."""
+    return _bind_and_call(view, request, "get", **kwargs)
+
+
 def _make_post(data):
     """Return a mock POST object backed by a real dict."""
     mock = MagicMock()
@@ -464,7 +484,10 @@ class TestSyncCablesViewPost:
         mock_device = MagicMock()
         mock_device.pk = 1
         with patch.object(view, "require_all_permissions", return_value=None):
-            with patch("netbox_librenms_plugin.views.sync.cables.get_object_or_404", return_value=mock_device):
+            with patch(
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+                return_value=mock_device,
+            ):
                 with patch("netbox_librenms_plugin.views.sync.cables.reverse", return_value="/fake/"):
                     with patch.object(view, "get_selected_interfaces", return_value=None):
                         with patch.object(view, "get_cached_links_data", return_value=None):
@@ -481,7 +504,10 @@ class TestSyncCablesViewPost:
         mock_device.pk = 1
         results = {"valid": ["eth0"], "invalid": [], "duplicate": [], "missing_remote": []}
         with patch.object(view, "require_all_permissions", return_value=None):
-            with patch("netbox_librenms_plugin.views.sync.cables.get_object_or_404", return_value=mock_device):
+            with patch(
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+                return_value=mock_device,
+            ):
                 with patch("netbox_librenms_plugin.views.sync.cables.reverse", return_value="/fake/"):
                     with patch.object(view, "get_selected_interfaces", return_value=[{"local_port_id": "1"}]):
                         with patch.object(view, "get_cached_links_data", return_value=[{"local_port_id": "1"}]):
@@ -500,7 +526,10 @@ class TestSyncCablesViewPost:
         mock_device = MagicMock()
         mock_device.pk = 1
         with patch.object(view, "require_all_permissions", return_value=None):
-            with patch("netbox_librenms_plugin.views.sync.cables.get_object_or_404", return_value=mock_device):
+            with patch(
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+                return_value=mock_device,
+            ):
                 with patch("netbox_librenms_plugin.views.sync.cables.reverse", return_value="/fake/"):
                     with patch.object(view, "get_selected_interfaces", return_value=None):
                         with patch.object(view, "get_cached_links_data", return_value=None):
@@ -573,7 +602,10 @@ class TestAddDeviceToLibreNMSViewGetObject:
 
         view = _make_view(AddDeviceToLibreNMSView)
         mock_vm = MagicMock()
-        with patch("netbox_librenms_plugin.views.sync.devices.get_object_or_404", return_value=mock_vm):
+        with patch(
+            "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+            return_value=mock_vm,
+        ):
             result = view.get_object(5, "virtualmachine")
         assert result is mock_vm
 
@@ -582,10 +614,13 @@ class TestAddDeviceToLibreNMSViewGetObject:
 
         view = _make_view(AddDeviceToLibreNMSView)
         mock_device = MagicMock()
-        with patch("netbox_librenms_plugin.views.sync.devices.get_object_or_404", return_value=mock_device) as mock_get:
+        with patch(
+            "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+            return_value=mock_device,
+        ) as mock_get:
             result = view.get_object(1, "device")
         assert result is mock_device
-        mock_get.assert_called_once_with(Device, pk=1)
+        mock_get.assert_called_once_with(Device, "change", pk=1)
 
 
 class TestAddDeviceToLibreNMSViewPost:
@@ -788,10 +823,13 @@ class TestUpdateDeviceLocationViewPost:
         device.site.name = "London"
         device.get_absolute_url.return_value = "/dcim/devices/1/"
         with patch.object(view, "require_write_permission", return_value=None):
-            with patch("netbox_librenms_plugin.views.sync.devices.get_object_or_404", return_value=device):
+            with patch(
+                "netbox_librenms_plugin.views.sync.devices.get_object_or_404",
+                return_value=device,
+            ):
                 with patch("netbox_librenms_plugin.views.sync.devices.redirect"):
                     with patch("netbox_librenms_plugin.views.sync.devices.messages") as mock_msg:
-                        view.post(view.request, pk=1)
+                        _post(view, view.request, pk=1)
         view._librenms_api.update_device_field.assert_called_once()
         mock_msg.success.assert_called_once()
 
@@ -802,10 +840,13 @@ class TestUpdateDeviceLocationViewPost:
         device.site = None
         device.pk = 1
         with patch.object(view, "require_write_permission", return_value=None):
-            with patch("netbox_librenms_plugin.views.sync.devices.get_object_or_404", return_value=device):
+            with patch(
+                "netbox_librenms_plugin.views.sync.devices.get_object_or_404",
+                return_value=device,
+            ):
                 with patch("netbox_librenms_plugin.views.sync.devices.redirect"):
                     with patch("netbox_librenms_plugin.views.sync.devices.messages") as mock_msg:
-                        view.post(view.request, pk=1)
+                        _post(view, view.request, pk=1)
         view._librenms_api.update_device_field.assert_not_called()
         mock_msg.warning.assert_called_once()
 
@@ -817,10 +858,13 @@ class TestUpdateDeviceLocationViewPost:
         device.site = MagicMock()
         device.site.name = "Paris"
         with patch.object(view, "require_write_permission", return_value=None):
-            with patch("netbox_librenms_plugin.views.sync.devices.get_object_or_404", return_value=device):
+            with patch(
+                "netbox_librenms_plugin.views.sync.devices.get_object_or_404",
+                return_value=device,
+            ):
                 with patch("netbox_librenms_plugin.views.sync.devices.redirect"):
                     with patch("netbox_librenms_plugin.views.sync.devices.messages") as mock_msg:
-                        view.post(view.request, pk=1)
+                        _post(view, view.request, pk=1)
         mock_msg.error.assert_called_once()
 
 
@@ -1629,7 +1673,7 @@ class TestSyncIPAddressesViewGetObject:
         view = _make_view(SyncIPAddressesView)
         mock_dev = MagicMock()
         with patch(
-            "netbox_librenms_plugin.views.sync.ip_addresses.get_object_or_404",
+            "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
             return_value=mock_dev,
         ):
             result = view.get_object("device", 1)
@@ -1641,7 +1685,7 @@ class TestSyncIPAddressesViewGetObject:
         view = _make_view(SyncIPAddressesView)
         mock_vm = MagicMock()
         with patch(
-            "netbox_librenms_plugin.views.sync.ip_addresses.get_object_or_404",
+            "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
             return_value=mock_vm,
         ):
             result = view.get_object("virtualmachine", 1)
@@ -2491,7 +2535,7 @@ class TestSyncVLANsViewGetObject:
         view = _make_view(SyncVLANsView)
         mock_dev = MagicMock()
         with patch(
-            "netbox_librenms_plugin.views.sync.vlans.get_object_or_404",
+            "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
             return_value=mock_dev,
         ):
             result = view.get_object("device", 1)

--- a/netbox_librenms_plugin/tests/test_coverage_sync_views.py
+++ b/netbox_librenms_plugin/tests/test_coverage_sync_views.py
@@ -1248,7 +1248,7 @@ class TestSyncInterfacesViewSyncInterface:
         assert member2.interfaces.filter(name="eth0").exists()
         assert not master.interfaces.filter(name="eth0").exists()
 
-    def test_device_with_invalid_vc_member_falls_back_to_obj(self):
+    def test_device_with_invalid_vc_member_is_skipped(self):
         from dcim.models import VirtualChassis
 
         from netbox_librenms_plugin.views.sync.interfaces import SyncInterfacesView
@@ -1261,7 +1261,7 @@ class TestSyncInterfacesViewSyncInterface:
         master.virtual_chassis = vc
         master.vc_position = 1
         master.save()
-        # An existing device that is NOT a member of this VC → not in valid_ids → fall back to master.
+        # An existing device that is not a member of this VC is an invalid explicit target.
         outsider = make_device("vc-sync-outsider")
         view.request = _make_request({"device_selection_eth0": str(outsider.id)})
         librenms_if = {"ifName": "eth0"}
@@ -1270,10 +1270,10 @@ class TestSyncInterfacesViewSyncInterface:
         with p_type, p_attrs, p_vlans:
             view.sync_interface(master, librenms_if, [], "ifName")
 
-        assert master.interfaces.filter(name="eth0").exists()
+        assert not master.interfaces.filter(name="eth0").exists()
         assert not outsider.interfaces.filter(name="eth0").exists()
 
-    def test_device_with_device_selection_wrong_device_falls_back(self):
+    def test_device_with_device_selection_wrong_device_is_skipped(self):
         from netbox_librenms_plugin.views.sync.interfaces import SyncInterfacesView
 
         view = _make_view(SyncInterfacesView)
@@ -1281,7 +1281,7 @@ class TestSyncInterfacesViewSyncInterface:
         view._lookup_maps = {}
         device = make_device("sync-iface-noVC")  # no virtual_chassis
         other = make_device("sync-iface-other")
-        # Selection points at another existing device but there's no VC → target.id != obj.id → fall back.
+        # A selection for another device is invalid when the page device has no chassis.
         view.request = _make_request({"device_selection_eth0": str(other.id)})
         librenms_if = {"ifName": "eth0"}
 
@@ -1289,7 +1289,7 @@ class TestSyncInterfacesViewSyncInterface:
         with p_type, p_attrs, p_vlans:
             view.sync_interface(device, librenms_if, [], "ifName")
 
-        assert device.interfaces.filter(name="eth0").exists()
+        assert not device.interfaces.filter(name="eth0").exists()
         assert not other.interfaces.filter(name="eth0").exists()
 
     def test_invalid_object_type_raises_value_error(self):

--- a/netbox_librenms_plugin/tests/test_coverage_sync_views.py
+++ b/netbox_librenms_plugin/tests/test_coverage_sync_views.py
@@ -1006,6 +1006,7 @@ class TestSyncInterfacesViewServerRebind:
             patch("netbox_librenms_plugin.views.sync.interfaces.messages") as mock_msg,
             patch.object(view, "sync_selected_interfaces") as mock_sync,
         ):
+            view.request = req
             resp = view.post(req, "device", 1)
         mock_sync.assert_not_called()
         mock_msg.error.assert_called_once()
@@ -1029,6 +1030,7 @@ class TestSyncInterfacesViewServerRebind:
             patch.object(view, "get_cached_ports_data", return_value=None),
             patch("netbox_librenms_plugin.views.sync.interfaces.messages"),
         ):
+            view.request = req
             resp = view.post(req, "device", 1)
         mock_build.assert_called_once_with("secondary")
         assert view._librenms_api is api
@@ -1322,6 +1324,7 @@ class TestSyncInterfacesViewGetNetboxInterfaceType:
                 "netbox_librenms_plugin.views.sync.interfaces.convert_speed_to_kbps",
                 return_value=1000000,
             ):
+                mock_itm.objects.restrict.return_value = mock_itm.objects
                 mock_itm.objects.filter.return_value = mock_qs
                 result = view.get_netbox_interface_type(librenms_if)
         assert result is not None
@@ -1340,6 +1343,7 @@ class TestSyncInterfacesViewGetNetboxInterfaceType:
                 "netbox_librenms_plugin.views.sync.interfaces.convert_speed_to_kbps",
                 return_value=None,
             ):
+                mock_itm.objects.restrict.return_value = mock_itm.objects
                 mock_itm.objects.filter.return_value = mock_qs
                 result = view.get_netbox_interface_type(librenms_if)
         assert result == "other"
@@ -1356,6 +1360,7 @@ class TestSyncInterfacesViewGetNetboxInterfaceType:
                 "netbox_librenms_plugin.views.sync.interfaces.convert_speed_to_kbps",
                 return_value=None,
             ):
+                mock_itm.objects.restrict.return_value = mock_itm.objects
                 mock_itm.objects.filter.return_value = mock_qs
                 result = view.get_netbox_interface_type(librenms_if)
         assert result == "other"
@@ -1434,6 +1439,7 @@ class TestDeleteNetBoxInterfacesViewPost:
         obj = make_device("del-noids-dev")
         req = _make_request({"interface_ids": []})
         with patch.object(view, "require_all_permissions_json", return_value=None):
+            view.request = req
             result = view.post(req, object_type="device", object_id=obj.pk)
         assert result.status_code == 400
 
@@ -1447,6 +1453,7 @@ class TestDeleteNetBoxInterfacesViewPost:
         iface = make_interface(other, "eth0")  # belongs to a different device
         req = _make_request({"interface_ids": [str(iface.pk)]})
         with patch.object(view, "require_all_permissions_json", return_value=None):
+            view.request = req
             result = view.post(req, object_type="device", object_id=obj.pk)
         data = json.loads(result.content)
         assert data["deleted_count"] == 0
@@ -1464,6 +1471,7 @@ class TestDeleteNetBoxInterfacesViewPost:
         vmiface = VMInterface.objects.create(virtual_machine=other_vm, name="eth0")
         req = _make_request({"interface_ids": [str(vmiface.pk)]})
         with patch.object(view, "require_all_permissions_json", return_value=None):
+            view.request = req
             result = view.post(req, object_type="virtualmachine", object_id=vm.pk)
         data = json.loads(result.content)
         assert data["deleted_count"] == 0
@@ -1480,6 +1488,7 @@ class TestDeleteNetBoxInterfacesViewPost:
         iface = make_interface(obj, "eth0")
         req = _make_request({"interface_ids": [str(iface.pk)]})
         with patch.object(view, "require_all_permissions_json", return_value=None):
+            view.request = req
             result = view.post(req, object_type="device", object_id=obj.pk)
         data = json.loads(result.content)
         assert data["deleted_count"] == 1
@@ -1496,6 +1505,7 @@ class TestDeleteNetBoxInterfacesViewPost:
         vmiface = VMInterface.objects.create(virtual_machine=vm, name="eth0")
         req = _make_request({"interface_ids": [str(vmiface.pk)]})
         with patch.object(view, "require_all_permissions_json", return_value=None):
+            view.request = req
             result = view.post(req, object_type="virtualmachine", object_id=vm.pk)
         data = json.loads(result.content)
         assert data["deleted_count"] == 1
@@ -1510,6 +1520,7 @@ class TestDeleteNetBoxInterfacesViewPost:
         # An interface id that does not exist → real Interface.DoesNotExist → recorded error.
         req = _make_request({"interface_ids": ["999999"]})
         with patch.object(view, "require_all_permissions_json", return_value=None):
+            view.request = req
             result = view.post(req, object_type="device", object_id=obj.pk)
         data = json.loads(result.content)
         assert "errors" in data
@@ -1531,6 +1542,7 @@ class TestDeleteNetBoxInterfacesViewPost:
         iface = make_interface(outsider, "eth0")
         req = _make_request({"interface_ids": [str(iface.pk)]})
         with patch.object(view, "require_all_permissions_json", return_value=None):
+            view.request = req
             result = view.post(req, object_type="device", object_id=member.pk)
         data = json.loads(result.content)
         assert data["deleted_count"] == 0
@@ -1582,6 +1594,7 @@ class TestSyncIPAddressesViewGetVrfSelection:
         req = _make_request({"vrf_192.168.1.1": "3"})
         mock_vrf = MagicMock()
         with patch("netbox_librenms_plugin.views.sync.ip_addresses.VRF") as mock_vrf_cls:
+            mock_vrf_cls.objects.restrict.return_value = mock_vrf_cls.objects
             mock_vrf_cls.objects.get.return_value = mock_vrf
             result = view.get_vrf_selection(req, "192.168.1.1")
         assert result is mock_vrf
@@ -1595,6 +1608,7 @@ class TestSyncIPAddressesViewGetVrfSelection:
         req = _make_request({"vrf_192.168.1.1": "999"})
         with patch("netbox_librenms_plugin.views.sync.ip_addresses.VRF") as mock_vrf_cls:
             mock_vrf_cls.DoesNotExist = VRF.DoesNotExist
+            mock_vrf_cls.objects.restrict.return_value = mock_vrf_cls.objects
             mock_vrf_cls.objects.get.side_effect = VRF.DoesNotExist
             result = view.get_vrf_selection(req, "192.168.1.1")
         assert result is None
@@ -2241,6 +2255,7 @@ class TestSyncSiteLocationViewGetSiteByPk:
         view = self._make_view()
         mock_site = MagicMock()
         with patch("netbox_librenms_plugin.views.sync.locations.Site") as mock_site_cls:
+            mock_site_cls.objects.restrict.return_value = mock_site_cls.objects
             mock_site_cls.objects.get.return_value = mock_site
             result = view.get_site_by_pk(1)
         assert result is mock_site
@@ -2250,6 +2265,7 @@ class TestSyncSiteLocationViewGetSiteByPk:
 
         view = self._make_view()
         with patch("netbox_librenms_plugin.views.sync.locations.Site") as mock_site_cls:
+            mock_site_cls.objects.restrict.return_value = mock_site_cls.objects
             mock_site_cls.objects.get.side_effect = ObjectDoesNotExist
             result = view.get_site_by_pk(999)
         assert result is None
@@ -2277,6 +2293,7 @@ class TestSyncSiteLocationViewPost:
         with patch.object(view, "require_write_permission", return_value=None):
             with patch("netbox_librenms_plugin.views.sync.locations.messages") as mock_msg:
                 with patch("netbox_librenms_plugin.views.sync.locations.redirect"):
+                    view.request = req
                     view.post(req)
         mock_msg.error.assert_called_once()
 
@@ -2287,6 +2304,7 @@ class TestSyncSiteLocationViewPost:
             with patch.object(view, "get_site_by_pk", return_value=None):
                 with patch("netbox_librenms_plugin.views.sync.locations.messages") as mock_msg:
                     with patch("netbox_librenms_plugin.views.sync.locations.redirect"):
+                        view.request = req
                         view.post(req)
         mock_msg.error.assert_called_once()
 
@@ -2298,6 +2316,7 @@ class TestSyncSiteLocationViewPost:
             with patch.object(view, "get_site_by_pk", return_value=mock_site):
                 with patch("netbox_librenms_plugin.views.sync.locations.messages") as mock_msg:
                     with patch("netbox_librenms_plugin.views.sync.locations.redirect"):
+                        view.request = req
                         view.post(req)
         mock_msg.error.assert_called_once()
 
@@ -2309,6 +2328,7 @@ class TestSyncSiteLocationViewPost:
         with patch.object(view, "require_write_permission", return_value=None):
             with patch.object(view, "get_site_by_pk", return_value=mock_site):
                 with patch.object(view, "create_librenms_location", return_value=mock_response) as mock_create:
+                    view.request = req
                     result = view.post(req)
         mock_create.assert_called_once_with(req, mock_site)
         assert result is mock_response
@@ -2321,6 +2341,7 @@ class TestSyncSiteLocationViewPost:
         with patch.object(view, "require_write_permission", return_value=None):
             with patch.object(view, "get_site_by_pk", return_value=mock_site):
                 with patch.object(view, "update_librenms_location", return_value=mock_response) as mock_update:
+                    view.request = req
                     result = view.post(req)
         mock_update.assert_called_once_with(req, mock_site)
         assert result is mock_response
@@ -2589,6 +2610,7 @@ class TestSyncVLANsViewPost:
             with patch.object(view, "get_object", return_value=mock_obj):
                 with patch("netbox_librenms_plugin.views.sync.vlans.messages") as mock_msg:
                     with patch.object(view, "_redirect", return_value=MagicMock()):
+                        view.request = req
                         view.post(req, object_type="device", object_id=1)
         mock_msg.error.assert_called_once()
 
@@ -2602,6 +2624,7 @@ class TestSyncVLANsViewPost:
         with patch.object(view, "require_all_permissions", return_value=None):
             with patch.object(view, "get_object", return_value=mock_obj):
                 with patch.object(view, "_handle_create_vlans", return_value=mock_response) as mock_handle:
+                    view.request = req
                     result = view.post(req, object_type="device", object_id=1)
         mock_handle.assert_called_once()
         assert result is mock_response

--- a/netbox_librenms_plugin/tests/test_coverage_sync_views.py
+++ b/netbox_librenms_plugin/tests/test_coverage_sync_views.py
@@ -65,11 +65,12 @@ class TestSyncCablesViewStructure:
         assert CacheMixin in mro
 
     def test_required_object_permissions(self):
-        from dcim.models import Cable, Interface
+        from dcim.models import Cable, Device, Interface
 
         from netbox_librenms_plugin.views.sync.cables import SyncCablesView
 
         perms = SyncCablesView.required_object_permissions["POST"]
+        assert ("view", Device) in perms
         assert ("add", Cable) in perms
         assert ("change", Cable) in perms
         assert ("change", Interface) in perms

--- a/netbox_librenms_plugin/tests/test_coverage_sync_views.py
+++ b/netbox_librenms_plugin/tests/test_coverage_sync_views.py
@@ -65,13 +65,14 @@ class TestSyncCablesViewStructure:
         assert CacheMixin in mro
 
     def test_required_object_permissions(self):
-        from dcim.models import Cable
+        from dcim.models import Cable, Interface
 
         from netbox_librenms_plugin.views.sync.cables import SyncCablesView
 
         perms = SyncCablesView.required_object_permissions["POST"]
         assert ("add", Cable) in perms
         assert ("change", Cable) in perms
+        assert ("change", Interface) in perms
 
 
 class TestSyncCablesViewGetSelectedInterfaces:

--- a/netbox_librenms_plugin/tests/test_coverage_sync_views2.py
+++ b/netbox_librenms_plugin/tests/test_coverage_sync_views2.py
@@ -613,6 +613,26 @@ class TestSyncCablesViewHelpers:
 
         assert view.check_existing_cable(local, free) is True
 
+    def test_missing_local_interface_is_invalid_not_missing_remote(self):
+        """A stale local interface ID must not be reported as missing remote data."""
+        from dcim.models import Interface
+
+        from netbox_librenms_plugin.views.sync.cables import SyncCablesView
+
+        remote = make_interface(make_device("cable-stale-local-remote"), "Gi0/2")
+        view = make_view(SyncCablesView)
+
+        result = view.handle_cable_creation(
+            {
+                "local_port": "Gi0/1",
+                "netbox_local_interface_id": missing_pk(Interface),
+                "netbox_remote_interface_id": remote.pk,
+            },
+            {"local_port_id": "port1"},
+        )
+
+        assert result == {"status": "invalid", "interface": "Gi0/1"}
+
 
 def _sync_cables_view_class():
     from netbox_librenms_plugin.views.sync.cables import SyncCablesView
@@ -2038,6 +2058,31 @@ class TestSyncVLANsViewWithGroup:
 
         assert not VLAN.objects.filter(vid=200).exists()
         assert any("no longer exists" in t for t in message_texts(req, "error"))
+
+    def test_existing_vlan_outside_change_grant_is_not_renamed(self):
+        """A matching hidden VLAN must not be changed through the unrestricted manager."""
+        from dcim.models import Device
+        from ipam.models import VLAN, VLANGroup
+
+        dev = make_device("vlan-hidden-existing")
+        visible = VLAN.objects.create(vid=300, name="Visible", status="active")
+        hidden = VLAN.objects.create(vid=301, name="Keep this name", status="active")
+        user = make_user_with_perms(
+            "vlan-hidden-existing",
+            [("view", Device), ("view", VLANGroup), ("add", VLAN)],
+        )
+        user = grant(user, "change", VLAN, constraints={"pk": visible.pk})
+        req = _make_request(
+            post_data={"action": "create_vlans", "select": ["301"]},
+            user=user,
+        )
+        view = _vlan_view(req, dev, [{"vlan_vlan": 301, "vlan_name": "Unauthorized rename"}])
+
+        _post(view, req, object_type="device", object_id=dev.pk)
+
+        hidden.refresh_from_db()
+        assert hidden.name == "Keep this name"
+        assert any("permission" in text.lower() for text in message_texts(req, "error"))
 
     def test_invalid_vid_string_skipped(self):
         """A non-numeric selection is skipped, and the rest of the batch still syncs.

--- a/netbox_librenms_plugin/tests/test_coverage_sync_views2.py
+++ b/netbox_librenms_plugin/tests/test_coverage_sync_views2.py
@@ -741,12 +741,32 @@ class TestAddDeviceToLibreNMSViewV3:
 
 class TestAddDeviceToLibreNMSViewUnknownVersion:
     def test_unknown_snmp_version_shows_error(self):
-        """No version toggle at all: the v3 form runs, reports "v3", and the add still happens.
+        """A version string that is neither v1/v2c nor v3 is refused before reaching LibreNMS.
 
-        The "Unknown SNMP version." branch is unreachable through post(): get_form_class falls
-        back to the v3 form, whose snmp_version field is a hidden constant. This pins what a
-        version-less POST actually does.
+        ``snmp_version`` on the v3 form is a plain CharField whose ``initial`` does not constrain a
+        BOUND form, so a posted "v99" survives validation, reaches form_valid as the version, and
+        must hit the guard rather than be sent on.
         """
+        dev = make_device("addsnmp-badversion")
+        req = _make_request(
+            post_data={
+                "object_type": "device",
+                "v3-snmp_version": "v99",
+                "v3-hostname": "router.example.com",
+                "v3-authlevel": "noAuthNoPriv",
+                "v3-authname": "user",
+            }
+        )
+        view = _add_device_view(req)
+
+        with _poller_groups([]):
+            _post(view, req, object_id=dev.pk)
+
+        assert message_texts(req, "error") == ["Unknown SNMP version."]
+        view._librenms_api.add_device.assert_not_called()
+
+    def test_no_version_toggle_falls_back_to_the_v3_form(self):
+        """With no toggle at all, get_form_class picks the v3 form and the add still happens."""
         dev = make_device("addsnmp-noversion")
         req = _make_request(
             post_data={

--- a/netbox_librenms_plugin/tests/test_coverage_sync_views2.py
+++ b/netbox_librenms_plugin/tests/test_coverage_sync_views2.py
@@ -765,14 +765,13 @@ class TestAddDeviceToLibreNMSViewUnknownVersion:
         assert message_texts(req, "error") == ["Unknown SNMP version."]
         view._librenms_api.add_device.assert_not_called()
 
-    def test_no_version_toggle_falls_back_to_the_v3_form(self):
-        """With no toggle at all, get_form_class picks the v3 form and the add still happens."""
+    def test_no_version_field_at_all_is_a_form_error(self):
+        """With no snmp_version posted, the v3 form's required field rejects the submission."""
         dev = make_device("addsnmp-noversion")
         req = _make_request(
             post_data={
                 "object_type": "device",
                 "v3-hostname": "router.example.com",
-                "v3-snmp_version": "v3",
                 "v3-authlevel": "noAuthNoPriv",
                 "v3-authname": "user",
             }
@@ -782,7 +781,8 @@ class TestAddDeviceToLibreNMSViewUnknownVersion:
         with _poller_groups([]):
             _post(view, req, object_id=dev.pk)
 
-        assert view._librenms_api.add_device.call_args[0][0]["snmp_version"] == "v3"
+        assert any(t.startswith("snmp_version:") for t in message_texts(req, "error"))
+        view._librenms_api.add_device.assert_not_called()
 
 
 class TestAddDeviceToLibreNMSViewGetFormClass:
@@ -1927,26 +1927,34 @@ class TestSyncVLANsViewWithGroup:
         assert any("no longer exists" in t for t in message_texts(req, "error"))
 
     def test_invalid_vid_string_skipped(self):
+        """A non-numeric selection is skipped, and the rest of the batch still syncs.
+
+        The batch carries a valid VID after the bad one so a `break` in place of the
+        `continue` would be caught — a single-item batch cannot tell them apart.
+        """
         from ipam.models import VLAN
 
         dev = make_device("vlan-badvid")
-        req = _make_request(post_data={"action": "create_vlans", "select": ["not-a-vid"]})
+        req = _make_request(post_data={"action": "create_vlans", "select": ["not-a-vid", "100"]})
         view = _vlan_view(req, dev, [{"vlan_vlan": 100, "vlan_name": "Mgmt"}])
 
         _post(view, req, object_type="device", object_id=dev.pk)
 
-        assert not VLAN.objects.filter(name="Mgmt").exists()
+        assert VLAN.objects.filter(vid=100, name="Mgmt").exists()
+        assert VLAN.objects.count() == 1
 
     def test_unknown_vid_in_cache_skipped(self):
+        """A VID absent from the cached snapshot is skipped, and the rest of the batch syncs."""
         from ipam.models import VLAN
 
         dev = make_device("vlan-unknownvid")
-        req = _make_request(post_data={"action": "create_vlans", "select": ["999"]})
+        req = _make_request(post_data={"action": "create_vlans", "select": ["999", "100"]})
         view = _vlan_view(req, dev, [{"vlan_vlan": 100, "vlan_name": "Mgmt"}])
 
         _post(view, req, object_type="device", object_id=dev.pk)
 
         assert not VLAN.objects.filter(vid=999).exists()
+        assert VLAN.objects.filter(vid=100, name="Mgmt").exists()
 
 
 class TestSyncVLANsViewGroupedUpdateSkip:

--- a/netbox_librenms_plugin/tests/test_coverage_sync_views2.py
+++ b/netbox_librenms_plugin/tests/test_coverage_sync_views2.py
@@ -430,6 +430,34 @@ class TestSyncCablesViewMissingRemote:
         assert any("Remote device or interface not found" in t for t in message_texts(req, "error"))
         assert not remote_iface.cable_terminations.exists()
 
+    def test_view_only_interface_grant_cannot_create_a_cable(self):
+        """Cable creation changes both terminations, so a view-only grant must not resolve them."""
+        from dcim.models import Cable, Interface
+
+        from netbox_librenms_plugin.views.sync.cables import SyncCablesView
+
+        local_device = make_device("cable-view-only-local")
+        remote_device = make_device("cable-view-only-remote")
+        local_iface = make_interface(local_device, "Gi0/1")
+        remote_iface = make_interface(remote_device, "Gi0/2")
+        user = make_user_with_perms("cable-view-only", [("view", Interface)])
+        request = _make_request(user=user)
+        view = SyncCablesView()
+        view.setup(request)
+        view._post_server_key = "default"
+
+        result = view.handle_cable_creation(
+            {
+                "local_port": "Gi0/1",
+                "netbox_local_interface_id": local_iface.pk,
+                "netbox_remote_interface_id": remote_iface.pk,
+            },
+            {"local_port_id": "1"},
+        )
+
+        assert result["status"] == "invalid"
+        assert not Cable.objects.filter(terminations__termination_id=local_iface.pk).exists()
+
 
 class TestSyncCablesViewMissingLinkData:
     def test_no_matching_link_data_reports_invalid(self):
@@ -1798,7 +1826,12 @@ class TestSyncIPAddressesViewInterfaceResolution:
         m1.refresh_from_db()
         assert m1.primary_ip4_id is None
         assert results["primary_set"] == []
-        assert results["primary_no_interface"] == ["10.0.0.2"]
+        assert results["primary_interface_not_eligible"] == ["10.0.0.2"]
+
+        view.display_sync_results(request, results)
+        warnings = message_texts(request, "warning")
+        assert any("matched interface is not eligible" in text for text in warnings)
+        assert all("Sync interfaces first" not in text for text in warnings)
 
     def test_build_interface_maps_vc_shared_name_prefers_viewed_member(self):
         """A name shared across VC members resolves to the VIEWED member's own interface (matching the rendered table), not ambiguous."""

--- a/netbox_librenms_plugin/tests/test_coverage_sync_views2.py
+++ b/netbox_librenms_plugin/tests/test_coverage_sync_views2.py
@@ -180,12 +180,14 @@ class TestSyncCablesViewSuccessPath:
         assert Cable.objects.filter(pk=local.cable_id).exists()
 
     def test_unrelated_posted_device_cannot_redirect_the_local_termination(self):
-        """A forged VC selection must keep the cached local interface on the page device."""
+        """A forged VC selection must reject the row, not cable the cached page interface."""
+        from dcim.models import Cable
+
         page_device = make_device("cable-page-device")
         unrelated_device = make_device("cable-unrelated-device")
         remote_device = make_device("cable-forged-remote")
         cached_local = make_interface(page_device, "Gi0/1")
-        unrelated_local = make_interface(unrelated_device, "Gi0/1")
+        make_interface(unrelated_device, "Gi0/1")
         remote = make_interface(remote_device, "Gi0/2")
         request = _make_request(
             post_data={
@@ -206,14 +208,19 @@ class TestSyncCablesViewSuccessPath:
             ],
         )
 
-        with patch.object(view, "create_cable", return_value=True) as create_cable:
-            _post(view, request, pk=page_device.pk)
+        selected = view.get_selected_interfaces(request, page_device)
+        assert selected == [{"device_id": str(unrelated_device.pk), "local_port_id": "port1"}]
+        view._initial_device = page_device
+        assert view._selected_device_is_in_page_context(unrelated_device.pk) is False
 
-        used_local, used_remote, used_request = create_cable.call_args.args
-        assert used_local == cached_local
-        assert used_local != unrelated_local
-        assert used_remote == remote
-        assert used_request is request
+        _post(view, request, pk=page_device.pk)
+
+        cached_local.refresh_from_db()
+        remote.refresh_from_db()
+        assert cached_local.cable_id is None
+        assert remote.cable_id is None
+        assert Cable.objects.count() == 0
+        assert any("Gi0/1" in text for text in message_texts(request, "error"))
 
     def test_missing_interface_on_selected_vc_member_does_not_cable_cached_interface(self):
         """A selected VC member without the port must not cable the page member's cached port."""

--- a/netbox_librenms_plugin/tests/test_coverage_sync_views2.py
+++ b/netbox_librenms_plugin/tests/test_coverage_sync_views2.py
@@ -270,7 +270,9 @@ class TestSyncCablesViewDuplicateCable:
             local_iface = MagicMock(pk=10)
             local_iface.device_id = 1  # match the device pk to skip VC branch
             remote_iface = MagicMock(pk=20)
+            mock_iface_cls.objects.restrict.return_value = mock_iface_cls.objects
             mock_iface_cls.objects.get.side_effect = [local_iface, remote_iface]
+            mock_cable_cls.objects.restrict.return_value = mock_cable_cls.objects
             mock_cable_cls.objects.filter.return_value.exists.return_value = True
             mock_ct.objects.get_for_model.return_value = MagicMock()
 
@@ -317,6 +319,7 @@ class TestSyncCablesViewMissingRemote:
         ):
             mock_cache.get.return_value = {"links": [link_data]}
             mock_iface_cls.DoesNotExist = _DNE
+            mock_iface_cls.objects.restrict.return_value = mock_iface_cls.objects
             mock_iface_cls.objects.get.side_effect = _DNE()
 
             view.post(view.request, pk=1)
@@ -517,6 +520,7 @@ class TestSyncCablesViewHelpers:
             patch("netbox_librenms_plugin.views.sync.cables.Cable") as mock_cable_cls,
             patch("netbox_librenms_plugin.views.sync.cables.ContentType") as mock_ct,
         ):
+            mock_cable_cls.objects.restrict.return_value = mock_cable_cls.objects
             mock_cable_cls.objects.filter.return_value.exists.return_value = True
             mock_ct.objects.get_for_model.return_value = MagicMock()
             result = view.check_existing_cable(local, remote)
@@ -580,6 +584,7 @@ class TestAddDeviceToLibreNMSViewFormInvalid:
             patch("netbox_librenms_plugin.views.sync.devices.redirect"),
             patch("netbox_librenms_plugin.forms._get_librenms_poller_group_choices", return_value=[]),
         ):
+            mock_device_cls.objects.restrict.return_value = mock_device_cls.objects
             mock_device_cls.objects.get.return_value = mock_device
             view.request = _make_request(post_data=post_data)
             view.object = mock_device
@@ -624,6 +629,7 @@ class TestAddDeviceToLibreNMSViewFormValid:
             patch("netbox_librenms_plugin.views.sync.devices.AddToLIbreSNMPV1V2", return_value=mock_form),
             patch.object(type(view), "librenms_api", new_callable=lambda: property(lambda s: mock_api)),
         ):
+            mock_device_cls.objects.restrict.return_value = mock_device_cls.objects
             mock_device_cls.objects.get.return_value = mock_device
             post_data = {"v1v2-snmp_version": "v2c", "object_type": "device"}
             view.request = _make_request(post_data=post_data)
@@ -670,6 +676,7 @@ class TestAddDeviceToLibreNMSViewFormValidExtraFields:
             patch("netbox_librenms_plugin.views.sync.devices.AddToLIbreSNMPV1V2", return_value=mock_form),
             patch.object(type(view), "librenms_api", new_callable=lambda: property(lambda s: mock_api)),
         ):
+            mock_device_cls.objects.restrict.return_value = mock_device_cls.objects
             mock_device_cls.objects.get.return_value = mock_device
             post_data = {"v1v2-snmp_version": "v2c", "object_type": "device"}
             view.request = _make_request(post_data=post_data)
@@ -714,6 +721,7 @@ class TestAddDeviceToLibreNMSViewFormValidExtraFields:
             patch("netbox_librenms_plugin.views.sync.devices.AddToLIbreSNMPV1V2", return_value=mock_form),
             patch.object(type(view), "librenms_api", new_callable=lambda: property(lambda s: mock_api)),
         ):
+            mock_device_cls.objects.restrict.return_value = mock_device_cls.objects
             mock_device_cls.objects.get.return_value = mock_device
             post_data = {"v1v2-snmp_version": "v2c", "object_type": "device"}
             view.request = _make_request(post_data=post_data)
@@ -763,6 +771,7 @@ class TestAddDeviceToLibreNMSViewV3:
             patch("netbox_librenms_plugin.views.sync.devices.AddToLIbreSNMPV3", return_value=mock_form),
             patch.object(type(view), "librenms_api", new_callable=lambda: property(lambda s: mock_api)),
         ):
+            mock_device_cls.objects.restrict.return_value = mock_device_cls.objects
             mock_device_cls.objects.get.return_value = mock_device
             post_data = {"v3-snmp_version": "v3", "object_type": "device"}
             view.request = _make_request(post_data=post_data)
@@ -803,6 +812,7 @@ class TestAddDeviceToLibreNMSViewUnknownVersion:
             patch("netbox_librenms_plugin.views.sync.devices.AddToLIbreSNMPV3", return_value=mock_form),
             patch.object(type(view), "librenms_api", new_callable=lambda: property(lambda s: mock_api)),
         ):
+            mock_device_cls.objects.restrict.return_value = mock_device_cls.objects
             mock_device_cls.objects.get.return_value = mock_device
             post_data = {"object_type": "device"}
             view.request = _make_request(post_data=post_data)
@@ -1259,8 +1269,10 @@ class TestSyncIPAddressesViewHelpers:
         view = object.__new__(SyncIPAddressesView)
         mock_vrf = MagicMock()
         req = _make_request(post_data={"vrf_10.0.0.1": "3"})
+        view.request = req  # dispatch() would set this; restricted_queryset reads request.user
 
         with patch("netbox_librenms_plugin.views.sync.ip_addresses.VRF") as mock_vrf_cls:
+            mock_vrf_cls.objects.restrict.return_value = mock_vrf_cls.objects
             mock_vrf_cls.objects.get.return_value = mock_vrf
             result = view.get_vrf_selection(req, "10.0.0.1")
         assert result is mock_vrf
@@ -1270,12 +1282,14 @@ class TestSyncIPAddressesViewHelpers:
 
         view = object.__new__(SyncIPAddressesView)
         req = _make_request(post_data={"vrf_10.0.0.1": "99"})
+        view.request = req  # dispatch() would set this; restricted_queryset reads request.user
 
         class _DNE(Exception):
             pass
 
         with patch("netbox_librenms_plugin.views.sync.ip_addresses.VRF") as mock_vrf_cls:
             mock_vrf_cls.DoesNotExist = _DNE
+            mock_vrf_cls.objects.restrict.return_value = mock_vrf_cls.objects
             mock_vrf_cls.objects.get.side_effect = _DNE()
             result = view.get_vrf_selection(req, "10.0.0.1")
         assert result is None
@@ -1385,6 +1399,7 @@ class TestSyncIPAddressesViewVMInterface:
             patch.object(type(view), "librenms_api", new_callable=lambda: property(lambda s: mock_api)),
         ):
             mock_cache.get.return_value = {"ip_addresses": [ip_data]}
+            mock_ip_cls.objects.restrict.return_value = mock_ip_cls.objects
             mock_ip_cls.objects.filter.return_value.first.return_value = None
 
             view.request = _make_request(post_data={"select": ["10.0.0.5"]})
@@ -1922,7 +1937,9 @@ class TestSyncVLANsViewWithGroup:
             patch.object(type(view), "librenms_api", new_callable=lambda: property(lambda s: mock_api)),
         ):
             mock_cache.get.return_value = librenms_vlans
+            mock_group_cls.objects.restrict.return_value = mock_group_cls.objects
             mock_group_cls.objects.get.return_value = mock_vlan_group
+            mock_vlan_cls.objects.restrict.return_value = mock_vlan_cls.objects
             mock_vlan_cls.objects.get_or_create.return_value = (mock_vlan, True)
 
             view.request = _make_request(post_data={"action": "create_vlans", "select": ["200"], "vlan_group_200": "3"})
@@ -1968,7 +1985,9 @@ class TestSyncVLANsViewWithGroup:
         ):
             mock_cache.get.return_value = librenms_vlans
             mock_group_cls.DoesNotExist = _DNE
+            mock_group_cls.objects.restrict.return_value = mock_group_cls.objects
             mock_group_cls.objects.get.side_effect = _DNE()
+            mock_vlan_cls.objects.restrict.return_value = mock_vlan_cls.objects
             mock_vlan_cls.objects.get_or_create.return_value = (mock_vlan, True)
 
             view.request = _make_request(
@@ -2111,7 +2130,9 @@ class TestSyncVLANsViewGroupedUpdateSkip:
             patch.object(type(view), "librenms_api", new_callable=lambda: property(lambda s: mock_api)),
         ):
             mock_cache.get.return_value = librenms_vlans
+            mock_group_cls.objects.restrict.return_value = mock_group_cls.objects
             mock_group_cls.objects.get.return_value = mock_vlan_group
+            mock_vlan_cls.objects.restrict.return_value = mock_vlan_cls.objects
             mock_vlan_cls.objects.get_or_create.return_value = (mock_vlan, False)  # exists
 
             view.request = _make_request(post_data={"action": "create_vlans", "select": ["300"], "vlan_group_300": "3"})
@@ -2150,7 +2171,9 @@ class TestSyncVLANsViewGroupedUpdateSkip:
             patch.object(type(view), "librenms_api", new_callable=lambda: property(lambda s: mock_api)),
         ):
             mock_cache.get.return_value = librenms_vlans
+            mock_group_cls.objects.restrict.return_value = mock_group_cls.objects
             mock_group_cls.objects.get.return_value = mock_vlan_group
+            mock_vlan_cls.objects.restrict.return_value = mock_vlan_cls.objects
             mock_vlan_cls.objects.get_or_create.return_value = (mock_vlan, False)
 
             view.request = _make_request(post_data={"action": "create_vlans", "select": ["300"], "vlan_group_300": "3"})
@@ -2248,6 +2271,7 @@ class TestSyncSiteLocationViewPost:
             patch("netbox_librenms_plugin.views.sync.locations.Site") as mock_site_cls,
             patch.object(type(view), "librenms_api", new_callable=lambda: property(lambda s: mock_api)),
         ):
+            mock_site_cls.objects.restrict.return_value = mock_site_cls.objects
             mock_site_cls.objects.get.side_effect = ObjectDoesNotExist()
             view.request = _make_request(post_data={"action": "create", "pk": "99"})
             view.post(view.request)
@@ -2268,6 +2292,7 @@ class TestSyncSiteLocationViewPost:
             patch("netbox_librenms_plugin.views.sync.locations.Site") as mock_site_cls,
             patch.object(type(view), "librenms_api", new_callable=lambda: property(lambda s: mock_api)),
         ):
+            mock_site_cls.objects.restrict.return_value = mock_site_cls.objects
             mock_site_cls.objects.get.return_value = mock_site
             view.request = _make_request(post_data={"action": "banana", "pk": "1"})
             view.post(view.request)
@@ -2293,6 +2318,7 @@ class TestSyncSiteLocationViewCreate:
             patch("netbox_librenms_plugin.views.sync.locations.Site") as mock_site_cls,
             patch.object(type(view), "librenms_api", new_callable=lambda: property(lambda s: mock_api)),
         ):
+            mock_site_cls.objects.restrict.return_value = mock_site_cls.objects
             mock_site_cls.objects.get.return_value = mock_site
             view.request = _make_request(post_data={"action": "create", "pk": "1"})
             view.post(view.request)
@@ -2317,6 +2343,7 @@ class TestSyncSiteLocationViewCreate:
             patch("netbox_librenms_plugin.views.sync.locations.Site") as mock_site_cls,
             patch.object(type(view), "librenms_api", new_callable=lambda: property(lambda s: mock_api)),
         ):
+            mock_site_cls.objects.restrict.return_value = mock_site_cls.objects
             mock_site_cls.objects.get.return_value = mock_site
             view.request = _make_request(post_data={"action": "create", "pk": "1"})
             view.post(view.request)
@@ -2341,6 +2368,7 @@ class TestSyncSiteLocationViewCreate:
             patch("netbox_librenms_plugin.views.sync.locations.Site") as mock_site_cls,
             patch.object(type(view), "librenms_api", new_callable=lambda: property(lambda s: mock_api)),
         ):
+            mock_site_cls.objects.restrict.return_value = mock_site_cls.objects
             mock_site_cls.objects.get.return_value = mock_site
             view.request = _make_request(post_data={"action": "create", "pk": "1"})
             view.post(view.request)
@@ -2366,6 +2394,7 @@ class TestSyncSiteLocationViewUpdate:
             patch("netbox_librenms_plugin.views.sync.locations.Site") as mock_site_cls,
             patch.object(type(view), "librenms_api", new_callable=lambda: property(lambda s: mock_api)),
         ):
+            mock_site_cls.objects.restrict.return_value = mock_site_cls.objects
             mock_site_cls.objects.get.return_value = mock_site
             view.request = _make_request(post_data={"action": "update", "pk": "1"})
             view.post(view.request)
@@ -2390,6 +2419,7 @@ class TestSyncSiteLocationViewUpdate:
             patch("netbox_librenms_plugin.views.sync.locations.Site") as mock_site_cls,
             patch.object(type(view), "librenms_api", new_callable=lambda: property(lambda s: mock_api)),
         ):
+            mock_site_cls.objects.restrict.return_value = mock_site_cls.objects
             mock_site_cls.objects.get.return_value = mock_site
             view.request = _make_request(post_data={"action": "update", "pk": "1"})
             view.post(view.request)
@@ -2415,6 +2445,7 @@ class TestSyncSiteLocationViewUpdate:
             patch("netbox_librenms_plugin.views.sync.locations.Site") as mock_site_cls,
             patch.object(type(view), "librenms_api", new_callable=lambda: property(lambda s: mock_api)),
         ):
+            mock_site_cls.objects.restrict.return_value = mock_site_cls.objects
             mock_site_cls.objects.get.return_value = mock_site
             view.request = _make_request(post_data={"action": "update", "pk": "1"})
             view.post(view.request)
@@ -2441,6 +2472,7 @@ class TestSyncSiteLocationViewUpdate:
             patch("netbox_librenms_plugin.views.sync.locations.Site") as mock_site_cls,
             patch.object(type(view), "librenms_api", new_callable=lambda: property(lambda s: mock_api)),
         ):
+            mock_site_cls.objects.restrict.return_value = mock_site_cls.objects
             mock_site_cls.objects.get.return_value = mock_site
             view.request = _make_request(post_data={"action": "update", "pk": "1"})
             view.post(view.request)
@@ -2467,6 +2499,7 @@ class TestSyncSiteLocationViewUpdate:
             patch("netbox_librenms_plugin.views.sync.locations.Site") as mock_site_cls,
             patch.object(type(view), "librenms_api", new_callable=lambda: property(lambda s: mock_api)),
         ):
+            mock_site_cls.objects.restrict.return_value = mock_site_cls.objects
             mock_site_cls.objects.get.return_value = mock_site
             view.request = _make_request(post_data={"action": "update", "pk": "1"})
             view.post(view.request)
@@ -2554,8 +2587,10 @@ class TestSyncSiteLocationViewHelpers:
         from netbox_librenms_plugin.views.sync.locations import SyncSiteLocationView
 
         view = object.__new__(SyncSiteLocationView)
+        view.request = MagicMock()  # restricted_queryset reads request.user
 
         with patch("netbox_librenms_plugin.views.sync.locations.Site") as mock_site_cls:
+            mock_site_cls.objects.restrict.return_value = mock_site_cls.objects
             mock_site_cls.objects.get.side_effect = ObjectDoesNotExist()
             result = view.get_site_by_pk(99)
         assert result is None

--- a/netbox_librenms_plugin/tests/test_coverage_sync_views2.py
+++ b/netbox_librenms_plugin/tests/test_coverage_sync_views2.py
@@ -12,24 +12,7 @@ import pytest
 from netbox_librenms_plugin.tests.conftest import make_device, make_interface
 
 
-def _bind_and_call(view, request, method, **kwargs):
-    """Call *view*.<method>, binding the request the way ``View.setup()`` does under dispatch().
-
-    A direct ``view.post(request, ...)`` leaves ``self.request`` unset, which the object-scoped
-    lookups read — production always goes through dispatch(), so bind it here too.
-    """
-    view.setup(request)
-    return getattr(view, method)(request, **kwargs)
-
-
-def _post(view, request, **kwargs):
-    """POST into *view* with the request bound (see :func:`_bind_and_call`)."""
-    return _bind_and_call(view, request, "post", **kwargs)
-
-
-def _get(view, request, **kwargs):
-    """GET into *view* with the request bound (see :func:`_bind_and_call`)."""
-    return _bind_and_call(view, request, "get", **kwargs)
+from netbox_librenms_plugin.tests.view_test_helpers import post as _post
 
 
 # ---------------------------------------------------------------------------
@@ -954,7 +937,7 @@ class TestUpdateDeviceLocationView:
 
         with (
             patch(
-                "netbox_librenms_plugin.views.sync.devices.get_object_or_404",
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
                 return_value=mock_device,
             ),
             patch("netbox_librenms_plugin.views.sync.devices.messages") as mock_msgs,
@@ -976,7 +959,7 @@ class TestUpdateDeviceLocationView:
 
         with (
             patch(
-                "netbox_librenms_plugin.views.sync.devices.get_object_or_404",
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
                 return_value=mock_device,
             ),
             patch("netbox_librenms_plugin.views.sync.devices.messages") as mock_msgs,
@@ -995,7 +978,7 @@ class TestUpdateDeviceLocationView:
 
         with (
             patch(
-                "netbox_librenms_plugin.views.sync.devices.get_object_or_404",
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
                 return_value=mock_device,
             ),
             patch("netbox_librenms_plugin.views.sync.devices.messages") as mock_msgs,

--- a/netbox_librenms_plugin/tests/test_coverage_sync_views2.py
+++ b/netbox_librenms_plugin/tests/test_coverage_sync_views2.py
@@ -410,7 +410,7 @@ class TestSyncCablesViewMissingRemote:
         local_iface = make_interface(dev, "Gi0/1")
         remote_iface = make_interface(remote, "Gi0/2")
         user = make_user_with_perms("cable-scoped", [("view", Device), ("add", Cable), ("change", Cable)])
-        user = grant(user, "view", Interface, constraints={"device__name": "cable-scoped-local"})
+        user = grant(user, "change", Interface, constraints={"device__name": "cable-scoped-local"})
         req = _make_request(post_data={"select": ["port1"]}, user=user)
         view = _cables_view(
             req,
@@ -1337,6 +1337,20 @@ class TestSyncIPAddressesViewIPWrites:
 
 
 class TestSyncIPAddressesViewHelpers:
+    def test_device_sync_declares_interface_view_permission(self):
+        from dcim.models import Interface
+
+        view = make_view(_sync_ip_view_class(), _make_request())
+
+        assert ("view", Interface) in view._required_permissions("device")["POST"]
+
+    def test_vm_sync_declares_interface_view_permission(self):
+        from virtualization.models import VMInterface
+
+        view = make_view(_sync_ip_view_class(), _make_request())
+
+        assert ("view", VMInterface) in view._required_permissions("virtualmachine")["POST"]
+
     def test_blank_vrf_selection_does_not_require_vrf_permission(self):
         from ipam.models import VRF
 
@@ -1583,7 +1597,7 @@ class TestSyncIPAddressesViewInterfaceResolution:
     def _view(self):
         from netbox_librenms_plugin.views.sync.ip_addresses import SyncIPAddressesView
 
-        return object.__new__(SyncIPAddressesView)
+        return make_view(SyncIPAddressesView)
 
     def test_match_interface_by_port_id(self):
         dev = make_device("ipres-byid")
@@ -1746,6 +1760,42 @@ class TestSyncIPAddressesViewInterfaceResolution:
         assert by_id["202"].pk == i2.pk  # cross-member: resolved from a different member
         assert by_name["Ethernet1"].pk == i1.pk
         assert by_name["Ethernet2"].pk == i2.pk
+
+    def test_ip_sync_skips_vc_interface_outside_the_users_grant(self):
+        """A cached sibling port must not bypass a constrained Interface view grant."""
+        from dcim.models import Device, Interface
+        from ipam.models import IPAddress
+
+        from netbox_librenms_plugin.utils import set_librenms_device_id
+
+        _vc, members = self._make_vc("ipres-vc-scoped", [1, 2])
+        visible = make_interface(members[1], "Ethernet1")
+        hidden = make_interface(members[2], "Ethernet2")
+        set_librenms_device_id(hidden, 202, "default")
+        hidden.save()
+
+        user = make_user_with_perms(
+            "ipres-vc-scoped",
+            [("view", Device), ("add", IPAddress), ("change", IPAddress)],
+        )
+        user = grant(user, "view", Interface, constraints={"pk": visible.pk})
+        request = _make_request(post_data={"select": ["10.0.0.2"]}, user=user)
+        view = make_view(_sync_ip_view_class(), request)
+        view._post_server_key = "default"
+        cached = [
+            {
+                "ip_address": "10.0.0.2",
+                "ip_with_mask": "10.0.0.2/24",
+                "port_id": 202,
+                "interface_name": "Ethernet2",
+            }
+        ]
+
+        with patch("netbox_librenms_plugin.views.sync.ip_addresses.resolve_set_primary_ip", return_value=False):
+            results = view.process_ip_sync(request, ["10.0.0.2"], cached, members[1], "device")
+
+        assert results["skipped_no_interface"] == ["10.0.0.2"]
+        assert not IPAddress.objects.filter(address="10.0.0.2/24").exists()
 
     def test_primary_ip_set_from_sibling_vc_member_interface(self):
         """Because _build_interface_maps indexes every VC member, a synced IP can resolve to a SIBLING member's interface — and NetBox's Device.clean() explicitly ACCEPTS a primary IP on any same-VC member's non-mgmt-only interface (vc_interfaces(if_master=False)), so the sync must set it rather than warn 'sync interfaces first' forever."""

--- a/netbox_librenms_plugin/tests/test_coverage_sync_views2.py
+++ b/netbox_librenms_plugin/tests/test_coverage_sync_views2.py
@@ -220,7 +220,10 @@ class TestSyncCablesViewSuccessPath:
         assert cached_local.cable_id is None
         assert remote.cable_id is None
         assert Cable.objects.count() == 0
-        assert any("Gi0/1" in text for text in message_texts(request, "error"))
+        assert any(
+            "Selected device is not part of this cable-sync page for interfaces: Gi0/1" in text
+            for text in message_texts(request, "error")
+        )
 
     def test_missing_interface_on_selected_vc_member_does_not_cable_cached_interface(self):
         """A selected VC member without the port must not cable the page member's cached port."""
@@ -1269,6 +1272,22 @@ class TestSyncIPAddressesViewIPWrites:
 
 
 class TestSyncIPAddressesViewHelpers:
+    def test_blank_vrf_selection_does_not_require_vrf_permission(self):
+        from ipam.models import VRF
+
+        req = _make_request(post_data={"vrf_10.0.0.1": ""})
+        view = make_view(_sync_ip_view_class(), req)
+
+        assert ("view", VRF) not in view._required_permissions("device")["POST"]
+
+    def test_nonblank_vrf_selection_requires_vrf_permission(self):
+        from ipam.models import VRF
+
+        req = _make_request(post_data={"vrf_10.0.0.1": "1"})
+        view = make_view(_sync_ip_view_class(), req)
+
+        assert ("view", VRF) in view._required_permissions("device")["POST"]
+
     def test_get_object_device(self):
         from netbox_librenms_plugin.views.sync.ip_addresses import SyncIPAddressesView
 

--- a/netbox_librenms_plugin/tests/test_coverage_sync_views2.py
+++ b/netbox_librenms_plugin/tests/test_coverage_sync_views2.py
@@ -1349,6 +1349,12 @@ class TestSyncIPAddressesViewHelpers:
 
         assert view.get_vrf_selection(req, "10.0.0.1") is None
 
+    def test_get_vrf_selection_invalid_id_returns_none(self):
+        req = _make_request(post_data={"vrf_10.0.0.1": "not-an-id"})
+        view = make_view(_sync_ip_view_class(), req)
+
+        assert view.get_vrf_selection(req, "10.0.0.1") is None
+
     def test_get_vrf_selection_returns_none_for_a_vrf_outside_the_grant(self):
         """The VRF id is posted by the client, so a constrained grant must not resolve it."""
         from ipam.models import VRF

--- a/netbox_librenms_plugin/tests/test_coverage_sync_views2.py
+++ b/netbox_librenms_plugin/tests/test_coverage_sync_views2.py
@@ -24,6 +24,20 @@ from netbox_librenms_plugin.tests.view_test_helpers import post as _post
 # The views here are built with real requests and real users, so the whole file needs the DB.
 pytestmark = pytest.mark.django_db
 
+_seeded_cache_keys = set()
+
+
+@pytest.fixture(autouse=True)
+def _clear_seeded_cache_keys():
+    """Delete the real-cache snapshots seeded by this module's view helpers."""
+    yield
+
+    from django.core.cache import cache
+
+    for key in _seeded_cache_keys:
+        cache.delete(key)
+    _seeded_cache_keys.clear()
+
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -328,7 +342,9 @@ def _cables_view(request, device, links):
 
     view = make_view(SyncCablesView, request)
     view._post_server_key = "default"
-    cache.set(view.get_cache_key(device, "links", "default"), {"links": links})
+    key = view.get_cache_key(device, "links", "default")
+    _seeded_cache_keys.add(key)
+    cache.set(key, {"links": links})
     return view
 
 
@@ -1309,6 +1325,17 @@ class TestSyncIPAddressesViewHelpers:
 
         assert ("view", VRF) in view._required_permissions("device")["POST"]
 
+    def test_required_permissions_are_stable_across_repeated_posts(self):
+        """Reusing a view instance must not accumulate duplicate owner or VRF permissions."""
+        req = _make_request(post_data={"vrf_10.0.0.1": "1"})
+        view = make_view(_sync_ip_view_class(), req)
+
+        first = view._required_permissions("device")
+        view.required_object_permissions = first
+        second = view._required_permissions("device")
+
+        assert second == first
+
     def test_get_object_device(self):
         from netbox_librenms_plugin.views.sync.ip_addresses import SyncIPAddressesView
 
@@ -1995,7 +2022,9 @@ def _vlan_view(request, device, cached_vlans):
 
     view = make_view(SyncVLANsView, request)
     view._post_server_key = "default"
-    cache.set(view.get_cache_key(device, "vlans", "default"), cached_vlans)
+    key = view.get_cache_key(device, "vlans", "default")
+    _seeded_cache_keys.add(key)
+    cache.set(key, cached_vlans)
     return view
 
 
@@ -2083,6 +2112,30 @@ class TestSyncVLANsViewWithGroup:
         hidden.refresh_from_db()
         assert hidden.name == "Keep this name"
         assert any("permission" in text.lower() for text in message_texts(req, "error"))
+
+    def test_duplicate_global_vid_is_skipped_without_aborting_the_batch(self):
+        """An ambiguous global VID must not pick one row or roll back later valid rows."""
+        from ipam.models import VLAN
+
+        dev = make_device("vlan-duplicate-global")
+        VLAN.objects.create(vid=300, name="First", status="active")
+        VLAN.objects.create(vid=300, name="Second", status="active")
+        req = _make_request(post_data={"action": "create_vlans", "select": ["300", "301"]})
+        view = _vlan_view(
+            req,
+            dev,
+            [
+                {"vlan_vlan": 300, "vlan_name": "Ambiguous rename"},
+                {"vlan_vlan": 301, "vlan_name": "Unambiguous"},
+            ],
+        )
+
+        _post(view, req, object_type="device", object_id=dev.pk)
+
+        assert set(VLAN.objects.filter(vid=300).values_list("name", flat=True)) == {"First", "Second"}
+        assert VLAN.objects.filter(vid=301, name="Unambiguous").exists()
+        assert any("several VLANs" in text for text in message_texts(req, "error"))
+        assert any("1 skipped (VLAN match ambiguous)" in text for text in message_texts(req, "success"))
 
     def test_invalid_vid_string_skipped(self):
         """A non-numeric selection is skipped, and the rest of the batch still syncs.

--- a/netbox_librenms_plugin/tests/test_coverage_sync_views2.py
+++ b/netbox_librenms_plugin/tests/test_coverage_sync_views2.py
@@ -1388,23 +1388,25 @@ class TestSyncIPAddressesViewHelpers:
 
         assert view.get_vrf_selection(req, "10.0.0.1") == vrf
 
-    def test_get_vrf_selection_not_found_returns_none(self):
+    def test_get_vrf_selection_fails_when_requested_vrf_is_missing(self):
         from ipam.models import VRF
 
         absent_pk = missing_pk(VRF)
         req = _make_request(post_data={"vrf_10.0.0.1": str(absent_pk)})
         view = make_view(_sync_ip_view_class(), req)
 
-        assert view.get_vrf_selection(req, "10.0.0.1") is None
+        with pytest.raises(ValueError, match="Selected VRF"):
+            view.get_vrf_selection(req, "10.0.0.1")
 
-    def test_get_vrf_selection_invalid_id_returns_none(self):
+    def test_get_vrf_selection_fails_when_id_is_invalid(self):
         req = _make_request(post_data={"vrf_10.0.0.1": "not-an-id"})
         view = make_view(_sync_ip_view_class(), req)
 
-        assert view.get_vrf_selection(req, "10.0.0.1") is None
+        with pytest.raises(ValueError, match="Selected VRF"):
+            view.get_vrf_selection(req, "10.0.0.1")
 
-    def test_get_vrf_selection_returns_none_for_a_vrf_outside_the_grant(self):
-        """The VRF id is posted by the client, so a constrained grant must not resolve it."""
+    def test_get_vrf_selection_fails_for_a_vrf_outside_the_grant(self):
+        """A constrained grant must not turn a requested VRF into global scope."""
         from ipam.models import VRF
 
         VRF.objects.create(name="Mine")
@@ -1413,7 +1415,33 @@ class TestSyncIPAddressesViewHelpers:
         req = _make_request(post_data={"vrf_10.0.0.1": str(theirs.pk)}, user=user)
         view = make_view(_sync_ip_view_class(), req)
 
-        assert view.get_vrf_selection(req, "10.0.0.1") is None
+        with pytest.raises(ValueError, match="Selected VRF"):
+            view.get_vrf_selection(req, "10.0.0.1")
+
+    def test_out_of_scope_vrf_fails_the_row_without_writing_a_global_ip(self):
+        """A restricted requested VRF must not silently create the address without a VRF."""
+        from ipam.models import IPAddress, VRF
+
+        from netbox_librenms_plugin.utils import set_librenms_device_id
+
+        mine = VRF.objects.create(name="VRF Mine")
+        theirs = VRF.objects.create(name="VRF Theirs")
+        user = make_user_with_perms("vrf-row-scoped", [("view", VRF)], constraints={"pk": mine.pk})
+        req = _make_request(post_data={"vrf_10.0.0.2": str(theirs.pk)}, user=user)
+        view = make_view(_sync_ip_view_class(), req)
+        view._post_server_key = "default"
+        device = make_device("vrf-row-device")
+        interface = make_interface(device, "eth0")
+        set_librenms_device_id(interface, 5, "default")
+        interface.save()
+        cached = [{"ip_address": "10.0.0.2", "ip_with_mask": "10.0.0.2/24", "port_id": 5}]
+
+        with patch("netbox_librenms_plugin.views.sync.ip_addresses.resolve_set_primary_ip", return_value=False):
+            results = view.process_ip_sync(req, ["10.0.0.2"], cached, device, "device")
+
+        assert results["failed"] == ["10.0.0.2"]
+        assert "Selected VRF" in results["errors"]["10.0.0.2"]
+        assert not IPAddress.objects.filter(address="10.0.0.2/24").exists()
 
     def test_get_ip_tab_url_device(self):
         from dcim.models import Device

--- a/netbox_librenms_plugin/tests/test_coverage_sync_views2.py
+++ b/netbox_librenms_plugin/tests/test_coverage_sync_views2.py
@@ -16,6 +16,7 @@ from netbox_librenms_plugin.tests.view_test_helpers import (
     make_user_with_perms,
     make_view,
     message_texts,
+    missing_pk,
 )
 from netbox_librenms_plugin.tests.view_test_helpers import get as _get
 from netbox_librenms_plugin.tests.view_test_helpers import post as _post
@@ -365,7 +366,7 @@ class TestSyncCablesViewMissingRemote:
 
         dev = make_device("cable-missing-local")
         local_iface = make_interface(dev, "Gi0/1")
-        gone_pk = Interface.objects.order_by("-pk").first().pk + 1000
+        gone_pk = missing_pk(Interface)
         req = _make_request(post_data={"select": ["port1"]})
         view = _cables_view(
             req,
@@ -1343,8 +1344,8 @@ class TestSyncIPAddressesViewHelpers:
     def test_get_vrf_selection_not_found_returns_none(self):
         from ipam.models import VRF
 
-        missing_pk = (VRF.objects.order_by("-pk").first().pk if VRF.objects.exists() else 0) + 1000
-        req = _make_request(post_data={"vrf_10.0.0.1": str(missing_pk)})
+        absent_pk = missing_pk(VRF)
+        req = _make_request(post_data={"vrf_10.0.0.1": str(absent_pk)})
         view = make_view(_sync_ip_view_class(), req)
 
         assert view.get_vrf_selection(req, "10.0.0.1") is None
@@ -2004,8 +2005,8 @@ class TestSyncVLANsViewWithGroup:
         from ipam.models import VLAN, VLANGroup
 
         dev = make_device("vlan-grp-missing")
-        missing_pk = (VLANGroup.objects.order_by("-pk").first().pk if VLANGroup.objects.exists() else 0) + 1000
-        req = _make_request(post_data={"action": "create_vlans", "select": ["200"], "vlan_group_200": str(missing_pk)})
+        absent_pk = missing_pk(VLANGroup)
+        req = _make_request(post_data={"action": "create_vlans", "select": ["200"], "vlan_group_200": str(absent_pk)})
         view = _vlan_view(req, dev, [{"vlan_vlan": 200, "vlan_name": "Production"}])
 
         _post(view, req, object_type="device", object_id=dev.pk)
@@ -2206,8 +2207,8 @@ class TestSyncSiteLocationViewPost:
     def test_site_not_found_shows_error(self):
         from dcim.models import Site
 
-        missing_pk = (Site.objects.order_by("-pk").first().pk if Site.objects.exists() else 0) + 1000
-        req = _make_request(post_data={"action": "create", "pk": str(missing_pk)})
+        absent_pk = missing_pk(Site)
+        req = _make_request(post_data={"action": "create", "pk": str(absent_pk)})
         view = _location_view(req)
 
         _post(view, req)
@@ -2374,9 +2375,9 @@ class TestSyncSiteLocationViewHelpers:
     def test_get_site_by_pk_returns_none_on_not_found(self):
         from dcim.models import Site
 
-        missing_pk = (Site.objects.order_by("-pk").first().pk if Site.objects.exists() else 0) + 1000
+        absent_pk = missing_pk(Site)
 
-        assert _location_view().get_site_by_pk(missing_pk) is None
+        assert _location_view().get_site_by_pk(absent_pk) is None
 
     def test_get_site_by_pk_returns_none_for_a_site_outside_the_grant(self):
         from dcim.models import Site

--- a/netbox_librenms_plugin/tests/test_coverage_sync_views2.py
+++ b/netbox_librenms_plugin/tests/test_coverage_sync_views2.py
@@ -1924,6 +1924,43 @@ class TestSyncIPAddressesViewInterfaceResolution:
         assert address_writes, "the address must be written"
         assert min(device_locks) < min(address_writes), "the device lock must precede the address write"
 
+    def test_primary_ip_row_fails_if_owner_disappears_before_lock(self):
+        """A concurrent owner deletion must not write an orphan address or recreate stale owner data."""
+        from ipam.models import IPAddress
+
+        from netbox_librenms_plugin.utils import set_librenms_device_id
+
+        dev = make_device("ipres-owner-gone")
+        iface = make_interface(dev, "eth0")
+        set_librenms_device_id(iface, 5, "default")
+        iface.save()
+
+        view = self._view()
+        view._post_server_key = "default"
+        view.get_management_ip = MagicMock(return_value="10.0.0.1")
+        ip_data = {
+            "ip_address": "10.0.0.1",
+            "ip_with_mask": "10.0.0.1/24",
+            "interface_url": None,
+            "port_id": 5,
+            "interface_name": "eth0",
+        }
+        request = _make_request(post_data={"select": ["10.0.0.1"]})
+
+        with (
+            patch(
+                "netbox_librenms_plugin.views.sync.ip_addresses.resolve_set_primary_ip",
+                return_value=True,
+            ),
+            patch.object(type(dev).objects, "select_for_update") as select_for_update,
+        ):
+            select_for_update.return_value.filter.return_value.first.return_value = None
+            results = view.process_ip_sync(request, ["10.0.0.1"], [ip_data], dev, "device")
+
+        assert results["failed"] == ["10.0.0.1"]
+        assert "no longer exists" in results["errors"]["10.0.0.1"]
+        assert not IPAddress.objects.filter(address="10.0.0.1/24").exists()
+
     def test_build_interface_maps_vc_shared_name_prefers_viewed_member(self):
         """A name shared across VC members resolves to the VIEWED member's own interface (matching the rendered table), not ambiguous."""
         _vc, members = self._make_vc("ipres-vcdup", [1, 2])

--- a/netbox_librenms_plugin/tests/test_coverage_sync_views2.py
+++ b/netbox_librenms_plugin/tests/test_coverage_sync_views2.py
@@ -17,6 +17,7 @@ from netbox_librenms_plugin.tests.view_test_helpers import (
     make_view,
     message_texts,
 )
+from netbox_librenms_plugin.tests.view_test_helpers import get as _get
 from netbox_librenms_plugin.tests.view_test_helpers import post as _post
 
 # The views here are built with real requests and real users, so the whole file needs the DB.
@@ -213,6 +214,48 @@ class TestSyncCablesViewSuccessPath:
         assert used_local != unrelated_local
         assert used_remote == remote
         assert used_request is request
+
+    def test_missing_interface_on_selected_vc_member_does_not_cable_cached_interface(self):
+        """A selected VC member without the port must not cable the page member's cached port."""
+        from dcim.models import Cable, VirtualChassis
+
+        vc = VirtualChassis.objects.create(name="cable-vc-missing-port")
+        page_device = make_device("cable-vc-page")
+        page_device.virtual_chassis = vc
+        page_device.vc_position = 1
+        page_device.save()
+        selected_member = make_device("cable-vc-selected")
+        selected_member.virtual_chassis = vc
+        selected_member.vc_position = 2
+        selected_member.save()
+        remote_device = make_device("cable-vc-remote")
+        cached_local = make_interface(page_device, "Gi0/1")
+        remote = make_interface(remote_device, "Gi0/2")
+        request = _make_request(
+            post_data={
+                "select": ["port1"],
+                "device_selection_port1": str(selected_member.pk),
+            }
+        )
+        view = _cables_view(
+            request,
+            page_device,
+            [
+                {
+                    "local_port_id": "port1",
+                    "local_port": "Gi0/1",
+                    "netbox_local_interface_id": cached_local.pk,
+                    "netbox_remote_interface_id": remote.pk,
+                }
+            ],
+        )
+
+        _post(view, request, pk=page_device.pk)
+
+        cached_local.refresh_from_db()
+        assert cached_local.cable_id is None
+        assert Cable.objects.count() == 0
+        assert any("Gi0/1" in text for text in message_texts(request, "error"))
 
 
 class TestSyncCablesViewSkipsOOBRows:
@@ -633,19 +676,20 @@ class TestAddDeviceToLibreNMSViewPermission:
 
         view._librenms_api.add_device.assert_not_called()
 
-    def test_a_user_without_the_change_grant_404s(self):
-        """The object resolve is scoped by "change", so a view-only grant never gets that far."""
+    def test_a_user_without_the_change_grant_gets_named_permission_error(self):
+        """The permission gate reports the missing change grant before the scoped lookup."""
         from dcim.models import Device
-        from django.http import Http404
 
         dev = make_device("addsnmp-viewonly")
         user = make_user_with_perms("addsnmp-viewer", [("view", Device)])
         req = _make_request(post_data=_snmp_post("v1v2", hostname="r.example.com", community="public"), user=user)
         view = _add_device_view(req)
 
-        with _poller_groups([]), pytest.raises(Http404):
-            _post(view, req, object_id=dev.pk)
+        with _poller_groups([]):
+            response = _post(view, req, object_id=dev.pk)
 
+        assert response.status_code == 302
+        assert any("dcim.change_device" in text for text in message_texts(req, "error"))
         view._librenms_api.add_device.assert_not_called()
 
     def test_a_device_outside_the_grant_404s(self):
@@ -2396,7 +2440,7 @@ class TestSyncSiteLocationViewGetQuerysetFilterset:
         assert {row.netbox_site.name for row in result} >= {"London", "Paris"}
 
     def test_get_queryset_lists_only_sites_in_the_users_grant(self):
-        """A constrained Site grant must hide all other rows from the sync table."""
+        """A read-only constrained grant renders only its sites through the GET gate."""
         from dcim.models import Site
 
         mine = _make_site("Location List Mine")
@@ -2407,6 +2451,10 @@ class TestSyncSiteLocationViewGetQuerysetFilterset:
             constraints={"pk": mine.pk},
             plugin_write=False,
         )
-        view = _location_view(_make_request(user=user), locations=[])
+        request = _make_request(user=user)
+        view = _location_view(request, locations=[])
 
-        assert [row.netbox_site.pk for row in view.get_queryset()] == [mine.pk]
+        response = _get(view, request)
+
+        assert response.status_code == 200
+        assert [row.netbox_site.pk for row in response.context_data["table"].data] == [mine.pk]

--- a/netbox_librenms_plugin/tests/test_coverage_sync_views2.py
+++ b/netbox_librenms_plugin/tests/test_coverage_sync_views2.py
@@ -2137,6 +2137,30 @@ class TestSyncVLANsViewWithGroup:
         assert any("several VLANs" in text for text in message_texts(req, "error"))
         assert any("1 skipped (VLAN match ambiguous)" in text for text in message_texts(req, "success"))
 
+    def test_duplicate_global_vid_is_ambiguous_before_change_scope_is_applied(self):
+        """A constrained grant must not make an ambiguous VID look unique."""
+        from dcim.models import Device
+        from ipam.models import VLAN, VLANGroup
+
+        dev = make_device("vlan-duplicate-scoped")
+        permitted = VLAN.objects.create(vid=302, name="Permitted", status="active")
+        hidden = VLAN.objects.create(vid=302, name="Hidden", status="active")
+        user = make_user_with_perms(
+            "vlan-duplicate-scoped",
+            [("view", Device), ("view", VLANGroup), ("add", VLAN)],
+        )
+        user = grant(user, "change", VLAN, constraints={"pk": permitted.pk})
+        req = _make_request(post_data={"action": "create_vlans", "select": ["302"]}, user=user)
+        view = _vlan_view(req, dev, [{"vlan_vlan": 302, "vlan_name": "Ambiguous rename"}])
+
+        _post(view, req, object_type="device", object_id=dev.pk)
+
+        permitted.refresh_from_db()
+        hidden.refresh_from_db()
+        assert permitted.name == "Permitted"
+        assert hidden.name == "Hidden"
+        assert any("several VLANs" in text for text in message_texts(req, "error"))
+
     def test_invalid_vid_string_skipped(self):
         """A non-numeric selection is skipped, and the rest of the batch still syncs.
 

--- a/netbox_librenms_plugin/tests/test_coverage_sync_views2.py
+++ b/netbox_librenms_plugin/tests/test_coverage_sync_views2.py
@@ -9,10 +9,18 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from netbox_librenms_plugin.tests.conftest import make_device, make_interface
-
-
+from netbox_librenms_plugin.tests.conftest import make_device, make_interface, make_vm
+from netbox_librenms_plugin.tests.view_test_helpers import (
+    grant,
+    make_request,
+    make_user_with_perms,
+    make_view,
+    message_texts,
+)
 from netbox_librenms_plugin.tests.view_test_helpers import post as _post
+
+# The views here are built with real requests and real users, so the whole file needs the DB.
+pytestmark = pytest.mark.django_db
 
 
 # ---------------------------------------------------------------------------
@@ -21,19 +29,13 @@ from netbox_librenms_plugin.tests.view_test_helpers import post as _post
 
 
 def _make_request(post_data=None, get_data=None, user=None):
-    req = MagicMock()
-    _post = post_data or {}
-    post_mock = MagicMock()
-    post_mock.get = lambda k, d=None: _post.get(k, d)
-    post_mock.getlist = lambda k: (
-        _post.get(k) if isinstance(_post.get(k), list) else ([] if k not in _post else [_post[k]])
-    )
-    req.POST = post_mock
-    req.GET = get_data or {}
-    req.user = user or MagicMock()
-    req.META = {}
-    req.htmx = False
-    return req
+    """A real request. POST wins when both are given; a GET-only call builds a GET request."""
+    if post_data is None and get_data:
+        return make_request("get", get_data, user=user)
+    request = make_request("post", post_data or {}, user=user)
+    request.GET = get_data or request.GET
+    request.htmx = False
+    return request
 
 
 def _denied_response():
@@ -127,7 +129,6 @@ class TestSyncCablesViewNoSelection:
         mock_msgs.error.assert_called_once()
 
 
-@pytest.mark.django_db
 class TestSyncCablesViewSuccessPath:
     def test_valid_cable_created(self):
         """A real Cable is created between two real Interfaces (verified via the interfaces' cable FKs)."""
@@ -178,7 +179,6 @@ class TestSyncCablesViewSuccessPath:
         assert Cable.objects.filter(pk=local.cable_id).exists()
 
 
-@pytest.mark.django_db
 class TestSyncCablesViewSkipsOOBRows:
     def test_oob_sourced_link_is_never_cabled(self):
         """An OOB-controller cable row (_source="oob") merged into the host list must never create a cable on the host interface — it's context-only (shared-LOM detection), mirroring the interface- and module-sync OOB guards."""
@@ -230,101 +230,99 @@ class TestSyncCablesViewSkipsOOBRows:
         mock_msgs.success.assert_not_called()
 
 
+def _cables_view(request, device, links):
+    """The real SyncCablesView with the LibreNMS link snapshot seeded into the real cache."""
+    from django.core.cache import cache
+
+    from netbox_librenms_plugin.views.sync.cables import SyncCablesView
+
+    view = make_view(SyncCablesView, request)
+    view._post_server_key = "default"
+    cache.set(view.get_cache_key(device, "links", "default"), {"links": links})
+    return view
+
+
 class TestSyncCablesViewDuplicateCable:
     def test_duplicate_cable_shows_warning(self):
-        from netbox_librenms_plugin.views.sync.cables import SyncCablesView
+        from netbox_librenms_plugin.tests.conftest import cable_together
 
-        view = object.__new__(SyncCablesView)
-        view.require_all_permissions = MagicMock(return_value=None)
-        view.request = _make_request(post_data={"select": ["port1"]})
-        view.get_cache_key = MagicMock(return_value="key")
-        view._post_server_key = "default"
+        dev = make_device("cable-dup-local")
+        remote = make_device("cable-dup-remote")
+        local_iface = make_interface(dev, "Gi0/1")
+        remote_iface = make_interface(remote, "Gi0/2")
+        cable_together(local_iface, remote_iface)  # already connected
+        req = _make_request(post_data={"select": ["port1"]})
+        view = _cables_view(
+            req,
+            dev,
+            [
+                {
+                    "local_port_id": "port1",
+                    "local_port": "Gi0/1",
+                    "netbox_local_interface_id": local_iface.pk,
+                    "netbox_remote_interface_id": remote_iface.pk,
+                }
+            ],
+        )
 
-        mock_device = MagicMock(pk=1)
-        mock_device.id = 1  # ensure id matches device_id on iface to skip VC branch
-        link_data = {
-            "local_port_id": "port1",
-            "local_port": "Gi0/1",
-            "netbox_local_interface_id": 10,
-            "netbox_remote_interface_id": 20,
-        }
+        _post(view, req, pk=dev.pk)
 
-        with (
-            patch(
-                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
-                return_value=mock_device,
-            ),
-            patch("netbox_librenms_plugin.views.sync.cables.cache") as mock_cache,
-            patch("netbox_librenms_plugin.views.sync.cables.messages") as mock_msgs,
-            patch("netbox_librenms_plugin.views.sync.cables.redirect"),
-            patch("netbox_librenms_plugin.views.sync.cables.reverse", return_value="/sync/"),
-            patch("netbox_librenms_plugin.views.sync.cables.Cable") as mock_cable_cls,
-            patch("netbox_librenms_plugin.views.sync.cables.Interface") as mock_iface_cls,
-            patch("netbox_librenms_plugin.views.sync.cables.ContentType") as mock_ct,
-            patch("netbox_librenms_plugin.views.sync.cables.transaction"),
-            patch.object(
-                type(view), "librenms_api", new_callable=lambda: property(lambda s: MagicMock(server_key="default"))
-            ),
-        ):
-            mock_cache.get.return_value = {"links": [link_data]}
-            local_iface = MagicMock(pk=10)
-            local_iface.device_id = 1  # match the device pk to skip VC branch
-            remote_iface = MagicMock(pk=20)
-            mock_iface_cls.objects.restrict.return_value = mock_iface_cls.objects
-            mock_iface_cls.objects.get.side_effect = [local_iface, remote_iface]
-            mock_cable_cls.objects.restrict.return_value = mock_cable_cls.objects
-            mock_cable_cls.objects.filter.return_value.exists.return_value = True
-            mock_ct.objects.get_for_model.return_value = MagicMock()
-
-            view.post(view.request, pk=1)
-
-        mock_msgs.warning.assert_called_once()
+        assert any("Cable already exists" in t for t in message_texts(req, "warning"))
 
 
 class TestSyncCablesViewMissingRemote:
     def test_interface_does_not_exist_shows_error(self):
-        from netbox_librenms_plugin.views.sync.cables import SyncCablesView
+        from dcim.models import Interface
 
-        view = object.__new__(SyncCablesView)
-        view.require_all_permissions = MagicMock(return_value=None)
-        view.request = _make_request(post_data={"select": ["port1"]})
-        view.get_cache_key = MagicMock(return_value="key")
-        view._post_server_key = "default"
+        dev = make_device("cable-missing-local")
+        local_iface = make_interface(dev, "Gi0/1")
+        gone_pk = Interface.objects.order_by("-pk").first().pk + 1000
+        req = _make_request(post_data={"select": ["port1"]})
+        view = _cables_view(
+            req,
+            dev,
+            [
+                {
+                    "local_port_id": "port1",
+                    "local_port": "Gi0/1",
+                    "netbox_local_interface_id": local_iface.pk,
+                    "netbox_remote_interface_id": gone_pk,
+                }
+            ],
+        )
 
-        mock_device = MagicMock(pk=1)
-        link_data = {
-            "local_port_id": "port1",
-            "local_port": "Gi0/1",
-            "netbox_local_interface_id": 10,
-            "netbox_remote_interface_id": 20,
-        }
+        _post(view, req, pk=dev.pk)
 
-        class _DNE(Exception):
-            pass
+        assert any("Remote device or interface not found" in t for t in message_texts(req, "error"))
 
-        with (
-            patch(
-                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
-                return_value=mock_device,
-            ),
-            patch("netbox_librenms_plugin.views.sync.cables.cache") as mock_cache,
-            patch("netbox_librenms_plugin.views.sync.cables.messages") as mock_msgs,
-            patch("netbox_librenms_plugin.views.sync.cables.redirect"),
-            patch("netbox_librenms_plugin.views.sync.cables.reverse", return_value="/sync/"),
-            patch("netbox_librenms_plugin.views.sync.cables.Interface") as mock_iface_cls,
-            patch("netbox_librenms_plugin.views.sync.cables.transaction"),
-            patch.object(
-                type(view), "librenms_api", new_callable=lambda: property(lambda s: MagicMock(server_key="default"))
-            ),
-        ):
-            mock_cache.get.return_value = {"links": [link_data]}
-            mock_iface_cls.DoesNotExist = _DNE
-            mock_iface_cls.objects.restrict.return_value = mock_iface_cls.objects
-            mock_iface_cls.objects.get.side_effect = _DNE()
+    def test_a_remote_interface_outside_the_grant_is_reported_missing(self):
+        """The remote id comes from the cached LibreNMS row; a constrained grant must not cable it."""
+        from dcim.models import Cable, Device, Interface
 
-            view.post(view.request, pk=1)
+        dev = make_device("cable-scoped-local")
+        remote = make_device("cable-scoped-remote")
+        local_iface = make_interface(dev, "Gi0/1")
+        remote_iface = make_interface(remote, "Gi0/2")
+        user = make_user_with_perms("cable-scoped", [("view", Device), ("add", Cable), ("change", Cable)])
+        user = grant(user, "view", Interface, constraints={"device__name": "cable-scoped-local"})
+        req = _make_request(post_data={"select": ["port1"]}, user=user)
+        view = _cables_view(
+            req,
+            dev,
+            [
+                {
+                    "local_port_id": "port1",
+                    "local_port": "Gi0/1",
+                    "netbox_local_interface_id": local_iface.pk,
+                    "netbox_remote_interface_id": remote_iface.pk,
+                }
+            ],
+        )
 
-        mock_msgs.error.assert_called_once()
+        _post(view, req, pk=dev.pk)
+
+        assert any("Remote device or interface not found" in t for t in message_texts(req, "error"))
+        assert not Cable.objects.filter(terminations__interface=remote_iface).exists()
 
 
 class TestSyncCablesViewMissingLinkData:
@@ -510,21 +508,26 @@ class TestSyncCablesViewHelpers:
         assert result == [{"local_port_id": "p"}]
 
     def test_check_existing_cable(self):
-        from netbox_librenms_plugin.views.sync.cables import SyncCablesView
+        from netbox_librenms_plugin.tests.conftest import cable_together
 
-        view = object.__new__(SyncCablesView)
-        local = MagicMock(pk=1)
-        remote = MagicMock(pk=2)
+        dev = make_device("cable-check")
+        remote = make_device("cable-check-remote")
+        local = make_interface(dev, "Gi0/1")
+        far = make_interface(remote, "Gi0/2")
+        free = make_interface(remote, "Gi0/3")
+        view = make_view(_sync_cables_view_class())
 
-        with (
-            patch("netbox_librenms_plugin.views.sync.cables.Cable") as mock_cable_cls,
-            patch("netbox_librenms_plugin.views.sync.cables.ContentType") as mock_ct,
-        ):
-            mock_cable_cls.objects.restrict.return_value = mock_cable_cls.objects
-            mock_cable_cls.objects.filter.return_value.exists.return_value = True
-            mock_ct.objects.get_for_model.return_value = MagicMock()
-            result = view.check_existing_cable(local, remote)
-        assert result is True
+        assert view.check_existing_cable(local, free) is False
+
+        cable_together(local, far)
+
+        assert view.check_existing_cable(local, free) is True
+
+
+def _sync_cables_view_class():
+    from netbox_librenms_plugin.views.sync.cables import SyncCablesView
+
+    return SyncCablesView
 
 
 class TestSyncCablesViewProcessInterfaceSyncException:
@@ -552,274 +555,214 @@ class TestSyncCablesViewProcessInterfaceSyncException:
         assert "port1" in results["invalid"]
 
 
+def _add_device_view(request, *, add_result=(True, "Device added"), poller_choices=()):
+    """The real AddDeviceToLibreNMSView; only the LibreNMS calls are stubbed.
+
+    ``poller_choices`` seeds the poller-group ChoiceField, whose options production fetches
+    from LibreNMS — that fetch is the external boundary, the form validation is not.
+    """
+    from netbox_librenms_plugin.views.sync.devices import AddDeviceToLibreNMSView
+
+    view = make_view(AddDeviceToLibreNMSView, request)
+    view._librenms_api.add_device.return_value = add_result
+    view._poller_choices = list(poller_choices)
+    return view
+
+
+def _poller_groups(choices):
+    return patch("netbox_librenms_plugin.forms._get_librenms_poller_group_choices", return_value=list(choices))
+
+
+def _snmp_post(prefix, **fields):
+    """POST data for the real SNMP form, prefixed the way the template renders it."""
+    data = {"object_type": "device", f"{prefix}-snmp_version": fields.pop("snmp_version", "v2c")}
+    data.update({f"{prefix}-{k}": v for k, v in fields.items()})
+    return data
+
+
 class TestAddDeviceToLibreNMSViewPermission:
     def test_permission_denied_returns_early(self):
-        from netbox_librenms_plugin.views.sync.devices import AddDeviceToLibreNMSView
+        """The plugin write gate refuses before anything reaches LibreNMS."""
+        from dcim.models import Device
 
-        view = object.__new__(AddDeviceToLibreNMSView)
-        view.require_all_permissions = MagicMock(return_value=_denied_response())
-        view.request = _make_request(post_data={"snmp_version": "v2c", "object_type": "device"})
-        # Permission check now runs after object resolution, so the get_object
-        # lookup must be stubbed out to reach it.
-        with patch.object(view, "get_object", return_value=MagicMock()):
-            result = view.post(view.request, object_id=1)
-        assert result.status_code == 403
+        dev = make_device("addsnmp-denied")
+        # Holds change_device (so the scoped resolve succeeds) but not the plugin write perm,
+        # which is the only way to reach require_all_permissions' denial branch here.
+        user = make_user_with_perms("addsnmp-noplugin", [("change", Device)], plugin_write=False)
+        req = _make_request(post_data=_snmp_post("v1v2", hostname="r.example.com", community="public"), user=user)
+        view = _add_device_view(req)
+
+        with _poller_groups([]):
+            _post(view, req, object_id=dev.pk)
+
+        view._librenms_api.add_device.assert_not_called()
+
+    def test_a_user_without_the_change_grant_404s(self):
+        """The object resolve is scoped by "change", so a view-only grant never gets that far."""
+        from dcim.models import Device
+        from django.http import Http404
+
+        dev = make_device("addsnmp-viewonly")
+        user = make_user_with_perms("addsnmp-viewer", [("view", Device)])
+        req = _make_request(post_data=_snmp_post("v1v2", hostname="r.example.com", community="public"), user=user)
+        view = _add_device_view(req)
+
+        with _poller_groups([]), pytest.raises(Http404):
+            _post(view, req, object_id=dev.pk)
+
+        view._librenms_api.add_device.assert_not_called()
+
+    def test_a_device_outside_the_grant_404s(self):
+        """The object_id is client-supplied, so an out-of-scope device must not be added."""
+        from dcim.models import Device
+        from django.http import Http404
+
+        make_device("addsnmp-mine")
+        theirs = make_device("addsnmp-theirs")
+        user = make_user_with_perms("addsnmp-scoped", [("change", Device)], constraints={"name": "addsnmp-mine"})
+        req = _make_request(post_data=_snmp_post("v1v2", hostname="r.example.com", community="public"), user=user)
+        view = _add_device_view(req)
+
+        with _poller_groups([]), pytest.raises(Http404):
+            _post(view, req, object_id=theirs.pk)
+
+        view._librenms_api.add_device.assert_not_called()
+
+    def test_unknown_object_type_returns_400(self):
+        dev = make_device("addsnmp-badtype")
+        req = _make_request(post_data={"object_type": "rack"})
+        view = _add_device_view(req)
+
+        response = _post(view, req, object_id=dev.pk)
+
+        assert response.status_code == 400
 
 
 class TestAddDeviceToLibreNMSViewFormInvalid:
     def test_invalid_form_shows_errors(self):
-        from netbox_librenms_plugin.views.sync.devices import AddDeviceToLibreNMSView
+        """The REAL form rejects the missing hostname/community, and each error is surfaced."""
+        dev = make_device("addsnmp-invalid")
+        req = _make_request(post_data={"v1v2-snmp_version": "v2c", "object_type": "device"})
+        view = _add_device_view(req)
 
-        view = object.__new__(AddDeviceToLibreNMSView)
-        view.require_all_permissions = MagicMock(return_value=None)
+        with _poller_groups([]):
+            _post(view, req, object_id=dev.pk)
 
-        mock_device = MagicMock()
-        mock_device.get_absolute_url.return_value = "/device/1/"
-
-        post_data = {"v1v2-snmp_version": "v2c", "object_type": "device"}
-
-        with (
-            patch("netbox_librenms_plugin.views.sync.devices.Device") as mock_device_cls,
-            patch("netbox_librenms_plugin.views.sync.devices.messages") as mock_msgs,
-            patch("netbox_librenms_plugin.views.sync.devices.redirect"),
-            patch("netbox_librenms_plugin.forms._get_librenms_poller_group_choices", return_value=[]),
-        ):
-            mock_device_cls.objects.restrict.return_value = mock_device_cls.objects
-            mock_device_cls.objects.get.return_value = mock_device
-            view.request = _make_request(post_data=post_data)
-            view.object = mock_device
-
-            # Provide an invalid form (missing required hostname)
-            view.post(view.request, object_id=1)
-
-        # Should show form errors (hostname and community are required)
-        assert mock_msgs.error.call_count >= 1
+        errors = message_texts(req, "error")
+        assert any(t.startswith("hostname:") for t in errors)
+        assert any(t.startswith("community:") for t in errors)
+        view._librenms_api.add_device.assert_not_called()
 
 
 class TestAddDeviceToLibreNMSViewFormValid:
     def test_valid_v2c_form_calls_api(self):
-        from netbox_librenms_plugin.views.sync.devices import AddDeviceToLibreNMSView
+        dev = make_device("addsnmp-v2c")
+        req = _make_request(post_data=_snmp_post("v1v2", hostname="router.example.com", community="public"))
+        view = _add_device_view(req, add_result=(True, "Device added"))
 
-        view = object.__new__(AddDeviceToLibreNMSView)
-        view.require_all_permissions = MagicMock(return_value=None)
+        with _poller_groups([]):
+            _post(view, req, object_id=dev.pk)
 
-        mock_device = MagicMock()
-        mock_device.get_absolute_url.return_value = "/device/1/"
-        mock_api = MagicMock()
-        mock_api.server_key = "default"
-        mock_api.add_device.return_value = (True, "Device added")
-
-        mock_form = MagicMock()
-        mock_form.is_valid.return_value = True
-        mock_form.cleaned_data = {
-            "hostname": "router.example.com",
-            "snmp_version": "v2c",
-            "community": "public",
-            "force_add": False,
-            "port": None,
-            "transport": None,
-            "port_association_mode": None,
-            "poller_group": None,
-        }
-
-        with (
-            patch("netbox_librenms_plugin.views.sync.devices.Device") as mock_device_cls,
-            patch("netbox_librenms_plugin.views.sync.devices.messages") as mock_msgs,
-            patch("netbox_librenms_plugin.views.sync.devices.redirect"),
-            patch("netbox_librenms_plugin.views.sync.devices.AddToLIbreSNMPV1V2", return_value=mock_form),
-            patch.object(type(view), "librenms_api", new_callable=lambda: property(lambda s: mock_api)),
-        ):
-            mock_device_cls.objects.restrict.return_value = mock_device_cls.objects
-            mock_device_cls.objects.get.return_value = mock_device
-            post_data = {"v1v2-snmp_version": "v2c", "object_type": "device"}
-            view.request = _make_request(post_data=post_data)
-            view.object = mock_device
-
-            view.post(view.request, object_id=1)
-
-        mock_api.add_device.assert_called_once()
-        mock_msgs.success.assert_called_once()
+        payload = view._librenms_api.add_device.call_args[0][0]
+        assert payload["hostname"] == "router.example.com"
+        assert payload["snmp_version"] == "v2c"
+        assert payload["community"] == "public"
+        assert message_texts(req, "success") == ["Device added"]
 
 
 class TestAddDeviceToLibreNMSViewFormValidExtraFields:
     """Covers lines 74-78: transport and port_association_mode optional fields."""
 
     def test_valid_form_with_transport_and_pam(self):
-        from netbox_librenms_plugin.views.sync.devices import AddDeviceToLibreNMSView
+        dev = make_device("addsnmp-extra")
+        req = _make_request(
+            post_data=_snmp_post(
+                "v1v2",
+                hostname="router.example.com",
+                community="public",
+                port="161",
+                transport="udp6",
+                port_association_mode="ifName",
+            )
+        )
+        view = _add_device_view(req)
 
-        view = object.__new__(AddDeviceToLibreNMSView)
-        view.require_all_permissions = MagicMock(return_value=None)
+        with _poller_groups([]):
+            _post(view, req, object_id=dev.pk)
 
-        mock_device = MagicMock()
-        mock_device.get_absolute_url.return_value = "/device/1/"
-        mock_api = MagicMock()
-        mock_api.server_key = "default"
-        mock_api.add_device.return_value = (True, "Device added")
-
-        mock_form = MagicMock()
-        mock_form.is_valid.return_value = True
-        mock_form.cleaned_data = {
-            "hostname": "router.example.com",
-            "snmp_version": "v2c",
-            "community": "public",
-            "force_add": False,
-            "port": 161,
-            "transport": "udp6",
-            "port_association_mode": 2,
-            "poller_group": None,
-        }
-
-        with (
-            patch("netbox_librenms_plugin.views.sync.devices.Device") as mock_device_cls,
-            patch("netbox_librenms_plugin.views.sync.devices.messages"),
-            patch("netbox_librenms_plugin.views.sync.devices.redirect"),
-            patch("netbox_librenms_plugin.views.sync.devices.AddToLIbreSNMPV1V2", return_value=mock_form),
-            patch.object(type(view), "librenms_api", new_callable=lambda: property(lambda s: mock_api)),
-        ):
-            mock_device_cls.objects.restrict.return_value = mock_device_cls.objects
-            mock_device_cls.objects.get.return_value = mock_device
-            post_data = {"v1v2-snmp_version": "v2c", "object_type": "device"}
-            view.request = _make_request(post_data=post_data)
-            view.object = mock_device
-
-            view.post(view.request, object_id=1)
-
-        call_kwargs = mock_api.add_device.call_args[0][0]
-        assert call_kwargs.get("transport") == "udp6"
-        assert call_kwargs.get("port_association_mode") == 2
+        payload = view._librenms_api.add_device.call_args[0][0]
+        assert payload["transport"] == "udp6"
+        assert payload["port_association_mode"] == "ifName"
+        assert payload["port"] == 161
 
     def test_invalid_poller_group_ignored(self):
-        """Covers lines 81-82: except (ValueError, TypeError) for non-int poller_group."""
-        from netbox_librenms_plugin.views.sync.devices import AddDeviceToLibreNMSView
+        """Covers lines 81-82: a non-numeric poller group id from LibreNMS is dropped, not fatal."""
+        dev = make_device("addsnmp-badpoller")
+        req = _make_request(
+            post_data=_snmp_post("v1v2", hostname="router.example.com", community="public", poller_group="not-a-number")
+        )
+        view = _add_device_view(req)
 
-        view = object.__new__(AddDeviceToLibreNMSView)
-        view.require_all_permissions = MagicMock(return_value=None)
+        # LibreNMS supplies the option list, so a non-numeric id is a real possibility.
+        with _poller_groups([("not-a-number", "Odd group")]):
+            _post(view, req, object_id=dev.pk)
 
-        mock_device = MagicMock()
-        mock_device.get_absolute_url.return_value = "/device/1/"
-        mock_api = MagicMock()
-        mock_api.server_key = "default"
-        mock_api.add_device.return_value = (True, "Device added")
-
-        mock_form = MagicMock()
-        mock_form.is_valid.return_value = True
-        mock_form.cleaned_data = {
-            "hostname": "router.example.com",
-            "snmp_version": "v2c",
-            "community": "public",
-            "force_add": False,
-            "port": None,
-            "transport": None,
-            "port_association_mode": None,
-            "poller_group": "not-a-number",  # Triggers except path
-        }
-
-        with (
-            patch("netbox_librenms_plugin.views.sync.devices.Device") as mock_device_cls,
-            patch("netbox_librenms_plugin.views.sync.devices.messages"),
-            patch("netbox_librenms_plugin.views.sync.devices.redirect"),
-            patch("netbox_librenms_plugin.views.sync.devices.AddToLIbreSNMPV1V2", return_value=mock_form),
-            patch.object(type(view), "librenms_api", new_callable=lambda: property(lambda s: mock_api)),
-        ):
-            mock_device_cls.objects.restrict.return_value = mock_device_cls.objects
-            mock_device_cls.objects.get.return_value = mock_device
-            post_data = {"v1v2-snmp_version": "v2c", "object_type": "device"}
-            view.request = _make_request(post_data=post_data)
-            view.object = mock_device
-
-            view.post(view.request, object_id=1)
-
-        call_kwargs = mock_api.add_device.call_args[0][0]
-        assert "poller_group" not in call_kwargs
+        payload = view._librenms_api.add_device.call_args[0][0]
+        assert "poller_group" not in payload
 
 
 class TestAddDeviceToLibreNMSViewV3:
     def test_v3_form_submits_v3_data(self):
-        from netbox_librenms_plugin.views.sync.devices import AddDeviceToLibreNMSView
+        dev = make_device("addsnmp-v3")
+        req = _make_request(
+            post_data=_snmp_post(
+                "v3",
+                snmp_version="v3",
+                hostname="router.example.com",
+                authlevel="authPriv",
+                authname="user",
+                authpass="auth123",
+                authalgo="MD5",
+                cryptopass="priv123",
+                cryptoalgo="DES",
+            )
+        )
+        view = _add_device_view(req, add_result=(False, "Error"))
 
-        view = object.__new__(AddDeviceToLibreNMSView)
-        view.require_all_permissions = MagicMock(return_value=None)
-        view.request = _make_request()
+        with _poller_groups([]):
+            _post(view, req, object_id=dev.pk)
 
-        mock_device = MagicMock()
-        mock_device.get_absolute_url.return_value = "/device/1/"
-        mock_api = MagicMock()
-        mock_api.add_device.return_value = (False, "Error")
-
-        mock_form = MagicMock()
-        mock_form.is_valid.return_value = True
-        mock_form.cleaned_data = {
-            "hostname": "router.example.com",
-            "snmp_version": "v3",
-            "authlevel": "authPriv",
-            "authname": "user",
-            "authpass": "auth123",
-            "authalgo": "MD5",
-            "cryptopass": "priv123",
-            "cryptoalgo": "DES",
-            "force_add": False,
-            "port": None,
-            "transport": None,
-            "port_association_mode": None,
-            "poller_group": None,
-        }
-
-        with (
-            patch("netbox_librenms_plugin.views.sync.devices.Device") as mock_device_cls,
-            patch("netbox_librenms_plugin.views.sync.devices.messages") as mock_msgs,
-            patch("netbox_librenms_plugin.views.sync.devices.redirect"),
-            patch("netbox_librenms_plugin.views.sync.devices.AddToLIbreSNMPV3", return_value=mock_form),
-            patch.object(type(view), "librenms_api", new_callable=lambda: property(lambda s: mock_api)),
-        ):
-            mock_device_cls.objects.restrict.return_value = mock_device_cls.objects
-            mock_device_cls.objects.get.return_value = mock_device
-            post_data = {"v3-snmp_version": "v3", "object_type": "device"}
-            view.request = _make_request(post_data=post_data)
-            view.object = mock_device
-            view.post(view.request, object_id=1)
-
-        mock_api.add_device.assert_called_once()
-        mock_msgs.error.assert_called_once()
+        payload = view._librenms_api.add_device.call_args[0][0]
+        assert payload["snmp_version"] == "v3"
+        assert payload["authlevel"] == "authPriv"
+        assert payload["cryptoalgo"] == "DES"
+        assert message_texts(req, "error") == ["Error"]
 
 
 class TestAddDeviceToLibreNMSViewUnknownVersion:
     def test_unknown_snmp_version_shows_error(self):
-        from netbox_librenms_plugin.views.sync.devices import AddDeviceToLibreNMSView
+        """No version toggle at all: the v3 form runs, reports "v3", and the add still happens.
 
-        view = object.__new__(AddDeviceToLibreNMSView)
-        view.require_all_permissions = MagicMock(return_value=None)
+        The "Unknown SNMP version." branch is unreachable through post(): get_form_class falls
+        back to the v3 form, whose snmp_version field is a hidden constant. This pins what a
+        version-less POST actually does.
+        """
+        dev = make_device("addsnmp-noversion")
+        req = _make_request(
+            post_data={
+                "object_type": "device",
+                "v3-hostname": "router.example.com",
+                "v3-snmp_version": "v3",
+                "v3-authlevel": "noAuthNoPriv",
+                "v3-authname": "user",
+            }
+        )
+        view = _add_device_view(req)
 
-        mock_device = MagicMock()
-        mock_device.get_absolute_url.return_value = "/device/1/"
-        mock_api = MagicMock()
+        with _poller_groups([]):
+            _post(view, req, object_id=dev.pk)
 
-        mock_form = MagicMock()
-        mock_form.is_valid.return_value = True
-        mock_form.cleaned_data = {
-            "hostname": "router.example.com",
-            "snmp_version": "v99",  # Unknown version
-            "force_add": False,
-            "port": None,
-            "transport": None,
-            "port_association_mode": None,
-            "poller_group": None,
-        }
-
-        with (
-            patch("netbox_librenms_plugin.views.sync.devices.Device") as mock_device_cls,
-            patch("netbox_librenms_plugin.views.sync.devices.messages") as mock_msgs,
-            patch("netbox_librenms_plugin.views.sync.devices.redirect"),
-            patch("netbox_librenms_plugin.views.sync.devices.AddToLIbreSNMPV3", return_value=mock_form),
-            patch.object(type(view), "librenms_api", new_callable=lambda: property(lambda s: mock_api)),
-        ):
-            mock_device_cls.objects.restrict.return_value = mock_device_cls.objects
-            mock_device_cls.objects.get.return_value = mock_device
-            post_data = {"object_type": "device"}
-            view.request = _make_request(post_data=post_data)
-            view.object = mock_device
-            view.post(view.request, object_id=1)
-
-        mock_msgs.error.assert_called()
+        assert view._librenms_api.add_device.call_args[0][0]["snmp_version"] == "v3"
 
 
 class TestAddDeviceToLibreNMSViewGetFormClass:
@@ -1131,7 +1074,6 @@ class TestSyncIPAddressesGetManagementIp:
         assert view._librenms_api.get_device_info.call_args.kwargs.get("use_cache") is False
 
 
-@pytest.mark.django_db
 class TestSyncIPAddressesViewIPWrites:
     """SyncIPAddressesView create/update/unchanged against real IPAddress rows."""
 
@@ -1264,35 +1206,34 @@ class TestSyncIPAddressesViewHelpers:
         assert result is None
 
     def test_get_vrf_selection_returns_vrf(self):
-        from netbox_librenms_plugin.views.sync.ip_addresses import SyncIPAddressesView
+        from ipam.models import VRF
 
-        view = object.__new__(SyncIPAddressesView)
-        mock_vrf = MagicMock()
-        req = _make_request(post_data={"vrf_10.0.0.1": "3"})
-        view.request = req  # dispatch() would set this; restricted_queryset reads request.user
+        vrf = VRF.objects.create(name="Blue")
+        req = _make_request(post_data={"vrf_10.0.0.1": str(vrf.pk)})
+        view = make_view(_sync_ip_view_class(), req)
 
-        with patch("netbox_librenms_plugin.views.sync.ip_addresses.VRF") as mock_vrf_cls:
-            mock_vrf_cls.objects.restrict.return_value = mock_vrf_cls.objects
-            mock_vrf_cls.objects.get.return_value = mock_vrf
-            result = view.get_vrf_selection(req, "10.0.0.1")
-        assert result is mock_vrf
+        assert view.get_vrf_selection(req, "10.0.0.1") == vrf
 
     def test_get_vrf_selection_not_found_returns_none(self):
-        from netbox_librenms_plugin.views.sync.ip_addresses import SyncIPAddressesView
+        from ipam.models import VRF
 
-        view = object.__new__(SyncIPAddressesView)
-        req = _make_request(post_data={"vrf_10.0.0.1": "99"})
-        view.request = req  # dispatch() would set this; restricted_queryset reads request.user
+        missing_pk = (VRF.objects.order_by("-pk").first().pk if VRF.objects.exists() else 0) + 1000
+        req = _make_request(post_data={"vrf_10.0.0.1": str(missing_pk)})
+        view = make_view(_sync_ip_view_class(), req)
 
-        class _DNE(Exception):
-            pass
+        assert view.get_vrf_selection(req, "10.0.0.1") is None
 
-        with patch("netbox_librenms_plugin.views.sync.ip_addresses.VRF") as mock_vrf_cls:
-            mock_vrf_cls.DoesNotExist = _DNE
-            mock_vrf_cls.objects.restrict.return_value = mock_vrf_cls.objects
-            mock_vrf_cls.objects.get.side_effect = _DNE()
-            result = view.get_vrf_selection(req, "10.0.0.1")
-        assert result is None
+    def test_get_vrf_selection_returns_none_for_a_vrf_outside_the_grant(self):
+        """The VRF id is posted by the client, so a constrained grant must not resolve it."""
+        from ipam.models import VRF
+
+        VRF.objects.create(name="Mine")
+        theirs = VRF.objects.create(name="Theirs")
+        user = make_user_with_perms("vrf-scoped", [("view", VRF)], constraints={"name": "Mine"})
+        req = _make_request(post_data={"vrf_10.0.0.1": str(theirs.pk)}, user=user)
+        view = make_view(_sync_ip_view_class(), req)
+
+        assert view.get_vrf_selection(req, "10.0.0.1") is None
 
     def test_get_ip_tab_url_device(self):
         from dcim.models import Device
@@ -1361,55 +1302,45 @@ class TestSyncIPAddressesViewHelpers:
         assert "server_key" not in url
 
 
+def _sync_ip_view_class():
+    from netbox_librenms_plugin.views.sync.ip_addresses import SyncIPAddressesView
+
+    return SyncIPAddressesView
+
+
 class TestSyncIPAddressesViewVMInterface:
     def test_vm_interface_resolved(self):
-        from netbox_librenms_plugin.views.sync.ip_addresses import SyncIPAddressesView
+        """A VM IP is bound to the VM's own interface, matched by name."""
+        from django.core.cache import cache
+        from ipam.models import IPAddress
+        from virtualization.models import VMInterface
 
-        view = object.__new__(SyncIPAddressesView)
-        view.require_all_permissions = MagicMock(return_value=None)
+        vm = make_vm("ipsync-vm")
+        vmiface = VMInterface.objects.create(virtual_machine=vm, name="eth0")
+        req = _make_request(post_data={"select": ["10.0.0.5"]})
+        view = make_view(_sync_ip_view_class(), req)
         view.rebind_api_for_server = MagicMock(return_value="default")
-        view.get_cache_key = MagicMock(return_value="k")
+        cache.set(
+            view.get_cache_key(vm, "ip_addresses", "default"),
+            {
+                "ip_addresses": [
+                    {
+                        "ip_address": "10.0.0.5",
+                        "ip_with_mask": "10.0.0.5/24",
+                        "port_id": 9,
+                        "interface_name": "eth0",
+                    }
+                ]
+            },
+        )
 
-        mock_vmiface = MagicMock()
-        mock_vmiface.name = "eth0"
-        mock_vm = MagicMock()
-        mock_vm.pk = 2
-        mock_vm.interfaces.all.return_value = [mock_vmiface]
-        mock_api = MagicMock(server_key="default")
+        with patch("netbox_librenms_plugin.views.sync.ip_addresses.get_librenms_device_id", return_value=9):
+            _post(view, req, object_type="virtualmachine", pk=vm.pk)
 
-        ip_data = {
-            "ip_address": "10.0.0.5",
-            "ip_with_mask": "10.0.0.5/24",
-            "port_id": 9,
-            "interface_name": "eth0",
-        }
-
-        with (
-            patch(
-                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
-                return_value=mock_vm,
-            ),
-            patch("netbox_librenms_plugin.views.sync.ip_addresses.cache") as mock_cache,
-            patch("netbox_librenms_plugin.views.sync.ip_addresses.messages"),
-            patch("netbox_librenms_plugin.views.sync.ip_addresses.redirect"),
-            patch("netbox_librenms_plugin.views.sync.ip_addresses.transaction"),
-            patch("netbox_librenms_plugin.views.sync.ip_addresses.reverse", return_value="/sync/"),
-            patch("netbox_librenms_plugin.views.sync.ip_addresses.IPAddress") as mock_ip_cls,
-            patch("netbox_librenms_plugin.views.sync.ip_addresses.get_librenms_device_id", return_value=9),
-            patch.object(type(view), "librenms_api", new_callable=lambda: property(lambda s: mock_api)),
-        ):
-            mock_cache.get.return_value = {"ip_addresses": [ip_data]}
-            mock_ip_cls.objects.restrict.return_value = mock_ip_cls.objects
-            mock_ip_cls.objects.filter.return_value.first.return_value = None
-
-            view.request = _make_request(post_data={"select": ["10.0.0.5"]})
-            view.post(view.request, object_type="virtualmachine", pk=2)
-
-        mock_ip_cls.objects.create.assert_called_once()
-        assert mock_ip_cls.objects.create.call_args.kwargs["assigned_object"] is mock_vmiface
+        ip = IPAddress.objects.get(address="10.0.0.5/24")
+        assert ip.assigned_object == vmiface
 
 
-@pytest.mark.django_db
 class TestSyncIPAddressesViewInterfaceResolution:
     """The sync re-resolves the target interface against current NetBox state rather than trusting the cached ``interface_url`` (which goes stale when an interface is synced after the IP rows were cached)."""
 
@@ -1804,7 +1735,6 @@ class TestSyncVLANsViewCacheMiss:
         mock_msgs.error.assert_called_once()
 
 
-@pytest.mark.django_db
 class TestSyncVLANsViewCreateVLAN:
     """SyncVLANsView create path against a real VLAN row (only the cached LibreNMS data and the messages/redirect/reverse framework seams are mocked; the real get_or_create + transaction run and the created VLAN is reloaded from the DB)."""
 
@@ -1846,7 +1776,6 @@ class TestSyncVLANsViewCreateVLAN:
         mock_msgs.success.assert_called_once()
 
 
-@pytest.mark.django_db
 class TestSyncVLANsViewUpdateVLAN:
     def test_existing_vlan_name_updated(self):
         from ipam.models import VLAN
@@ -1875,7 +1804,6 @@ class TestSyncVLANsViewUpdateVLAN:
         assert VLAN.objects.get(vid=100, group=None).name == "Management"  # renamed in place
 
 
-@pytest.mark.django_db
 class TestSyncVLANsViewUnchangedVLAN:
     def test_unchanged_vlan_counts_as_skipped(self):
         from ipam.models import VLAN
@@ -1906,282 +1834,131 @@ class TestSyncVLANsViewUnchangedVLAN:
         assert VLAN.objects.filter(vid=100).count() == 1  # no duplicate created
 
 
+def _vlan_view(request, device, cached_vlans):
+    """The real SyncVLANsView with the LibreNMS VLAN snapshot seeded into the real cache."""
+    from django.core.cache import cache
+
+    from netbox_librenms_plugin.views.sync.vlans import SyncVLANsView
+
+    view = make_view(SyncVLANsView, request)
+    view._post_server_key = "default"
+    cache.set(view.get_cache_key(device, "vlans", "default"), cached_vlans)
+    return view
+
+
+def _vlan_group(name):
+    from ipam.models import VLANGroup
+
+    return VLANGroup.objects.create(name=name, slug=name.lower().replace(" ", "-"))
+
+
 class TestSyncVLANsViewWithGroup:
     def test_vlan_created_in_group(self):
-        from netbox_librenms_plugin.views.sync.vlans import SyncVLANsView
+        from ipam.models import VLAN
 
-        view = object.__new__(SyncVLANsView)
-        view.require_all_permissions = MagicMock(return_value=None)
-        view._post_server_key = "default"
-        view.get_cache_key = MagicMock(return_value="k")
-        mock_api = MagicMock(server_key="default")
+        dev = make_device("vlan-grp-create")
+        group = _vlan_group("Prod Group")
+        req = _make_request(post_data={"action": "create_vlans", "select": ["200"], "vlan_group_200": str(group.pk)})
+        view = _vlan_view(req, dev, [{"vlan_vlan": 200, "vlan_name": "Production"}])
 
-        mock_device = MagicMock(pk=1)
-        mock_vlan_group = MagicMock(pk=3)
-        mock_vlan = MagicMock()
+        _post(view, req, object_type="device", object_id=dev.pk)
 
-        librenms_vlans = [{"vlan_vlan": 200, "vlan_name": "Production"}]
-
-        with (
-            patch(
-                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
-                return_value=mock_device,
-            ),
-            patch("netbox_librenms_plugin.views.sync.vlans.cache") as mock_cache,
-            patch("netbox_librenms_plugin.views.sync.vlans.messages"),
-            patch("netbox_librenms_plugin.views.sync.vlans.redirect"),
-            patch("netbox_librenms_plugin.views.sync.vlans.transaction"),
-            patch("netbox_librenms_plugin.views.sync.vlans.reverse", return_value="/sync/"),
-            patch("netbox_librenms_plugin.views.sync.vlans.VLAN") as mock_vlan_cls,
-            patch("netbox_librenms_plugin.views.sync.vlans.VLANGroup") as mock_group_cls,
-            patch.object(type(view), "librenms_api", new_callable=lambda: property(lambda s: mock_api)),
-        ):
-            mock_cache.get.return_value = librenms_vlans
-            mock_group_cls.objects.restrict.return_value = mock_group_cls.objects
-            mock_group_cls.objects.get.return_value = mock_vlan_group
-            mock_vlan_cls.objects.restrict.return_value = mock_vlan_cls.objects
-            mock_vlan_cls.objects.get_or_create.return_value = (mock_vlan, True)
-
-            view.request = _make_request(post_data={"action": "create_vlans", "select": ["200"], "vlan_group_200": "3"})
-            view.post(view.request, object_type="device", object_id=1)
-
-        mock_vlan_cls.objects.get_or_create.assert_called_once_with(
-            vid=200,
-            group=mock_vlan_group,
-            defaults={"name": "Production", "status": "active"},
-        )
+        vlan = VLAN.objects.get(vid=200, group=group)
+        assert vlan.name == "Production"
+        assert vlan.status == "active"
 
     def test_invalid_vlan_group_id_is_rejected(self):
         """A requested-but-missing VLAN group fails closed: no VLAN is created (not even a global one) and an error is surfaced."""
-        from netbox_librenms_plugin.views.sync.vlans import SyncVLANsView
+        from ipam.models import VLAN, VLANGroup
 
-        view = object.__new__(SyncVLANsView)
-        view.require_all_permissions = MagicMock(return_value=None)
-        view._post_server_key = "default"
-        view.get_cache_key = MagicMock(return_value="k")
-        mock_api = MagicMock(server_key="default")
+        dev = make_device("vlan-grp-missing")
+        missing_pk = (VLANGroup.objects.order_by("-pk").first().pk if VLANGroup.objects.exists() else 0) + 1000
+        req = _make_request(post_data={"action": "create_vlans", "select": ["200"], "vlan_group_200": str(missing_pk)})
+        view = _vlan_view(req, dev, [{"vlan_vlan": 200, "vlan_name": "Production"}])
 
-        mock_device = MagicMock(pk=1)
-        mock_vlan = MagicMock()
-
-        librenms_vlans = [{"vlan_vlan": 200, "vlan_name": "Production"}]
-
-        class _DNE(Exception):
-            pass
-
-        with (
-            patch(
-                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
-                return_value=mock_device,
-            ),
-            patch("netbox_librenms_plugin.views.sync.vlans.cache") as mock_cache,
-            patch("netbox_librenms_plugin.views.sync.vlans.messages") as mock_messages,
-            patch("netbox_librenms_plugin.views.sync.vlans.redirect"),
-            patch("netbox_librenms_plugin.views.sync.vlans.transaction"),
-            patch("netbox_librenms_plugin.views.sync.vlans.reverse", return_value="/sync/"),
-            patch("netbox_librenms_plugin.views.sync.vlans.VLAN") as mock_vlan_cls,
-            patch("netbox_librenms_plugin.views.sync.vlans.VLANGroup") as mock_group_cls,
-            patch.object(type(view), "librenms_api", new_callable=lambda: property(lambda s: mock_api)),
-        ):
-            mock_cache.get.return_value = librenms_vlans
-            mock_group_cls.DoesNotExist = _DNE
-            mock_group_cls.objects.restrict.return_value = mock_group_cls.objects
-            mock_group_cls.objects.get.side_effect = _DNE()
-            mock_vlan_cls.objects.restrict.return_value = mock_vlan_cls.objects
-            mock_vlan_cls.objects.get_or_create.return_value = (mock_vlan, True)
-
-            view.request = _make_request(
-                post_data={"action": "create_vlans", "select": ["200"], "vlan_group_200": "99"}
-            )
-            view.post(view.request, object_type="device", object_id=1)
+        _post(view, req, object_type="device", object_id=dev.pk)
 
         # Fail closed: never create a VLAN in any scope, and surface an error.
-        mock_vlan_cls.objects.get_or_create.assert_not_called()
-        mock_messages.error.assert_called()
+        assert not VLAN.objects.filter(vid=200).exists()
+        assert any("no longer exists" in t for t in message_texts(req, "error"))
+
+    def test_a_vlan_group_outside_the_grant_is_rejected(self):
+        """The group id is posted by the client, so a constrained grant must not widen the scope."""
+        from dcim.models import Device
+        from ipam.models import VLAN, VLANGroup
+
+        dev = make_device("vlan-grp-scoped")
+        mine = _vlan_group("Scoped Mine")
+        theirs = _vlan_group("Scoped Theirs")
+        user = make_user_with_perms(
+            "vlan-scoped",
+            [("view", Device), ("add", VLAN), ("change", VLAN)],
+        )
+        user = grant(user, "view", VLANGroup, constraints={"name": mine.name})
+        req = _make_request(
+            post_data={"action": "create_vlans", "select": ["200"], "vlan_group_200": str(theirs.pk)},
+            user=user,
+        )
+        view = _vlan_view(req, dev, [{"vlan_vlan": 200, "vlan_name": "Production"}])
+
+        _post(view, req, object_type="device", object_id=dev.pk)
+
+        assert not VLAN.objects.filter(vid=200).exists()
+        assert any("no longer exists" in t for t in message_texts(req, "error"))
 
     def test_invalid_vid_string_skipped(self):
-        from netbox_librenms_plugin.views.sync.vlans import SyncVLANsView
+        from ipam.models import VLAN
 
-        view = object.__new__(SyncVLANsView)
-        view.require_all_permissions = MagicMock(return_value=None)
-        view._post_server_key = "default"
-        view.get_cache_key = MagicMock(return_value="k")
-        mock_api = MagicMock(server_key="default")
+        dev = make_device("vlan-badvid")
+        req = _make_request(post_data={"action": "create_vlans", "select": ["not-a-vid"]})
+        view = _vlan_view(req, dev, [{"vlan_vlan": 100, "vlan_name": "Mgmt"}])
 
-        mock_device = MagicMock(pk=1)
-        librenms_vlans = [{"vlan_vlan": 100, "vlan_name": "Mgmt"}]
+        _post(view, req, object_type="device", object_id=dev.pk)
 
-        with (
-            patch(
-                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
-                return_value=mock_device,
-            ),
-            patch("netbox_librenms_plugin.views.sync.vlans.cache") as mock_cache,
-            patch("netbox_librenms_plugin.views.sync.vlans.messages"),
-            patch("netbox_librenms_plugin.views.sync.vlans.redirect"),
-            patch("netbox_librenms_plugin.views.sync.vlans.transaction"),
-            patch("netbox_librenms_plugin.views.sync.vlans.reverse", return_value="/sync/"),
-            patch("netbox_librenms_plugin.views.sync.vlans.VLAN") as mock_vlan_cls,
-            patch.object(type(view), "librenms_api", new_callable=lambda: property(lambda s: mock_api)),
-        ):
-            mock_cache.get.return_value = librenms_vlans
-            # "not-a-vid" → int() fails → skip
-            view.request = _make_request(post_data={"action": "create_vlans", "select": ["not-a-vid"]})
-            view.post(view.request, object_type="device", object_id=1)
-
-        # no VLAN created, shows "no VLANs" warning
-        mock_vlan_cls.objects.get_or_create.assert_not_called()
+        assert not VLAN.objects.filter(name="Mgmt").exists()
 
     def test_unknown_vid_in_cache_skipped(self):
-        from netbox_librenms_plugin.views.sync.vlans import SyncVLANsView
+        from ipam.models import VLAN
 
-        view = object.__new__(SyncVLANsView)
-        view.require_all_permissions = MagicMock(return_value=None)
-        view._post_server_key = "default"
-        view.get_cache_key = MagicMock(return_value="k")
-        mock_api = MagicMock(server_key="default")
+        dev = make_device("vlan-unknownvid")
+        req = _make_request(post_data={"action": "create_vlans", "select": ["999"]})
+        view = _vlan_view(req, dev, [{"vlan_vlan": 100, "vlan_name": "Mgmt"}])
 
-        mock_device = MagicMock(pk=1)
-        librenms_vlans = [{"vlan_vlan": 100, "vlan_name": "Mgmt"}]
+        _post(view, req, object_type="device", object_id=dev.pk)
 
-        with (
-            patch(
-                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
-                return_value=mock_device,
-            ),
-            patch("netbox_librenms_plugin.views.sync.vlans.cache") as mock_cache,
-            patch("netbox_librenms_plugin.views.sync.vlans.messages"),
-            patch("netbox_librenms_plugin.views.sync.vlans.redirect"),
-            patch("netbox_librenms_plugin.views.sync.vlans.transaction"),
-            patch("netbox_librenms_plugin.views.sync.vlans.reverse", return_value="/sync/"),
-            patch("netbox_librenms_plugin.views.sync.vlans.VLAN") as mock_vlan_cls,
-            patch.object(type(view), "librenms_api", new_callable=lambda: property(lambda s: mock_api)),
-        ):
-            mock_cache.get.return_value = librenms_vlans
-            # VID 999 not in cached vlans → skipped
-            view.request = _make_request(post_data={"action": "create_vlans", "select": ["999"]})
-            view.post(view.request, object_type="device", object_id=1)
-
-        mock_vlan_cls.objects.get_or_create.assert_not_called()
-
-    def test_no_vlans_shows_warning(self):
-        from netbox_librenms_plugin.views.sync.vlans import SyncVLANsView
-
-        view = object.__new__(SyncVLANsView)
-        view.require_all_permissions = MagicMock(return_value=None)
-        view._post_server_key = "default"
-        view.get_cache_key = MagicMock(return_value="k")
-        mock_api = MagicMock(server_key="default")
-
-        mock_device = MagicMock(pk=1)
-        librenms_vlans = [{"vlan_vlan": 100, "vlan_name": "Mgmt"}]
-
-        with (
-            patch(
-                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
-                return_value=mock_device,
-            ),
-            patch("netbox_librenms_plugin.views.sync.vlans.cache") as mock_cache,
-            patch("netbox_librenms_plugin.views.sync.vlans.messages") as mock_msgs,
-            patch("netbox_librenms_plugin.views.sync.vlans.redirect"),
-            patch("netbox_librenms_plugin.views.sync.vlans.transaction"),
-            patch("netbox_librenms_plugin.views.sync.vlans.reverse", return_value="/sync/"),
-            patch("netbox_librenms_plugin.views.sync.vlans.VLAN"),
-            patch.object(type(view), "librenms_api", new_callable=lambda: property(lambda s: mock_api)),
-        ):
-            mock_cache.get.return_value = librenms_vlans
-            view.request = _make_request(post_data={"action": "create_vlans", "select": ["not-a-vid"]})
-            view.post(view.request, object_type="device", object_id=1)
-
-        mock_msgs.warning.assert_called()
+        assert not VLAN.objects.filter(vid=999).exists()
 
 
 class TestSyncVLANsViewGroupedUpdateSkip:
     """Lines 134-139: grouped VLAN update (elif) and unchanged (else) paths."""
 
     def test_grouped_vlan_name_updated(self):
-        from netbox_librenms_plugin.views.sync.vlans import SyncVLANsView
+        from ipam.models import VLAN
 
-        view = object.__new__(SyncVLANsView)
-        view.require_all_permissions = MagicMock(return_value=None)
-        view._post_server_key = "default"
-        view.get_cache_key = MagicMock(return_value="k")
-        mock_api = MagicMock(server_key="default")
+        dev = make_device("vlan-grp-update")
+        group = _vlan_group("Update Group")
+        vlan = VLAN.objects.create(vid=300, group=group, name="OldGroupedName", status="active")
+        req = _make_request(post_data={"action": "create_vlans", "select": ["300"], "vlan_group_300": str(group.pk)})
+        view = _vlan_view(req, dev, [{"vlan_vlan": 300, "vlan_name": "NewGroupedName"}])
 
-        mock_device = MagicMock(pk=1)
-        mock_vlan_group = MagicMock(pk=3)
-        mock_vlan = MagicMock()
-        mock_vlan.name = "OldGroupedName"  # Different from librenms → update path
+        _post(view, req, object_type="device", object_id=dev.pk)
 
-        librenms_vlans = [{"vlan_vlan": 300, "vlan_name": "NewGroupedName"}]
-
-        with (
-            patch(
-                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
-                return_value=mock_device,
-            ),
-            patch("netbox_librenms_plugin.views.sync.vlans.cache") as mock_cache,
-            patch("netbox_librenms_plugin.views.sync.vlans.messages"),
-            patch("netbox_librenms_plugin.views.sync.vlans.redirect"),
-            patch("netbox_librenms_plugin.views.sync.vlans.transaction"),
-            patch("netbox_librenms_plugin.views.sync.vlans.reverse", return_value="/sync/"),
-            patch("netbox_librenms_plugin.views.sync.vlans.VLAN") as mock_vlan_cls,
-            patch("netbox_librenms_plugin.views.sync.vlans.VLANGroup") as mock_group_cls,
-            patch.object(type(view), "librenms_api", new_callable=lambda: property(lambda s: mock_api)),
-        ):
-            mock_cache.get.return_value = librenms_vlans
-            mock_group_cls.objects.restrict.return_value = mock_group_cls.objects
-            mock_group_cls.objects.get.return_value = mock_vlan_group
-            mock_vlan_cls.objects.restrict.return_value = mock_vlan_cls.objects
-            mock_vlan_cls.objects.get_or_create.return_value = (mock_vlan, False)  # exists
-
-            view.request = _make_request(post_data={"action": "create_vlans", "select": ["300"], "vlan_group_300": "3"})
-            view.post(view.request, object_type="device", object_id=1)
-
-        mock_vlan.save.assert_called_once()
+        assert VLAN.objects.get(pk=vlan.pk).name == "NewGroupedName"
 
     def test_grouped_vlan_unchanged_skipped(self):
-        from netbox_librenms_plugin.views.sync.vlans import SyncVLANsView
+        from ipam.models import VLAN
 
-        view = object.__new__(SyncVLANsView)
-        view.require_all_permissions = MagicMock(return_value=None)
-        view._post_server_key = "default"
-        view.get_cache_key = MagicMock(return_value="k")
-        mock_api = MagicMock(server_key="default")
+        dev = make_device("vlan-grp-same")
+        group = _vlan_group("Same Group")
+        vlan = VLAN.objects.create(vid=300, group=group, name="SameName", status="active")
+        last_updated = VLAN.objects.get(pk=vlan.pk).last_updated
+        req = _make_request(post_data={"action": "create_vlans", "select": ["300"], "vlan_group_300": str(group.pk)})
+        view = _vlan_view(req, dev, [{"vlan_vlan": 300, "vlan_name": "SameName"}])
 
-        mock_device = MagicMock(pk=1)
-        mock_vlan_group = MagicMock(pk=3)
-        mock_vlan = MagicMock()
-        mock_vlan.name = "SameName"  # Same name → skipped_count path
+        _post(view, req, object_type="device", object_id=dev.pk)
 
-        librenms_vlans = [{"vlan_vlan": 300, "vlan_name": "SameName"}]
-
-        with (
-            patch(
-                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
-                return_value=mock_device,
-            ),
-            patch("netbox_librenms_plugin.views.sync.vlans.cache") as mock_cache,
-            patch("netbox_librenms_plugin.views.sync.vlans.messages") as mock_msgs,
-            patch("netbox_librenms_plugin.views.sync.vlans.redirect"),
-            patch("netbox_librenms_plugin.views.sync.vlans.transaction"),
-            patch("netbox_librenms_plugin.views.sync.vlans.reverse", return_value="/sync/"),
-            patch("netbox_librenms_plugin.views.sync.vlans.VLAN") as mock_vlan_cls,
-            patch("netbox_librenms_plugin.views.sync.vlans.VLANGroup") as mock_group_cls,
-            patch.object(type(view), "librenms_api", new_callable=lambda: property(lambda s: mock_api)),
-        ):
-            mock_cache.get.return_value = librenms_vlans
-            mock_group_cls.objects.restrict.return_value = mock_group_cls.objects
-            mock_group_cls.objects.get.return_value = mock_vlan_group
-            mock_vlan_cls.objects.restrict.return_value = mock_vlan_cls.objects
-            mock_vlan_cls.objects.get_or_create.return_value = (mock_vlan, False)
-
-            view.request = _make_request(post_data={"action": "create_vlans", "select": ["300"], "vlan_group_300": "3"})
-            view.post(view.request, object_type="device", object_id=1)
-
-        mock_vlan.save.assert_not_called()
-        mock_msgs.success.assert_called()
-        assert "unchanged" in str(mock_msgs.success.call_args_list)
+        assert VLAN.objects.get(pk=vlan.pk).last_updated == last_updated
+        assert any("unchanged" in t for t in message_texts(req, "success"))
 
     def test_get_object_device(self):
         from netbox_librenms_plugin.views.sync.vlans import SyncVLANsView
@@ -2229,413 +2006,250 @@ class TestSyncVLANsViewGroupedUpdateSkip:
 # ===========================================================================
 
 
+def _make_site(name, *, latitude=None, longitude=None):
+    """A real Site, optionally with coordinates.
+
+    Re-read from the DB so the coordinate fields come back as the Decimals the view actually
+    formats in production, not the Python floats that were passed in.
+    """
+    from dcim.models import Site
+    from django.utils.text import slugify
+
+    site = Site.objects.create(name=name, slug=slugify(name), latitude=latitude, longitude=longitude)
+    return Site.objects.get(pk=site.pk)
+
+
+def _location_view(request=None, *, locations=None, add_result=None, update_result=None):
+    """The real SyncSiteLocationView with only the LibreNMS location calls stubbed."""
+    from netbox_librenms_plugin.views.sync.locations import SyncSiteLocationView
+
+    view = make_view(SyncSiteLocationView, request)
+    view._librenms_api.get_locations.return_value = (True, locations if locations is not None else [])
+    view._librenms_api.add_location.return_value = add_result or (True, "ok")
+    view._librenms_api.update_location.return_value = update_result or (True, "ok")
+    return view
+
+
 class TestSyncSiteLocationViewPost:
     def test_permission_denied_returns_early(self):
-        from netbox_librenms_plugin.views.sync.locations import SyncSiteLocationView
+        """Without the plugin write permission the LibreNMS API is never called."""
+        site = _make_site("Perm Site", latitude=51.5, longitude=-0.12)
+        user = make_user_with_perms("loc-noplugin", [], plugin_write=False)
+        req = _make_request(post_data={"action": "create", "pk": str(site.pk)}, user=user)
+        view = _location_view(req)
 
-        view = object.__new__(SyncSiteLocationView)
-        view.require_write_permission = MagicMock(return_value=_denied_response())
-        view.request = _make_request(post_data={"action": "create", "pk": "1"})
+        _post(view, req)
 
-        result = view.post(view.request)
-        assert result.status_code == 403
+        view._librenms_api.add_location.assert_not_called()
 
     def test_missing_pk_shows_error(self):
-        from netbox_librenms_plugin.views.sync.locations import SyncSiteLocationView
+        req = _make_request(post_data={"action": "create"})
+        view = _location_view(req)
 
-        view = object.__new__(SyncSiteLocationView)
-        view.require_write_permission = MagicMock(return_value=None)
-        mock_api = MagicMock()
+        _post(view, req)
 
-        with (
-            patch("netbox_librenms_plugin.views.sync.locations.messages") as mock_msgs,
-            patch("netbox_librenms_plugin.views.sync.locations.redirect"),
-            patch.object(type(view), "librenms_api", new_callable=lambda: property(lambda s: mock_api)),
-        ):
-            view.request = _make_request(post_data={"action": "create"})
-            view.post(view.request)
-
-        mock_msgs.error.assert_called_once()
+        assert message_texts(req, "error") == ["No site ID provided."]
 
     def test_site_not_found_shows_error(self):
-        from django.core.exceptions import ObjectDoesNotExist
-        from netbox_librenms_plugin.views.sync.locations import SyncSiteLocationView
+        from dcim.models import Site
 
-        view = object.__new__(SyncSiteLocationView)
-        view.require_write_permission = MagicMock(return_value=None)
-        mock_api = MagicMock()
+        missing_pk = (Site.objects.order_by("-pk").first().pk if Site.objects.exists() else 0) + 1000
+        req = _make_request(post_data={"action": "create", "pk": str(missing_pk)})
+        view = _location_view(req)
 
-        with (
-            patch("netbox_librenms_plugin.views.sync.locations.messages") as mock_msgs,
-            patch("netbox_librenms_plugin.views.sync.locations.redirect"),
-            patch("netbox_librenms_plugin.views.sync.locations.Site") as mock_site_cls,
-            patch.object(type(view), "librenms_api", new_callable=lambda: property(lambda s: mock_api)),
-        ):
-            mock_site_cls.objects.restrict.return_value = mock_site_cls.objects
-            mock_site_cls.objects.get.side_effect = ObjectDoesNotExist()
-            view.request = _make_request(post_data={"action": "create", "pk": "99"})
-            view.post(view.request)
+        _post(view, req)
 
-        mock_msgs.error.assert_called_once()
+        assert message_texts(req, "error") == ["Site not found."]
+
+    def test_site_outside_the_grant_is_reported_as_not_found(self):
+        """The pk is posted by the client, so an out-of-scope site must not reach LibreNMS."""
+        from dcim.models import Site
+
+        _make_site("Loc Mine", latitude=1.0, longitude=1.0)
+        theirs = _make_site("Loc Theirs", latitude=2.0, longitude=2.0)
+        user = make_user_with_perms("loc-scoped", [("view", Site)], constraints={"name": "Loc Mine"})
+        req = _make_request(post_data={"action": "create", "pk": str(theirs.pk)}, user=user)
+        view = _location_view(req)
+
+        _post(view, req)
+
+        assert message_texts(req, "error") == ["Site not found."]
+        view._librenms_api.add_location.assert_not_called()
 
     def test_unknown_action_shows_error(self):
-        from netbox_librenms_plugin.views.sync.locations import SyncSiteLocationView
+        site = _make_site("Action Site")
+        req = _make_request(post_data={"action": "banana", "pk": str(site.pk)})
+        view = _location_view(req)
 
-        view = object.__new__(SyncSiteLocationView)
-        view.require_write_permission = MagicMock(return_value=None)
-        mock_api = MagicMock()
-        mock_site = MagicMock()
+        _post(view, req)
 
-        with (
-            patch("netbox_librenms_plugin.views.sync.locations.messages") as mock_msgs,
-            patch("netbox_librenms_plugin.views.sync.locations.redirect"),
-            patch("netbox_librenms_plugin.views.sync.locations.Site") as mock_site_cls,
-            patch.object(type(view), "librenms_api", new_callable=lambda: property(lambda s: mock_api)),
-        ):
-            mock_site_cls.objects.restrict.return_value = mock_site_cls.objects
-            mock_site_cls.objects.get.return_value = mock_site
-            view.request = _make_request(post_data={"action": "banana", "pk": "1"})
-            view.post(view.request)
-
-        mock_msgs.error.assert_called_once()
+        assert message_texts(req, "error") == ["Unknown action 'banana'."]
 
 
 class TestSyncSiteLocationViewCreate:
     def test_create_without_coords_shows_warning(self):
-        from netbox_librenms_plugin.views.sync.locations import SyncSiteLocationView
+        site = _make_site("London")
+        req = _make_request(post_data={"action": "create", "pk": str(site.pk)})
+        view = _location_view(req)
 
-        view = object.__new__(SyncSiteLocationView)
-        view.require_write_permission = MagicMock(return_value=None)
-        mock_api = MagicMock()
-        mock_site = MagicMock()
-        mock_site.name = "London"
-        mock_site.latitude = None
-        mock_site.longitude = None
+        _post(view, req)
 
-        with (
-            patch("netbox_librenms_plugin.views.sync.locations.messages") as mock_msgs,
-            patch("netbox_librenms_plugin.views.sync.locations.redirect"),
-            patch("netbox_librenms_plugin.views.sync.locations.Site") as mock_site_cls,
-            patch.object(type(view), "librenms_api", new_callable=lambda: property(lambda s: mock_api)),
-        ):
-            mock_site_cls.objects.restrict.return_value = mock_site_cls.objects
-            mock_site_cls.objects.get.return_value = mock_site
-            view.request = _make_request(post_data={"action": "create", "pk": "1"})
-            view.post(view.request)
-
-        mock_msgs.warning.assert_called_once()
+        assert any("Latitude and/or longitude is missing" in t for t in message_texts(req, "warning"))
+        view._librenms_api.add_location.assert_not_called()
 
     def test_create_success(self):
-        from netbox_librenms_plugin.views.sync.locations import SyncSiteLocationView
+        site = _make_site("London", latitude=51.5, longitude=-0.12)
+        req = _make_request(post_data={"action": "create", "pk": str(site.pk)})
+        view = _location_view(req, add_result=(True, "ok"))
 
-        view = object.__new__(SyncSiteLocationView)
-        view.require_write_permission = MagicMock(return_value=None)
-        mock_api = MagicMock()
-        mock_api.add_location.return_value = (True, "ok")
-        mock_site = MagicMock()
-        mock_site.name = "London"
-        mock_site.latitude = 51.5
-        mock_site.longitude = -0.12
+        _post(view, req)
 
-        with (
-            patch("netbox_librenms_plugin.views.sync.locations.messages") as mock_msgs,
-            patch("netbox_librenms_plugin.views.sync.locations.redirect"),
-            patch("netbox_librenms_plugin.views.sync.locations.Site") as mock_site_cls,
-            patch.object(type(view), "librenms_api", new_callable=lambda: property(lambda s: mock_api)),
-        ):
-            mock_site_cls.objects.restrict.return_value = mock_site_cls.objects
-            mock_site_cls.objects.get.return_value = mock_site
-            view.request = _make_request(post_data={"action": "create", "pk": "1"})
-            view.post(view.request)
-
-        mock_msgs.success.assert_called_once()
+        assert message_texts(req, "success") == ["Location 'London' created in LibreNMS successfully."]
+        # The site's real coordinates are what gets sent, stringified.
+        view._librenms_api.add_location.assert_called_once_with(
+            {"lat": "51.500000", "lng": "-0.120000", "location": "London"}
+        )
 
     def test_create_failure(self):
-        from netbox_librenms_plugin.views.sync.locations import SyncSiteLocationView
+        site = _make_site("London", latitude=51.5, longitude=-0.12)
+        req = _make_request(post_data={"action": "create", "pk": str(site.pk)})
+        view = _location_view(req, add_result=(False, "Server error"))
 
-        view = object.__new__(SyncSiteLocationView)
-        view.require_write_permission = MagicMock(return_value=None)
-        mock_api = MagicMock()
-        mock_api.add_location.return_value = (False, "Server error")
-        mock_site = MagicMock()
-        mock_site.name = "London"
-        mock_site.latitude = 51.5
-        mock_site.longitude = -0.12
+        _post(view, req)
 
-        with (
-            patch("netbox_librenms_plugin.views.sync.locations.messages") as mock_msgs,
-            patch("netbox_librenms_plugin.views.sync.locations.redirect"),
-            patch("netbox_librenms_plugin.views.sync.locations.Site") as mock_site_cls,
-            patch.object(type(view), "librenms_api", new_callable=lambda: property(lambda s: mock_api)),
-        ):
-            mock_site_cls.objects.restrict.return_value = mock_site_cls.objects
-            mock_site_cls.objects.get.return_value = mock_site
-            view.request = _make_request(post_data={"action": "create", "pk": "1"})
-            view.post(view.request)
-
-        mock_msgs.error.assert_called_once()
+        assert any("Server error" in t for t in message_texts(req, "error"))
 
 
 class TestSyncSiteLocationViewUpdate:
     def test_update_without_coords_shows_warning(self):
-        from netbox_librenms_plugin.views.sync.locations import SyncSiteLocationView
+        site = _make_site("Berlin", longitude=13.4)
+        req = _make_request(post_data={"action": "update", "pk": str(site.pk)})
+        view = _location_view(req)
 
-        view = object.__new__(SyncSiteLocationView)
-        view.require_write_permission = MagicMock(return_value=None)
-        mock_api = MagicMock()
-        mock_site = MagicMock()
-        mock_site.name = "Berlin"
-        mock_site.latitude = None
-        mock_site.longitude = 13.4
+        _post(view, req)
 
-        with (
-            patch("netbox_librenms_plugin.views.sync.locations.messages") as mock_msgs,
-            patch("netbox_librenms_plugin.views.sync.locations.redirect"),
-            patch("netbox_librenms_plugin.views.sync.locations.Site") as mock_site_cls,
-            patch.object(type(view), "librenms_api", new_callable=lambda: property(lambda s: mock_api)),
-        ):
-            mock_site_cls.objects.restrict.return_value = mock_site_cls.objects
-            mock_site_cls.objects.get.return_value = mock_site
-            view.request = _make_request(post_data={"action": "update", "pk": "1"})
-            view.post(view.request)
-
-        mock_msgs.warning.assert_called_once()
+        assert any("Latitude and/or longitude is missing" in t for t in message_texts(req, "warning"))
 
     def test_update_api_failure_fetching_locations(self):
-        from netbox_librenms_plugin.views.sync.locations import SyncSiteLocationView
+        site = _make_site("Berlin", latitude=52.5, longitude=13.4)
+        req = _make_request(post_data={"action": "update", "pk": str(site.pk)})
+        view = _location_view(req)
+        view._librenms_api.get_locations.return_value = (False, "Connection error")
 
-        view = object.__new__(SyncSiteLocationView)
-        view.require_write_permission = MagicMock(return_value=None)
-        mock_api = MagicMock()
-        mock_api.get_locations.return_value = (False, "Connection error")
-        mock_site = MagicMock()
-        mock_site.name = "Berlin"
-        mock_site.latitude = 52.5
-        mock_site.longitude = 13.4
+        _post(view, req)
 
-        with (
-            patch("netbox_librenms_plugin.views.sync.locations.messages") as mock_msgs,
-            patch("netbox_librenms_plugin.views.sync.locations.redirect"),
-            patch("netbox_librenms_plugin.views.sync.locations.Site") as mock_site_cls,
-            patch.object(type(view), "librenms_api", new_callable=lambda: property(lambda s: mock_api)),
-        ):
-            mock_site_cls.objects.restrict.return_value = mock_site_cls.objects
-            mock_site_cls.objects.get.return_value = mock_site
-            view.request = _make_request(post_data={"action": "update", "pk": "1"})
-            view.post(view.request)
-
-        mock_msgs.error.assert_called_once()
+        assert message_texts(req, "error") == ["Failed to retrieve LibreNMS locations."]
 
     def test_update_no_matching_location(self):
-        from netbox_librenms_plugin.views.sync.locations import SyncSiteLocationView
+        site = _make_site("Berlin", latitude=52.5, longitude=13.4)
+        req = _make_request(post_data={"action": "update", "pk": str(site.pk)})
+        view = _location_view(req, locations=[{"location": "Paris"}])
 
-        view = object.__new__(SyncSiteLocationView)
-        view.require_write_permission = MagicMock(return_value=None)
-        mock_api = MagicMock()
-        mock_api.get_locations.return_value = (True, [{"location": "Paris"}])  # No Berlin
-        mock_site = MagicMock()
-        mock_site.name = "Berlin"
-        mock_site.slug = "berlin"
-        mock_site.latitude = 52.5
-        mock_site.longitude = 13.4
+        _post(view, req)
 
-        with (
-            patch("netbox_librenms_plugin.views.sync.locations.messages") as mock_msgs,
-            patch("netbox_librenms_plugin.views.sync.locations.redirect"),
-            patch("netbox_librenms_plugin.views.sync.locations.Site") as mock_site_cls,
-            patch.object(type(view), "librenms_api", new_callable=lambda: property(lambda s: mock_api)),
-        ):
-            mock_site_cls.objects.restrict.return_value = mock_site_cls.objects
-            mock_site_cls.objects.get.return_value = mock_site
-            view.request = _make_request(post_data={"action": "update", "pk": "1"})
-            view.post(view.request)
-
-        mock_msgs.error.assert_called_once()
+        assert message_texts(req, "error") == ["Could not find matching location for site 'Berlin'"]
 
     def test_update_success(self):
-        from netbox_librenms_plugin.views.sync.locations import SyncSiteLocationView
+        site = _make_site("Berlin", latitude=52.5, longitude=13.4)
+        req = _make_request(post_data={"action": "update", "pk": str(site.pk)})
+        view = _location_view(req, locations=[{"location": "Berlin"}], update_result=(True, "ok"))
 
-        view = object.__new__(SyncSiteLocationView)
-        view.require_write_permission = MagicMock(return_value=None)
-        mock_api = MagicMock()
-        mock_api.get_locations.return_value = (True, [{"location": "Berlin"}])
-        mock_api.update_location.return_value = (True, "ok")
-        mock_site = MagicMock()
-        mock_site.name = "Berlin"
-        mock_site.slug = "berlin"
-        mock_site.latitude = 52.5
-        mock_site.longitude = 13.4
+        _post(view, req)
 
-        with (
-            patch("netbox_librenms_plugin.views.sync.locations.messages") as mock_msgs,
-            patch("netbox_librenms_plugin.views.sync.locations.redirect"),
-            patch("netbox_librenms_plugin.views.sync.locations.Site") as mock_site_cls,
-            patch.object(type(view), "librenms_api", new_callable=lambda: property(lambda s: mock_api)),
-        ):
-            mock_site_cls.objects.restrict.return_value = mock_site_cls.objects
-            mock_site_cls.objects.get.return_value = mock_site
-            view.request = _make_request(post_data={"action": "update", "pk": "1"})
-            view.post(view.request)
-
-        mock_msgs.success.assert_called_once()
+        assert message_texts(req, "success") == ["Location 'Berlin' updated in LibreNMS successfully."]
+        # The update payload carries coordinates only — renaming is not this action's job.
+        view._librenms_api.update_location.assert_called_once_with("Berlin", {"lat": "52.500000", "lng": "13.400000"})
 
     def test_update_failure(self):
-        from netbox_librenms_plugin.views.sync.locations import SyncSiteLocationView
+        site = _make_site("Berlin", latitude=52.5, longitude=13.4)
+        req = _make_request(post_data={"action": "update", "pk": str(site.pk)})
+        view = _location_view(req, locations=[{"location": "Berlin"}], update_result=(False, "boom"))
 
-        view = object.__new__(SyncSiteLocationView)
-        view.require_write_permission = MagicMock(return_value=None)
-        mock_api = MagicMock()
-        mock_api.get_locations.return_value = (True, [{"location": "Berlin"}])
-        mock_api.update_location.return_value = (False, "Not found in LibreNMS")
-        mock_site = MagicMock()
-        mock_site.name = "Berlin"
-        mock_site.slug = "berlin"
-        mock_site.latitude = 52.5
-        mock_site.longitude = 13.4
+        _post(view, req)
 
-        with (
-            patch("netbox_librenms_plugin.views.sync.locations.messages") as mock_msgs,
-            patch("netbox_librenms_plugin.views.sync.locations.redirect"),
-            patch("netbox_librenms_plugin.views.sync.locations.Site") as mock_site_cls,
-            patch.object(type(view), "librenms_api", new_callable=lambda: property(lambda s: mock_api)),
-        ):
-            mock_site_cls.objects.restrict.return_value = mock_site_cls.objects
-            mock_site_cls.objects.get.return_value = mock_site
-            view.request = _make_request(post_data={"action": "update", "pk": "1"})
-            view.post(view.request)
-
-        mock_msgs.error.assert_called_once()
+        assert any("boom" in t for t in message_texts(req, "error"))
 
 
 class TestSyncSiteLocationViewHelpers:
     def test_match_site_by_name(self):
-        from netbox_librenms_plugin.views.sync.locations import SyncSiteLocationView
-
-        view = object.__new__(SyncSiteLocationView)
-        site = MagicMock()
-        site.name = "London"
-        site.slug = "london"
+        site = _make_site("London")
         locations = [{"location": "London"}, {"location": "Berlin"}]
-        result = view.match_site_with_location(site, locations)
+
+        result = _location_view().match_site_with_location(site, locations)
+
         assert result["location"] == "London"
 
     def test_match_site_by_slug(self):
-        from netbox_librenms_plugin.views.sync.locations import SyncSiteLocationView
+        from dcim.models import Site
 
-        view = object.__new__(SyncSiteLocationView)
-        site = MagicMock()
-        site.name = "LondonDC"
-        site.slug = "london"
-        locations = [{"location": "london"}]
-        result = view.match_site_with_location(site, locations)
+        site = Site.objects.create(name="LondonDC", slug="london")
+
+        result = _location_view().match_site_with_location(site, [{"location": "london"}])
+
         assert result is not None
 
     def test_match_site_not_found(self):
-        from netbox_librenms_plugin.views.sync.locations import SyncSiteLocationView
+        site = _make_site("Tokyo")
 
-        view = object.__new__(SyncSiteLocationView)
-        site = MagicMock()
-        site.name = "Tokyo"
-        site.slug = "tokyo"
-        locations = [{"location": "London"}]
-        result = view.match_site_with_location(site, locations)
+        result = _location_view().match_site_with_location(site, [{"location": "London"}])
+
         assert result is None
 
     def test_check_coordinates_match_true(self):
-        from netbox_librenms_plugin.views.sync.locations import SyncSiteLocationView
-
-        view = object.__new__(SyncSiteLocationView)
-        assert view.check_coordinates_match(51.5, -0.12, "51.5", "-0.12") is True
+        assert _location_view().check_coordinates_match(51.5, -0.12, "51.5", "-0.12") is True
 
     def test_check_coordinates_match_false(self):
-        from netbox_librenms_plugin.views.sync.locations import SyncSiteLocationView
-
-        view = object.__new__(SyncSiteLocationView)
-        assert view.check_coordinates_match(51.5, -0.12, "52.0", "-0.12") is False
+        assert _location_view().check_coordinates_match(51.5, -0.12, "52.0", "-0.12") is False
 
     def test_check_coordinates_none_returns_false(self):
-        from netbox_librenms_plugin.views.sync.locations import SyncSiteLocationView
-
-        view = object.__new__(SyncSiteLocationView)
-        assert view.check_coordinates_match(None, -0.12, "51.5", "-0.12") is False
+        assert _location_view().check_coordinates_match(None, -0.12, "51.5", "-0.12") is False
 
     def test_build_location_data_with_name(self):
-        from netbox_librenms_plugin.views.sync.locations import SyncSiteLocationView
+        site = _make_site("London", latitude=51.5, longitude=-0.12)
 
-        view = object.__new__(SyncSiteLocationView)
-        site = MagicMock()
-        site.name = "London"
-        site.latitude = "51.5"
-        site.longitude = "-0.12"
-        data = view.build_location_data(site)
-        assert data["location"] == "London"
-        assert data["lat"] == "51.5"
+        data = _location_view().build_location_data(site)
+
+        assert data == {"location": "London", "lat": "51.500000", "lng": "-0.120000"}
 
     def test_build_location_data_without_name(self):
-        from netbox_librenms_plugin.views.sync.locations import SyncSiteLocationView
+        site = _make_site("London", latitude=51.5, longitude=-0.12)
 
-        view = object.__new__(SyncSiteLocationView)
-        site = MagicMock()
-        site.name = "London"
-        site.latitude = "51.5"
-        site.longitude = "-0.12"
-        data = view.build_location_data(site, include_name=False)
+        data = _location_view().build_location_data(site, include_name=False)
+
         assert "location" not in data
 
     def test_get_site_by_pk_returns_none_on_not_found(self):
-        from django.core.exceptions import ObjectDoesNotExist
-        from netbox_librenms_plugin.views.sync.locations import SyncSiteLocationView
+        from dcim.models import Site
 
-        view = object.__new__(SyncSiteLocationView)
-        view.request = MagicMock()  # restricted_queryset reads request.user
+        missing_pk = (Site.objects.order_by("-pk").first().pk if Site.objects.exists() else 0) + 1000
 
-        with patch("netbox_librenms_plugin.views.sync.locations.Site") as mock_site_cls:
-            mock_site_cls.objects.restrict.return_value = mock_site_cls.objects
-            mock_site_cls.objects.get.side_effect = ObjectDoesNotExist()
-            result = view.get_site_by_pk(99)
-        assert result is None
+        assert _location_view().get_site_by_pk(missing_pk) is None
+
+    def test_get_site_by_pk_returns_none_for_a_site_outside_the_grant(self):
+        from dcim.models import Site
+
+        _make_site("Bypk Mine")
+        theirs = _make_site("Bypk Theirs")
+        user = make_user_with_perms("loc-bypk", [("view", Site)], constraints={"name": "Bypk Mine"})
+
+        view = _location_view(_make_request(user=user))
+
+        assert view.get_site_by_pk(theirs.pk) is None
 
     def test_get_queryset_api_failure_returns_empty(self):
-        from netbox_librenms_plugin.views.sync.locations import SyncSiteLocationView
+        _make_site("Any Site")
+        view = _location_view(_make_request())
+        view._librenms_api.get_locations.return_value = (False, "Error")
 
-        view = object.__new__(SyncSiteLocationView)
-        view.request = _make_request()
-        view.filterset = None
-        mock_api = MagicMock()
-        mock_api.get_locations.return_value = (False, "Error")
-
-        with (
-            patch("netbox_librenms_plugin.views.sync.locations.Site") as mock_site_cls,
-            patch.object(type(view), "librenms_api", new_callable=lambda: property(lambda s: mock_api)),
-        ):
-            mock_site_cls.objects.all.return_value = []
-            result = view.get_queryset()
-        assert result == []
+        assert view.get_queryset() == []
 
     def test_create_sync_data_no_match(self):
-        from netbox_librenms_plugin.views.sync.locations import SyncSiteLocationView
+        site = _make_site("Atlantis")
 
-        view = object.__new__(SyncSiteLocationView)
-        site = MagicMock()
-        site.name = "Atlantis"
-        site.slug = "atlantis"
-        locations = [{"location": "London"}]
-        sync_data = view.create_sync_data(site, locations)
-        assert sync_data.is_synced is False
-        assert sync_data.librenms_location is None
+        result = _location_view().create_sync_data(site, [{"location": "London"}])
 
-    def test_create_sync_data_with_match(self):
-        from netbox_librenms_plugin.views.sync.locations import SyncSiteLocationView
-
-        view = object.__new__(SyncSiteLocationView)
-        site = MagicMock()
-        site.name = "London"
-        site.slug = "london"
-        site.latitude = 51.5
-        site.longitude = -0.12
-        locations = [{"location": "London", "lat": "51.5", "lng": "-0.12"}]
-        sync_data = view.create_sync_data(site, locations)
-        assert sync_data.is_synced is True
+        assert result.librenms_location is None
+        assert result.is_synced is False
 
 
 class TestSyncSiteLocationViewSuperMethods:
@@ -2682,53 +2296,24 @@ class TestSyncSiteLocationViewGetQuerysetFilterset:
     """Lines 44-49: filterset branch in get_queryset."""
 
     def test_get_queryset_with_filterset_and_get_params(self):
-        from netbox_librenms_plugin.views.sync.locations import SyncSiteLocationView
+        """A GET query runs the real filterset over the real Site rows."""
+        _make_site("London")
+        _make_site("Paris")
+        view = _location_view(_make_request(get_data={"q": "London"}), locations=[{"location": "London"}])
 
-        view = object.__new__(SyncSiteLocationView)
-        mock_api = MagicMock(server_key="default")
-        mock_request = MagicMock()
-        mock_request.GET = {"name": "London"}
-        view.request = mock_request
-        view.filterset = MagicMock()
-        view._post_server_key = "default"
-        view.get_cache_key = MagicMock(return_value="k")
-        view.get_librenms_locations = MagicMock(return_value=(True, [{"location": "London"}]))
-        view.create_sync_data = MagicMock(side_effect=lambda s, _locs: s)
+        result = view.get_queryset()
 
-        mock_site = MagicMock()
-        mock_site.name = "London"
-
-        mock_qs = MagicMock()
-        view.filterset.return_value.qs = mock_qs
-
-        with (
-            patch("netbox_librenms_plugin.views.sync.locations.Site") as mock_site_cls,
-            patch.object(type(view), "librenms_api", new_callable=lambda: property(lambda s: mock_api)),
-        ):
-            mock_site_cls.objects.all.return_value = [mock_site]
-            result = view.get_queryset()
-
-        assert result is mock_qs
+        assert [row.netbox_site.name for row in result] == ["London"]
 
     def test_get_queryset_no_get_params_returns_list(self):
-        from netbox_librenms_plugin.views.sync.locations import SyncSiteLocationView
+        """No GET params → the unfiltered sync-data list, one row per Site."""
+        from dcim.models import Site
 
-        view = object.__new__(SyncSiteLocationView)
-        mock_api = MagicMock(server_key="default")
-        mock_request = MagicMock()
-        mock_request.GET = {}  # Empty GET → falls through to return sync_data (line 49)
-        view.request = mock_request
-        view.filterset = None  # Falsy → line 47 skipped
-        view.get_librenms_locations = MagicMock(return_value=(True, [{"location": "London"}]))
-        mock_site = MagicMock()
-        mock_site.name = "London"
-        view.create_sync_data = MagicMock(side_effect=lambda s, _locs: s)
+        _make_site("London")
+        _make_site("Paris")
+        view = _location_view(_make_request(), locations=[{"location": "London"}])
 
-        with (
-            patch("netbox_librenms_plugin.views.sync.locations.Site") as mock_site_cls,
-            patch.object(type(view), "librenms_api", new_callable=lambda: property(lambda s: mock_api)),
-        ):
-            mock_site_cls.objects.all.return_value = [mock_site]
-            result = view.get_queryset()
+        result = view.get_queryset()
 
-        assert result == [mock_site]
+        assert len(result) == Site.objects.count()
+        assert {row.netbox_site.name for row in result} >= {"London", "Paris"}

--- a/netbox_librenms_plugin/tests/test_coverage_sync_views2.py
+++ b/netbox_librenms_plugin/tests/test_coverage_sync_views2.py
@@ -178,6 +178,42 @@ class TestSyncCablesViewSuccessPath:
         assert local.cable_id == remote.cable_id
         assert Cable.objects.filter(pk=local.cable_id).exists()
 
+    def test_unrelated_posted_device_cannot_redirect_the_local_termination(self):
+        """A forged VC selection must keep the cached local interface on the page device."""
+        page_device = make_device("cable-page-device")
+        unrelated_device = make_device("cable-unrelated-device")
+        remote_device = make_device("cable-forged-remote")
+        cached_local = make_interface(page_device, "Gi0/1")
+        unrelated_local = make_interface(unrelated_device, "Gi0/1")
+        remote = make_interface(remote_device, "Gi0/2")
+        request = _make_request(
+            post_data={
+                "select": ["port1"],
+                "device_selection_port1": str(unrelated_device.pk),
+            }
+        )
+        view = _cables_view(
+            request,
+            page_device,
+            [
+                {
+                    "local_port_id": "port1",
+                    "local_port": "Gi0/1",
+                    "netbox_local_interface_id": cached_local.pk,
+                    "netbox_remote_interface_id": remote.pk,
+                }
+            ],
+        )
+
+        with patch.object(view, "create_cable", return_value=True) as create_cable:
+            _post(view, request, pk=page_device.pk)
+
+        used_local, used_remote, used_request = create_cable.call_args.args
+        assert used_local == cached_local
+        assert used_local != unrelated_local
+        assert used_remote == remote
+        assert used_request is request
+
 
 class TestSyncCablesViewSkipsOOBRows:
     def test_oob_sourced_link_is_never_cabled(self):
@@ -322,7 +358,7 @@ class TestSyncCablesViewMissingRemote:
         _post(view, req, pk=dev.pk)
 
         assert any("Remote device or interface not found" in t for t in message_texts(req, "error"))
-        assert not Cable.objects.filter(terminations__interface=remote_iface).exists()
+        assert not remote_iface.cable_terminations.exists()
 
 
 class TestSyncCablesViewMissingLinkData:
@@ -2070,6 +2106,19 @@ class TestSyncSiteLocationViewPost:
 
         view._librenms_api.add_location.assert_not_called()
 
+    def test_site_view_permission_is_required_before_post_processing(self):
+        """Plugin write permission alone must not authorize reading the posted Site."""
+        site = _make_site("No Site Read", latitude=1.0, longitude=1.0)
+        user = make_user_with_perms("loc-no-site-read", [])
+        req = _make_request(post_data={"action": "create", "pk": str(site.pk)}, user=user)
+        view = _location_view(req)
+
+        response = _post(view, req)
+
+        assert response.status_code == 302
+        assert any("dcim.view_site" in text for text in message_texts(req, "error"))
+        view._librenms_api.add_location.assert_not_called()
+
     def test_missing_pk_shows_error(self):
         req = _make_request(post_data={"action": "create"})
         view = _location_view(req)
@@ -2345,3 +2394,19 @@ class TestSyncSiteLocationViewGetQuerysetFilterset:
 
         assert len(result) == Site.objects.count()
         assert {row.netbox_site.name for row in result} >= {"London", "Paris"}
+
+    def test_get_queryset_lists_only_sites_in_the_users_grant(self):
+        """A constrained Site grant must hide all other rows from the sync table."""
+        from dcim.models import Site
+
+        mine = _make_site("Location List Mine")
+        _make_site("Location List Theirs")
+        user = make_user_with_perms(
+            "loc-list-scoped",
+            [("view", Site)],
+            constraints={"pk": mine.pk},
+            plugin_write=False,
+        )
+        view = _location_view(_make_request(user=user), locations=[])
+
+        assert [row.netbox_site.pk for row in view.get_queryset()] == [mine.pk]

--- a/netbox_librenms_plugin/tests/test_coverage_sync_views2.py
+++ b/netbox_librenms_plugin/tests/test_coverage_sync_views2.py
@@ -2302,6 +2302,30 @@ class TestSyncVLANsViewWithGroup:
         assert not VLAN.objects.filter(vid=999).exists()
         assert VLAN.objects.filter(vid=100, name="Mgmt").exists()
 
+    def test_invalid_vlan_name_does_not_abort_the_batch(self):
+        """An invalid LibreNMS name is skipped while the next valid VLAN is created."""
+        from ipam.models import VLAN
+
+        dev = make_device("vlan-invalid-name")
+        max_length = VLAN._meta.get_field("name").max_length
+        invalid_name = "x" * (max_length + 1)
+        req = _make_request(post_data={"action": "create_vlans", "select": ["400", "401"]})
+        view = _vlan_view(
+            req,
+            dev,
+            [
+                {"vlan_vlan": 400, "vlan_name": invalid_name},
+                {"vlan_vlan": 401, "vlan_name": "Valid name"},
+            ],
+        )
+
+        _post(view, req, object_type="device", object_id=dev.pk)
+
+        assert not VLAN.objects.filter(vid=400).exists()
+        assert VLAN.objects.filter(vid=401, name="Valid name").exists()
+        assert any("name is invalid" in text for text in message_texts(req, "error"))
+        assert any("1 skipped (invalid VLAN name)" in text for text in message_texts(req, "success"))
+
 
 class TestSyncVLANsViewGroupedUpdateSkip:
     """Lines 134-139: grouped VLAN update (elif) and unchanged (else) paths."""

--- a/netbox_librenms_plugin/tests/test_coverage_sync_views2.py
+++ b/netbox_librenms_plugin/tests/test_coverage_sync_views2.py
@@ -12,6 +12,26 @@ import pytest
 from netbox_librenms_plugin.tests.conftest import make_device, make_interface
 
 
+def _bind_and_call(view, request, method, **kwargs):
+    """Call *view*.<method>, binding the request the way ``View.setup()`` does under dispatch().
+
+    A direct ``view.post(request, ...)`` leaves ``self.request`` unset, which the object-scoped
+    lookups read — production always goes through dispatch(), so bind it here too.
+    """
+    view.setup(request)
+    return getattr(view, method)(request, **kwargs)
+
+
+def _post(view, request, **kwargs):
+    """POST into *view* with the request bound (see :func:`_bind_and_call`)."""
+    return _bind_and_call(view, request, "post", **kwargs)
+
+
+def _get(view, request, **kwargs):
+    """GET into *view* with the request bound (see :func:`_bind_and_call`)."""
+    return _bind_and_call(view, request, "get", **kwargs)
+
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -52,7 +72,9 @@ class TestSyncCablesViewPermissionDenied:
         view.require_all_permissions = MagicMock(return_value=_denied_response())
         view.request = _make_request()
 
-        with patch("netbox_librenms_plugin.views.sync.cables.get_object_or_404") as mock_get:
+        with patch(
+            "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404"
+        ) as mock_get:
             result = view.post(view.request, pk=1)
 
         assert result.status_code == 403
@@ -72,7 +94,10 @@ class TestSyncCablesViewCacheMiss:
         mock_device = MagicMock(pk=1)
 
         with (
-            patch("netbox_librenms_plugin.views.sync.cables.get_object_or_404", return_value=mock_device),
+            patch(
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+                return_value=mock_device,
+            ),
             patch("netbox_librenms_plugin.views.sync.cables.cache") as mock_cache,
             patch("netbox_librenms_plugin.views.sync.cables.messages") as mock_msgs,
             patch("netbox_librenms_plugin.views.sync.cables.redirect") as mock_redirect,
@@ -101,7 +126,10 @@ class TestSyncCablesViewNoSelection:
         mock_device = MagicMock(pk=1)
 
         with (
-            patch("netbox_librenms_plugin.views.sync.cables.get_object_or_404", return_value=mock_device),
+            patch(
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+                return_value=mock_device,
+            ),
             patch("netbox_librenms_plugin.views.sync.cables.cache") as mock_cache,
             patch("netbox_librenms_plugin.views.sync.cables.messages") as mock_msgs,
             patch("netbox_librenms_plugin.views.sync.cables.redirect"),
@@ -143,7 +171,10 @@ class TestSyncCablesViewSuccessPath:
         }
 
         with (
-            patch("netbox_librenms_plugin.views.sync.cables.get_object_or_404", return_value=dev_local),
+            patch(
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+                return_value=dev_local,
+            ),
             patch("netbox_librenms_plugin.views.sync.cables.cache") as mock_cache,
             patch("netbox_librenms_plugin.views.sync.cables.messages") as mock_msgs,
             patch("netbox_librenms_plugin.views.sync.cables.redirect"),
@@ -194,7 +225,10 @@ class TestSyncCablesViewSkipsOOBRows:
         }
 
         with (
-            patch("netbox_librenms_plugin.views.sync.cables.get_object_or_404", return_value=dev_local),
+            patch(
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+                return_value=dev_local,
+            ),
             patch("netbox_librenms_plugin.views.sync.cables.cache") as mock_cache,
             patch("netbox_librenms_plugin.views.sync.cables.messages") as mock_msgs,
             patch("netbox_librenms_plugin.views.sync.cables.redirect"),
@@ -233,7 +267,10 @@ class TestSyncCablesViewDuplicateCable:
         }
 
         with (
-            patch("netbox_librenms_plugin.views.sync.cables.get_object_or_404", return_value=mock_device),
+            patch(
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+                return_value=mock_device,
+            ),
             patch("netbox_librenms_plugin.views.sync.cables.cache") as mock_cache,
             patch("netbox_librenms_plugin.views.sync.cables.messages") as mock_msgs,
             patch("netbox_librenms_plugin.views.sync.cables.redirect"),
@@ -281,7 +318,10 @@ class TestSyncCablesViewMissingRemote:
             pass
 
         with (
-            patch("netbox_librenms_plugin.views.sync.cables.get_object_or_404", return_value=mock_device),
+            patch(
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+                return_value=mock_device,
+            ),
             patch("netbox_librenms_plugin.views.sync.cables.cache") as mock_cache,
             patch("netbox_librenms_plugin.views.sync.cables.messages") as mock_msgs,
             patch("netbox_librenms_plugin.views.sync.cables.redirect"),
@@ -314,7 +354,10 @@ class TestSyncCablesViewMissingLinkData:
         mock_device = MagicMock(pk=1)
 
         with (
-            patch("netbox_librenms_plugin.views.sync.cables.get_object_or_404", return_value=mock_device),
+            patch(
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+                return_value=mock_device,
+            ),
             patch("netbox_librenms_plugin.views.sync.cables.cache") as mock_cache,
             patch("netbox_librenms_plugin.views.sync.cables.messages") as mock_msgs,
             patch("netbox_librenms_plugin.views.sync.cables.redirect"),
@@ -345,7 +388,10 @@ class TestSyncCablesViewInvalidLinkData:
         link_data = {"local_port_id": "port1", "local_port": "Gi0/1", "netbox_remote_interface_id": 20}
 
         with (
-            patch("netbox_librenms_plugin.views.sync.cables.get_object_or_404", return_value=mock_device),
+            patch(
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+                return_value=mock_device,
+            ),
             patch("netbox_librenms_plugin.views.sync.cables.cache") as mock_cache,
             patch("netbox_librenms_plugin.views.sync.cables.messages") as mock_msgs,
             patch("netbox_librenms_plugin.views.sync.cables.redirect"),
@@ -811,7 +857,10 @@ class TestAddDeviceToLibreNMSViewGetFormClass:
         view = object.__new__(AddDeviceToLibreNMSView)
         mock_vm = MagicMock()
 
-        with patch("netbox_librenms_plugin.views.sync.devices.get_object_or_404", return_value=mock_vm):
+        with patch(
+            "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+            return_value=mock_vm,
+        ):
             result = view.get_object(5, object_type="virtualmachine")
         assert result is mock_vm
 
@@ -833,7 +882,7 @@ class TestAddDeviceToLibreNMSViewGetFormClass:
         import pytest
 
         with patch(
-            "netbox_librenms_plugin.views.sync.devices.get_object_or_404",
+            "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
             side_effect=Http404,
         ):
             with pytest.raises(Http404):
@@ -904,12 +953,15 @@ class TestUpdateDeviceLocationView:
         mock_api.update_device_field.return_value = (True, "ok")
 
         with (
-            patch("netbox_librenms_plugin.views.sync.devices.get_object_or_404", return_value=mock_device),
+            patch(
+                "netbox_librenms_plugin.views.sync.devices.get_object_or_404",
+                return_value=mock_device,
+            ),
             patch("netbox_librenms_plugin.views.sync.devices.messages") as mock_msgs,
             patch("netbox_librenms_plugin.views.sync.devices._device_sync_redirect"),
         ):
             view.request = _make_request()
-            view.post(view.request, pk=1)
+            _post(view, view.request, pk=1)
 
         mock_api.update_device_field.assert_called_once()
         mock_msgs.success.assert_called_once()
@@ -923,12 +975,15 @@ class TestUpdateDeviceLocationView:
         mock_api.update_device_field.return_value = (False, "Connection refused")
 
         with (
-            patch("netbox_librenms_plugin.views.sync.devices.get_object_or_404", return_value=mock_device),
+            patch(
+                "netbox_librenms_plugin.views.sync.devices.get_object_or_404",
+                return_value=mock_device,
+            ),
             patch("netbox_librenms_plugin.views.sync.devices.messages") as mock_msgs,
             patch("netbox_librenms_plugin.views.sync.devices._device_sync_redirect"),
         ):
             view.request = _make_request()
-            view.post(view.request, pk=1)
+            _post(view, view.request, pk=1)
 
         mock_msgs.error.assert_called_once()
 
@@ -939,12 +994,15 @@ class TestUpdateDeviceLocationView:
         mock_device.site = None
 
         with (
-            patch("netbox_librenms_plugin.views.sync.devices.get_object_or_404", return_value=mock_device),
+            patch(
+                "netbox_librenms_plugin.views.sync.devices.get_object_or_404",
+                return_value=mock_device,
+            ),
             patch("netbox_librenms_plugin.views.sync.devices.messages") as mock_msgs,
             patch("netbox_librenms_plugin.views.sync.devices._device_sync_redirect"),
         ):
             view.request = _make_request()
-            view.post(view.request, pk=1)
+            _post(view, view.request, pk=1)
 
         mock_msgs.warning.assert_called_once()
 
@@ -977,7 +1035,10 @@ class TestSyncIPAddressesViewUnknownServerKey:
         mock_api = MagicMock(server_key="default")
 
         with (
-            patch("netbox_librenms_plugin.views.sync.ip_addresses.get_object_or_404", return_value=mock_device),
+            patch(
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+                return_value=mock_device,
+            ),
             # Drive the REAL failure mode end to end: LibreNMSAPI raises KeyError for an
             # unknown key, and the real build_librenms_api must swallow it into None so
             # the view degrades gracefully. Mocking build_librenms_api=None directly would
@@ -1011,7 +1072,10 @@ class TestSyncIPAddressesViewCacheMiss:
         mock_api = MagicMock(server_key="default")
 
         with (
-            patch("netbox_librenms_plugin.views.sync.ip_addresses.get_object_or_404", return_value=mock_device),
+            patch(
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+                return_value=mock_device,
+            ),
             patch("netbox_librenms_plugin.views.sync.ip_addresses.cache") as mock_cache,
             patch("netbox_librenms_plugin.views.sync.ip_addresses.messages") as mock_msgs,
             patch("netbox_librenms_plugin.views.sync.ip_addresses.redirect"),
@@ -1039,7 +1103,10 @@ class TestSyncIPAddressesViewNoSelection:
         mock_api = MagicMock(server_key="default")
 
         with (
-            patch("netbox_librenms_plugin.views.sync.ip_addresses.get_object_or_404", return_value=mock_device),
+            patch(
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+                return_value=mock_device,
+            ),
             patch("netbox_librenms_plugin.views.sync.ip_addresses.cache") as mock_cache,
             patch("netbox_librenms_plugin.views.sync.ip_addresses.messages") as mock_msgs,
             patch("netbox_librenms_plugin.views.sync.ip_addresses.redirect"),
@@ -1165,7 +1232,10 @@ class TestSyncIPAddressesViewHelpers:
 
         view = object.__new__(SyncIPAddressesView)
         mock_device = MagicMock()
-        with patch("netbox_librenms_plugin.views.sync.ip_addresses.get_object_or_404", return_value=mock_device):
+        with patch(
+            "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+            return_value=mock_device,
+        ):
             result = view.get_object("device", 1)
         assert result is mock_device
 
@@ -1174,7 +1244,10 @@ class TestSyncIPAddressesViewHelpers:
 
         view = object.__new__(SyncIPAddressesView)
         mock_vm = MagicMock()
-        with patch("netbox_librenms_plugin.views.sync.ip_addresses.get_object_or_404", return_value=mock_vm):
+        with patch(
+            "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+            return_value=mock_vm,
+        ):
             result = view.get_object("virtualmachine", 1)
         assert result is mock_vm
 
@@ -1315,7 +1388,10 @@ class TestSyncIPAddressesViewVMInterface:
         }
 
         with (
-            patch("netbox_librenms_plugin.views.sync.ip_addresses.get_object_or_404", return_value=mock_vm),
+            patch(
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+                return_value=mock_vm,
+            ),
             patch("netbox_librenms_plugin.views.sync.ip_addresses.cache") as mock_cache,
             patch("netbox_librenms_plugin.views.sync.ip_addresses.messages"),
             patch("netbox_librenms_plugin.views.sync.ip_addresses.redirect"),
@@ -1652,7 +1728,10 @@ class TestSyncVLANsViewInvalidAction:
         mock_device = MagicMock(pk=1)
 
         with (
-            patch("netbox_librenms_plugin.views.sync.vlans.get_object_or_404", return_value=mock_device),
+            patch(
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+                return_value=mock_device,
+            ),
             patch("netbox_librenms_plugin.views.sync.vlans.messages") as mock_msgs,
             patch("netbox_librenms_plugin.views.sync.vlans.redirect"),
             patch("netbox_librenms_plugin.views.sync.vlans.transaction"),
@@ -1678,7 +1757,10 @@ class TestSyncVLANsViewNoSelection:
         mock_device = MagicMock(pk=1)
 
         with (
-            patch("netbox_librenms_plugin.views.sync.vlans.get_object_or_404", return_value=mock_device),
+            patch(
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+                return_value=mock_device,
+            ),
             patch("netbox_librenms_plugin.views.sync.vlans.cache") as mock_cache,
             patch("netbox_librenms_plugin.views.sync.vlans.messages") as mock_msgs,
             patch("netbox_librenms_plugin.views.sync.vlans.redirect"),
@@ -1706,7 +1788,10 @@ class TestSyncVLANsViewCacheMiss:
         mock_device = MagicMock(pk=1)
 
         with (
-            patch("netbox_librenms_plugin.views.sync.vlans.get_object_or_404", return_value=mock_device),
+            patch(
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+                return_value=mock_device,
+            ),
             patch("netbox_librenms_plugin.views.sync.vlans.cache") as mock_cache,
             patch("netbox_librenms_plugin.views.sync.vlans.messages") as mock_msgs,
             patch("netbox_librenms_plugin.views.sync.vlans.redirect"),
@@ -1840,7 +1925,10 @@ class TestSyncVLANsViewWithGroup:
         librenms_vlans = [{"vlan_vlan": 200, "vlan_name": "Production"}]
 
         with (
-            patch("netbox_librenms_plugin.views.sync.vlans.get_object_or_404", return_value=mock_device),
+            patch(
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+                return_value=mock_device,
+            ),
             patch("netbox_librenms_plugin.views.sync.vlans.cache") as mock_cache,
             patch("netbox_librenms_plugin.views.sync.vlans.messages"),
             patch("netbox_librenms_plugin.views.sync.vlans.redirect"),
@@ -1882,7 +1970,10 @@ class TestSyncVLANsViewWithGroup:
             pass
 
         with (
-            patch("netbox_librenms_plugin.views.sync.vlans.get_object_or_404", return_value=mock_device),
+            patch(
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+                return_value=mock_device,
+            ),
             patch("netbox_librenms_plugin.views.sync.vlans.cache") as mock_cache,
             patch("netbox_librenms_plugin.views.sync.vlans.messages") as mock_messages,
             patch("netbox_librenms_plugin.views.sync.vlans.redirect"),
@@ -1919,7 +2010,10 @@ class TestSyncVLANsViewWithGroup:
         librenms_vlans = [{"vlan_vlan": 100, "vlan_name": "Mgmt"}]
 
         with (
-            patch("netbox_librenms_plugin.views.sync.vlans.get_object_or_404", return_value=mock_device),
+            patch(
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+                return_value=mock_device,
+            ),
             patch("netbox_librenms_plugin.views.sync.vlans.cache") as mock_cache,
             patch("netbox_librenms_plugin.views.sync.vlans.messages"),
             patch("netbox_librenms_plugin.views.sync.vlans.redirect"),
@@ -1949,7 +2043,10 @@ class TestSyncVLANsViewWithGroup:
         librenms_vlans = [{"vlan_vlan": 100, "vlan_name": "Mgmt"}]
 
         with (
-            patch("netbox_librenms_plugin.views.sync.vlans.get_object_or_404", return_value=mock_device),
+            patch(
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+                return_value=mock_device,
+            ),
             patch("netbox_librenms_plugin.views.sync.vlans.cache") as mock_cache,
             patch("netbox_librenms_plugin.views.sync.vlans.messages"),
             patch("netbox_librenms_plugin.views.sync.vlans.redirect"),
@@ -1978,7 +2075,10 @@ class TestSyncVLANsViewWithGroup:
         librenms_vlans = [{"vlan_vlan": 100, "vlan_name": "Mgmt"}]
 
         with (
-            patch("netbox_librenms_plugin.views.sync.vlans.get_object_or_404", return_value=mock_device),
+            patch(
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+                return_value=mock_device,
+            ),
             patch("netbox_librenms_plugin.views.sync.vlans.cache") as mock_cache,
             patch("netbox_librenms_plugin.views.sync.vlans.messages") as mock_msgs,
             patch("netbox_librenms_plugin.views.sync.vlans.redirect"),
@@ -2014,7 +2114,10 @@ class TestSyncVLANsViewGroupedUpdateSkip:
         librenms_vlans = [{"vlan_vlan": 300, "vlan_name": "NewGroupedName"}]
 
         with (
-            patch("netbox_librenms_plugin.views.sync.vlans.get_object_or_404", return_value=mock_device),
+            patch(
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+                return_value=mock_device,
+            ),
             patch("netbox_librenms_plugin.views.sync.vlans.cache") as mock_cache,
             patch("netbox_librenms_plugin.views.sync.vlans.messages"),
             patch("netbox_librenms_plugin.views.sync.vlans.redirect"),
@@ -2050,7 +2153,10 @@ class TestSyncVLANsViewGroupedUpdateSkip:
         librenms_vlans = [{"vlan_vlan": 300, "vlan_name": "SameName"}]
 
         with (
-            patch("netbox_librenms_plugin.views.sync.vlans.get_object_or_404", return_value=mock_device),
+            patch(
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+                return_value=mock_device,
+            ),
             patch("netbox_librenms_plugin.views.sync.vlans.cache") as mock_cache,
             patch("netbox_librenms_plugin.views.sync.vlans.messages") as mock_msgs,
             patch("netbox_librenms_plugin.views.sync.vlans.redirect"),
@@ -2076,7 +2182,10 @@ class TestSyncVLANsViewGroupedUpdateSkip:
 
         view = object.__new__(SyncVLANsView)
         mock_device = MagicMock()
-        with patch("netbox_librenms_plugin.views.sync.vlans.get_object_or_404", return_value=mock_device):
+        with patch(
+            "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+            return_value=mock_device,
+        ):
             result = view.get_object("device", 1)
         assert result is mock_device
 

--- a/netbox_librenms_plugin/tests/test_coverage_sync_views2.py
+++ b/netbox_librenms_plugin/tests/test_coverage_sync_views2.py
@@ -1883,6 +1883,47 @@ class TestSyncIPAddressesViewInterfaceResolution:
         assert any("matched interface is not eligible" in text for text in warnings)
         assert all("Sync interfaces first" not in text for text in warnings)
 
+    def test_primary_ip_row_locks_the_device_before_writing_the_address(self):
+        """The primary-IP row writes the address and then the device (primary_ip4), while the migrate move views lock Device then IPAddress — so this path must take the device row lock FIRST or the two orders close a deadlock cycle."""
+        from django.db import connection
+        from django.test.utils import CaptureQueriesContext
+
+        from netbox_librenms_plugin.utils import set_librenms_device_id
+
+        dev = make_device("ipres-lockorder")
+        iface = make_interface(dev, "eth0")
+        set_librenms_device_id(iface, 5, "default")
+        iface.save()
+
+        view = self._view()
+        view._post_server_key = "default"
+        view.get_management_ip = MagicMock(return_value="10.0.0.1")
+
+        ip_data = {
+            "ip_address": "10.0.0.1",
+            "ip_with_mask": "10.0.0.1/24",
+            "interface_url": None,
+            "port_id": 5,
+            "interface_name": "eth0",
+        }
+        request = _make_request(post_data={"select": ["10.0.0.1"]})
+        with (
+            patch(
+                "netbox_librenms_plugin.views.sync.ip_addresses.resolve_set_primary_ip",
+                return_value=True,
+            ),
+            CaptureQueriesContext(connection) as ctx,
+        ):
+            results = view.process_ip_sync(request, ["10.0.0.1"], [ip_data], dev, "device")
+
+        assert results["primary_set"] == ["10.0.0.1"]
+        sqls = [q["sql"] for q in ctx.captured_queries]
+        device_locks = [i for i, sql in enumerate(sqls) if 'FROM "dcim_device"' in sql and "FOR UPDATE" in sql]
+        address_writes = [i for i, sql in enumerate(sqls) if 'INSERT INTO "ipam_ipaddress"' in sql]
+        assert device_locks, "the primary-IP row must lock the device row (SELECT ... FOR UPDATE)"
+        assert address_writes, "the address must be written"
+        assert min(device_locks) < min(address_writes), "the device lock must precede the address write"
+
     def test_build_interface_maps_vc_shared_name_prefers_viewed_member(self):
         """A name shared across VC members resolves to the VIEWED member's own interface (matching the rendered table), not ambiguous."""
         _vc, members = self._make_vc("ipres-vcdup", [1, 2])

--- a/netbox_librenms_plugin/tests/test_coverage_sync_views3.py
+++ b/netbox_librenms_plugin/tests/test_coverage_sync_views3.py
@@ -20,6 +20,7 @@ from netbox_librenms_plugin.tests.view_test_helpers import (
     make_user_with_perms,
     make_view,
     message_texts,
+    missing_pk,
 )
 from netbox_librenms_plugin.tests.view_test_helpers import post as _post
 
@@ -375,8 +376,8 @@ class TestSyncInterface:
         from dcim.models import Device, Interface
 
         dev = make_device("sync-gone")
-        missing_pk = Device.objects.order_by("-pk").first().pk + 1000
-        req = make_request("post", {"device_selection_eth0": str(missing_pk)})
+        absent_pk = missing_pk(Device)
+        req = make_request("post", {"device_selection_eth0": str(absent_pk)})
         v = self._v(req)
 
         v.sync_interface(dev, {"ifName": "eth0"}, [], "ifName")
@@ -704,7 +705,7 @@ class TestDeleteNetBoxInterfacesPost:
         from dcim.models import Interface
 
         dev = make_device("del-missing")
-        gone_pk = (Interface.objects.order_by("-pk").first().pk if Interface.objects.exists() else 0) + 1000
+        gone_pk = missing_pk(Interface)
         req = make_request("post", {"interface_ids": [str(gone_pk)]})
 
         response = _post(_make_dv(req), req, object_type="device", object_id=dev.pk)

--- a/netbox_librenms_plugin/tests/test_coverage_sync_views3.py
+++ b/netbox_librenms_plugin/tests/test_coverage_sync_views3.py
@@ -13,7 +13,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from netbox_librenms_plugin.tests.conftest import make_device, make_interface, make_vm
+from netbox_librenms_plugin.tests.conftest import make_device, make_interface, make_virtual_chassis, make_vm
 from netbox_librenms_plugin.tests.view_test_helpers import (
     grant,
     make_request,
@@ -307,21 +307,6 @@ class TestSyncInterface:
         v._skipped_conflicts = []
         return v
 
-    @staticmethod
-    def _vc(tag, count=2):
-        """A real VirtualChassis with *count* members at consecutive positions."""
-        from dcim.models import VirtualChassis
-
-        vc = VirtualChassis.objects.create(name=f"vc-{tag}")
-        members = []
-        for position in range(1, count + 1):
-            member = make_device(f"{tag}-m{position}")
-            member.virtual_chassis = vc
-            member.vc_position = position
-            member.save()
-            members.append(member)
-        return vc, members
-
     def test_device_no_vc_uses_obj(self):
         from dcim.models import Interface
 
@@ -337,7 +322,7 @@ class TestSyncInterface:
         """A posted sibling of the same chassis is honoured: the interface lands on the sibling."""
         from dcim.models import Interface
 
-        _vc, (host, sibling) = self._vc("sync-vc-ok")
+        _vc, (host, sibling) = make_virtual_chassis("sync-vc-ok")
         req = make_request("post", {"device_selection_eth0": str(sibling.pk)})
         v = self._v(req)
 
@@ -350,7 +335,7 @@ class TestSyncInterface:
         """A device outside the chassis is refused without writing to the page device."""
         from dcim.models import Interface
 
-        _vc, (host, _sibling) = self._vc("sync-vc-outsider")
+        _vc, (host, _sibling) = make_virtual_chassis("sync-vc-outsider")
         outsider = make_device("sync-vc-outsider-x")
         req = make_request("post", {"device_selection_eth0": str(outsider.pk)})
         v = self._v(req)
@@ -359,7 +344,7 @@ class TestSyncInterface:
 
         assert not Interface.objects.filter(device=host, name="eth0").exists()
         assert not Interface.objects.filter(device=outsider, name="eth0").exists()
-        assert v._skipped_conflicts == ["eth0"]
+        assert v._skipped_conflicts == ["eth0 (selected target unavailable)"]
 
     def test_device_no_vc_wrong_selection_is_skipped(self):
         from dcim.models import Interface
@@ -373,7 +358,7 @@ class TestSyncInterface:
 
         assert not Interface.objects.filter(device=dev, name="eth0").exists()
         assert not Interface.objects.filter(device=other, name="eth0").exists()
-        assert v._skipped_conflicts == ["eth0"]
+        assert v._skipped_conflicts == ["eth0 (selected target unavailable)"]
 
     def test_device_selection_does_not_exist_is_skipped(self):
         from dcim.models import Device, Interface
@@ -386,13 +371,13 @@ class TestSyncInterface:
         v.sync_interface(dev, {"ifName": "eth0"}, [], "ifName")
 
         assert not Interface.objects.filter(device=dev, name="eth0").exists()
-        assert v._skipped_conflicts == ["eth0"]
+        assert v._skipped_conflicts == ["eth0 (selected target unavailable)"]
 
     def test_device_selection_outside_the_grant_is_skipped(self):
         """The posted id is client-supplied, so a constrained grant must not reach the sibling."""
         from dcim.models import Device, Interface
 
-        _vc, (host, sibling) = self._vc("sync-vc-scoped")
+        _vc, (host, sibling) = make_virtual_chassis("sync-vc-scoped")
         user = make_user_with_perms("sync-scoped", [("view", Device)], constraints={"name": "sync-vc-scoped-m1"})
         req = make_request("post", {"device_selection_eth0": str(sibling.pk)}, user=user)
         v = self._v(req)
@@ -401,7 +386,7 @@ class TestSyncInterface:
 
         assert not Interface.objects.filter(device=host, name="eth0").exists()
         assert not Interface.objects.filter(device=sibling, name="eth0").exists()
-        assert v._skipped_conflicts == ["eth0"]
+        assert v._skipped_conflicts == ["eth0 (selected target unavailable)"]
 
     def test_vm_uses_vminterface(self):
         from virtualization.models import VMInterface

--- a/netbox_librenms_plugin/tests/test_coverage_sync_views3.py
+++ b/netbox_librenms_plugin/tests/test_coverage_sync_views3.py
@@ -13,7 +13,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from netbox_librenms_plugin.tests.conftest import make_device, make_interface, make_virtual_chassis, make_vm
+from netbox_librenms_plugin.tests.conftest import make_device, make_interface, make_virtual_chassis_members, make_vm
 from netbox_librenms_plugin.tests.view_test_helpers import (
     grant,
     make_request,
@@ -322,7 +322,7 @@ class TestSyncInterface:
         """A posted sibling of the same chassis is honoured: the interface lands on the sibling."""
         from dcim.models import Interface
 
-        _vc, (host, sibling) = make_virtual_chassis("sync-vc-ok")
+        _vc, (host, sibling) = make_virtual_chassis_members("sync-vc-ok")
         req = make_request("post", {"device_selection_eth0": str(sibling.pk)})
         v = self._v(req)
 
@@ -335,7 +335,7 @@ class TestSyncInterface:
         """A device outside the chassis is refused without writing to the page device."""
         from dcim.models import Interface
 
-        _vc, (host, _sibling) = make_virtual_chassis("sync-vc-outsider")
+        _vc, (host, _sibling) = make_virtual_chassis_members("sync-vc-outsider")
         outsider = make_device("sync-vc-outsider-x")
         req = make_request("post", {"device_selection_eth0": str(outsider.pk)})
         v = self._v(req)
@@ -377,7 +377,7 @@ class TestSyncInterface:
         """The posted id is client-supplied, so a constrained grant must not reach the sibling."""
         from dcim.models import Device, Interface
 
-        _vc, (host, sibling) = make_virtual_chassis("sync-vc-scoped")
+        _vc, (host, sibling) = make_virtual_chassis_members("sync-vc-scoped")
         user = make_user_with_perms("sync-scoped", [("view", Device)], constraints={"name": "sync-vc-scoped-m1"})
         req = make_request("post", {"device_selection_eth0": str(sibling.pk)}, user=user)
         v = self._v(req)

--- a/netbox_librenms_plugin/tests/test_coverage_sync_views3.py
+++ b/netbox_librenms_plugin/tests/test_coverage_sync_views3.py
@@ -586,6 +586,7 @@ class TestDeleteNetBoxInterfacesPost:
             "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404", return_value=obj
         ):
             with patch("netbox_librenms_plugin.views.sync.interfaces.Interface") as mc:
+                mc.objects.restrict.return_value = mc.objects
                 mc.objects.get.return_value = iface
                 with patch("netbox_librenms_plugin.views.sync.interfaces.transaction") as mt:
                     mt.atomic = _pa
@@ -612,6 +613,7 @@ class TestDeleteNetBoxInterfacesPost:
             "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404", return_value=obj
         ):
             with patch("netbox_librenms_plugin.views.sync.interfaces.Interface") as mc:
+                mc.objects.restrict.return_value = mc.objects
                 mc.objects.get.return_value = iface
                 with patch("netbox_librenms_plugin.views.sync.interfaces.transaction") as mt:
                     mt.atomic = _pa
@@ -644,6 +646,7 @@ class TestDeleteNetBoxInterfacesPost:
             "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404", return_value=obj
         ):
             with patch("netbox_librenms_plugin.views.sync.interfaces.Interface") as mc:
+                mc.objects.restrict.return_value = mc.objects
                 mc.objects.get.return_value = iface
                 with patch("netbox_librenms_plugin.views.sync.interfaces.transaction") as mt:
                     mt.atomic = _pa
@@ -676,6 +679,7 @@ class TestDeleteNetBoxInterfacesPost:
             "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404", return_value=obj
         ):
             with patch("netbox_librenms_plugin.views.sync.interfaces.Interface") as mc:
+                mc.objects.restrict.return_value = mc.objects
                 mc.objects.get.return_value = iface
                 with patch("netbox_librenms_plugin.views.sync.interfaces.transaction") as mt:
                     mt.atomic = _pa
@@ -700,6 +704,7 @@ class TestDeleteNetBoxInterfacesPost:
             "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404", return_value=obj
         ):
             with patch("netbox_librenms_plugin.views.sync.interfaces.VMInterface") as mc:
+                mc.objects.restrict.return_value = mc.objects
                 mc.objects.get.return_value = iface
                 with patch("netbox_librenms_plugin.views.sync.interfaces.transaction") as mt:
                     mt.atomic = _pa
@@ -725,6 +730,7 @@ class TestDeleteNetBoxInterfacesPost:
             "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404", return_value=obj
         ):
             with patch("netbox_librenms_plugin.views.sync.interfaces.VMInterface") as mc:
+                mc.objects.restrict.return_value = mc.objects
                 mc.objects.get.return_value = iface
                 with patch("netbox_librenms_plugin.views.sync.interfaces.transaction") as mt:
                     mt.atomic = _pa
@@ -751,6 +757,7 @@ class TestDeleteNetBoxInterfacesPost:
         ):
             with patch("netbox_librenms_plugin.views.sync.interfaces.Interface") as mc:
                 mc.DoesNotExist = Interface.DoesNotExist
+                mc.objects.restrict.return_value = mc.objects
                 mc.objects.get.side_effect = Interface.DoesNotExist
                 with patch("netbox_librenms_plugin.views.sync.interfaces.VMInterface") as mvc:
                     mvc.DoesNotExist = VMI.DoesNotExist
@@ -787,6 +794,7 @@ class TestDeleteNetBoxInterfacesPost:
             "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404", return_value=obj
         ):
             with patch("netbox_librenms_plugin.views.sync.interfaces.Interface") as mc:
+                mc.objects.restrict.return_value = mc.objects
                 mc.objects.get.side_effect = get_se
                 with patch("netbox_librenms_plugin.views.sync.interfaces.transaction") as mt:
                     mt.atomic = _pa

--- a/netbox_librenms_plugin/tests/test_coverage_sync_views3.py
+++ b/netbox_librenms_plugin/tests/test_coverage_sync_views3.py
@@ -304,6 +304,7 @@ class TestSyncInterface:
         v.update_interface_attributes = MagicMock()
         v._sync_interface_vlans = MagicMock()
         v._lookup_maps = {}
+        v._skipped_conflicts = []
         return v
 
     @staticmethod
@@ -345,8 +346,8 @@ class TestSyncInterface:
         assert Interface.objects.filter(device=sibling, name="eth0").exists()
         assert not Interface.objects.filter(device=host, name="eth0").exists()
 
-    def test_device_vc_target_not_in_valid_ids_falls_back(self):
-        """A device outside the chassis is refused; the row lands on the page device."""
+    def test_device_vc_target_not_in_valid_ids_is_skipped(self):
+        """A device outside the chassis is refused without writing to the page device."""
         from dcim.models import Interface
 
         _vc, (host, _sibling) = self._vc("sync-vc-outsider")
@@ -356,10 +357,11 @@ class TestSyncInterface:
 
         v.sync_interface(host, {"ifName": "eth0"}, [], "ifName")
 
-        assert Interface.objects.filter(device=host, name="eth0").exists()
+        assert not Interface.objects.filter(device=host, name="eth0").exists()
         assert not Interface.objects.filter(device=outsider, name="eth0").exists()
+        assert v._skipped_conflicts == ["eth0"]
 
-    def test_device_no_vc_wrong_selection_falls_back(self):
+    def test_device_no_vc_wrong_selection_is_skipped(self):
         from dcim.models import Interface
 
         dev = make_device("sync-novc-self")
@@ -369,10 +371,11 @@ class TestSyncInterface:
 
         v.sync_interface(dev, {"ifName": "eth0"}, [], "ifName")
 
-        assert Interface.objects.filter(device=dev, name="eth0").exists()
+        assert not Interface.objects.filter(device=dev, name="eth0").exists()
         assert not Interface.objects.filter(device=other, name="eth0").exists()
+        assert v._skipped_conflicts == ["eth0"]
 
-    def test_device_selection_does_not_exist_falls_back(self):
+    def test_device_selection_does_not_exist_is_skipped(self):
         from dcim.models import Device, Interface
 
         dev = make_device("sync-gone")
@@ -382,9 +385,10 @@ class TestSyncInterface:
 
         v.sync_interface(dev, {"ifName": "eth0"}, [], "ifName")
 
-        assert Interface.objects.filter(device=dev, name="eth0").exists()
+        assert not Interface.objects.filter(device=dev, name="eth0").exists()
+        assert v._skipped_conflicts == ["eth0"]
 
-    def test_device_selection_outside_the_grant_falls_back(self):
+    def test_device_selection_outside_the_grant_is_skipped(self):
         """The posted id is client-supplied, so a constrained grant must not reach the sibling."""
         from dcim.models import Device, Interface
 
@@ -395,8 +399,9 @@ class TestSyncInterface:
 
         v.sync_interface(host, {"ifName": "eth0"}, [], "ifName")
 
-        assert Interface.objects.filter(device=host, name="eth0").exists()
+        assert not Interface.objects.filter(device=host, name="eth0").exists()
         assert not Interface.objects.filter(device=sibling, name="eth0").exists()
+        assert v._skipped_conflicts == ["eth0"]
 
     def test_vm_uses_vminterface(self):
         from virtualization.models import VMInterface

--- a/netbox_librenms_plugin/tests/test_coverage_sync_views3.py
+++ b/netbox_librenms_plugin/tests/test_coverage_sync_views3.py
@@ -11,32 +11,40 @@ Targets:
 from contextlib import contextmanager
 from unittest.mock import MagicMock, patch
 
+import pytest
+
+from netbox_librenms_plugin.tests.conftest import make_device, make_interface, make_vm
+from netbox_librenms_plugin.tests.view_test_helpers import (
+    grant,
+    make_request,
+    make_user_with_perms,
+    make_view,
+    message_texts,
+)
+from netbox_librenms_plugin.tests.view_test_helpers import post as _post
+
+# Every view here is now built with a real request and a real user, so all of it needs the DB.
+pytestmark = pytest.mark.django_db
+
 
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
 
 
-def _make_iv():
+def _make_iv(request=None):
     from netbox_librenms_plugin.views.sync.interfaces import SyncInterfacesView
 
-    v = object.__new__(SyncInterfacesView)
-    v._librenms_api = MagicMock()
-    v._librenms_api.server_key = "default"
+    v = make_view(SyncInterfacesView, request)
     v._post_server_key = "default"
-    v.request = MagicMock()
-    v.request.POST.get = lambda k, *a: None
     v.object = MagicMock()
     return v
 
 
-def _make_dv():
+def _make_dv(request=None):
     from netbox_librenms_plugin.views.sync.interfaces import DeleteNetBoxInterfacesView
 
-    v = object.__new__(DeleteNetBoxInterfacesView)
-    v._librenms_api = MagicMock()
-    v.request = MagicMock()
-    return v
+    return make_view(DeleteNetBoxInterfacesView, request)
 
 
 @contextmanager
@@ -67,7 +75,6 @@ class TestGetRequiredPermissionsForObjectType:
         assert any(a == "add" and m is VMInterface for a, m in perms)
 
     def test_invalid_raises_http404(self):
-        import pytest
         from django.http import Http404
 
         v = _make_iv()
@@ -82,25 +89,29 @@ class TestGetRequiredPermissionsForObjectType:
 
 class TestSyncInterfacesGetObject:
     def test_device_type(self):
-        v = _make_iv()
-        mock_obj = MagicMock()
-        with patch(
-            "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
-            return_value=mock_obj,
-        ):
-            assert v.get_object("device", 1) is mock_obj
+        dev = make_device("getobj-device")
+
+        assert _make_iv().get_object("device", dev.pk) == dev
 
     def test_vm_type(self):
-        v = _make_iv()
-        mock_obj = MagicMock()
-        with patch(
-            "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
-            return_value=mock_obj,
-        ):
-            assert v.get_object("virtualmachine", 2) is mock_obj
+        vm = make_vm("getobj-vm")
+
+        assert _make_iv().get_object("virtualmachine", vm.pk) == vm
+
+    def test_a_device_outside_the_grant_404s(self):
+        """The pk comes from the URL, so an out-of-scope id must 404 like a missing one."""
+        from dcim.models import Device
+        from django.http import Http404
+
+        make_device("getobj-mine")
+        theirs = make_device("getobj-theirs")
+        user = make_user_with_perms("getobj-scoped", [("view", Device)], constraints={"name": "getobj-mine"})
+        v = _make_iv(make_request(user=user))
+
+        with pytest.raises(Http404):
+            v.get_object("device", theirs.pk)
 
     def test_invalid_raises_http404(self):
-        import pytest
         from django.http import Http404
 
         v = _make_iv()
@@ -281,151 +292,136 @@ class TestSyncSelectedInterfaces:
 
 
 class TestSyncInterface:
-    def _v(self):
-        v = _make_iv()
+    """Which device the LibreNMS row is written to, resolved against real rows.
+
+    ``update_interface_attributes`` and ``_sync_interface_vlans`` stay stubbed: they are the
+    view's own next steps, and these tests are about target selection, not field copying.
+    """
+
+    def _v(self, request=None):
+        v = _make_iv(request)
         v.update_interface_attributes = MagicMock()
         v._sync_interface_vlans = MagicMock()
-        v.get_netbox_interface_type = MagicMock(return_value="1000base-t")
         v._lookup_maps = {}
         return v
 
-    def test_device_no_vc_uses_obj(self):
-        from dcim.models import Device
+    @staticmethod
+    def _vc(tag, count=2):
+        """A real VirtualChassis with *count* members at consecutive positions."""
+        from dcim.models import VirtualChassis
 
+        vc = VirtualChassis.objects.create(name=f"vc-{tag}")
+        members = []
+        for position in range(1, count + 1):
+            member = make_device(f"{tag}-m{position}")
+            member.virtual_chassis = vc
+            member.vc_position = position
+            member.save()
+            members.append(member)
+        return vc, members
+
+    def test_device_no_vc_uses_obj(self):
+        from dcim.models import Interface
+
+        dev = make_device("sync-novc")
         v = self._v()
-        obj = MagicMock(spec=Device)
-        obj.id = 1
-        obj.virtual_chassis = None
-        iface = MagicMock()
-        with patch("netbox_librenms_plugin.views.sync.interfaces.Interface") as mc:
-            mc.objects.restrict.return_value = mc.objects
-            mc.objects.get_or_create.return_value = (iface, True)
-            v.sync_interface(obj, {"ifName": "eth0"}, [], "ifName")
-        mc.objects.get_or_create.assert_called_once_with(device=obj, name="eth0")
+
+        v.sync_interface(dev, {"ifName": "eth0"}, [], "ifName")
+
+        assert Interface.objects.filter(device=dev, name="eth0").exists()
         v.update_interface_attributes.assert_called_once()
 
     def test_device_vc_target_in_valid_ids(self):
-        from dcim.models import Device
+        """A posted sibling of the same chassis is honoured: the interface lands on the sibling."""
+        from dcim.models import Interface
 
-        v = self._v()
-        obj = MagicMock(spec=Device)
-        obj.id = 1
-        vc = MagicMock()
-        vc.members.values_list.return_value = [1, 2, 3]
-        obj.virtual_chassis = vc
-        target = MagicMock()
-        target.id = 2
-        v.request.POST.get = lambda k, *a: "2" if k == "device_selection_eth0" else None
-        iface = MagicMock()
-        # Patch only Device.objects.get, not Device itself (isinstance must work)
-        # The VC-selected device is read through restrict(user, "view"), so stub that chain.
-        with patch("netbox_librenms_plugin.views.sync.interfaces.Device.objects.restrict") as mock_restrict:
-            mock_restrict.return_value.get.return_value = target
-            with patch("netbox_librenms_plugin.views.sync.interfaces.Interface") as mc:
-                mc.objects.restrict.return_value = mc.objects
-                mc.objects.get_or_create.return_value = (iface, True)
-                v.sync_interface(obj, {"ifName": "eth0"}, [], "ifName")
-        mc.objects.get_or_create.assert_called_once_with(device=target, name="eth0")
+        _vc, (host, sibling) = self._vc("sync-vc-ok")
+        req = make_request("post", {"device_selection_eth0": str(sibling.pk)})
+        v = self._v(req)
+
+        v.sync_interface(host, {"ifName": "eth0"}, [], "ifName")
+
+        assert Interface.objects.filter(device=sibling, name="eth0").exists()
+        assert not Interface.objects.filter(device=host, name="eth0").exists()
 
     def test_device_vc_target_not_in_valid_ids_falls_back(self):
-        from dcim.models import Device
+        """A device outside the chassis is refused; the row lands on the page device."""
+        from dcim.models import Interface
 
-        v = self._v()
-        obj = MagicMock(spec=Device)
-        obj.id = 1
-        vc = MagicMock()
-        vc.members.values_list.return_value = [1, 2, 3]
-        obj.virtual_chassis = vc
-        target = MagicMock()
-        target.id = 99
-        v.request.POST.get = lambda k, *a: "99" if k == "device_selection_eth0" else None
-        iface = MagicMock()
-        # The VC-selected device is read through restrict(user, "view"), so stub that chain.
-        with patch("netbox_librenms_plugin.views.sync.interfaces.Device.objects.restrict") as mock_restrict:
-            mock_restrict.return_value.get.return_value = target
-            with patch("netbox_librenms_plugin.views.sync.interfaces.Interface") as mc:
-                mc.objects.restrict.return_value = mc.objects
-                mc.objects.get_or_create.return_value = (iface, True)
-                v.sync_interface(obj, {"ifName": "eth0"}, [], "ifName")
-        mc.objects.get_or_create.assert_called_once_with(device=obj, name="eth0")
+        _vc, (host, _sibling) = self._vc("sync-vc-outsider")
+        outsider = make_device("sync-vc-outsider-x")
+        req = make_request("post", {"device_selection_eth0": str(outsider.pk)})
+        v = self._v(req)
+
+        v.sync_interface(host, {"ifName": "eth0"}, [], "ifName")
+
+        assert Interface.objects.filter(device=host, name="eth0").exists()
+        assert not Interface.objects.filter(device=outsider, name="eth0").exists()
 
     def test_device_no_vc_wrong_selection_falls_back(self):
-        from dcim.models import Device
+        from dcim.models import Interface
 
-        v = self._v()
-        obj = MagicMock(spec=Device)
-        obj.id = 1
-        obj.virtual_chassis = None
-        target = MagicMock()
-        target.id = 99
-        v.request.POST.get = lambda k, *a: "99" if k == "device_selection_eth0" else None
-        iface = MagicMock()
-        # The VC-selected device is read through restrict(user, "view"), so stub that chain.
-        with patch("netbox_librenms_plugin.views.sync.interfaces.Device.objects.restrict") as mock_restrict:
-            mock_restrict.return_value.get.return_value = target
-            with patch("netbox_librenms_plugin.views.sync.interfaces.Interface") as mc:
-                mc.objects.restrict.return_value = mc.objects
-                mc.objects.get_or_create.return_value = (iface, True)
-                v.sync_interface(obj, {"ifName": "eth0"}, [], "ifName")
-        mc.objects.get_or_create.assert_called_once_with(device=obj, name="eth0")
+        dev = make_device("sync-novc-self")
+        other = make_device("sync-novc-other")
+        req = make_request("post", {"device_selection_eth0": str(other.pk)})
+        v = self._v(req)
+
+        v.sync_interface(dev, {"ifName": "eth0"}, [], "ifName")
+
+        assert Interface.objects.filter(device=dev, name="eth0").exists()
+        assert not Interface.objects.filter(device=other, name="eth0").exists()
 
     def test_device_selection_does_not_exist_falls_back(self):
-        from dcim.models import Device
+        from dcim.models import Device, Interface
 
-        v = self._v()
-        obj = MagicMock(spec=Device)
-        obj.id = 1
-        obj.virtual_chassis = None
-        v.request.POST.get = lambda k, *a: "999" if k == "device_selection_eth0" else None
-        iface = MagicMock()
-        # Same chain: an unknown id raises DoesNotExist out of the restricted queryset.
-        with patch("netbox_librenms_plugin.views.sync.interfaces.Device.objects.restrict") as mock_restrict:
-            mock_restrict.return_value.get.side_effect = Device.DoesNotExist
-            with patch("netbox_librenms_plugin.views.sync.interfaces.Interface") as mc:
-                mc.objects.restrict.return_value = mc.objects
-                mc.objects.get_or_create.return_value = (iface, True)
-                v.sync_interface(obj, {"ifName": "eth0"}, [], "ifName")
-        mc.objects.get_or_create.assert_called_once_with(device=obj, name="eth0")
+        dev = make_device("sync-gone")
+        missing_pk = Device.objects.order_by("-pk").first().pk + 1000
+        req = make_request("post", {"device_selection_eth0": str(missing_pk)})
+        v = self._v(req)
+
+        v.sync_interface(dev, {"ifName": "eth0"}, [], "ifName")
+
+        assert Interface.objects.filter(device=dev, name="eth0").exists()
+
+    def test_device_selection_outside_the_grant_falls_back(self):
+        """The posted id is client-supplied, so a constrained grant must not reach the sibling."""
+        from dcim.models import Device, Interface
+
+        _vc, (host, sibling) = self._vc("sync-vc-scoped")
+        user = make_user_with_perms("sync-scoped", [("view", Device)], constraints={"name": "sync-vc-scoped-m1"})
+        req = make_request("post", {"device_selection_eth0": str(sibling.pk)}, user=user)
+        v = self._v(req)
+
+        v.sync_interface(host, {"ifName": "eth0"}, [], "ifName")
+
+        assert Interface.objects.filter(device=host, name="eth0").exists()
+        assert not Interface.objects.filter(device=sibling, name="eth0").exists()
 
     def test_vm_uses_vminterface(self):
-        from virtualization.models import VirtualMachine
+        from virtualization.models import VMInterface
 
+        vm = make_vm("sync-vm")
         v = self._v()
-        obj = MagicMock(spec=VirtualMachine)
-        iface = MagicMock()
-        with patch("netbox_librenms_plugin.views.sync.interfaces.VMInterface") as mc:
-            mc.objects.restrict.return_value = mc.objects
-            mc.objects.get_or_create.return_value = (iface, True)
-            v.sync_interface(obj, {"ifName": "eth0"}, [], "ifName")
-        mc.objects.get_or_create.assert_called_once_with(virtual_machine=obj, name="eth0")
+
+        v.sync_interface(vm, {"ifName": "eth0"}, [], "ifName")
+
+        assert VMInterface.objects.filter(virtual_machine=vm, name="eth0").exists()
         v.update_interface_attributes.assert_called_once()
 
     def test_vlans_excluded_skips_sync(self):
-        from dcim.models import Device
-
+        dev = make_device("sync-novlan")
         v = self._v()
-        obj = MagicMock(spec=Device)
-        obj.id = 1
-        obj.virtual_chassis = None
-        iface = MagicMock()
-        with patch("netbox_librenms_plugin.views.sync.interfaces.Interface") as mc:
-            mc.objects.restrict.return_value = mc.objects
-            mc.objects.get_or_create.return_value = (iface, True)
-            v.sync_interface(obj, {"ifName": "eth0"}, ["vlans"], "ifName")
+
+        v.sync_interface(dev, {"ifName": "eth0"}, ["vlans"], "ifName")
+
         v._sync_interface_vlans.assert_not_called()
 
     def test_vlans_not_excluded_calls_sync(self):
-        from dcim.models import Device
-
+        dev = make_device("sync-vlan")
         v = self._v()
-        obj = MagicMock(spec=Device)
-        obj.id = 1
-        obj.virtual_chassis = None
-        iface = MagicMock()
-        with patch("netbox_librenms_plugin.views.sync.interfaces.Interface") as mc:
-            mc.objects.restrict.return_value = mc.objects
-            mc.objects.get_or_create.return_value = (iface, True)
-            v.sync_interface(obj, {"ifName": "eth0"}, [], "ifName")
+
+        v.sync_interface(dev, {"ifName": "eth0"}, [], "ifName")
+
         v._sync_interface_vlans.assert_called_once()
 
 
@@ -435,55 +431,48 @@ class TestSyncInterface:
 
 
 class TestGetNetboxInterfaceType:
+    """Type selection driven by real InterfaceTypeMapping rows and the real speed filters."""
+
+    @staticmethod
+    def _mapping(librenms_type, netbox_type, speed=None):
+        from netbox_librenms_plugin.models import InterfaceTypeMapping
+
+        return InterfaceTypeMapping.objects.create(
+            librenms_type=librenms_type, netbox_type=netbox_type, librenms_speed=speed
+        )
+
     def test_speed_mapping_found(self):
-        v = _make_iv()
-        mm = MagicMock()
-        mm.netbox_type = "1000base-t"
-        with patch("netbox_librenms_plugin.views.sync.interfaces.convert_speed_to_kbps", return_value=1000000):
-            with patch("netbox_librenms_plugin.views.sync.interfaces.InterfaceTypeMapping") as mc:
-                qs = MagicMock()
-                mc.objects.restrict.return_value = mc.objects
-                mc.objects.filter.return_value = qs
-                qs.filter.return_value.order_by.return_value.first.return_value = mm
-                result = v.get_netbox_interface_type({"ifType": "ethernetCsmacd", "ifSpeed": 1000000000})
+        """The highest speed row at or below the port's speed wins over the catch-all."""
+        self._mapping("ethernetCsmacd", "virtual")  # NULL-speed catch-all
+        self._mapping("ethernetCsmacd", "100base-tx", speed=100000)
+        self._mapping("ethernetCsmacd", "1000base-t", speed=1000000)
+        self._mapping("ethernetCsmacd", "10gbase-x-sfpp", speed=10000000)  # above the port speed
+
+        result = _make_iv().get_netbox_interface_type({"ifType": "ethernetCsmacd", "ifSpeed": 1000000000})
+
         assert result == "1000base-t"
 
     def test_speed_not_found_falls_back_to_null(self):
-        v = _make_iv()
-        null_m = MagicMock()
-        null_m.netbox_type = "null-type"
-        with patch("netbox_librenms_plugin.views.sync.interfaces.convert_speed_to_kbps", return_value=1000000):
-            with patch("netbox_librenms_plugin.views.sync.interfaces.InterfaceTypeMapping") as mc:
-                qs = MagicMock()
-                mc.objects.restrict.return_value = mc.objects
-                mc.objects.filter.return_value = qs
-                qs.filter.return_value.order_by.return_value.first.return_value = None
-                qs.filter.return_value.first.return_value = null_m
-                result = v.get_netbox_interface_type({"ifType": "ethernetCsmacd", "ifSpeed": 1000000000})
-        assert result == "null-type"
+        """No speed row at or below the port's speed → the NULL-speed row for that type."""
+        self._mapping("ethernetCsmacd", "virtual")
+        self._mapping("ethernetCsmacd", "10gbase-x-sfpp", speed=10000000)
+
+        result = _make_iv().get_netbox_interface_type({"ifType": "ethernetCsmacd", "ifSpeed": 1000000})
+
+        assert result == "virtual"
 
     def test_no_speed_uses_null_mapping(self):
-        v = _make_iv()
-        m = MagicMock()
-        m.netbox_type = "virtual"
-        with patch("netbox_librenms_plugin.views.sync.interfaces.convert_speed_to_kbps", return_value=None):
-            with patch("netbox_librenms_plugin.views.sync.interfaces.InterfaceTypeMapping") as mc:
-                qs = MagicMock()
-                mc.objects.restrict.return_value = mc.objects
-                mc.objects.filter.return_value = qs
-                qs.filter.return_value.first.return_value = m
-                result = v.get_netbox_interface_type({"ifType": "eth", "ifSpeed": None})
+        self._mapping("softwareLoopback", "virtual")
+
+        result = _make_iv().get_netbox_interface_type({"ifType": "softwareLoopback", "ifSpeed": None})
+
         assert result == "virtual"
 
     def test_no_mapping_returns_other(self):
-        v = _make_iv()
-        with patch("netbox_librenms_plugin.views.sync.interfaces.convert_speed_to_kbps", return_value=None):
-            with patch("netbox_librenms_plugin.views.sync.interfaces.InterfaceTypeMapping") as mc:
-                qs = MagicMock()
-                mc.objects.restrict.return_value = mc.objects
-                mc.objects.filter.return_value = qs
-                qs.filter.return_value.first.return_value = None
-                result = v.get_netbox_interface_type({"ifType": "unknown", "ifSpeed": None})
+        self._mapping("ethernetCsmacd", "virtual")  # a mapping exists, but not for this type
+
+        result = _make_iv().get_netbox_interface_type({"ifType": "unknown", "ifSpeed": None})
+
         assert result == "other"
 
 
@@ -547,7 +536,6 @@ class TestDeleteGetRequiredPermissions:
         assert any(a == "delete" and m is VMInterface for a, m in perms)
 
     def test_invalid_raises_http404(self):
-        import pytest
         from django.http import Http404
 
         v = _make_dv()
@@ -561,279 +549,184 @@ class TestDeleteGetRequiredPermissions:
 
 
 class TestDeleteNetBoxInterfacesPost:
+    """The delete endpoint against real interfaces: every count is a real row disappearing."""
+
+    @staticmethod
+    def _payload(response):
+        import json
+
+        return json.loads(response.content)
+
     def test_permission_denied(self):
-        v = _make_dv()
-        err = MagicMock()
-        v.require_all_permissions_json = MagicMock(return_value=err)
-        v.get_required_permissions_for_object_type = MagicMock(return_value=[])
-        req = MagicMock()
-        req.POST.getlist.return_value = ["1"]
-        v.request = req
-        assert v.post(req, "device", 1) is err
+        """Without delete_interface nothing is removed and the JSON gate refuses."""
+        from dcim.models import Device, Interface
+
+        dev = make_device("del-denied")
+        iface = make_interface(dev, "eth0")
+        user = make_user_with_perms("del-viewer", [("view", Device), ("view", Interface)])
+        req = make_request("post", {"interface_ids": [str(iface.pk)]}, user=user)
+
+        response = _post(_make_dv(req), req, object_type="device", object_id=dev.pk)
+
+        assert response.status_code == 403
+        assert Interface.objects.filter(pk=iface.pk).exists()
 
     def test_invalid_object_type_400(self):
-        v = _make_dv()
-        v.require_all_permissions_json = MagicMock(return_value=None)
-        v.get_required_permissions_for_object_type = MagicMock(return_value=[])
-        req = MagicMock()
-        req.POST.getlist.return_value = ["1"]
-        v.request = req
-        resp = v.post(req, "rack", 1)
-        assert resp.status_code == 400
+        from django.http import Http404
+
+        req = make_request("post", {"interface_ids": ["1"]})
+
+        with pytest.raises(Http404):
+            _post(_make_dv(req), req, object_type="rack", object_id=1)
 
     def test_no_ids_400(self):
-        v = _make_dv()
-        v.require_all_permissions_json = MagicMock(return_value=None)
-        v.get_required_permissions_for_object_type = MagicMock(return_value=[])
-        req = MagicMock()
-        req.POST.getlist.return_value = []
-        with patch("netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404"):
-            v.request = req
-            resp = v.post(req, "device", 1)
-        assert resp.status_code == 400
+        dev = make_device("del-noids")
+        req = make_request("post", {})
+
+        response = _post(_make_dv(req), req, object_type="device", object_id=dev.pk)
+
+        assert response.status_code == 400
 
     def test_device_successful_delete(self):
-        import json
+        from dcim.models import Interface
 
-        v = _make_dv()
-        v.require_all_permissions_json = MagicMock(return_value=None)
-        v.get_required_permissions_for_object_type = MagicMock(return_value=[])
-        obj = MagicMock()
-        obj.id = 1
-        obj.virtual_chassis = None
-        iface = MagicMock()
-        iface.name = "eth0"
-        iface.device_id = 1
-        req = MagicMock()
-        req.POST.getlist.side_effect = lambda k: ["10"] if k == "interface_ids" else []
-        with patch(
-            "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404", return_value=obj
-        ):
-            with patch("netbox_librenms_plugin.views.sync.interfaces.Interface") as mc:
-                mc.objects.restrict.return_value = mc.objects
-                mc.objects.get.return_value = iface
-                with patch("netbox_librenms_plugin.views.sync.interfaces.transaction") as mt:
-                    mt.atomic = _pa
-                    v.request = req
-                    resp = v.post(req, "device", 1)
-        data = json.loads(resp.content)
-        assert data["deleted_count"] == 1
-        iface.delete.assert_called_once()
+        dev = make_device("del-ok")
+        iface = make_interface(dev, "eth0")
+        req = make_request("post", {"interface_ids": [str(iface.pk)]})
+
+        response = _post(_make_dv(req), req, object_type="device", object_id=dev.pk)
+
+        assert self._payload(response)["deleted_count"] == 1
+        assert not Interface.objects.filter(pk=iface.pk).exists()
 
     def test_device_wrong_device_id_error(self):
-        import json
+        from dcim.models import Interface
 
-        v = _make_dv()
-        v.require_all_permissions_json = MagicMock(return_value=None)
-        v.get_required_permissions_for_object_type = MagicMock(return_value=[])
-        obj = MagicMock()
-        obj.id = 1
-        obj.virtual_chassis = None
-        iface = MagicMock()
-        iface.name = "eth0"
-        iface.device_id = 99
-        req = MagicMock()
-        req.POST.getlist.side_effect = lambda k: ["10"] if k == "interface_ids" else []
-        with patch(
-            "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404", return_value=obj
-        ):
-            with patch("netbox_librenms_plugin.views.sync.interfaces.Interface") as mc:
-                mc.objects.restrict.return_value = mc.objects
-                mc.objects.get.return_value = iface
-                with patch("netbox_librenms_plugin.views.sync.interfaces.transaction") as mt:
-                    mt.atomic = _pa
-                    v.request = req
-                    resp = v.post(req, "device", 1)
-        data = json.loads(resp.content)
+        dev = make_device("del-owner")
+        other = make_device("del-other")
+        stranger = make_interface(other, "eth0")
+        req = make_request("post", {"interface_ids": [str(stranger.pk)]})
+
+        response = _post(_make_dv(req), req, object_type="device", object_id=dev.pk)
+
+        data = self._payload(response)
         assert data["deleted_count"] == 0
-        assert len(data["errors"]) > 0
+        assert any("does not belong to this device" in e for e in data["errors"])
+        assert Interface.objects.filter(pk=stranger.pk).exists()
+
+    def test_interface_outside_the_grant_is_reported_not_deleted(self):
+        """The interface id is client-supplied, so a constrained delete grant must fail closed."""
+        from dcim.models import Device, Interface
+
+        dev = make_device("del-scoped")
+        keep = make_interface(dev, "eth0")
+        make_interface(dev, "eth1")
+        user = make_user_with_perms("del-scoped-user", [("view", Device)])
+        user = grant(user, "delete", Interface, constraints={"name": "eth1"})
+        req = make_request("post", {"interface_ids": [str(keep.pk)]}, user=user)
+
+        response = _post(_make_dv(req), req, object_type="device", object_id=dev.pk)
+
+        data = self._payload(response)
+        assert data["deleted_count"] == 0
+        assert any(f"Interface with ID {keep.pk} not found" in e for e in data["errors"])
+        assert Interface.objects.filter(pk=keep.pk).exists()
 
     def test_device_vc_interface_not_in_members(self):
-        import json
+        from dcim.models import Interface, VirtualChassis
 
-        v = _make_dv()
-        v.require_all_permissions_json = MagicMock(return_value=None)
-        v.get_required_permissions_for_object_type = MagicMock(return_value=[])
-        obj = MagicMock()
-        obj.id = 1
-        vc = MagicMock()
-        m1 = MagicMock()
-        m1.id = 1
-        m2 = MagicMock()
-        m2.id = 2
-        vc.members.all.return_value = [m1, m2]
-        obj.virtual_chassis = vc
-        iface = MagicMock()
-        iface.name = "eth0"
-        iface.device_id = 99
-        req = MagicMock()
-        req.POST.getlist.side_effect = lambda k: ["10"] if k == "interface_ids" else []
-        with patch(
-            "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404", return_value=obj
-        ):
-            with patch("netbox_librenms_plugin.views.sync.interfaces.Interface") as mc:
-                mc.objects.restrict.return_value = mc.objects
-                mc.objects.get.return_value = iface
-                with patch("netbox_librenms_plugin.views.sync.interfaces.transaction") as mt:
-                    mt.atomic = _pa
-                    v.request = req
-                    resp = v.post(req, "device", 1)
-        data = json.loads(resp.content)
+        vc = VirtualChassis.objects.create(name="vc-del")
+        host = make_device("del-vc-host")
+        host.virtual_chassis = vc
+        host.vc_position = 1
+        host.save()
+        outsider = make_device("del-vc-outsider")
+        stranger = make_interface(outsider, "eth0")
+        req = make_request("post", {"interface_ids": [str(stranger.pk)]})
+
+        response = _post(_make_dv(req), req, object_type="device", object_id=host.pk)
+
+        data = self._payload(response)
         assert data["deleted_count"] == 0
-        assert len(data["errors"]) > 0
+        assert any("virtual chassis" in e for e in data["errors"])
+        assert Interface.objects.filter(pk=stranger.pk).exists()
 
     def test_device_vc_interface_in_members_deleted(self):
-        import json
+        """An interface on a sibling of the same chassis is in scope and is removed."""
+        from dcim.models import Interface, VirtualChassis
 
-        v = _make_dv()
-        v.require_all_permissions_json = MagicMock(return_value=None)
-        v.get_required_permissions_for_object_type = MagicMock(return_value=[])
-        obj = MagicMock()
-        obj.id = 1
-        vc = MagicMock()
-        m1 = MagicMock()
-        m1.id = 1
-        m2 = MagicMock()
-        m2.id = 2
-        vc.members.all.return_value = [m1, m2]
-        obj.virtual_chassis = vc
-        iface = MagicMock()
-        iface.name = "eth0"
-        iface.device_id = 2
-        req = MagicMock()
-        req.POST.getlist.side_effect = lambda k: ["10"] if k == "interface_ids" else []
-        with patch(
-            "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404", return_value=obj
-        ):
-            with patch("netbox_librenms_plugin.views.sync.interfaces.Interface") as mc:
-                mc.objects.restrict.return_value = mc.objects
-                mc.objects.get.return_value = iface
-                with patch("netbox_librenms_plugin.views.sync.interfaces.transaction") as mt:
-                    mt.atomic = _pa
-                    v.request = req
-                    resp = v.post(req, "device", 1)
-        data = json.loads(resp.content)
-        assert data["deleted_count"] == 1
+        vc = VirtualChassis.objects.create(name="vc-del-ok")
+        host = make_device("del-vcok-host")
+        host.virtual_chassis = vc
+        host.vc_position = 1
+        host.save()
+        sibling = make_device("del-vcok-member")
+        sibling.virtual_chassis = vc
+        sibling.vc_position = 2
+        sibling.save()
+        iface = make_interface(sibling, "eth0")
+        req = make_request("post", {"interface_ids": [str(iface.pk)]})
+
+        response = _post(_make_dv(req), req, object_type="device", object_id=host.pk)
+
+        assert self._payload(response)["deleted_count"] == 1
+        assert not Interface.objects.filter(pk=iface.pk).exists()
 
     def test_vm_successful_delete(self):
-        import json
+        from virtualization.models import VMInterface
 
-        v = _make_dv()
-        v.require_all_permissions_json = MagicMock(return_value=None)
-        v.get_required_permissions_for_object_type = MagicMock(return_value=[])
-        obj = MagicMock()
-        obj.id = 5
-        iface = MagicMock()
-        iface.name = "eth0"
-        iface.virtual_machine_id = 5
-        req = MagicMock()
-        req.POST.getlist.side_effect = lambda k: ["20"] if k == "interface_ids" else []
-        with patch(
-            "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404", return_value=obj
-        ):
-            with patch("netbox_librenms_plugin.views.sync.interfaces.VMInterface") as mc:
-                mc.objects.restrict.return_value = mc.objects
-                mc.objects.get.return_value = iface
-                with patch("netbox_librenms_plugin.views.sync.interfaces.transaction") as mt:
-                    mt.atomic = _pa
-                    v.request = req
-                    resp = v.post(req, "virtualmachine", 5)
-        data = json.loads(resp.content)
-        assert data["deleted_count"] == 1
-        iface.delete.assert_called_once()
+        vm = make_vm("del-vm")
+        iface = VMInterface.objects.create(virtual_machine=vm, name="eth0")
+        req = make_request("post", {"interface_ids": [str(iface.pk)]})
+
+        response = _post(_make_dv(req), req, object_type="virtualmachine", object_id=vm.pk)
+
+        assert self._payload(response)["deleted_count"] == 1
+        assert not VMInterface.objects.filter(pk=iface.pk).exists()
 
     def test_vm_wrong_vm_error(self):
-        import json
+        from virtualization.models import VMInterface
 
-        v = _make_dv()
-        v.require_all_permissions_json = MagicMock(return_value=None)
-        v.get_required_permissions_for_object_type = MagicMock(return_value=[])
-        obj = MagicMock()
-        obj.id = 5
-        iface = MagicMock()
-        iface.name = "eth0"
-        iface.virtual_machine_id = 99
-        req = MagicMock()
-        req.POST.getlist.side_effect = lambda k: ["20"] if k == "interface_ids" else []
-        with patch(
-            "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404", return_value=obj
-        ):
-            with patch("netbox_librenms_plugin.views.sync.interfaces.VMInterface") as mc:
-                mc.objects.restrict.return_value = mc.objects
-                mc.objects.get.return_value = iface
-                with patch("netbox_librenms_plugin.views.sync.interfaces.transaction") as mt:
-                    mt.atomic = _pa
-                    v.request = req
-                    resp = v.post(req, "virtualmachine", 5)
-        data = json.loads(resp.content)
+        vm = make_vm("del-vm-owner")
+        other = make_vm("del-vm-other")
+        stranger = VMInterface.objects.create(virtual_machine=other, name="eth0")
+        req = make_request("post", {"interface_ids": [str(stranger.pk)]})
+
+        response = _post(_make_dv(req), req, object_type="virtualmachine", object_id=vm.pk)
+
+        data = self._payload(response)
         assert data["deleted_count"] == 0
-        assert len(data["errors"]) > 0
+        assert any("does not belong to this virtual machine" in e for e in data["errors"])
+        assert VMInterface.objects.filter(pk=stranger.pk).exists()
 
     def test_interface_not_found_adds_error(self):
-        import json
         from dcim.models import Interface
-        from virtualization.models import VMInterface as VMI
 
-        v = _make_dv()
-        v.require_all_permissions_json = MagicMock(return_value=None)
-        v.get_required_permissions_for_object_type = MagicMock(return_value=[])
-        obj = MagicMock()
-        obj.id = 1
-        obj.virtual_chassis = None
-        req = MagicMock()
-        req.POST.getlist.side_effect = lambda k: ["999"] if k == "interface_ids" else []
-        with patch(
-            "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404", return_value=obj
-        ):
-            with patch("netbox_librenms_plugin.views.sync.interfaces.Interface") as mc:
-                mc.DoesNotExist = Interface.DoesNotExist
-                mc.objects.restrict.return_value = mc.objects
-                mc.objects.get.side_effect = Interface.DoesNotExist
-                with patch("netbox_librenms_plugin.views.sync.interfaces.VMInterface") as mvc:
-                    mvc.DoesNotExist = VMI.DoesNotExist
-                    with patch("netbox_librenms_plugin.views.sync.interfaces.transaction") as mt:
-                        mt.atomic = _pa
-                        v.request = req
-                        resp = v.post(req, "device", 1)
-        data = json.loads(resp.content)
-        assert any("999" in e for e in data.get("errors", []))
+        dev = make_device("del-missing")
+        gone_pk = (Interface.objects.order_by("-pk").first().pk if Interface.objects.exists() else 0) + 1000
+        req = make_request("post", {"interface_ids": [str(gone_pk)]})
+
+        response = _post(_make_dv(req), req, object_type="device", object_id=dev.pk)
+
+        assert any(str(gone_pk) in e for e in self._payload(response)["errors"])
 
     def test_response_with_errors_includes_error_message(self):
-        import json
+        """A mixed batch deletes what it may and reports the rest — in one transaction."""
+        from dcim.models import Interface
 
-        v = _make_dv()
-        v.require_all_permissions_json = MagicMock(return_value=None)
-        v.get_required_permissions_for_object_type = MagicMock(return_value=[])
-        obj = MagicMock()
-        obj.id = 1
-        obj.virtual_chassis = None
-        iface_ok = MagicMock()
-        iface_ok.name = "eth0"
-        iface_ok.device_id = 1
-        iface_bad = MagicMock()
-        iface_bad.name = "eth1"
-        iface_bad.device_id = 99
-        n = [0]
+        dev = make_device("del-mixed")
+        other = make_device("del-mixed-other")
+        mine = make_interface(dev, "eth0")
+        stranger = make_interface(other, "eth1")
+        req = make_request("post", {"interface_ids": [str(mine.pk), str(stranger.pk)]})
 
-        def get_se(**kw):
-            n[0] += 1
-            return iface_ok if n[0] == 1 else iface_bad
+        response = _post(_make_dv(req), req, object_type="device", object_id=dev.pk)
 
-        req = MagicMock()
-        req.POST.getlist.side_effect = lambda k: ["10", "20"] if k == "interface_ids" else []
-        with patch(
-            "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404", return_value=obj
-        ):
-            with patch("netbox_librenms_plugin.views.sync.interfaces.Interface") as mc:
-                mc.objects.restrict.return_value = mc.objects
-                mc.objects.get.side_effect = get_se
-                with patch("netbox_librenms_plugin.views.sync.interfaces.transaction") as mt:
-                    mt.atomic = _pa
-                    v.request = req
-                    resp = v.post(req, "device", 1)
-        data = json.loads(resp.content)
+        data = self._payload(response)
         assert data["deleted_count"] == 1
         assert "error(s)" in data["message"]
+        assert not Interface.objects.filter(pk=mine.pk).exists()
+        assert Interface.objects.filter(pk=stranger.pk).exists()
 
 
 # ===========================================================================
@@ -942,39 +835,39 @@ class TestSyncSiteLocationViewGetContextData:
 
 
 class TestSyncSiteLocationViewGetQuerysetSuccess:
-    def test_returns_sync_data(self):
-        """Lines 44, 49: build sync_data list and return it."""
+    def _view(self, get_params, locations):
+        """The real view over the real Site table, with only the LibreNMS locations call stubbed."""
         from netbox_librenms_plugin.views.sync.locations import SyncSiteLocationView
 
-        v = object.__new__(SyncSiteLocationView)
-        v.request = MagicMock()
-        v.request.GET = {}
-        v.filterset = None
-        sd = MagicMock()
-        with patch("netbox_librenms_plugin.views.sync.locations.Site") as ms:
-            ms.objects.all.return_value = [MagicMock()]
-            with patch.object(v, "get_librenms_locations", return_value=(True, [{"location": "T"}])):
-                with patch.object(v, "create_sync_data", return_value=sd):
-                    result = v.get_queryset()
-        assert result == [sd]
+        v = make_view(SyncSiteLocationView, make_request("get", get_params))
+        v._librenms_api.get_locations.return_value = (True, locations)
+        return v
+
+    def test_returns_sync_data(self):
+        """One SyncData row per real Site, paired with its LibreNMS location."""
+        from dcim.models import Site
+
+        Site.objects.create(name="Loc Site A", slug="loc-site-a")
+        Site.objects.create(name="Loc Site B", slug="loc-site-b")
+        v = self._view({}, [{"location": "Loc Site A"}])
+
+        result = v.get_queryset()
+
+        assert {row.netbox_site.name for row in result} == set(Site.objects.values_list("name", flat=True))
+        matched = next(row for row in result if row.netbox_site.name == "Loc Site A")
+        assert matched.librenms_location == {"location": "Loc Site A"}
 
     def test_filterset_branch(self):
-        """Lines 46-47: filterset branch when request.GET is truthy."""
-        from netbox_librenms_plugin.views.sync.locations import SyncSiteLocationView
+        """A GET query narrows the rows through the real SiteLocationFilterSet."""
+        from dcim.models import Site
 
-        v = object.__new__(SyncSiteLocationView)
-        v.request = MagicMock()
-        v.request.GET = {"name": "x"}
-        mf = MagicMock()
-        filtered = [MagicMock()]
-        mf.return_value.qs = filtered
-        v.filterset = mf
-        with patch("netbox_librenms_plugin.views.sync.locations.Site") as ms:
-            ms.objects.all.return_value = [MagicMock()]
-            with patch.object(v, "get_librenms_locations", return_value=(True, [{"location": "T"}])):
-                with patch.object(v, "create_sync_data", return_value=MagicMock()):
-                    result = v.get_queryset()
-        assert result is filtered
+        Site.objects.create(name="Filter Hit", slug="filter-hit")
+        Site.objects.create(name="Filter Miss", slug="filter-miss")
+        v = self._view({"q": "Hit"}, [{"location": "Filter Hit"}])
+
+        result = v.get_queryset()
+
+        assert [row.netbox_site.name for row in result] == ["Filter Hit"]
 
 
 # ===========================================================================
@@ -983,64 +876,44 @@ class TestSyncSiteLocationViewGetQuerysetSuccess:
 
 
 class TestVlansGroupedUpdateAndSkip:
-    def _v(self):
+    def _setup(self, tag, cached_name, existing_name):
+        """A real grouped VLAN plus a request selecting it; returns (view, request, device, vlan)."""
+        from django.core.cache import cache
+        from ipam.models import VLAN, VLANGroup
+
         from netbox_librenms_plugin.views.sync.vlans import SyncVLANsView
 
-        v = object.__new__(SyncVLANsView)
-        v._librenms_api = MagicMock()
-        v._librenms_api.server_key = "default"
-        v._post_server_key = "default"
-        v.get_cache_key = MagicMock(return_value="k")
-        v._redirect = MagicMock(return_value=MagicMock())
-        req = MagicMock()
-        req.POST.getlist = lambda k: ["100"] if k == "select" else []
-        req.POST.get = lambda key, default="": "3" if key == "vlan_group_100" else default
-        v.request = req
-        return v
+        group = VLANGroup.objects.create(name=f"grp-{tag}", slug=f"grp-{tag}")
+        vlan = VLAN.objects.create(vid=100, group=group, name=existing_name, status="active")
+        dev = make_device(f"vlan-{tag}")
+        req = make_request("post", {"select": ["100"], "vlan_group_100": str(group.pk)})
+        view = make_view(SyncVLANsView, req)
+        view._post_server_key = "default"
+        cache.set(
+            view.get_cache_key(dev, "vlans", "default"),
+            [{"vlan_vlan": 100, "vlan_name": cached_name}],
+        )
+        return view, req, dev, vlan
 
     def test_grouped_update_path_lines_134_to_137(self):
-        """elif vlan.name != librenms_name: update triggered."""
-        from ipam.models import VLANGroup
+        """A grouped VLAN whose LibreNMS name differs is renamed and persisted."""
+        from ipam.models import VLAN
 
-        v = self._v()
-        mg = MagicMock()
-        mv = MagicMock()
-        mv.name = "OldName"
-        with patch("netbox_librenms_plugin.views.sync.vlans.cache") as mc:
-            mc.get.return_value = [{"vlan_vlan": 100, "vlan_name": "NewName"}]
-            with patch("netbox_librenms_plugin.views.sync.vlans.VLANGroup") as mvg:
-                mvg.DoesNotExist = VLANGroup.DoesNotExist
-                mvg.objects.restrict.return_value = mvg.objects
-                mvg.objects.get.return_value = mg
-                with patch("netbox_librenms_plugin.views.sync.vlans.VLAN") as mvl:
-                    mvl.objects.restrict.return_value = mvl.objects
-                    mvl.objects.get_or_create.return_value = (mv, False)
-                    with patch("netbox_librenms_plugin.views.sync.vlans.transaction"):
-                        with patch("netbox_librenms_plugin.views.sync.vlans.messages") as mm:
-                            v._handle_create_vlans(v.request, MagicMock(), "device", 1)
-        mv.save.assert_called_once()
-        assert mv.name == "NewName"
-        assert "updated" in str(mm.success.call_args)
+        view, req, dev, vlan = self._setup("update", cached_name="NewName", existing_name="OldName")
+
+        view._handle_create_vlans(req, dev, "device", dev.pk)
+
+        assert VLAN.objects.get(pk=vlan.pk).name == "NewName"
+        assert any("updated" in t for t in message_texts(req, "success"))
 
     def test_grouped_skip_path_lines_138_to_139(self):
-        """else: skipped_count when name unchanged."""
-        from ipam.models import VLANGroup
+        """A grouped VLAN already carrying the LibreNMS name is left untouched."""
+        from ipam.models import VLAN
 
-        v = self._v()
-        mg = MagicMock()
-        mv = MagicMock()
-        mv.name = "Same"
-        with patch("netbox_librenms_plugin.views.sync.vlans.cache") as mc:
-            mc.get.return_value = [{"vlan_vlan": 100, "vlan_name": "Same"}]
-            with patch("netbox_librenms_plugin.views.sync.vlans.VLANGroup") as mvg:
-                mvg.DoesNotExist = VLANGroup.DoesNotExist
-                mvg.objects.restrict.return_value = mvg.objects
-                mvg.objects.get.return_value = mg
-                with patch("netbox_librenms_plugin.views.sync.vlans.VLAN") as mvl:
-                    mvl.objects.restrict.return_value = mvl.objects
-                    mvl.objects.get_or_create.return_value = (mv, False)
-                    with patch("netbox_librenms_plugin.views.sync.vlans.transaction"):
-                        with patch("netbox_librenms_plugin.views.sync.vlans.messages") as mm:
-                            v._handle_create_vlans(v.request, MagicMock(), "device", 1)
-        mv.save.assert_not_called()
-        assert "unchanged" in str(mm.success.call_args)
+        view, req, dev, vlan = self._setup("skip", cached_name="Same", existing_name="Same")
+        last_updated = VLAN.objects.get(pk=vlan.pk).last_updated
+
+        view._handle_create_vlans(req, dev, "device", dev.pk)
+
+        assert VLAN.objects.get(pk=vlan.pk).last_updated == last_updated
+        assert any("unchanged" in t for t in message_texts(req, "success"))

--- a/netbox_librenms_plugin/tests/test_coverage_sync_views3.py
+++ b/netbox_librenms_plugin/tests/test_coverage_sync_views3.py
@@ -902,7 +902,7 @@ class TestVlansGroupedUpdateAndSkip:
         )
         return view, req, dev, vlan
 
-    def test_grouped_update_path_lines_134_to_137(self):
+    def test_grouped_vlan_with_different_name_is_renamed(self):
         """A grouped VLAN whose LibreNMS name differs is renamed and persisted."""
         from ipam.models import VLAN
 
@@ -913,7 +913,7 @@ class TestVlansGroupedUpdateAndSkip:
         assert VLAN.objects.get(pk=vlan.pk).name == "NewName"
         assert any("updated" in t for t in message_texts(req, "success"))
 
-    def test_grouped_skip_path_lines_138_to_139(self):
+    def test_grouped_vlan_with_matching_name_is_unchanged(self):
         """A grouped VLAN already carrying the LibreNMS name is left untouched."""
         from ipam.models import VLAN
 

--- a/netbox_librenms_plugin/tests/test_coverage_sync_views3.py
+++ b/netbox_librenms_plugin/tests/test_coverage_sync_views3.py
@@ -571,7 +571,8 @@ class TestDeleteNetBoxInterfacesPost:
         assert response.status_code == 403
         assert Interface.objects.filter(pk=iface.pk).exists()
 
-    def test_invalid_object_type_400(self):
+    def test_invalid_object_type_raises_http404(self):
+        """get_required_permissions_for_object_type rejects the type before any lookup."""
         from django.http import Http404
 
         req = make_request("post", {"interface_ids": ["1"]})

--- a/netbox_librenms_plugin/tests/test_coverage_sync_views3.py
+++ b/netbox_librenms_plugin/tests/test_coverage_sync_views3.py
@@ -188,6 +188,7 @@ class TestSyncInterfacesPost:
         with patch("netbox_librenms_plugin.views.sync.interfaces.get_interface_name_field", return_value="ifName"):
             with patch("netbox_librenms_plugin.views.sync.interfaces.reverse", return_value="/s/"):
                 with patch("netbox_librenms_plugin.views.sync.interfaces.redirect") as mr:
+                    v.request = req
                     v.post(req, "device", 1)
         mr.assert_called_once()
 
@@ -206,6 +207,7 @@ class TestSyncInterfacesPost:
         with patch("netbox_librenms_plugin.views.sync.interfaces.get_interface_name_field", return_value="ifName"):
             with patch("netbox_librenms_plugin.views.sync.interfaces.reverse", return_value="/s/"):
                 with patch("netbox_librenms_plugin.views.sync.interfaces.redirect") as mr:
+                    v.request = req
                     v.post(req, "device", 1)
         mr.assert_called_once()
 
@@ -226,6 +228,7 @@ class TestSyncInterfacesPost:
             with patch("netbox_librenms_plugin.views.sync.interfaces.reverse", return_value="/s/"):
                 with patch("netbox_librenms_plugin.views.sync.interfaces.redirect") as mr:
                     with patch("netbox_librenms_plugin.views.sync.interfaces.messages") as mm:
+                        v.request = req
                         v.post(req, "device", 1)
         v.sync_selected_interfaces.assert_called_once()
         mm.success.assert_called_once()
@@ -248,6 +251,7 @@ class TestSyncInterfacesPost:
             with patch("netbox_librenms_plugin.views.sync.interfaces.reverse", return_value="/s/"):
                 with patch("netbox_librenms_plugin.views.sync.interfaces.redirect"):
                     with patch("netbox_librenms_plugin.views.sync.interfaces.messages"):
+                        v.request = req
                         v.post(req, "virtualmachine", 2)
         v.sync_selected_interfaces.assert_called_once()
 
@@ -294,6 +298,7 @@ class TestSyncInterface:
         obj.virtual_chassis = None
         iface = MagicMock()
         with patch("netbox_librenms_plugin.views.sync.interfaces.Interface") as mc:
+            mc.objects.restrict.return_value = mc.objects
             mc.objects.get_or_create.return_value = (iface, True)
             v.sync_interface(obj, {"ifName": "eth0"}, [], "ifName")
         mc.objects.get_or_create.assert_called_once_with(device=obj, name="eth0")
@@ -313,8 +318,11 @@ class TestSyncInterface:
         v.request.POST.get = lambda k, *a: "2" if k == "device_selection_eth0" else None
         iface = MagicMock()
         # Patch only Device.objects.get, not Device itself (isinstance must work)
-        with patch("netbox_librenms_plugin.views.sync.interfaces.Device.objects.get", return_value=target):
+        # The VC-selected device is read through restrict(user, "view"), so stub that chain.
+        with patch("netbox_librenms_plugin.views.sync.interfaces.Device.objects.restrict") as mock_restrict:
+            mock_restrict.return_value.get.return_value = target
             with patch("netbox_librenms_plugin.views.sync.interfaces.Interface") as mc:
+                mc.objects.restrict.return_value = mc.objects
                 mc.objects.get_or_create.return_value = (iface, True)
                 v.sync_interface(obj, {"ifName": "eth0"}, [], "ifName")
         mc.objects.get_or_create.assert_called_once_with(device=target, name="eth0")
@@ -332,8 +340,11 @@ class TestSyncInterface:
         target.id = 99
         v.request.POST.get = lambda k, *a: "99" if k == "device_selection_eth0" else None
         iface = MagicMock()
-        with patch("netbox_librenms_plugin.views.sync.interfaces.Device.objects.get", return_value=target):
+        # The VC-selected device is read through restrict(user, "view"), so stub that chain.
+        with patch("netbox_librenms_plugin.views.sync.interfaces.Device.objects.restrict") as mock_restrict:
+            mock_restrict.return_value.get.return_value = target
             with patch("netbox_librenms_plugin.views.sync.interfaces.Interface") as mc:
+                mc.objects.restrict.return_value = mc.objects
                 mc.objects.get_or_create.return_value = (iface, True)
                 v.sync_interface(obj, {"ifName": "eth0"}, [], "ifName")
         mc.objects.get_or_create.assert_called_once_with(device=obj, name="eth0")
@@ -349,8 +360,11 @@ class TestSyncInterface:
         target.id = 99
         v.request.POST.get = lambda k, *a: "99" if k == "device_selection_eth0" else None
         iface = MagicMock()
-        with patch("netbox_librenms_plugin.views.sync.interfaces.Device.objects.get", return_value=target):
+        # The VC-selected device is read through restrict(user, "view"), so stub that chain.
+        with patch("netbox_librenms_plugin.views.sync.interfaces.Device.objects.restrict") as mock_restrict:
+            mock_restrict.return_value.get.return_value = target
             with patch("netbox_librenms_plugin.views.sync.interfaces.Interface") as mc:
+                mc.objects.restrict.return_value = mc.objects
                 mc.objects.get_or_create.return_value = (iface, True)
                 v.sync_interface(obj, {"ifName": "eth0"}, [], "ifName")
         mc.objects.get_or_create.assert_called_once_with(device=obj, name="eth0")
@@ -364,11 +378,11 @@ class TestSyncInterface:
         obj.virtual_chassis = None
         v.request.POST.get = lambda k, *a: "999" if k == "device_selection_eth0" else None
         iface = MagicMock()
-        with patch(
-            "netbox_librenms_plugin.views.sync.interfaces.Device.objects.get",
-            side_effect=Device.DoesNotExist,
-        ):
+        # Same chain: an unknown id raises DoesNotExist out of the restricted queryset.
+        with patch("netbox_librenms_plugin.views.sync.interfaces.Device.objects.restrict") as mock_restrict:
+            mock_restrict.return_value.get.side_effect = Device.DoesNotExist
             with patch("netbox_librenms_plugin.views.sync.interfaces.Interface") as mc:
+                mc.objects.restrict.return_value = mc.objects
                 mc.objects.get_or_create.return_value = (iface, True)
                 v.sync_interface(obj, {"ifName": "eth0"}, [], "ifName")
         mc.objects.get_or_create.assert_called_once_with(device=obj, name="eth0")
@@ -380,6 +394,7 @@ class TestSyncInterface:
         obj = MagicMock(spec=VirtualMachine)
         iface = MagicMock()
         with patch("netbox_librenms_plugin.views.sync.interfaces.VMInterface") as mc:
+            mc.objects.restrict.return_value = mc.objects
             mc.objects.get_or_create.return_value = (iface, True)
             v.sync_interface(obj, {"ifName": "eth0"}, [], "ifName")
         mc.objects.get_or_create.assert_called_once_with(virtual_machine=obj, name="eth0")
@@ -394,6 +409,7 @@ class TestSyncInterface:
         obj.virtual_chassis = None
         iface = MagicMock()
         with patch("netbox_librenms_plugin.views.sync.interfaces.Interface") as mc:
+            mc.objects.restrict.return_value = mc.objects
             mc.objects.get_or_create.return_value = (iface, True)
             v.sync_interface(obj, {"ifName": "eth0"}, ["vlans"], "ifName")
         v._sync_interface_vlans.assert_not_called()
@@ -407,6 +423,7 @@ class TestSyncInterface:
         obj.virtual_chassis = None
         iface = MagicMock()
         with patch("netbox_librenms_plugin.views.sync.interfaces.Interface") as mc:
+            mc.objects.restrict.return_value = mc.objects
             mc.objects.get_or_create.return_value = (iface, True)
             v.sync_interface(obj, {"ifName": "eth0"}, [], "ifName")
         v._sync_interface_vlans.assert_called_once()
@@ -425,6 +442,7 @@ class TestGetNetboxInterfaceType:
         with patch("netbox_librenms_plugin.views.sync.interfaces.convert_speed_to_kbps", return_value=1000000):
             with patch("netbox_librenms_plugin.views.sync.interfaces.InterfaceTypeMapping") as mc:
                 qs = MagicMock()
+                mc.objects.restrict.return_value = mc.objects
                 mc.objects.filter.return_value = qs
                 qs.filter.return_value.order_by.return_value.first.return_value = mm
                 result = v.get_netbox_interface_type({"ifType": "ethernetCsmacd", "ifSpeed": 1000000000})
@@ -437,6 +455,7 @@ class TestGetNetboxInterfaceType:
         with patch("netbox_librenms_plugin.views.sync.interfaces.convert_speed_to_kbps", return_value=1000000):
             with patch("netbox_librenms_plugin.views.sync.interfaces.InterfaceTypeMapping") as mc:
                 qs = MagicMock()
+                mc.objects.restrict.return_value = mc.objects
                 mc.objects.filter.return_value = qs
                 qs.filter.return_value.order_by.return_value.first.return_value = None
                 qs.filter.return_value.first.return_value = null_m
@@ -450,6 +469,7 @@ class TestGetNetboxInterfaceType:
         with patch("netbox_librenms_plugin.views.sync.interfaces.convert_speed_to_kbps", return_value=None):
             with patch("netbox_librenms_plugin.views.sync.interfaces.InterfaceTypeMapping") as mc:
                 qs = MagicMock()
+                mc.objects.restrict.return_value = mc.objects
                 mc.objects.filter.return_value = qs
                 qs.filter.return_value.first.return_value = m
                 result = v.get_netbox_interface_type({"ifType": "eth", "ifSpeed": None})
@@ -460,6 +480,7 @@ class TestGetNetboxInterfaceType:
         with patch("netbox_librenms_plugin.views.sync.interfaces.convert_speed_to_kbps", return_value=None):
             with patch("netbox_librenms_plugin.views.sync.interfaces.InterfaceTypeMapping") as mc:
                 qs = MagicMock()
+                mc.objects.restrict.return_value = mc.objects
                 mc.objects.filter.return_value = qs
                 qs.filter.return_value.first.return_value = None
                 result = v.get_netbox_interface_type({"ifType": "unknown", "ifSpeed": None})
@@ -547,6 +568,7 @@ class TestDeleteNetBoxInterfacesPost:
         v.get_required_permissions_for_object_type = MagicMock(return_value=[])
         req = MagicMock()
         req.POST.getlist.return_value = ["1"]
+        v.request = req
         assert v.post(req, "device", 1) is err
 
     def test_invalid_object_type_400(self):
@@ -555,6 +577,7 @@ class TestDeleteNetBoxInterfacesPost:
         v.get_required_permissions_for_object_type = MagicMock(return_value=[])
         req = MagicMock()
         req.POST.getlist.return_value = ["1"]
+        v.request = req
         resp = v.post(req, "rack", 1)
         assert resp.status_code == 400
 
@@ -565,6 +588,7 @@ class TestDeleteNetBoxInterfacesPost:
         req = MagicMock()
         req.POST.getlist.return_value = []
         with patch("netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404"):
+            v.request = req
             resp = v.post(req, "device", 1)
         assert resp.status_code == 400
 
@@ -590,6 +614,7 @@ class TestDeleteNetBoxInterfacesPost:
                 mc.objects.get.return_value = iface
                 with patch("netbox_librenms_plugin.views.sync.interfaces.transaction") as mt:
                     mt.atomic = _pa
+                    v.request = req
                     resp = v.post(req, "device", 1)
         data = json.loads(resp.content)
         assert data["deleted_count"] == 1
@@ -617,6 +642,7 @@ class TestDeleteNetBoxInterfacesPost:
                 mc.objects.get.return_value = iface
                 with patch("netbox_librenms_plugin.views.sync.interfaces.transaction") as mt:
                     mt.atomic = _pa
+                    v.request = req
                     resp = v.post(req, "device", 1)
         data = json.loads(resp.content)
         assert data["deleted_count"] == 0
@@ -650,6 +676,7 @@ class TestDeleteNetBoxInterfacesPost:
                 mc.objects.get.return_value = iface
                 with patch("netbox_librenms_plugin.views.sync.interfaces.transaction") as mt:
                     mt.atomic = _pa
+                    v.request = req
                     resp = v.post(req, "device", 1)
         data = json.loads(resp.content)
         assert data["deleted_count"] == 0
@@ -683,6 +710,7 @@ class TestDeleteNetBoxInterfacesPost:
                 mc.objects.get.return_value = iface
                 with patch("netbox_librenms_plugin.views.sync.interfaces.transaction") as mt:
                     mt.atomic = _pa
+                    v.request = req
                     resp = v.post(req, "device", 1)
         data = json.loads(resp.content)
         assert data["deleted_count"] == 1
@@ -708,6 +736,7 @@ class TestDeleteNetBoxInterfacesPost:
                 mc.objects.get.return_value = iface
                 with patch("netbox_librenms_plugin.views.sync.interfaces.transaction") as mt:
                     mt.atomic = _pa
+                    v.request = req
                     resp = v.post(req, "virtualmachine", 5)
         data = json.loads(resp.content)
         assert data["deleted_count"] == 1
@@ -734,6 +763,7 @@ class TestDeleteNetBoxInterfacesPost:
                 mc.objects.get.return_value = iface
                 with patch("netbox_librenms_plugin.views.sync.interfaces.transaction") as mt:
                     mt.atomic = _pa
+                    v.request = req
                     resp = v.post(req, "virtualmachine", 5)
         data = json.loads(resp.content)
         assert data["deleted_count"] == 0
@@ -763,6 +793,7 @@ class TestDeleteNetBoxInterfacesPost:
                     mvc.DoesNotExist = VMI.DoesNotExist
                     with patch("netbox_librenms_plugin.views.sync.interfaces.transaction") as mt:
                         mt.atomic = _pa
+                        v.request = req
                         resp = v.post(req, "device", 1)
         data = json.loads(resp.content)
         assert any("999" in e for e in data.get("errors", []))
@@ -798,6 +829,7 @@ class TestDeleteNetBoxInterfacesPost:
                 mc.objects.get.side_effect = get_se
                 with patch("netbox_librenms_plugin.views.sync.interfaces.transaction") as mt:
                     mt.atomic = _pa
+                    v.request = req
                     resp = v.post(req, "device", 1)
         data = json.loads(resp.content)
         assert data["deleted_count"] == 1
@@ -978,8 +1010,10 @@ class TestVlansGroupedUpdateAndSkip:
             mc.get.return_value = [{"vlan_vlan": 100, "vlan_name": "NewName"}]
             with patch("netbox_librenms_plugin.views.sync.vlans.VLANGroup") as mvg:
                 mvg.DoesNotExist = VLANGroup.DoesNotExist
+                mvg.objects.restrict.return_value = mvg.objects
                 mvg.objects.get.return_value = mg
                 with patch("netbox_librenms_plugin.views.sync.vlans.VLAN") as mvl:
+                    mvl.objects.restrict.return_value = mvl.objects
                     mvl.objects.get_or_create.return_value = (mv, False)
                     with patch("netbox_librenms_plugin.views.sync.vlans.transaction"):
                         with patch("netbox_librenms_plugin.views.sync.vlans.messages") as mm:
@@ -1000,8 +1034,10 @@ class TestVlansGroupedUpdateAndSkip:
             mc.get.return_value = [{"vlan_vlan": 100, "vlan_name": "Same"}]
             with patch("netbox_librenms_plugin.views.sync.vlans.VLANGroup") as mvg:
                 mvg.DoesNotExist = VLANGroup.DoesNotExist
+                mvg.objects.restrict.return_value = mvg.objects
                 mvg.objects.get.return_value = mg
                 with patch("netbox_librenms_plugin.views.sync.vlans.VLAN") as mvl:
+                    mvl.objects.restrict.return_value = mvl.objects
                     mvl.objects.get_or_create.return_value = (mv, False)
                     with patch("netbox_librenms_plugin.views.sync.vlans.transaction"):
                         with patch("netbox_librenms_plugin.views.sync.vlans.messages") as mm:

--- a/netbox_librenms_plugin/tests/test_coverage_sync_views3.py
+++ b/netbox_librenms_plugin/tests/test_coverage_sync_views3.py
@@ -84,13 +84,19 @@ class TestSyncInterfacesGetObject:
     def test_device_type(self):
         v = _make_iv()
         mock_obj = MagicMock()
-        with patch("netbox_librenms_plugin.views.sync.interfaces.get_object_or_404", return_value=mock_obj):
+        with patch(
+            "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+            return_value=mock_obj,
+        ):
             assert v.get_object("device", 1) is mock_obj
 
     def test_vm_type(self):
         v = _make_iv()
         mock_obj = MagicMock()
-        with patch("netbox_librenms_plugin.views.sync.interfaces.get_object_or_404", return_value=mock_obj):
+        with patch(
+            "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+            return_value=mock_obj,
+        ):
             assert v.get_object("virtualmachine", 2) is mock_obj
 
     def test_invalid_raises_http404(self):
@@ -558,7 +564,7 @@ class TestDeleteNetBoxInterfacesPost:
         v.get_required_permissions_for_object_type = MagicMock(return_value=[])
         req = MagicMock()
         req.POST.getlist.return_value = []
-        with patch("netbox_librenms_plugin.views.sync.interfaces.get_object_or_404"):
+        with patch("netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404"):
             resp = v.post(req, "device", 1)
         assert resp.status_code == 400
 
@@ -576,7 +582,9 @@ class TestDeleteNetBoxInterfacesPost:
         iface.device_id = 1
         req = MagicMock()
         req.POST.getlist.side_effect = lambda k: ["10"] if k == "interface_ids" else []
-        with patch("netbox_librenms_plugin.views.sync.interfaces.get_object_or_404", return_value=obj):
+        with patch(
+            "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404", return_value=obj
+        ):
             with patch("netbox_librenms_plugin.views.sync.interfaces.Interface") as mc:
                 mc.objects.get.return_value = iface
                 with patch("netbox_librenms_plugin.views.sync.interfaces.transaction") as mt:
@@ -600,7 +608,9 @@ class TestDeleteNetBoxInterfacesPost:
         iface.device_id = 99
         req = MagicMock()
         req.POST.getlist.side_effect = lambda k: ["10"] if k == "interface_ids" else []
-        with patch("netbox_librenms_plugin.views.sync.interfaces.get_object_or_404", return_value=obj):
+        with patch(
+            "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404", return_value=obj
+        ):
             with patch("netbox_librenms_plugin.views.sync.interfaces.Interface") as mc:
                 mc.objects.get.return_value = iface
                 with patch("netbox_librenms_plugin.views.sync.interfaces.transaction") as mt:
@@ -630,7 +640,9 @@ class TestDeleteNetBoxInterfacesPost:
         iface.device_id = 99
         req = MagicMock()
         req.POST.getlist.side_effect = lambda k: ["10"] if k == "interface_ids" else []
-        with patch("netbox_librenms_plugin.views.sync.interfaces.get_object_or_404", return_value=obj):
+        with patch(
+            "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404", return_value=obj
+        ):
             with patch("netbox_librenms_plugin.views.sync.interfaces.Interface") as mc:
                 mc.objects.get.return_value = iface
                 with patch("netbox_librenms_plugin.views.sync.interfaces.transaction") as mt:
@@ -660,7 +672,9 @@ class TestDeleteNetBoxInterfacesPost:
         iface.device_id = 2
         req = MagicMock()
         req.POST.getlist.side_effect = lambda k: ["10"] if k == "interface_ids" else []
-        with patch("netbox_librenms_plugin.views.sync.interfaces.get_object_or_404", return_value=obj):
+        with patch(
+            "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404", return_value=obj
+        ):
             with patch("netbox_librenms_plugin.views.sync.interfaces.Interface") as mc:
                 mc.objects.get.return_value = iface
                 with patch("netbox_librenms_plugin.views.sync.interfaces.transaction") as mt:
@@ -682,7 +696,9 @@ class TestDeleteNetBoxInterfacesPost:
         iface.virtual_machine_id = 5
         req = MagicMock()
         req.POST.getlist.side_effect = lambda k: ["20"] if k == "interface_ids" else []
-        with patch("netbox_librenms_plugin.views.sync.interfaces.get_object_or_404", return_value=obj):
+        with patch(
+            "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404", return_value=obj
+        ):
             with patch("netbox_librenms_plugin.views.sync.interfaces.VMInterface") as mc:
                 mc.objects.get.return_value = iface
                 with patch("netbox_librenms_plugin.views.sync.interfaces.transaction") as mt:
@@ -705,7 +721,9 @@ class TestDeleteNetBoxInterfacesPost:
         iface.virtual_machine_id = 99
         req = MagicMock()
         req.POST.getlist.side_effect = lambda k: ["20"] if k == "interface_ids" else []
-        with patch("netbox_librenms_plugin.views.sync.interfaces.get_object_or_404", return_value=obj):
+        with patch(
+            "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404", return_value=obj
+        ):
             with patch("netbox_librenms_plugin.views.sync.interfaces.VMInterface") as mc:
                 mc.objects.get.return_value = iface
                 with patch("netbox_librenms_plugin.views.sync.interfaces.transaction") as mt:
@@ -728,7 +746,9 @@ class TestDeleteNetBoxInterfacesPost:
         obj.virtual_chassis = None
         req = MagicMock()
         req.POST.getlist.side_effect = lambda k: ["999"] if k == "interface_ids" else []
-        with patch("netbox_librenms_plugin.views.sync.interfaces.get_object_or_404", return_value=obj):
+        with patch(
+            "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404", return_value=obj
+        ):
             with patch("netbox_librenms_plugin.views.sync.interfaces.Interface") as mc:
                 mc.DoesNotExist = Interface.DoesNotExist
                 mc.objects.get.side_effect = Interface.DoesNotExist
@@ -763,7 +783,9 @@ class TestDeleteNetBoxInterfacesPost:
 
         req = MagicMock()
         req.POST.getlist.side_effect = lambda k: ["10", "20"] if k == "interface_ids" else []
-        with patch("netbox_librenms_plugin.views.sync.interfaces.get_object_or_404", return_value=obj):
+        with patch(
+            "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404", return_value=obj
+        ):
             with patch("netbox_librenms_plugin.views.sync.interfaces.Interface") as mc:
                 mc.objects.get.side_effect = get_se
                 with patch("netbox_librenms_plugin.views.sync.interfaces.transaction") as mt:

--- a/netbox_librenms_plugin/tests/test_coverage_tables.py
+++ b/netbox_librenms_plugin/tests/test_coverage_tables.py
@@ -2588,27 +2588,21 @@ class TestGetInterfaceMapping:
         )
 
     def test_exact_match_returned(self):
-        from netbox_librenms_plugin.tables.interfaces import LibreNMSInterfaceTable
-
-        table = object.__new__(LibreNMSInterfaceTable)
+        table = self._table()
         mapping = self._mapping("ethernetCsmacd", 1000000)
         self._mapping("ethernetCsmacd", None, netbox_type="virtual")  # type-only fallback
 
         assert table.get_interface_mapping("ethernetCsmacd", 1000000) == mapping
 
     def test_fallback_type_only_match(self):
-        from netbox_librenms_plugin.tables.interfaces import LibreNMSInterfaceTable
-
-        table = object.__new__(LibreNMSInterfaceTable)
+        table = self._table()
         # Only a type-only (speed is None) mapping exists; the exact (type, speed) lookup misses.
         fallback = self._mapping("ethernetCsmacd", None, netbox_type="virtual")
 
         assert table.get_interface_mapping("ethernetCsmacd", 1000000) == fallback
 
     def test_no_match_returns_none(self):
-        from netbox_librenms_plugin.tables.interfaces import LibreNMSInterfaceTable
-
-        table = object.__new__(LibreNMSInterfaceTable)
+        table = self._table()
         self._mapping("ethernetCsmacd", 1000000)  # a mapping exists, but not for this type
 
         assert table.get_interface_mapping("unknown_type", 0) is None
@@ -2618,9 +2612,7 @@ class TestGetInterfaceMapping:
         from django.test.utils import CaptureQueriesContext
         from django.db import connection
 
-        from netbox_librenms_plugin.tables.interfaces import LibreNMSInterfaceTable
-
-        table = object.__new__(LibreNMSInterfaceTable)
+        table = self._table()
         self._mapping("ethernetCsmacd", 1000000)
         self._mapping("ethernetCsmacd", None, netbox_type="virtual")
 

--- a/netbox_librenms_plugin/tests/test_coverage_tables.py
+++ b/netbox_librenms_plugin/tests/test_coverage_tables.py
@@ -2571,6 +2571,7 @@ class TestRenderType:
 # ===========================================================================
 
 
+@pytest.mark.django_db
 class TestGetInterfaceMapping:
     """Tests for LibreNMSInterfaceTable.get_interface_mapping()."""
 
@@ -2579,63 +2580,56 @@ class TestGetInterfaceMapping:
 
         return object.__new__(LibreNMSInterfaceTable)
 
-    def _mapping(self, librenms_type, librenms_speed):
-        m = MagicMock()
-        m.librenms_type = librenms_type
-        m.librenms_speed = librenms_speed
-        return m
+    def _mapping(self, librenms_type, librenms_speed, netbox_type="1000base-t"):
+        from netbox_librenms_plugin.models import InterfaceTypeMapping
+
+        return InterfaceTypeMapping.objects.create(
+            librenms_type=librenms_type, librenms_speed=librenms_speed, netbox_type=netbox_type
+        )
 
     def test_exact_match_returned(self):
         from netbox_librenms_plugin.tables.interfaces import LibreNMSInterfaceTable
 
         table = object.__new__(LibreNMSInterfaceTable)
         mapping = self._mapping("ethernetCsmacd", 1000000)
+        self._mapping("ethernetCsmacd", None, netbox_type="virtual")  # type-only fallback
 
-        # The mappings are snapshotted once via .all() and resolved in memory.
-        with patch("netbox_librenms_plugin.tables.interfaces.InterfaceTypeMapping") as mock_model:
-            mock_model.objects.all.return_value = [mapping]
-            result = table.get_interface_mapping("ethernetCsmacd", 1000000)
-
-        assert result is mapping
+        assert table.get_interface_mapping("ethernetCsmacd", 1000000) == mapping
 
     def test_fallback_type_only_match(self):
         from netbox_librenms_plugin.tables.interfaces import LibreNMSInterfaceTable
 
         table = object.__new__(LibreNMSInterfaceTable)
         # Only a type-only (speed is None) mapping exists; the exact (type, speed) lookup misses.
-        fallback_mapping = self._mapping("ethernetCsmacd", None)
+        fallback = self._mapping("ethernetCsmacd", None, netbox_type="virtual")
 
-        with patch("netbox_librenms_plugin.tables.interfaces.InterfaceTypeMapping") as mock_model:
-            mock_model.objects.all.return_value = [fallback_mapping]
-            result = table.get_interface_mapping("ethernetCsmacd", 1000000)
-
-        assert result is fallback_mapping
+        assert table.get_interface_mapping("ethernetCsmacd", 1000000) == fallback
 
     def test_no_match_returns_none(self):
         from netbox_librenms_plugin.tables.interfaces import LibreNMSInterfaceTable
 
         table = object.__new__(LibreNMSInterfaceTable)
+        self._mapping("ethernetCsmacd", 1000000)  # a mapping exists, but not for this type
 
-        with patch("netbox_librenms_plugin.tables.interfaces.InterfaceTypeMapping") as mock_model:
-            mock_model.objects.all.return_value = []
-            result = table.get_interface_mapping("unknown_type", 0)
-
-        assert result is None
+        assert table.get_interface_mapping("unknown_type", 0) is None
 
     def test_mappings_snapshotted_once_for_repeated_lookups(self):
-        """The mapping table is read once (InterfaceTypeMapping.objects.all()), not per lookup, so a multi-row render doesn't re-query the static table."""
+        """The mapping table is read once, not per lookup, so a multi-row render doesn't re-query the static table."""
+        from django.test.utils import CaptureQueriesContext
+        from django.db import connection
+
         from netbox_librenms_plugin.tables.interfaces import LibreNMSInterfaceTable
 
         table = object.__new__(LibreNMSInterfaceTable)
-        m1 = self._mapping("ethernetCsmacd", 1000000)
-        m2 = self._mapping("ethernetCsmacd", None)
+        self._mapping("ethernetCsmacd", 1000000)
+        self._mapping("ethernetCsmacd", None, netbox_type="virtual")
 
-        with patch("netbox_librenms_plugin.tables.interfaces.InterfaceTypeMapping") as mock_model:
-            mock_model.objects.all.return_value = [m1, m2]
+        with CaptureQueriesContext(connection) as queries:
             for _ in range(5):
                 table.get_interface_mapping("ethernetCsmacd", 1000000)
 
-        assert mock_model.objects.all.call_count == 1
+        mapping_queries = [q for q in queries.captured_queries if "interfacetypemapping" in q["sql"].lower()]
+        assert len(mapping_queries) == 1
 
 
 # ===========================================================================

--- a/netbox_librenms_plugin/tests/test_coverage_utils.py
+++ b/netbox_librenms_plugin/tests/test_coverage_utils.py
@@ -662,36 +662,24 @@ class TestFindMatchingSiteMultipleReturned:
             assert result["site"] is mock_site
 
 
+@pytest.mark.django_db
 class TestFindMatchingPlatformMultipleReturned:
-    """Tests for find_matching_platform MultipleObjectsReturned (lines 358-360)."""
+    """find_matching_platform must fail closed when the Platform name is ambiguous."""
 
     def test_multiple_objects_returned_returns_ambiguous(self):
+        from dcim.models import Platform
+
         from netbox_librenms_plugin.utils import find_matching_platform
 
-        Platform_DoesNotExist = type("DoesNotExist", (Exception,), {})
-        Platform_MultipleObjectsReturned = type("MultipleObjectsReturned", (Exception,), {})
-        PlatformMapping_DoesNotExist = type("DoesNotExist", (Exception,), {})
+        # Platform.name is unique case-SENSITIVELY while the lookup is case-INsensitive, so
+        # these two rows coexist and name__iexact matches both. No PlatformMapping exists to
+        # break the tie, so the ambiguity is surfaced rather than resolved arbitrarily.
+        Platform.objects.create(name="ios", slug="ios")
+        Platform.objects.create(name="IOS", slug="ios-upper")
 
-        with patch("netbox_librenms_plugin.models.PlatformMapping") as MockPlatformMapping:
-            MockPlatformMapping.DoesNotExist = PlatformMapping_DoesNotExist
-            MockPlatformMapping.objects.get.side_effect = PlatformMapping_DoesNotExist("no mapping")
+        result = find_matching_platform("ios")
 
-            with patch("dcim.models.Platform") as MockPlatform:
-                MockPlatform.DoesNotExist = Platform_DoesNotExist
-                MockPlatform.MultipleObjectsReturned = Platform_MultipleObjectsReturned
-                MockPlatform.objects.get.side_effect = Platform_MultipleObjectsReturned("multiple")
-
-                result = find_matching_platform("ios")
-                assert result["found"] is False
-                assert result["platform"] is None
-                assert result["match_type"] == "ambiguous"
-                assert result["ambiguity_source"] == "platform"
-                # Per the fix for the "PlatformMapping never consulted" CodeRabbit
-                # finding: when Platform.MultipleObjectsReturned fires, the function
-                # now defers the ambiguity decision and consults PlatformMapping
-                # first so an explicit override can disambiguate. Only when the
-                # mapping also misses do we surface ambiguous(platform).
-                MockPlatformMapping.objects.get.assert_called_once_with(librenms_os__iexact="ios")
+        assert result == {"found": False, "platform": None, "match_type": "ambiguous", "ambiguity_source": "platform"}
 
 
 class TestGetMissingVlanWarning:

--- a/netbox_librenms_plugin/tests/test_device_fields_server_scoping.py
+++ b/netbox_librenms_plugin/tests/test_device_fields_server_scoping.py
@@ -23,6 +23,26 @@ from netbox_librenms_plugin.librenms_api import LibreNMSAPI
 from netbox_librenms_plugin.tests.conftest import make_device
 
 
+def _bind_and_call(view, request, method, **kwargs):
+    """Call *view*.<method>, binding the request the way ``View.setup()`` does under dispatch().
+
+    A direct ``view.post(request, ...)`` leaves ``self.request`` unset, which the object-scoped
+    lookups read — production always goes through dispatch(), so bind it here too.
+    """
+    view.setup(request)
+    return getattr(view, method)(request, **kwargs)
+
+
+def _post(view, request, **kwargs):
+    """POST into *view* with the request bound (see :func:`_bind_and_call`)."""
+    return _bind_and_call(view, request, "post", **kwargs)
+
+
+def _get(view, request, **kwargs):
+    """GET into *view* with the request bound (see :func:`_bind_and_call`)."""
+    return _bind_and_call(view, request, "get", **kwargs)
+
+
 @pytest.fixture(autouse=True)
 def mock_librenms_config():
     """Neutralize the suite-wide autouse config mock (registered via ``pytest_plugins``).
@@ -105,7 +125,7 @@ class TestUpdateDeviceNameServerScoping:
             patch("netbox_librenms_plugin.views.sync.device_fields.messages"),
             patch("netbox_librenms_plugin.views.sync.device_fields.redirect_with_server_key"),
         ):
-            view.post(request, pk=viewed.pk)
+            _post(view, request, pk=viewed.pk)
 
         assert recorded["device_pk"] == sib_siteB.pk, (
             "VC sync-device resolution was not scoped to the POSTed server_key "

--- a/netbox_librenms_plugin/tests/test_device_fields_server_scoping.py
+++ b/netbox_librenms_plugin/tests/test_device_fields_server_scoping.py
@@ -23,24 +23,7 @@ from netbox_librenms_plugin.librenms_api import LibreNMSAPI
 from netbox_librenms_plugin.tests.conftest import make_device
 
 
-def _bind_and_call(view, request, method, **kwargs):
-    """Call *view*.<method>, binding the request the way ``View.setup()`` does under dispatch().
-
-    A direct ``view.post(request, ...)`` leaves ``self.request`` unset, which the object-scoped
-    lookups read — production always goes through dispatch(), so bind it here too.
-    """
-    view.setup(request)
-    return getattr(view, method)(request, **kwargs)
-
-
-def _post(view, request, **kwargs):
-    """POST into *view* with the request bound (see :func:`_bind_and_call`)."""
-    return _bind_and_call(view, request, "post", **kwargs)
-
-
-def _get(view, request, **kwargs):
-    """GET into *view* with the request bound (see :func:`_bind_and_call`)."""
-    return _bind_and_call(view, request, "get", **kwargs)
+from netbox_librenms_plugin.tests.view_test_helpers import post as _post
 
 
 @pytest.fixture(autouse=True)

--- a/netbox_librenms_plugin/tests/test_device_validation_details_template.py
+++ b/netbox_librenms_plugin/tests/test_device_validation_details_template.py
@@ -563,14 +563,15 @@ class TestPromoteModalAccessibility:
 
 
 @pytest.mark.django_db
-class TestMergePromoteFormsShareServerKeyInclude:
-    """The merge and promote POST forms carry server_key via the shared include.
+class TestMappingFormsShareServerKeyInclude:
+    """Mapping-writing POST forms carry server_key once via the shared include.
 
     Every other action form in this template routes the hidden input through
     inc/_hidden_server_key.html, which renders NOTHING when the context has no
-    server_key. The merge/promote forms were the last two with a raw
+    server_key. The merge/promote forms were the first two converted from a raw
     <input value="{{ server_key }}">, which posts server_key="" on a keyless
-    render instead of omitting the field like their sibling forms.
+    render instead of omitting the field like their sibling forms. Link/update shares the same
+    contract and must not combine a raw input with the include.
     """
 
     def _render(self, server_key, pane):
@@ -595,9 +596,11 @@ class TestMergePromoteFormsShareServerKeyInclude:
                 "host_named": {"pk": existing.pk, "name": existing.name},
                 "oob_named": {"pk": donor.pk, "name": donor.name},
             }
-        else:
+        elif pane == "promote":
             validation["serial_action"] = "promote_to_host"
             validation["promote_to_host"] = {"existing_libre_id": 88, "existing_oob_type": "idrac"}
+        else:
+            validation["serial_action"] = "link"
         ctx = {
             "validation": validation,
             "libre_device": {"device_id": 12, "sysName": "srvkey-forms", "hostname": "srvkey-forms"},
@@ -623,16 +626,25 @@ class TestMergePromoteFormsShareServerKeyInclude:
 
     @pytest.mark.parametrize(
         ("pane", "marker"),
-        [("merge", "merge-netbox-devices"), ("promote", "promote-to-host")],
+        [
+            ("merge", "merge-netbox-devices"),
+            ("promote", "promote-to-host"),
+            ("link", 'name="action" value="link"'),
+        ],
     )
     def test_form_carries_the_scoped_server_key(self, pane, marker):
         html = self._render(server_key="tab-scope-key", pane=pane)
         form = self._form_containing(html, marker)
         assert 'name="server_key" value="tab-scope-key"' in form
+        assert form.count('name="server_key"') == 1
 
     @pytest.mark.parametrize(
         ("pane", "marker"),
-        [("merge", "merge-netbox-devices"), ("promote", "promote-to-host")],
+        [
+            ("merge", "merge-netbox-devices"),
+            ("promote", "promote-to-host"),
+            ("link", 'name="action" value="link"'),
+        ],
     )
     def test_keyless_render_omits_the_input_instead_of_posting_blank(self, pane, marker):
         html = self._render(server_key=None, pane=pane)

--- a/netbox_librenms_plugin/tests/test_device_validation_details_template.py
+++ b/netbox_librenms_plugin/tests/test_device_validation_details_template.py
@@ -458,6 +458,10 @@ class TestPromoteToHostFallbackPane:
         """Branch-agnostic: whether the fallback or the real promote pane renders, the row must offer an action inside the Host div."""
         html = self._render()
         assert 'id="serial-role-host-5"' in html
+        pane_start = html.find('id="serial-role-host-5"')
+        pane_end = html.find('id="serial-role-oob-5"', pane_start)
+        pane = html[pane_start : pane_end if pane_end != -1 else None]
+        assert "device_conflict_action" in pane or "promote-modal-trigger" in pane
 
 
 def test_promote_override_handler_clears_hidden_when_switching_back_to_keep():

--- a/netbox_librenms_plugin/tests/test_device_validation_details_template.py
+++ b/netbox_librenms_plugin/tests/test_device_validation_details_template.py
@@ -559,7 +559,7 @@ class TestPromoteModalAccessibility:
         assert re.search(
             r'<h\d(?=[^>]*\bid="promote-modal-label-12")(?=[^>]*\bclass="[^"]*\bmodal-title\b)[^>]*>',
             html,
-        )
+        ), "aria-labelledby must reference the modal-title heading"
 
 
 @pytest.mark.django_db

--- a/netbox_librenms_plugin/tests/test_import_utils.py
+++ b/netbox_librenms_plugin/tests/test_import_utils.py
@@ -5,7 +5,7 @@ Phase 2 tests covering cache key generation, device name determination,
 device retrieval, and device validation functions.
 """
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, call, patch
 
 import pytest
 
@@ -2298,6 +2298,10 @@ class TestDeviceConflictActionView:
         assert existing_device.custom_field_data["librenms_id"] == {"default": 10}
         assert existing_device.name == "switch-01.example.com"
         existing_device.save.assert_called_once()
+        assert mock_device_cls.objects.restrict.call_args_list == [
+            call(request.user, "change"),
+            call(request.user, "change"),
+        ]
 
     @patch("netbox_librenms_plugin.views.imports.actions.cache")
     @patch("netbox_librenms_plugin.views.imports.actions.get_import_device_cache_key")

--- a/netbox_librenms_plugin/tests/test_import_utils.py
+++ b/netbox_librenms_plugin/tests/test_import_utils.py
@@ -2282,7 +2282,8 @@ class TestDeviceConflictActionView:
             patch("netbox_librenms_plugin.views.imports.actions.transaction") as mock_tx,
         ):
             mock_tx.atomic.return_value = MagicMock()
-            mock_device_cls.objects.restrict.return_value.get.return_value = existing_device
+            mock_device_cls.objects.restrict.return_value = mock_device_cls.objects
+            mock_device_cls.objects.get.return_value = existing_device
             mock_device_cls.objects.select_for_update.return_value.get.return_value = existing_device
             mock_device_cls.objects.filter.return_value.exclude.return_value.first.return_value = None
             mock_device_cls.objects.filter.return_value.first.return_value = None
@@ -2329,7 +2330,8 @@ class TestDeviceConflictActionView:
             patch("netbox_librenms_plugin.views.imports.actions.transaction") as mock_tx,
         ):
             mock_tx.atomic.return_value = MagicMock()
-            mock_device_cls.objects.restrict.return_value.get.return_value = existing_device
+            mock_device_cls.objects.restrict.return_value = mock_device_cls.objects
+            mock_device_cls.objects.get.return_value = existing_device
             mock_device_cls.objects.select_for_update.return_value.get.return_value = existing_device
             mock_device_cls.objects.filter.return_value.first.return_value = None
             mock_device_cls.objects.filter.return_value.exclude.return_value.first.return_value = None
@@ -2373,7 +2375,8 @@ class TestDeviceConflictActionView:
             patch("netbox_librenms_plugin.views.imports.actions.transaction") as mock_tx,
         ):
             mock_tx.atomic.return_value = MagicMock()
-            mock_device_cls.objects.restrict.return_value.get.return_value = existing_device
+            mock_device_cls.objects.restrict.return_value = mock_device_cls.objects
+            mock_device_cls.objects.get.return_value = existing_device
             mock_device_cls.objects.select_for_update.return_value.get.return_value = existing_device
             mock_device_cls.objects.filter.return_value.exclude.return_value.first.return_value = None
             mock_device_cls.objects.filter.return_value.first.return_value = None
@@ -2424,7 +2427,8 @@ class TestDeviceConflictActionView:
             patch("netbox_librenms_plugin.views.imports.actions.transaction") as mock_tx,
         ):
             mock_tx.atomic.return_value = MagicMock()
-            mock_device_cls.objects.restrict.return_value.get.return_value = existing_device
+            mock_device_cls.objects.restrict.return_value = mock_device_cls.objects
+            mock_device_cls.objects.get.return_value = existing_device
             mock_device_cls.objects.select_for_update.return_value.get.return_value = existing_device
             mock_device_cls.objects.filter.return_value.exclude.return_value.first.return_value = None
             mock_device_cls.objects.filter.return_value.first.return_value = None
@@ -2464,7 +2468,8 @@ class TestDeviceConflictActionView:
             patch("netbox_librenms_plugin.views.imports.actions.transaction") as mock_tx,
         ):
             mock_tx.atomic.return_value = MagicMock()
-            mock_device_cls.objects.restrict.return_value.get.return_value = existing_device
+            mock_device_cls.objects.restrict.return_value = mock_device_cls.objects
+            mock_device_cls.objects.get.return_value = existing_device
             mock_device_cls.objects.select_for_update.return_value.get.return_value = existing_device
             mock_device_cls.objects.filter.return_value.exclude.return_value.first.return_value = None
             mock_device_cls.objects.filter.return_value.first.return_value = None
@@ -2508,7 +2513,8 @@ class TestDeviceConflictActionView:
             patch("netbox_librenms_plugin.views.imports.actions.transaction") as mock_tx,
         ):
             mock_tx.atomic.return_value = MagicMock()
-            mock_device_cls.objects.restrict.return_value.get.return_value = existing_device
+            mock_device_cls.objects.restrict.return_value = mock_device_cls.objects
+            mock_device_cls.objects.get.return_value = existing_device
             mock_device_cls.objects.select_for_update.return_value.get.return_value = existing_device
             mock_device_cls.objects.filter.return_value.exclude.return_value.first.return_value = None
             mock_device_cls.objects.filter.return_value.exclude.return_value.exists.return_value = False
@@ -2549,7 +2555,8 @@ class TestDeviceConflictActionView:
             patch.object(DeviceConflictActionView, "require_object_permissions", return_value=None),
             patch("dcim.models.Device") as mock_device_cls,
         ):
-            mock_device_cls.objects.restrict.return_value.get.return_value = existing_device
+            mock_device_cls.objects.restrict.return_value = mock_device_cls.objects
+            mock_device_cls.objects.get.return_value = existing_device
             mock_device_cls.objects.select_for_update.return_value.get.return_value = existing_device
             mock_device_cls.objects.filter.return_value.exclude.return_value.first.return_value = None
             # Include existing_device so the validated-conflict-target guard passes;
@@ -2590,7 +2597,8 @@ class TestDeviceConflictActionView:
             patch.object(DeviceConflictActionView, "render_device_row") as mock_render,
             patch("dcim.models.Device") as mock_device_cls,
         ):
-            mock_device_cls.objects.restrict.return_value.get.return_value = existing_device
+            mock_device_cls.objects.restrict.return_value = mock_device_cls.objects
+            mock_device_cls.objects.get.return_value = existing_device
             mock_device_cls.objects.select_for_update.return_value.get.return_value = existing_device
             mock_device_cls.objects.filter.return_value.exclude.return_value.first.return_value = None
             mock_validate.return_value = (libre_device, validation, selections)
@@ -2624,7 +2632,8 @@ class TestDeviceConflictActionView:
             patch.object(DeviceConflictActionView, "get_validated_device_with_selections") as mock_validate,
             patch("dcim.models.Device") as mock_device_cls,
         ):
-            mock_device_cls.objects.restrict.return_value.get.return_value = existing_device
+            mock_device_cls.objects.restrict.return_value = mock_device_cls.objects
+            mock_device_cls.objects.get.return_value = existing_device
             mock_device_cls.objects.select_for_update.return_value.get.return_value = existing_device
             mock_device_cls.objects.filter.return_value.exclude.return_value.first.return_value = None
             mock_validate.return_value = (libre_device, validation, selections)
@@ -2667,7 +2676,8 @@ class TestDeviceConflictActionView:
             patch("netbox_librenms_plugin.views.imports.actions.transaction") as mock_tx,
         ):
             mock_tx.atomic.return_value = MagicMock()
-            mock_device_cls.objects.restrict.return_value.get.return_value = existing_device
+            mock_device_cls.objects.restrict.return_value = mock_device_cls.objects
+            mock_device_cls.objects.get.return_value = existing_device
             mock_device_cls.objects.select_for_update.return_value.get.return_value = existing_device
             mock_device_cls.objects.filter.return_value.exclude.return_value.first.return_value = None
             mock_device_cls.objects.filter.return_value.first.return_value = None
@@ -2722,7 +2732,8 @@ class TestDeviceConflictActionView:
             patch("netbox_librenms_plugin.views.imports.actions.transaction") as mock_tx,
         ):
             mock_tx.atomic.return_value = MagicMock()
-            mock_device_cls.objects.restrict.return_value.get.return_value = existing_device
+            mock_device_cls.objects.restrict.return_value = mock_device_cls.objects
+            mock_device_cls.objects.get.return_value = existing_device
             mock_device_cls.objects.select_for_update.return_value.get.return_value = existing_device
             mock_device_cls.objects.filter.return_value.exclude.return_value.first.return_value = None
             mock_device_cls.objects.filter.return_value.first.return_value = None
@@ -2777,7 +2788,8 @@ class TestDeviceConflictActionView:
             patch.object(DeviceConflictActionView, "render_device_row") as mock_render,
             patch("dcim.models.Device") as mock_device_cls,
         ):
-            mock_device_cls.objects.restrict.return_value.get.return_value = existing_device
+            mock_device_cls.objects.restrict.return_value = mock_device_cls.objects
+            mock_device_cls.objects.get.return_value = existing_device
             mock_device_cls.objects.select_for_update.return_value.get.return_value = existing_device
             mock_device_cls.objects.filter.return_value.exclude.return_value.first.return_value = None
             mock_validate.return_value = (libre_device, validation, selections)
@@ -2812,7 +2824,8 @@ class TestDeviceConflictActionView:
             patch("netbox_librenms_plugin.views.imports.actions.transaction") as mock_tx,
         ):
             mock_tx.atomic.return_value = MagicMock()
-            mock_device_cls.objects.restrict.return_value.get.return_value = existing_device
+            mock_device_cls.objects.restrict.return_value = mock_device_cls.objects
+            mock_device_cls.objects.get.return_value = existing_device
             mock_device_cls.objects.select_for_update.return_value.get.return_value = existing_device
             mock_device_cls.objects.filter.return_value.exclude.return_value.first.return_value = None
             mock_device_cls.objects.filter.return_value.first.return_value = None
@@ -2852,7 +2865,8 @@ class TestDeviceConflictActionView:
             # it from netbox_librenms_plugin.utils, so that is the correct seam to mock.
             patch("netbox_librenms_plugin.utils.find_matching_platform") as mock_find_platform,
         ):
-            mock_device_cls.objects.restrict.return_value.get.return_value = existing_device
+            mock_device_cls.objects.restrict.return_value = mock_device_cls.objects
+            mock_device_cls.objects.get.return_value = existing_device
             mock_device_cls.objects.select_for_update.return_value.get.return_value = existing_device
             mock_device_cls.objects.filter.return_value.exclude.return_value.first.return_value = None
             mock_find_platform.return_value = {"found": True, "platform": mock_platform, "match_type": "exact"}
@@ -2888,7 +2902,8 @@ class TestDeviceConflictActionView:
             patch("dcim.models.Device") as mock_device_cls,
             patch("netbox_librenms_plugin.utils.match_librenms_hardware_to_device_type") as mock_hw_match,
         ):
-            mock_device_cls.objects.restrict.return_value.get.return_value = existing_device
+            mock_device_cls.objects.restrict.return_value = mock_device_cls.objects
+            mock_device_cls.objects.get.return_value = existing_device
             mock_device_cls.objects.select_for_update.return_value.get.return_value = existing_device
             mock_device_cls.objects.filter.return_value.exclude.return_value.first.return_value = None
             mock_hw_match.return_value = {"matched": True, "device_type": new_device_type}

--- a/netbox_librenms_plugin/tests/test_import_utils.py
+++ b/netbox_librenms_plugin/tests/test_import_utils.py
@@ -4537,7 +4537,12 @@ class TestBulkImportCancellation:
         ):
             mock_api = MagicMock()
             mock_api.server_key = "default"
-            mock_api.get_device_info.return_value = (True, {"device_id": 1, "hostname": "sw"})
+            # Echo the requested id like the real API — the import loop's identity check
+            # (row_identity_matches) rejects a payload describing another device.
+            mock_api.get_device_info.side_effect = lambda did, **_kwargs: (
+                True,
+                {"device_id": did, "hostname": "sw"},
+            )
             mock_api_cls.return_value = mock_api
             mock_import.return_value = {"success": True, "device": MagicMock(), "is_vm": False}
 

--- a/netbox_librenms_plugin/tests/test_import_validation_helpers.py
+++ b/netbox_librenms_plugin/tests/test_import_validation_helpers.py
@@ -719,3 +719,9 @@ class TestMergeCandidatePks:
 
         validation = {"merge_candidates": {"host_named": {"pk": 0}, "oob_named": {"pk": "not-int"}}}
         assert merge_candidate_pks(validation) == set()
+
+    def test_non_dict_validation_is_rejected(self):
+        from netbox_librenms_plugin.import_validation_helpers import merge_candidate_pks
+
+        assert merge_candidate_pks(["malformed"]) == set()
+        assert merge_candidate_pks("malformed") == set()

--- a/netbox_librenms_plugin/tests/test_import_validation_helpers.py
+++ b/netbox_librenms_plugin/tests/test_import_validation_helpers.py
@@ -696,3 +696,26 @@ class TestApplyMergeCandidates:
         assert result["serial_role_choice_available"] is False
         # And the merge path is now the single source of truth.
         assert result["serial_action"] == "merge_netbox_devices"
+
+
+class TestMergeCandidatePks:
+    """merge_candidate_pks must fail closed on corrupt pk values, never crash on an unhashable one."""
+
+    def test_returns_positive_pks_from_both_slots(self):
+        from netbox_librenms_plugin.import_validation_helpers import merge_candidate_pks
+
+        validation = {"merge_candidates": {"host_named": {"pk": 5}, "oob_named": {"pk": 9}}}
+        assert merge_candidate_pks(validation) == {5, 9}
+
+    def test_corrupt_unhashable_pk_is_skipped_not_crashing(self):
+        from netbox_librenms_plugin.import_validation_helpers import merge_candidate_pks
+
+        # {"pk": []} is unhashable; the old set.add(pk) raised TypeError on this row.
+        validation = {"merge_candidates": {"host_named": {"pk": []}, "oob_named": {"pk": 7}}}
+        assert merge_candidate_pks(validation) == {7}
+
+    def test_non_positive_and_non_int_pks_are_dropped(self):
+        from netbox_librenms_plugin.import_validation_helpers import merge_candidate_pks
+
+        validation = {"merge_candidates": {"host_named": {"pk": 0}, "oob_named": {"pk": "not-int"}}}
+        assert merge_candidate_pks(validation) == set()

--- a/netbox_librenms_plugin/tests/test_import_validation_helpers.py
+++ b/netbox_librenms_plugin/tests/test_import_validation_helpers.py
@@ -725,3 +725,14 @@ class TestMergeCandidatePks:
 
         assert merge_candidate_pks(["malformed"]) == set()
         assert merge_candidate_pks("malformed") == set()
+
+    def test_non_dict_merge_candidates_is_rejected(self):
+        from netbox_librenms_plugin.import_validation_helpers import merge_candidate_pks
+
+        assert merge_candidate_pks({"merge_candidates": ["host_named"]}) == set()
+
+    def test_non_dict_slot_entry_is_skipped(self):
+        from netbox_librenms_plugin.import_validation_helpers import merge_candidate_pks
+
+        validation = {"merge_candidates": {"host_named": "corrupt", "oob_named": {"pk": 3}}}
+        assert merge_candidate_pks(validation) == {3}

--- a/netbox_librenms_plugin/tests/test_librenms_api.py
+++ b/netbox_librenms_plugin/tests/test_librenms_api.py
@@ -1364,7 +1364,7 @@ class TestLibreNMSAPIPortsAndInventory:
         response.raise_for_status.side_effect = error
         response.json.return_value = {
             "status": "error",
-            "message": "Device 123 does not have any IP addresses",
+            "message": "The device does not have any IP addresses",
         }
 
         from netbox_librenms_plugin.librenms_api import LibreNMSAPI

--- a/netbox_librenms_plugin/tests/test_migrate_views.py
+++ b/netbox_librenms_plugin/tests/test_migrate_views.py
@@ -905,6 +905,7 @@ class TestTransferDeviceIPView:
         winner.refresh_from_db()
         assert winner.oob_ip_id == oob_ip.pk
         assert donor.oob_ip_id is None
+        assert state["moved"], "the injected interface move did not run"
 
     def test_rejects_when_address_still_attached_to_donor(self):
         """The transfer only flips the FK (save skips full_clean), so it must refuse to point the winner at an address still assigned to a DONOR interface — otherwise the winner would own an oob_ip that isn't on one of its interfaces."""

--- a/netbox_librenms_plugin/tests/test_migrate_views.py
+++ b/netbox_librenms_plugin/tests/test_migrate_views.py
@@ -1714,6 +1714,18 @@ class TestMovableIpsForMigration:
         assert result[0]["address"] == "10.10.0.5/24"
         assert result[0]["interface_name"] == "eth0"
 
+    def test_none_server_key_uses_the_default_marker_scope(self):
+        """A degraded render with no bound key still finds a marker stored in default scope."""
+        from netbox_librenms_plugin.utils import mark_librenms_migrated
+
+        winner = make_device("mv-winner-none-key")
+        donor = make_device("mv-donor-none-key")
+        ip_on(donor, "10.10.0.8/24", "eth0")
+        mark_librenms_migrated(donor, winner.pk, "default")
+        donor.save()
+
+        assert len(self._movable(donor, None)) == 1
+
     def test_excludes_unassigned_ip(self):
         from netbox_librenms_plugin.tests.conftest import make_ip
         from netbox_librenms_plugin.utils import mark_librenms_migrated

--- a/netbox_librenms_plugin/tests/test_migrate_views.py
+++ b/netbox_librenms_plugin/tests/test_migrate_views.py
@@ -293,6 +293,7 @@ def _hx_request(post=None):
     req.htmx = True  # pin branch intent: implementations may check `if request.htmx`
     req.META = {"HTTP_REFERER": "/back"}
     req.user = MagicMock(is_superuser=True)
+    req._messages = MagicMock()  # parity with _nonhtmx_request: HTMX rejection paths call messages.error()
     return req
 
 

--- a/netbox_librenms_plugin/tests/test_migrate_views.py
+++ b/netbox_librenms_plugin/tests/test_migrate_views.py
@@ -895,6 +895,7 @@ class TestTransferDeviceIPView:
             return queryset
 
         req = _hx_request({"server_key": "default"})
+        view.request = req
         with patch.object(Interface.objects, "select_for_update", moving_sfu):
             resp = view.post(req, pk=donor.pk, ip_kind="oob")
 

--- a/netbox_librenms_plugin/tests/test_migrate_views.py
+++ b/netbox_librenms_plugin/tests/test_migrate_views.py
@@ -75,6 +75,47 @@ class TestGetMigratedToMarker:
 
         assert get_migrated_to_marker(None, "default") is None
 
+    def test_blank_or_none_server_key_reads_the_default_marker(self):
+        # A blank/None key means the default server everywhere else in the plugin; a reader
+        # passing a raw unnormalized key must not miss the default-server marker (and flip a
+        # migrated donor's UI back to ordinary sync mode).
+        from netbox_librenms_plugin.utils import get_migrated_to_marker
+
+        marker_data = {"device_id": 42, "server_key": "default", "at": "2025-01-01T00:00:00Z"}
+        donor = _make_migrate_device("mig-blank-key", {"default": {"_migrated_to": marker_data}})
+        assert get_migrated_to_marker(donor, "") == marker_data
+        assert get_migrated_to_marker(donor, None) == marker_data
+
+    def test_build_migrated_context_with_blank_key_carries_the_marker(self):
+        from netbox_librenms_plugin.utils import build_migrated_context
+
+        winner = _make_migrate_device("mig-blank-ctx-winner")
+        donor = _make_migrate_device(
+            "mig-blank-ctx-donor",
+            {
+                "default": {
+                    "_migrated_to": {"device_id": winner.pk, "server_key": "default", "at": "2025-01-01T00:00:00Z"}
+                }
+            },
+        )
+        ctx = build_migrated_context(donor, "")
+        assert ctx["migrated_to_marker"] is not None
+        assert bool(ctx["migrated_to_winner"])
+
+    def test_mark_librenms_migrated_normalizes_blank_key_to_default(self):
+        # Writer/reader pairing: stamping with a blank key must land under "default" so the
+        # normalized readers find it (marker server_key stamped as "default" too).
+        from netbox_librenms_plugin.utils import get_migrated_to_marker, mark_librenms_migrated
+
+        winner = _make_migrate_device("mig-blank-write-winner")
+        donor = _make_migrate_device("mig-blank-write-donor", {"default": {"id": 7}})
+        mark_librenms_migrated(donor, winner.pk, "")
+        donor.save()
+        marker = get_migrated_to_marker(donor, "default")
+        assert marker is not None
+        assert marker["server_key"] == "default"
+        assert marker["device_id"] == winner.pk
+
     def test_returns_none_when_device_id_is_bool(self):
         # bool is a subclass of int; a marker with device_id=True must not be
         # treated as a valid pk (would otherwise map to device #1).
@@ -818,6 +859,52 @@ class TestTransferDeviceIPView:
         winner.refresh_from_db()
         assert winner.oob_ip_id == oob_ip.pk  # winner claimed it
         assert donor.oob_ip_id is None  # donor released it
+
+    def test_transfer_survives_interface_move_onto_winner_between_read_and_lock(self):
+        """A concurrent interface move ONTO the winner, landing between the GFK read and the interface lock, must not spuriously 409 the transfer: the freshly locked (winner-owned) row is assigned back onto donor_ip before set_device_ip_fk re-checks ownership."""
+        from dcim.models import Interface
+
+        view = self._setup_view()
+        donor = make_device("tx-race-donor")
+        winner = make_device("tx-race-winner")
+        self._mark(donor, winner)
+        # The address starts on a DONOR interface, so the view's assigned_object read caches
+        # a device_id=donor snapshot on the locked IP row.
+        oob_ip = ip_on(donor, "10.0.0.7/24", "mgmt0")
+        donor.oob_ip = oob_ip
+        donor.save()
+        iface_pk = oob_ip.assigned_object_id
+
+        # Simulate the concurrent move: the owning-interface SELECT ... FOR UPDATE fires AFTER
+        # the GFK read cached device_id=donor. Move the interface onto the winner right then,
+        # so the locked row is winner-owned while the cached GFK snapshot is stale.
+        real_sfu = Interface.objects.select_for_update
+        state = {"moved": False}
+
+        def moving_sfu(*args, **kwargs):
+            queryset = real_sfu(*args, **kwargs)
+            real_filter = queryset.filter
+
+            def moving_filter(*f_args, **f_kwargs):
+                if not state["moved"] and f_kwargs.get("pk") == iface_pk:
+                    state["moved"] = True
+                    Interface.objects.filter(pk=iface_pk).update(device=winner)
+                return real_filter(*f_args, **f_kwargs)
+
+            queryset.filter = moving_filter
+            return queryset
+
+        req = _hx_request({"server_key": "default"})
+        with patch.object(Interface.objects, "select_for_update", moving_sfu):
+            resp = view.post(req, pk=donor.pk, ip_kind="oob")
+
+        # The interface is winner-owned at lock time, so the transfer MUST complete — not be
+        # rejected against the stale cached device_id and rolled back.
+        assert resp.headers.get("HX-Refresh") == "true"
+        donor.refresh_from_db()
+        winner.refresh_from_db()
+        assert winner.oob_ip_id == oob_ip.pk
+        assert donor.oob_ip_id is None
 
     def test_rejects_when_address_still_attached_to_donor(self):
         """The transfer only flips the FK (save skips full_clean), so it must refuse to point the winner at an address still assigned to a DONOR interface — otherwise the winner would own an oob_ip that isn't on one of its interfaces."""

--- a/netbox_librenms_plugin/tests/test_migrate_views.py
+++ b/netbox_librenms_plugin/tests/test_migrate_views.py
@@ -326,6 +326,7 @@ class TestMoveInterfaceToWinnerView:
         interface = make_interface(donor, "Eth0")
         req = _hx_request({"server_key": "default"})
 
+        view.request = req
         resp = view.post(req, pk=interface.pk)
 
         assert resp.status_code == 200
@@ -350,6 +351,7 @@ class TestMoveInterfaceToWinnerView:
         donor.save()
         req = _hx_request({"server_key": "default"})
 
+        view.request = req
         resp = view.post(req, pk=iface.pk)
 
         assert resp.status_code == 200
@@ -377,6 +379,7 @@ class TestMoveInterfaceToWinnerView:
         interface = make_interface(donor, "Eth0")
         req = _hx_request({"server_key": "default"})
 
+        view.request = req
         resp = view.post(req, pk=interface.pk)
 
         assert resp.status_code == 200
@@ -397,6 +400,7 @@ class TestMoveInterfaceToWinnerView:
         interface = make_interface(donor, "Eth0")
         req = _hx_request({"server_key": "default"})
 
+        view.request = req
         resp = view.post(req, pk=interface.pk)
 
         assert resp.status_code == 200
@@ -416,6 +420,7 @@ class TestMoveInterfaceToWinnerView:
         make_interface(winner, "Eth0")  # collision on the winner side
         req = _hx_request({"server_key": "default"})
 
+        view.request = req
         resp = view.post(req, pk=interface.pk)
 
         assert resp.status_code == 200
@@ -435,6 +440,7 @@ class TestMoveInterfaceToWinnerView:
         interface = make_interface(donor, "Eth0")
         req = _hx_request({"server_key": "default"})
 
+        view.request = req
         resp = view.post(req, pk=interface.pk)
 
         assert resp.status_code == 200
@@ -458,6 +464,7 @@ class TestMoveInterfaceToWinnerView:
             "netbox_librenms_plugin.views.mixins.LibreNMSAPI",
             side_effect=ValueError("LibreNMS URL or API token is not configured for server 'default'."),
         ) as api_ctor:
+            view.request = req
             resp = view.post(req, pk=interface.pk)
 
         api_ctor.assert_not_called()  # the fix never builds the (broken) client
@@ -478,6 +485,7 @@ class TestMoveInterfaceToWinnerView:
         member.save()
         req = _hx_request({"server_key": "default"})
 
+        view.request = req
         resp = view.post(req, pk=member.pk)
 
         # full_clean() failed for real → row not saved, error surfaced via the OOB toast.
@@ -501,6 +509,7 @@ class TestMoveInterfaceToWinnerView:
         member.save()
         req = _hx_request({"server_key": "default"})
 
+        view.request = req
         resp = view.post(req, pk=lag.pk)
 
         assert resp.status_code == 200
@@ -527,6 +536,7 @@ class TestMoveInterfaceToWinnerView:
         bridged.save()
         req = _hx_request({"server_key": "default"})
 
+        view.request = req
         resp = view.post(req, pk=parent.pk)
 
         assert resp.status_code == 200
@@ -550,6 +560,7 @@ class TestMoveInterfaceToWinnerView:
         make_interface(winner, "Eth0")  # collides with the member, not the master
         req = _hx_request({"server_key": "default"})
 
+        view.request = req
         resp = view.post(req, pk=lag.pk)
 
         assert resp.status_code == 200
@@ -576,6 +587,7 @@ class TestMoveInterfaceToWinnerView:
         cable_together(iface, peer_iface)
         req = _hx_request({"server_key": "default"})
 
+        view.request = req
         resp = view.post(req, pk=iface.pk)
 
         assert resp.status_code == 200
@@ -609,6 +621,7 @@ class TestMoveInterfaceToWinnerView:
             return real_save(self, *args, **kwargs)
 
         with patch.object(Interface, "save", boom):
+            view.request = req
             resp = view.post(req, pk=interface.pk)
 
         # Caught and surfaced as the collision 409 OOB toast (HTTP 200, HX-Reswap:none, no HX-Refresh).
@@ -645,6 +658,7 @@ class TestMoveInterfaceToWinnerView:
             return result
 
         with patch.object(Interface, "full_clean", racing_full_clean):
+            view.request = req
             resp = view.post(req, pk=interface.pk)
 
         assert state["raced"]
@@ -686,6 +700,7 @@ class TestMoveInterfaceToWinnerView:
             return result
 
         with patch.object(migrate_mod, "_resolve_winner_for_donor", side_effect=repoint_then_resolve):
+            view.request = req
             resp = view.post(req, pk=interface.pk)
 
         # Aborted with the concurrency conflict toast; the interface is moved to neither winner.
@@ -706,6 +721,7 @@ class TestMoveInterfaceToWinnerView:
         view.request = _hx_request()
         view.require_all_permissions = MagicMock(return_value=HttpResponse(status=403))
         req = _hx_request()
+        view.request = req
         resp = view.post(req, pk=5)
         assert resp.status_code == 403
 
@@ -747,6 +763,7 @@ class TestTransferDeviceIPView:
         # so a bare request (no device needed) is sufficient.
         view = self._setup_view()
         req = _hx_request()
+        view.request = req
         resp = view.post(req, pk=10, ip_kind="bogus")
         assert resp.status_code == 200
         assert b"django-messages" in resp.content
@@ -768,6 +785,7 @@ class TestTransferDeviceIPView:
         winner.save()
         req = _hx_request({"server_key": "default"})
 
+        view.request = req
         resp = view.post(req, pk=donor.pk, ip_kind="primary4")
 
         assert resp.status_code == 200
@@ -791,6 +809,7 @@ class TestTransferDeviceIPView:
         donor.save()
         req = _hx_request({"server_key": "default"})
 
+        view.request = req
         resp = view.post(req, pk=donor.pk, ip_kind="oob")
 
         assert resp.headers.get("HX-Refresh") == "true"
@@ -811,6 +830,7 @@ class TestTransferDeviceIPView:
         donor.save()
         req = _hx_request({"server_key": "default"})
 
+        view.request = req
         resp = view.post(req, pk=donor.pk, ip_kind="oob")
 
         assert b"django-messages" in resp.content
@@ -834,6 +854,7 @@ class TestTransferDeviceIPView:
         donor.save()
         req = _hx_request({"server_key": "default"})
 
+        view.request = req
         resp = view.post(req, pk=donor.pk, ip_kind="primary4")
 
         # Graceful HTMX error toast, not an uncaught 500.
@@ -864,6 +885,7 @@ class TestTransferDeviceIPView:
         donor.save()  # save() skips full_clean(), so the cross-type dangling FK persists
         req = _hx_request({"server_key": "default"})
 
+        view.request = req
         resp = view.post(req, pk=donor.pk, ip_kind="oob")
 
         # Reject path flows through _fail(): HX-Reswap:none and never the success HX-Refresh header.
@@ -905,6 +927,7 @@ class TestMoveIPAddressToWinnerView:
         ip = make_ip("10.0.0.1/24")  # unassigned
         req = _hx_request({"server_key": "default"})
 
+        view.request = req
         resp = view.post(req, pk=ip.pk)
 
         assert resp.status_code == 200
@@ -925,6 +948,7 @@ class TestMoveIPAddressToWinnerView:
         ip = make_ip("10.0.0.1/24", assigned_object=donor_iface)
         req = _hx_request({"server_key": "default"})
 
+        view.request = req
         resp = view.post(req, pk=ip.pk)
 
         assert resp.status_code == 200
@@ -947,6 +971,7 @@ class TestMoveIPAddressToWinnerView:
         ip = make_ip("10.0.0.1/24", assigned_object=donor_iface)
 
         req = _hx_request({"server_key": "default"})
+        view.request = req
         resp = view.post(req, pk=ip.pk)
 
         assert resp.status_code == 200
@@ -1274,6 +1299,7 @@ class TestNonHtmxFallbackRedirect:
                 return_value={"siteB": "Site B"},
             ),
         ):
+            view.request = req
             resp = view.post(req, pk=5)
 
         # Degraded non-HTMX path: a real redirect carrying tab + server context,
@@ -1336,6 +1362,7 @@ class TestVlanStaleServerMigratedContext:
             patch("netbox_librenms_plugin.utils.build_migrated_context", return_value={}) as mock_mig,
             patch("netbox_librenms_plugin.views.mixins.render", return_value="rendered"),
         ):
+            view.request = request
             result = view.post(request, pk=1)
 
         mock_mig.assert_called_once_with(obj, "test-server")  # session key, not "ghost-server"
@@ -1401,6 +1428,7 @@ class TestMigratedContextServerKeyFallback:
             patch("netbox_librenms_plugin.views.base.ip_addresses_view.messages"),
             patch("netbox_librenms_plugin.views.base.interfaces_view.messages"),
         ):
+            view.request = request
             result = view.post(request, pk=donor.pk)
 
         assert result == "rendered"
@@ -1469,6 +1497,7 @@ class TestMigratedContextServerKeyFallback:
                 side_effect=AssertionError("lazy librenms_api touched on the rebind-fail path"),
             ),
         ):
+            view.request = request
             view.post(request, pk=1)
 
         bmc.assert_called_once()
@@ -1500,6 +1529,7 @@ class TestMigratedContextServerKeyFallback:
                 side_effect=AssertionError("lazy librenms_api touched on the rebind-fail path"),
             ),
         ):
+            view.request = request
             view.post(request, pk=1)
 
         bmc.assert_called_once()
@@ -1531,6 +1561,7 @@ class TestMigratedContextServerKeyFallback:
                 side_effect=AssertionError("lazy librenms_api touched on the rebind-fail path"),
             ),
         ):
+            view.request = request
             view.post(request, pk=1)
 
         bmc.assert_called_once()
@@ -1561,6 +1592,7 @@ class TestMigratedContextServerKeyFallback:
                 side_effect=AssertionError("lazy librenms_api touched on the rebind-fail path"),
             ),
         ):
+            view.request = request
             view.post(request, pk=1)
 
         bmc.assert_called_once()
@@ -1592,6 +1624,7 @@ class TestMigratedContextServerKeyFallback:
                 side_effect=AssertionError("lazy librenms_api touched on the rebind-fail path"),
             ),
         ):
+            view.request = request
             view.post(request, pk=1)
 
         bmc.assert_called_once()
@@ -1616,6 +1649,7 @@ class TestMigratedContextServerKeyFallback:
             patch("netbox_librenms_plugin.views.mixins.render") as mock_render,
             patch("netbox_librenms_plugin.utils.build_migrated_context", return_value={}),
         ):
+            view.request = request
             view.post(request, pk=1)
 
         ip_sync = mock_render.call_args.args[2]["ip_sync"]
@@ -1642,6 +1676,7 @@ class TestMigratedContextServerKeyFallback:
             patch("netbox_librenms_plugin.views.mixins.render") as mock_render,
             patch("netbox_librenms_plugin.utils.build_migrated_context", return_value={}),
         ):
+            view.request = request
             view.post(request, pk=1)
 
         ip_sync = mock_render.call_args.args[2]["ip_sync"]

--- a/netbox_librenms_plugin/tests/test_module_replace.py
+++ b/netbox_librenms_plugin/tests/test_module_replace.py
@@ -167,8 +167,7 @@ class TestModuleMismatchPreviewView:
         ):
             mock_cache.get.return_value = {"inventory": cached, "librenms_id": "test"}
             mock_module_cls.objects.restrict.return_value = mock_module_cls.objects
-            mock_module_cls.objects.filter.return_value.exclude.return_value.select_related.return_value.count.return_value = 0
-            mock_module_cls.objects.filter.return_value.exclude.return_value.select_related.return_value.first.return_value = None
+            mock_module_cls.objects.filter.return_value.exclude.return_value.count.return_value = 0
             resp = view.get(request, pk=24)
 
         assert resp.status_code == 200
@@ -209,8 +208,8 @@ class TestModuleMismatchPreviewView:
         ):
             mock_cache.get.return_value = {"inventory": cached, "librenms_id": "test"}
             mock_module_cls.objects.restrict.return_value = mock_module_cls.objects
-            mock_module_cls.objects.filter.return_value.exclude.return_value.select_related.return_value.count.return_value = 1
-            mock_module_cls.objects.filter.return_value.exclude.return_value.select_related.return_value.first.return_value = conflict_module
+            mock_module_cls.objects.filter.return_value.exclude.return_value.count.return_value = 1
+            mock_module_cls.objects.filter.return_value.select_related.return_value.first.return_value = conflict_module
             view.get(request, pk=24)
 
         ctx = mock_render.call_args[0][2]
@@ -462,6 +461,7 @@ class TestReplaceModuleView:
             )
             mock_module_cls.objects.restrict.return_value = mock_module_cls.objects
             mock_module_cls.objects.select_for_update.side_effect = [installed_chain, conflict_chain]
+            mock_module_cls.objects.filter.return_value.exclude.return_value.count.return_value = 0
 
             _post(view, request, pk=24)
 
@@ -527,6 +527,7 @@ class TestReplaceModuleView:
             )
             mock_module_cls.objects.restrict.return_value = mock_module_cls.objects
             mock_module_cls.objects.select_for_update.side_effect = [installed_chain, conflict_chain]
+            mock_module_cls.objects.filter.return_value.exclude.return_value.count.return_value = 1
 
             _post(view, request, pk=24)
 

--- a/netbox_librenms_plugin/tests/test_module_replace.py
+++ b/netbox_librenms_plugin/tests/test_module_replace.py
@@ -5,6 +5,26 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 
+def _bind_and_call(view, request, method, **kwargs):
+    """Call *view*.<method>, binding the request the way ``View.setup()`` does under dispatch().
+
+    A direct ``view.post(request, ...)`` leaves ``self.request`` unset, which the object-scoped
+    lookups read — production always goes through dispatch(), so bind it here too.
+    """
+    view.setup(request)
+    return getattr(view, method)(request, **kwargs)
+
+
+def _post(view, request, **kwargs):
+    """POST into *view* with the request bound (see :func:`_bind_and_call`)."""
+    return _bind_and_call(view, request, "post", **kwargs)
+
+
+def _get(view, request, **kwargs):
+    """GET into *view* with the request bound (see :func:`_bind_and_call`)."""
+    return _bind_and_call(view, request, "get", **kwargs)
+
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -67,7 +87,10 @@ class TestModuleMismatchPreviewView:
         request = _make_request(data={})
         view.request = request
 
-        with patch("netbox_librenms_plugin.views.sync.modules.get_object_or_404", return_value=device):
+        with patch(
+            "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+            return_value=device,
+        ):
             resp = view.get(request, pk=24)
 
         assert resp.status_code == 400
@@ -79,7 +102,10 @@ class TestModuleMismatchPreviewView:
         request = _make_request(data={"module_id": "42", "ent_index": "notanint"})
         view.request = request
 
-        with patch("netbox_librenms_plugin.views.sync.modules.get_object_or_404", return_value=device):
+        with patch(
+            "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+            return_value=device,
+        ):
             resp = view.get(request, pk=24)
 
         assert resp.status_code == 400
@@ -94,14 +120,14 @@ class TestModuleMismatchPreviewView:
 
         with (
             patch(
-                "netbox_librenms_plugin.views.sync.modules.get_object_or_404",
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
                 side_effect=[device, installed],
             ),
             patch.object(view, "get_cache_key", return_value="cache-key"),
             patch("netbox_librenms_plugin.views.sync.modules.cache") as mock_cache,
         ):
             mock_cache.get.return_value = None
-            resp = view.get(request, pk=24)
+            resp = _get(view, request, pk=24)
 
         assert resp.status_code == 400
 
@@ -116,14 +142,14 @@ class TestModuleMismatchPreviewView:
 
         with (
             patch(
-                "netbox_librenms_plugin.views.sync.modules.get_object_or_404",
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
                 side_effect=[device, installed],
             ),
             patch.object(view, "get_cache_key", return_value="cache-key"),
             patch("netbox_librenms_plugin.views.sync.modules.cache") as mock_cache,
         ):
             mock_cache.get.return_value = {"inventory": cached, "librenms_id": "test"}
-            resp = view.get(request, pk=24)
+            resp = _get(view, request, pk=24)
 
         assert resp.status_code == 400
 
@@ -143,7 +169,7 @@ class TestModuleMismatchPreviewView:
 
         with (
             patch(
-                "netbox_librenms_plugin.views.sync.modules.get_object_or_404",
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
                 side_effect=[device, installed],
             ),
             patch.object(view, "get_cache_key", return_value="cache-key"),
@@ -184,7 +210,7 @@ class TestModuleMismatchPreviewView:
 
         with (
             patch(
-                "netbox_librenms_plugin.views.sync.modules.get_object_or_404",
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
                 side_effect=[device, installed],
             ),
             patch.object(view, "get_cache_key", return_value="cache-key"),
@@ -256,9 +282,10 @@ class TestModuleMismatchTypeMatchedBadge:
     def _render_modal(self, device, module, librenms_model, librenms_serial):
         from unittest.mock import MagicMock
 
-        from django.contrib.auth.models import AnonymousUser
         from django.core.cache import cache
         from django.test import RequestFactory
+
+        from netbox_librenms_plugin.tests.conftest import make_superuser
 
         from netbox_librenms_plugin.views.sync.modules import (
             ModuleMismatchPreviewView,
@@ -269,7 +296,9 @@ class TestModuleMismatchTypeMatchedBadge:
         view._librenms_api = MagicMock()
         view._librenms_api.server_key = "default"
         request = RequestFactory().get("/", {"module_id": str(module.pk), "ent_index": "100", "server_key": "default"})
-        request.user = AnonymousUser()
+        # A real user: the view resolves the device through a restricted queryset, and an
+        # anonymous caller legitimately sees nothing.
+        request.user = make_superuser("mmb-su")
         view.setup(request)
 
         sync_device = _get_sync_device_for_inventory(device, "default")
@@ -351,7 +380,10 @@ class TestReplaceModuleView:
         request = _make_request("POST", data={})
 
         with (
-            patch("netbox_librenms_plugin.views.sync.modules.get_object_or_404", return_value=device),
+            patch(
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+                return_value=device,
+            ),
             patch.object(view, "require_all_permissions", return_value=None),
             patch("netbox_librenms_plugin.views.sync.modules.reverse", return_value="/sync/"),
             patch("netbox_librenms_plugin.views.sync.modules.messages") as mock_msg,
@@ -370,7 +402,10 @@ class TestReplaceModuleView:
         request = _make_request("POST", data={"module_id": "42", "ent_index": "100"})
 
         with (
-            patch("netbox_librenms_plugin.views.sync.modules.get_object_or_404", side_effect=[device, installed]),
+            patch(
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+                side_effect=[device, installed],
+            ),
             patch.object(view, "require_all_permissions", return_value=None),
             patch.object(view, "get_cache_key", return_value="ck"),
             patch("netbox_librenms_plugin.views.sync.modules.reverse", return_value="/sync/"),
@@ -379,7 +414,7 @@ class TestReplaceModuleView:
             patch("netbox_librenms_plugin.views.sync.modules.redirect") as mock_redirect,
         ):
             mock_cache.get.return_value = None
-            view.post(request, pk=24)
+            _post(view, request, pk=24)
 
         mock_msg.error.assert_called_once()
         mock_redirect.assert_called_once()
@@ -398,7 +433,10 @@ class TestReplaceModuleView:
         new_module = MagicMock()
 
         with (
-            patch("netbox_librenms_plugin.views.sync.modules.get_object_or_404", side_effect=[device, installed]),
+            patch(
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+                side_effect=[device, installed],
+            ),
             patch.object(view, "require_all_permissions", return_value=None),
             # "prod" must be a configured server for resolve_posted_server_key to honour the posted key
             # (else it degrades to the active "default"); mirrors a real multi-server deployment.
@@ -438,7 +476,7 @@ class TestReplaceModuleView:
             )
             mock_module_cls.objects.select_for_update.side_effect = [installed_chain, conflict_chain]
 
-            view.post(request, pk=24)
+            _post(view, request, pk=24)
 
         installed.delete.assert_called_once()
         new_module.full_clean.assert_called_once()
@@ -465,7 +503,10 @@ class TestReplaceModuleView:
         new_module = MagicMock()
 
         with (
-            patch("netbox_librenms_plugin.views.sync.modules.get_object_or_404", side_effect=[device, installed]),
+            patch(
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+                side_effect=[device, installed],
+            ),
             patch.object(view, "require_all_permissions", return_value=None),
             patch.object(view, "get_cache_key", return_value="ck"),
             patch("netbox_librenms_plugin.views.sync.modules.reverse", return_value="/sync/"),
@@ -499,7 +540,7 @@ class TestReplaceModuleView:
             )
             mock_module_cls.objects.select_for_update.side_effect = [installed_chain, conflict_chain]
 
-            view.post(request, pk=24)
+            _post(view, request, pk=24)
 
         # Conflict module must be deleted, then the installed module, then new one saved
         conflict.delete.assert_called_once()
@@ -519,7 +560,10 @@ class TestReplaceModuleView:
         deny = HttpResponse(status=403)
 
         with (
-            patch("netbox_librenms_plugin.views.sync.modules.get_object_or_404", return_value=device),
+            patch(
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+                return_value=device,
+            ),
             patch.object(view, "require_all_permissions", return_value=deny),
         ):
             resp = view.post(request, pk=24)
@@ -547,7 +591,10 @@ class TestMoveModuleView:
         request = _make_request("POST", data={})
 
         with (
-            patch("netbox_librenms_plugin.views.sync.modules.get_object_or_404", return_value=device),
+            patch(
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+                return_value=device,
+            ),
             patch.object(view, "require_all_permissions", return_value=None),
             patch("netbox_librenms_plugin.views.sync.modules.reverse", return_value="/sync/"),
             patch("netbox_librenms_plugin.views.sync.modules.messages") as mock_msg,
@@ -570,7 +617,7 @@ class TestMoveModuleView:
 
         with (
             patch(
-                "netbox_librenms_plugin.views.sync.modules.get_object_or_404",
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
                 side_effect=[device, target_bay],
             ),
             patch.object(view, "require_all_permissions", return_value=None),
@@ -610,7 +657,10 @@ class TestMoveModuleView:
 
         deny = HttpResponse(status=403)
         with (
-            patch("netbox_librenms_plugin.views.sync.modules.get_object_or_404", return_value=device),
+            patch(
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+                return_value=device,
+            ),
             patch.object(view, "require_all_permissions", return_value=deny),
         ):
             resp = view.post(request, pk=24)

--- a/netbox_librenms_plugin/tests/test_module_replace.py
+++ b/netbox_librenms_plugin/tests/test_module_replace.py
@@ -665,7 +665,6 @@ class TestMoveModuleView:
             mock_tx.atomic.return_value.__enter__ = lambda context: context
             mock_tx.atomic.return_value.__exit__ = MagicMock(return_value=False)
             bay_qs = MagicMock()
-            bay_qs.select_for_update.return_value.get.side_effect = ModuleBay.DoesNotExist
             bay_qs.select_for_update.return_value.filter.return_value.first.return_value = None
             module_qs = MagicMock()
             mock_scoped.side_effect = lambda model, *args, **kwargs: bay_qs if model is ModuleBay else module_qs

--- a/netbox_librenms_plugin/tests/test_module_replace.py
+++ b/netbox_librenms_plugin/tests/test_module_replace.py
@@ -166,6 +166,7 @@ class TestModuleMismatchPreviewView:
             patch("netbox_librenms_plugin.views.sync.modules.render", return_value=HttpResponse("OK")) as mock_render,
         ):
             mock_cache.get.return_value = {"inventory": cached, "librenms_id": "test"}
+            mock_module_cls.objects.restrict.return_value = mock_module_cls.objects
             mock_module_cls.objects.filter.return_value.exclude.return_value.select_related.return_value.count.return_value = 0
             mock_module_cls.objects.filter.return_value.exclude.return_value.select_related.return_value.first.return_value = None
             resp = view.get(request, pk=24)
@@ -207,6 +208,7 @@ class TestModuleMismatchPreviewView:
             patch("netbox_librenms_plugin.views.sync.modules.render", return_value=HttpResponse("OK")) as mock_render,
         ):
             mock_cache.get.return_value = {"inventory": cached, "librenms_id": "test"}
+            mock_module_cls.objects.restrict.return_value = mock_module_cls.objects
             mock_module_cls.objects.filter.return_value.exclude.return_value.select_related.return_value.count.return_value = 1
             mock_module_cls.objects.filter.return_value.exclude.return_value.select_related.return_value.first.return_value = conflict_module
             view.get(request, pk=24)
@@ -372,6 +374,7 @@ class TestReplaceModuleView:
             patch("netbox_librenms_plugin.views.sync.modules.messages") as mock_msg,
             patch("netbox_librenms_plugin.views.sync.modules.redirect") as mock_redirect,
         ):
+            view.request = request
             view.post(request, pk=24)
 
         mock_msg.error.assert_called_once()
@@ -457,6 +460,7 @@ class TestReplaceModuleView:
             conflict_chain.filter.return_value.exclude.return_value.select_related.return_value.__iter__ = lambda s: (
                 iter([])
             )
+            mock_module_cls.objects.restrict.return_value = mock_module_cls.objects
             mock_module_cls.objects.select_for_update.side_effect = [installed_chain, conflict_chain]
 
             _post(view, request, pk=24)
@@ -521,6 +525,7 @@ class TestReplaceModuleView:
             conflict_chain.filter.return_value.exclude.return_value.select_related.return_value.__iter__ = lambda s: (
                 iter([conflict])
             )
+            mock_module_cls.objects.restrict.return_value = mock_module_cls.objects
             mock_module_cls.objects.select_for_update.side_effect = [installed_chain, conflict_chain]
 
             _post(view, request, pk=24)
@@ -549,6 +554,7 @@ class TestReplaceModuleView:
             ),
             patch.object(view, "require_all_permissions", return_value=deny),
         ):
+            view.request = request
             resp = view.post(request, pk=24)
 
         assert resp.status_code == 403
@@ -583,6 +589,7 @@ class TestMoveModuleView:
             patch("netbox_librenms_plugin.views.sync.modules.messages") as mock_msg,
             patch("netbox_librenms_plugin.views.sync.modules.redirect") as mock_redirect,
         ):
+            view.request = request
             view.post(request, pk=24)
 
         mock_msg.error.assert_called_once()
@@ -608,7 +615,7 @@ class TestMoveModuleView:
             patch("netbox_librenms_plugin.views.sync.modules.transaction") as mock_tx,
             patch("netbox_librenms_plugin.views.sync.modules.messages") as mock_msg,
             patch("netbox_librenms_plugin.views.sync.modules.redirect"),
-            patch("dcim.models.Module") as mock_module_cls,
+            patch("dcim.models.Module"),
             patch("dcim.models.ModuleBay") as mock_bay_cls,
             # The conflict module is resolved through the SCOPED queryset (it is mutated below),
             # so that is the seam this test stubs.
@@ -616,14 +623,13 @@ class TestMoveModuleView:
         ):
             mock_tx.atomic.return_value.__enter__ = lambda s: s
             mock_tx.atomic.return_value.__exit__ = MagicMock(return_value=False)
-            # select_for_update on ModuleBay returns locked target_bay
-            mock_bay_cls.objects.select_for_update.return_value.get.return_value = target_bay
-            # scoped select_for_update chain returns conflict_module
-            scoped_qs = MagicMock()
-            scoped_qs.select_for_update.return_value.filter.return_value.select_related.return_value.first.return_value = conflict_module
-            mock_scoped.return_value = scoped_qs
-            # No occupant in target bay
-            mock_module_cls.objects.select_for_update.return_value.filter.return_value.first.return_value = None
+            # Both the locked target bay and the conflict module are resolved through
+            # restricted_queryset now, so dispatch on the model the view asks for.
+            bay_qs = MagicMock()
+            bay_qs.select_for_update.return_value.get.return_value = target_bay
+            module_qs = MagicMock()
+            module_qs.select_for_update.return_value.filter.return_value.select_related.return_value.first.return_value = conflict_module
+            mock_scoped.side_effect = lambda model, *a, **kw: bay_qs if model is mock_bay_cls else module_qs
 
             _post(view, request, pk=24)
 
@@ -649,6 +655,7 @@ class TestMoveModuleView:
             ),
             patch.object(view, "require_all_permissions", return_value=deny),
         ):
+            view.request = request
             resp = view.post(request, pk=24)
 
         assert resp.status_code == 403

--- a/netbox_librenms_plugin/tests/test_module_replace.py
+++ b/netbox_librenms_plugin/tests/test_module_replace.py
@@ -534,6 +534,7 @@ class TestReplaceModuleView:
         conflict.delete.assert_called_once()
         installed.delete.assert_called_once()
         new_module.save.assert_called_once()
+        mock_module_cls.objects.restrict.assert_any_call(request.user, "delete")
         mock_msg.info.assert_called_once()
         mock_msg.success.assert_called_once()
 

--- a/netbox_librenms_plugin/tests/test_module_replace.py
+++ b/netbox_librenms_plugin/tests/test_module_replace.py
@@ -628,7 +628,7 @@ class TestMoveModuleView:
             # Both the locked target bay and the conflict module are resolved through
             # restricted_queryset now, so dispatch on the model the view asks for.
             bay_qs = MagicMock()
-            bay_qs.select_for_update.return_value.get.return_value = target_bay
+            bay_qs.select_for_update.return_value.filter.return_value.first.return_value = target_bay
             module_qs = MagicMock()
             module_qs.select_for_update.return_value.filter.return_value.select_related.return_value.first.return_value = conflict_module
             mock_scoped.side_effect = lambda model, *a, **kw: bay_qs if model is mock_bay_cls else module_qs
@@ -640,6 +640,40 @@ class TestMoveModuleView:
         conflict_module.full_clean.assert_called_once()
         conflict_module.save.assert_called_once()
         mock_msg.success.assert_called_once()
+
+    def test_target_bay_deleted_before_lock_reports_error(self):
+        """A target bay removed after validation must not cause an uncaught exception."""
+        from dcim.models import ModuleBay
+
+        view = self._view()
+        device = _make_device(pk=24)
+        target_bay = MagicMock()
+        request = _make_request("POST", data={"conflict_module_id": "99", "target_bay_id": "10"})
+
+        with (
+            patch(
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+                side_effect=[device, target_bay],
+            ),
+            patch.object(view, "require_all_permissions", return_value=None),
+            patch("netbox_librenms_plugin.views.sync.modules.reverse", return_value="/sync/"),
+            patch("netbox_librenms_plugin.views.sync.modules.transaction") as mock_tx,
+            patch("netbox_librenms_plugin.views.sync.modules.messages") as mock_msg,
+            patch("netbox_librenms_plugin.views.sync.modules.redirect") as mock_redirect,
+            patch.object(view, "restricted_queryset") as mock_scoped,
+        ):
+            mock_tx.atomic.return_value.__enter__ = lambda context: context
+            mock_tx.atomic.return_value.__exit__ = MagicMock(return_value=False)
+            bay_qs = MagicMock()
+            bay_qs.select_for_update.return_value.get.side_effect = ModuleBay.DoesNotExist
+            bay_qs.select_for_update.return_value.filter.return_value.first.return_value = None
+            module_qs = MagicMock()
+            mock_scoped.side_effect = lambda model, *args, **kwargs: bay_qs if model is ModuleBay else module_qs
+
+            _post(view, request, pk=24)
+
+        mock_msg.error.assert_called_once_with(request, "Module bay no longer exists.")
+        mock_redirect.assert_called_once()
 
     def test_requires_all_permissions(self):
         """POST returns early when require_all_permissions returns a response."""

--- a/netbox_librenms_plugin/tests/test_module_replace.py
+++ b/netbox_librenms_plugin/tests/test_module_replace.py
@@ -5,24 +5,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 
-def _bind_and_call(view, request, method, **kwargs):
-    """Call *view*.<method>, binding the request the way ``View.setup()`` does under dispatch().
-
-    A direct ``view.post(request, ...)`` leaves ``self.request`` unset, which the object-scoped
-    lookups read — production always goes through dispatch(), so bind it here too.
-    """
-    view.setup(request)
-    return getattr(view, method)(request, **kwargs)
-
-
-def _post(view, request, **kwargs):
-    """POST into *view* with the request bound (see :func:`_bind_and_call`)."""
-    return _bind_and_call(view, request, "post", **kwargs)
-
-
-def _get(view, request, **kwargs):
-    """GET into *view* with the request bound (see :func:`_bind_and_call`)."""
-    return _bind_and_call(view, request, "get", **kwargs)
+from netbox_librenms_plugin.tests.view_test_helpers import get as _get, post as _post
 
 
 # ---------------------------------------------------------------------------
@@ -627,19 +610,22 @@ class TestMoveModuleView:
             patch("netbox_librenms_plugin.views.sync.modules.redirect"),
             patch("dcim.models.Module") as mock_module_cls,
             patch("dcim.models.ModuleBay") as mock_bay_cls,
+            # The conflict module is resolved through the SCOPED queryset (it is mutated below),
+            # so that is the seam this test stubs.
+            patch.object(view, "restricted_queryset") as mock_scoped,
         ):
             mock_tx.atomic.return_value.__enter__ = lambda s: s
             mock_tx.atomic.return_value.__exit__ = MagicMock(return_value=False)
             # select_for_update on ModuleBay returns locked target_bay
             mock_bay_cls.objects.select_for_update.return_value.get.return_value = target_bay
-            # select_for_update chain returns conflict_module
-            sfu_qs = MagicMock()
-            sfu_qs.filter.return_value.select_related.return_value.first.return_value = conflict_module
-            mock_module_cls.objects.select_for_update.return_value = sfu_qs
+            # scoped select_for_update chain returns conflict_module
+            scoped_qs = MagicMock()
+            scoped_qs.select_for_update.return_value.filter.return_value.select_related.return_value.first.return_value = conflict_module
+            mock_scoped.return_value = scoped_qs
             # No occupant in target bay
             mock_module_cls.objects.select_for_update.return_value.filter.return_value.first.return_value = None
 
-            view.post(request, pk=24)
+            _post(view, request, pk=24)
 
         assert conflict_module.module_bay is target_bay
         assert conflict_module.device is device

--- a/netbox_librenms_plugin/tests/test_modules_view.py
+++ b/netbox_librenms_plugin/tests/test_modules_view.py
@@ -1771,6 +1771,27 @@ class TestCollectDescendants:
         depths = [d for d, _ in results]
         assert depths == [1, 2], f"Expected [1, 2] but got {depths}"
 
+    def test_numeric_model_child_is_collected(self):
+        """An all-digit descendant model decoded as an int remains a real hardware row."""
+        child = {
+            "entPhysicalIndex": 1,
+            "entPhysicalModelName": 123456,
+            "entPhysicalContainedIn": 0,
+        }
+        view = self._view()
+        results = []
+
+        view._collect_descendants(
+            0,
+            {0: [child]},
+            {1: child},
+            ignore_rules=[],
+            depth=1,
+            results=results,
+        )
+
+        assert results == [(1, child)]
+
 
 class TestDetermineStatus:
     """Tests for _determine_status logic."""
@@ -4238,6 +4259,27 @@ class TestFindIntegratingAncestor:
 
         assert BaseModuleTableView._find_integrating_ancestor(mda, self._index([xiom, mda])) is xiom
 
+    def test_numeric_model_finds_integrating_ancestor(self):
+        """Numeric ENTITY models are normalized on both sides of the integrated-card comparison."""
+        from netbox_librenms_plugin.views.base.modules_view import BaseModuleTableView
+
+        xiom = {
+            "entPhysicalIndex": 100,
+            "entPhysicalClass": "xioModule",
+            "entPhysicalSerialNum": "NS241462069",
+            "entPhysicalModelName": 123456,
+            "entPhysicalContainedIn": 0,
+        }
+        mda = {
+            "entPhysicalIndex": 200,
+            "entPhysicalClass": "mdaModule",
+            "entPhysicalSerialNum": "NS241462069",
+            "entPhysicalModelName": 123456,
+            "entPhysicalContainedIn": 100,
+        }
+
+        assert BaseModuleTableView._find_integrating_ancestor(mda, self._index([xiom, mda])) is xiom
+
     def test_returns_none_when_serial_differs(self):
         from netbox_librenms_plugin.views.base.modules_view import BaseModuleTableView
 
@@ -4367,6 +4409,31 @@ class TestFindIntegratingAncestor:
 
 class TestBuildRowIntegratedDedupe:
     """_build_row short-circuits to status='Integrated' when an integrating ancestor exists."""
+
+    def test_numeric_model_reaches_the_integrated_row_path(self):
+        """The production row builder normalizes numeric models before ancestor matching."""
+        view = _make_view()
+        xiom = {
+            "entPhysicalIndex": 100,
+            "entPhysicalName": "XIOM 2/x1",
+            "entPhysicalClass": "xioModule",
+            "entPhysicalSerialNum": "NS241462069",
+            "entPhysicalModelName": 123456,
+            "entPhysicalContainedIn": 0,
+        }
+        mda = {
+            "entPhysicalIndex": 200,
+            "entPhysicalName": "MDA 2/x1/1",
+            "entPhysicalClass": "mdaModule",
+            "entPhysicalSerialNum": "NS241462069",
+            "entPhysicalModelName": 123456,
+            "entPhysicalContainedIn": 100,
+        }
+
+        row = view._build_row(mda, {100: xiom, 200: mda}, {}, {})
+
+        assert row["status"] == "Integrated"
+        assert row["model"] == "123456"
 
     def test_mda_under_xiom_becomes_integrated(self):
         view = _make_view()

--- a/netbox_librenms_plugin/tests/test_modules_view.py
+++ b/netbox_librenms_plugin/tests/test_modules_view.py
@@ -5344,3 +5344,15 @@ class TestInferVcMemberSerialNormalization:
 
         assert target.pk == master.pk
         assert source == "serial"
+
+    @pytest.mark.parametrize("field", ["entPhysicalName", "entPhysicalDescr"])
+    def test_numeric_name_hints_do_not_crash(self, field):
+        """Numeric ENTITY hint fields are normalized before prefix matching."""
+        view = _make_view()
+        master, member2 = self._vc_members(["100004", "100005"])
+        item = {"entPhysicalIndex": 3, field: 2, "entPhysicalContainedIn": 0}
+
+        target, source = view._infer_vc_member_for_item(master, item, {}, [master, member2])
+
+        assert target.pk == master.pk
+        assert source == "default"

--- a/netbox_librenms_plugin/tests/test_modules_view.py
+++ b/netbox_librenms_plugin/tests/test_modules_view.py
@@ -1771,11 +1771,12 @@ class TestCollectDescendants:
         depths = [d for d, _ in results]
         assert depths == [1, 2], f"Expected [1, 2] but got {depths}"
 
-    def test_numeric_model_child_is_collected(self):
+    @pytest.mark.parametrize("model_value", [0, 123456])
+    def test_numeric_model_child_is_collected(self, model_value):
         """An all-digit descendant model decoded as an int remains a real hardware row."""
         child = {
             "entPhysicalIndex": 1,
-            "entPhysicalModelName": 123456,
+            "entPhysicalModelName": model_value,
             "entPhysicalContainedIn": 0,
         }
         view = self._view()

--- a/netbox_librenms_plugin/tests/test_permissions.py
+++ b/netbox_librenms_plugin/tests/test_permissions.py
@@ -1093,6 +1093,7 @@ class TestRemoveServerMappingViewErrorHandling:
             patch("netbox_librenms_plugin.views.sync.device_fields.transaction") as mock_tx,
         ):
             mock_settings.PLUGINS_CONFIG = plugins_cfg
+            mock_Device_cls.objects.restrict.return_value = mock_Device_cls.objects
             mock_Device_cls.objects.select_for_update.return_value.get.return_value = mock_locked
 
             # Make transaction.atomic() a no-op context manager
@@ -1100,6 +1101,7 @@ class TestRemoveServerMappingViewErrorHandling:
             mock_tx.atomic.return_value.__exit__ = lambda s, *a: None
             mock_tx.set_rollback = MagicMock()
 
+            view.request = request
             view.post(request, pk=1)
 
         mock_messages.error.assert_called_once()
@@ -1126,6 +1128,7 @@ class TestRemoveServerMappingViewErrorHandling:
             patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
         ):
             mock_settings.PLUGINS_CONFIG = plugins_cfg
+            view.request = request
             view.post(request, pk=1)
 
         mock_messages.error.assert_called_once()
@@ -1159,12 +1162,14 @@ class TestRemoveServerMappingViewErrorHandling:
             patch("netbox_librenms_plugin.views.sync.device_fields.transaction") as mock_tx,
         ):
             mock_settings.PLUGINS_CONFIG = plugins_cfg
+            mock_Device_cls.objects.restrict.return_value = mock_Device_cls.objects
             mock_Device_cls.objects.select_for_update.return_value.get.return_value = mock_locked
 
             mock_tx.atomic.return_value.__enter__ = lambda s: None
             mock_tx.atomic.return_value.__exit__ = lambda s, *a: None
             mock_tx.set_rollback = MagicMock()
 
+            view.request = request
             view.post(request, pk=1)
 
         # The "orphan-server" key should have been removed and the device saved.

--- a/netbox_librenms_plugin/tests/test_permissions.py
+++ b/netbox_librenms_plugin/tests/test_permissions.py
@@ -339,6 +339,32 @@ class TestObjectPermissionHelpers:
 class TestNetBoxObjectPermissionMixin:
     """Tests for the NetBoxObjectPermissionMixin class."""
 
+    @pytest.mark.django_db
+    def test_restricted_queryset_locks_only_model_row_with_nullable_constraint(self):
+        """A PostgreSQL lock must exclude nullable joins added by object permission constraints."""
+        from types import SimpleNamespace
+
+        from dcim.models import Device
+        from django.db import transaction
+
+        from netbox_librenms_plugin.tests.conftest import make_device
+        from netbox_librenms_plugin.tests.view_test_helpers import make_user_with_perms
+        from netbox_librenms_plugin.views.mixins import NetBoxObjectPermissionMixin
+
+        device = make_device("permission-lock-nullable")
+        user = make_user_with_perms(
+            "permission-lock-nullable",
+            [("change", Device)],
+            constraints={"site__region": None},
+        )
+        view = NetBoxObjectPermissionMixin()
+        view.request = SimpleNamespace(user=user)
+
+        with transaction.atomic():
+            locked = view.restricted_queryset(Device, "change").select_for_update(of=("self",)).get(pk=device.pk)
+
+        assert locked == device
+
     def test_check_object_permissions_all_granted(self):
         """Returns True when user has all object permissions."""
         from netbox_librenms_plugin.views.mixins import NetBoxObjectPermissionMixin

--- a/netbox_librenms_plugin/tests/test_permissions.py
+++ b/netbox_librenms_plugin/tests/test_permissions.py
@@ -978,19 +978,25 @@ class TestObjectTypeValidation:
 
     def test_sync_interfaces_device_type(self):
         """SyncInterfacesView returns correct perms for device type."""
+        from dcim.models import Device, Interface
+
         from netbox_librenms_plugin.views.sync.interfaces import SyncInterfacesView
 
         view = SyncInterfacesView()
         perms = view.get_required_permissions_for_object_type("device")
-        assert len(perms) == 2
+        # The owner read is declared alongside the writes: the device is resolved through a
+        # restricted queryset, so a missing view grant is a stated 403, not a 404 at the lookup.
+        assert perms == [("view", Device), ("add", Interface), ("change", Interface)]
 
     def test_sync_interfaces_vm_type(self):
         """SyncInterfacesView returns correct perms for virtualmachine type."""
+        from virtualization.models import VirtualMachine, VMInterface
+
         from netbox_librenms_plugin.views.sync.interfaces import SyncInterfacesView
 
         view = SyncInterfacesView()
         perms = view.get_required_permissions_for_object_type("virtualmachine")
-        assert len(perms) == 2
+        assert perms == [("view", VirtualMachine), ("add", VMInterface), ("change", VMInterface)]
 
     def test_sync_interfaces_invalid_type_raises_404(self):
         """SyncInterfacesView raises Http404 for invalid object type."""
@@ -1072,7 +1078,10 @@ class TestRemoveServerMappingViewErrorHandling:
         plugins_cfg = {"netbox_librenms_plugin": {"servers": {}}}  # orphan-server NOT configured
 
         with (
-            patch("netbox_librenms_plugin.views.sync.device_fields.get_object_or_404", return_value=mock_device),
+            patch(
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+                return_value=mock_device,
+            ),
             patch("netbox_librenms_plugin.views.sync.device_fields.Device") as mock_Device_cls,
             patch("django.conf.settings") as mock_settings,
             patch("netbox_librenms_plugin.views.sync.device_fields.messages") as mock_messages,
@@ -1104,7 +1113,10 @@ class TestRemoveServerMappingViewErrorHandling:
         plugins_cfg = {"netbox_librenms_plugin": {"servers": {"active-server": {"librenms_url": "http://x"}}}}
 
         with (
-            patch("netbox_librenms_plugin.views.sync.device_fields.get_object_or_404", return_value=mock_device),
+            patch(
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+                return_value=mock_device,
+            ),
             patch("django.conf.settings") as mock_settings,
             patch("netbox_librenms_plugin.views.sync.device_fields.messages") as mock_messages,
             patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
@@ -1132,7 +1144,10 @@ class TestRemoveServerMappingViewErrorHandling:
         plugins_cfg = {"netbox_librenms_plugin": {"servers": {}}}  # orphan-server NOT configured
 
         with (
-            patch("netbox_librenms_plugin.views.sync.device_fields.get_object_or_404", return_value=mock_device),
+            patch(
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+                return_value=mock_device,
+            ),
             patch("netbox_librenms_plugin.views.sync.device_fields.Device") as mock_Device_cls,
             patch("django.conf.settings") as mock_settings,
             patch("netbox_librenms_plugin.views.sync.device_fields.messages") as mock_messages,

--- a/netbox_librenms_plugin/tests/test_permissions.py
+++ b/netbox_librenms_plugin/tests/test_permissions.py
@@ -1,5 +1,7 @@
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 
 class TestLibreNMSPermissionMixin:
     """Tests for permission mixin functionality."""
@@ -1046,137 +1048,80 @@ class TestObjectTypeValidation:
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.django_db
 class TestRemoveServerMappingViewErrorHandling:
     """Test RemoveServerMappingView handles full_clean/save failures gracefully."""
 
-    def _make_view(self, server_key, post_extra=None):
+    def _make_view(self, device, server_key, post_extra=None):
         """Return a (view, request) pair with permissions satisfied."""
-        from unittest.mock import MagicMock
-
+        from netbox_librenms_plugin.tests.view_test_helpers import make_request, make_view
         from netbox_librenms_plugin.views.sync.device_fields import RemoveServerMappingView
 
-        request = MagicMock()
-        request.POST = {"server_key": server_key, "object_type": "device", **(post_extra or {})}
-        request.user = MagicMock()
-        request.user.has_perm.return_value = True
+        request = make_request("post", {"server_key": server_key, "object_type": "device", **(post_extra or {})})
+        return make_view(RemoveServerMappingView, request), request
 
-        view = RemoveServerMappingView()
-        view.request = request  # required by mixin's has_write_permission
-        return view, request
+    @staticmethod
+    def _plugins_config(servers):
+        from django.test import override_settings
+
+        return override_settings(PLUGINS_CONFIG={"netbox_librenms_plugin": {"servers": servers}})
 
     def test_validation_error_returns_error_message(self):
         """ValidationError from full_clean leads to error message, not 500."""
-        from unittest.mock import MagicMock, patch
-
+        from dcim.models import Device
         from django.core.exceptions import ValidationError
 
-        view, request = self._make_view(server_key="orphan-server")
+        from netbox_librenms_plugin.tests.conftest import make_device
+        from netbox_librenms_plugin.tests.view_test_helpers import message_texts, post as _post
 
-        mock_device = MagicMock()
-        mock_device.custom_field_data = {"librenms_id": {"orphan-server": 99}}
+        dev = make_device("perm-rm-validation", librenms_cf={"orphan-server": 99})
+        view, request = self._make_view(dev, "orphan-server")
 
-        mock_locked = MagicMock()
-        mock_locked.custom_field_data = {"librenms_id": {"orphan-server": 99}}
-        mock_locked.full_clean.side_effect = ValidationError("CF validation failed")
-
-        plugins_cfg = {"netbox_librenms_plugin": {"servers": {}}}  # orphan-server NOT configured
-
+        # The custom field accepts any dict, so the rejection has to be injected; the manager,
+        # the lock and the transaction all stay real.
         with (
-            patch(
-                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
-                return_value=mock_device,
-            ),
-            patch("netbox_librenms_plugin.views.sync.device_fields.Device") as mock_Device_cls,
-            patch("django.conf.settings") as mock_settings,
-            patch("netbox_librenms_plugin.views.sync.device_fields.messages") as mock_messages,
-            patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
-            patch("netbox_librenms_plugin.views.sync.device_fields.transaction") as mock_tx,
+            self._plugins_config({}),  # orphan-server NOT configured
+            patch.object(Device, "full_clean", side_effect=ValidationError("CF validation failed")),
         ):
-            mock_settings.PLUGINS_CONFIG = plugins_cfg
-            mock_Device_cls.objects.restrict.return_value = mock_Device_cls.objects
-            mock_Device_cls.objects.select_for_update.return_value.get.return_value = mock_locked
+            _post(view, request, pk=dev.pk)
 
-            # Make transaction.atomic() a no-op context manager
-            mock_tx.atomic.return_value.__enter__ = lambda s: None
-            mock_tx.atomic.return_value.__exit__ = lambda s, *a: None
-            mock_tx.set_rollback = MagicMock()
-
-            view.request = request
-            view.post(request, pk=1)
-
-        mock_messages.error.assert_called_once()
-        error_args = mock_messages.error.call_args[0]
-        assert "Validation error" in str(error_args[1]) or "CF validation failed" in str(error_args[1])
+        errors = message_texts(request, "error")
+        assert len(errors) == 1
+        assert "Validation error" in errors[0] or "CF validation failed" in errors[0]
+        # Rolled back: the mapping the user tried to remove is still there.
+        assert Device.objects.get(pk=dev.pk).custom_field_data["librenms_id"] == {"orphan-server": 99}
 
     def test_configured_server_refused(self):
         """Configured server mapping cannot be removed — error message shown."""
-        from unittest.mock import MagicMock, patch
+        from dcim.models import Device
 
-        view, request = self._make_view(server_key="active-server")
-        mock_device = MagicMock()
-        mock_device.custom_field_data = {"librenms_id": {"active-server": 5}}
+        from netbox_librenms_plugin.tests.conftest import make_device
+        from netbox_librenms_plugin.tests.view_test_helpers import message_texts, post as _post
 
-        plugins_cfg = {"netbox_librenms_plugin": {"servers": {"active-server": {"librenms_url": "http://x"}}}}
+        dev = make_device("perm-rm-configured", librenms_cf={"active-server": 5})
+        view, request = self._make_view(dev, "active-server")
 
-        with (
-            patch(
-                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
-                return_value=mock_device,
-            ),
-            patch("django.conf.settings") as mock_settings,
-            patch("netbox_librenms_plugin.views.sync.device_fields.messages") as mock_messages,
-            patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
-        ):
-            mock_settings.PLUGINS_CONFIG = plugins_cfg
-            view.request = request
-            view.post(request, pk=1)
+        with self._plugins_config({"active-server": {"librenms_url": "http://x"}}):
+            _post(view, request, pk=dev.pk)
 
-        mock_messages.error.assert_called_once()
-        assert "Cannot remove" in mock_messages.error.call_args[0][1]
+        errors = message_texts(request, "error")
+        assert len(errors) == 1
+        assert "Cannot remove" in errors[0]
+        assert Device.objects.get(pk=dev.pk).custom_field_data["librenms_id"] == {"active-server": 5}
 
     def test_successful_removal_mutates_and_saves(self):
         """Successful removal deletes the key from custom_field_data and saves the device."""
-        from unittest.mock import MagicMock, patch
+        from dcim.models import Device
 
-        view, request = self._make_view(server_key="orphan-server")
+        from netbox_librenms_plugin.tests.conftest import make_device
+        from netbox_librenms_plugin.tests.view_test_helpers import message_texts, post as _post
 
-        mock_device = MagicMock()
-        mock_device.custom_field_data = {"librenms_id": {"orphan-server": 42, "other-server": 7}}
+        dev = make_device("perm-rm-ok", librenms_cf={"orphan-server": 42, "other-server": 7})
+        view, request = self._make_view(dev, "orphan-server")
 
-        mock_locked = MagicMock()
-        mock_locked.custom_field_data = {"librenms_id": {"orphan-server": 42, "other-server": 7}}
-        mock_locked.full_clean = MagicMock()
-        mock_locked.save = MagicMock()
+        with self._plugins_config({}):  # orphan-server NOT configured
+            _post(view, request, pk=dev.pk)
 
-        plugins_cfg = {"netbox_librenms_plugin": {"servers": {}}}  # orphan-server NOT configured
-
-        with (
-            patch(
-                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
-                return_value=mock_device,
-            ),
-            patch("netbox_librenms_plugin.views.sync.device_fields.Device") as mock_Device_cls,
-            patch("django.conf.settings") as mock_settings,
-            patch("netbox_librenms_plugin.views.sync.device_fields.messages") as mock_messages,
-            patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
-            patch("netbox_librenms_plugin.views.sync.device_fields.transaction") as mock_tx,
-        ):
-            mock_settings.PLUGINS_CONFIG = plugins_cfg
-            mock_Device_cls.objects.restrict.return_value = mock_Device_cls.objects
-            mock_Device_cls.objects.select_for_update.return_value.get.return_value = mock_locked
-
-            mock_tx.atomic.return_value.__enter__ = lambda s: None
-            mock_tx.atomic.return_value.__exit__ = lambda s, *a: None
-            mock_tx.set_rollback = MagicMock()
-
-            view.request = request
-            view.post(request, pk=1)
-
-        # The "orphan-server" key should have been removed and the device saved.
-        # Assert the exact shape of custom_field_data so misspelled keys are caught.
-        assert mock_locked.custom_field_data == {"librenms_id": {"other-server": 7}}
-        remaining = mock_locked.custom_field_data["librenms_id"]
-        assert "orphan-server" not in remaining
-        assert remaining.get("other-server") == 7  # sibling key preserved
-        mock_locked.save.assert_called_once()
-        mock_messages.success.assert_called_once()
+        # Assert the exact shape of the persisted value so a misspelled key is caught.
+        assert Device.objects.get(pk=dev.pk).custom_field_data["librenms_id"] == {"other-server": 7}
+        assert len(message_texts(request, "success")) == 1

--- a/netbox_librenms_plugin/tests/test_permissions.py
+++ b/netbox_librenms_plugin/tests/test_permissions.py
@@ -335,6 +335,24 @@ class TestObjectPermissionHelpers:
         assert "dcim.add_device" in error_msg
         assert "dcim.add_interface" in error_msg
 
+    @pytest.mark.parametrize(
+        ("device_ids", "vm_imports", "expected"),
+        [
+            ([], {}, []),
+            ([1], {}, ["dcim.add_device", "dcim.change_device"]),
+            ([], {2: {}}, ["virtualization.add_virtualmachine"]),
+            (
+                [1],
+                {2: {}},
+                ["dcim.add_device", "dcim.change_device", "virtualization.add_virtualmachine"],
+            ),
+        ],
+    )
+    def test_required_import_permissions(self, device_ids, vm_imports, expected):
+        from netbox_librenms_plugin.import_utils import required_import_permissions
+
+        assert required_import_permissions(device_ids, vm_imports) == expected
+
 
 class TestNetBoxObjectPermissionMixin:
     """Tests for the NetBoxObjectPermissionMixin class."""

--- a/netbox_librenms_plugin/tests/test_permissions.py
+++ b/netbox_librenms_plugin/tests/test_permissions.py
@@ -1011,19 +1011,23 @@ class TestObjectTypeValidation:
 
     def test_delete_interfaces_device_type(self):
         """DeleteNetBoxInterfacesView returns correct perms for device type."""
+        from dcim.models import Device, Interface
+
         from netbox_librenms_plugin.views.sync.interfaces import DeleteNetBoxInterfacesView
 
         view = DeleteNetBoxInterfacesView()
         perms = view.get_required_permissions_for_object_type("device")
-        assert len(perms) == 1
+        assert perms == [("view", Device), ("delete", Interface)]
 
     def test_delete_interfaces_vm_type(self):
         """DeleteNetBoxInterfacesView returns correct perms for virtualmachine type."""
+        from virtualization.models import VirtualMachine, VMInterface
+
         from netbox_librenms_plugin.views.sync.interfaces import DeleteNetBoxInterfacesView
 
         view = DeleteNetBoxInterfacesView()
         perms = view.get_required_permissions_for_object_type("virtualmachine")
-        assert len(perms) == 1
+        assert perms == [("view", VirtualMachine), ("delete", VMInterface)]
 
     def test_delete_interfaces_invalid_type_raises_404(self):
         """DeleteNetBoxInterfacesView raises Http404 for invalid object type."""

--- a/netbox_librenms_plugin/tests/test_platform_mapping.py
+++ b/netbox_librenms_plugin/tests/test_platform_mapping.py
@@ -7,6 +7,8 @@ TDD: these tests are written before implementation.
 
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 
 def _set_fk_cache(instance, field_name, value):
     """Set a FK field value directly via Django's _state.fields_cache, bypassing descriptor validation."""
@@ -315,194 +317,120 @@ class TestToYamlOnAllMappingModels:
 # =============================================================================
 
 
+@pytest.mark.django_db
 class TestFindMatchingPlatformWithMapping:
     """find_matching_platform checks PlatformMapping before direct name match."""
 
+    @staticmethod
+    def _platform(name, slug=None):
+        from dcim.models import Platform
+        from django.utils.text import slugify
+
+        return Platform.objects.create(name=name, slug=slug or slugify(name) or name.lower())
+
+    @staticmethod
+    def _duplicate_mappings(librenms_os, platform):
+        """Insert case-variant mappings for one OS string.
+
+        ``PlatformMapping.clean()`` lowercases ``librenms_os`` and the column is unique, so
+        ordinary saves cannot produce this. bulk_create bypasses full_clean, standing in for
+        rows that predate the normalisation — the only way the ambiguity guard is reachable.
+        """
+        from netbox_librenms_plugin.models import PlatformMapping
+
+        PlatformMapping.objects.bulk_create(
+            [
+                PlatformMapping(librenms_os=librenms_os.lower(), netbox_platform=platform),
+                PlatformMapping(librenms_os=librenms_os.upper(), netbox_platform=platform),
+            ]
+        )
+
     def test_platform_mapping_used_as_fallback_when_no_name_match(self):
         """When no Platform name matches, PlatformMapping is used as fallback."""
+        from netbox_librenms_plugin.models import PlatformMapping
         from netbox_librenms_plugin.utils import find_matching_platform
 
-        mock_mapped_platform = MagicMock(name="mapped_platform")
-        mock_mapping = MagicMock()
-        mock_mapping.netbox_platform = mock_mapped_platform
+        mapped = self._platform("Cisco IOS")
+        PlatformMapping.objects.create(librenms_os="ios", netbox_platform=mapped)
 
-        mock_pm_class = MagicMock()
-        mock_pm_class.objects.get.return_value = mock_mapping
-        mock_pm_class.DoesNotExist = type("DoesNotExist", (Exception,), {})
-
-        mock_platform_model = MagicMock()
-        mock_platform_model.DoesNotExist = type("DoesNotExist", (Exception,), {})
-        mock_platform_model.objects.get.side_effect = mock_platform_model.DoesNotExist
-
-        with (
-            patch("netbox_librenms_plugin.models.PlatformMapping", mock_pm_class),
-            patch("dcim.models.Platform", mock_platform_model),
-        ):
-            result = find_matching_platform("ios")
+        result = find_matching_platform("ios")
 
         assert result["found"] is True
-        assert result["platform"] is mock_mapped_platform
+        assert result["platform"] == mapped
         assert result["match_type"] == "mapping"
 
     def test_falls_back_to_name_match_when_no_platform_mapping(self):
         """When no PlatformMapping exists, falls back to exact Platform name match."""
         from netbox_librenms_plugin.utils import find_matching_platform
 
-        mock_platform = MagicMock()
+        platform = self._platform("ios")
 
-        mock_pm_class = MagicMock()
-        mock_pm_class.DoesNotExist = type("DoesNotExist", (Exception,), {})
-        mock_pm_class.objects.get.side_effect = mock_pm_class.DoesNotExist
-
-        mock_platform_model = MagicMock()
-        mock_platform_model.objects.get.return_value = mock_platform
-
-        with (
-            patch("netbox_librenms_plugin.models.PlatformMapping", mock_pm_class),
-            patch("dcim.models.Platform", mock_platform_model),
-        ):
-            result = find_matching_platform("ios")
+        result = find_matching_platform("ios")
 
         assert result["found"] is True
-        assert result["platform"] is mock_platform
+        assert result["platform"] == platform
         assert result["match_type"] == "exact"
 
     def test_returns_not_found_when_neither_mapping_nor_platform(self):
         """Returns found=False when neither PlatformMapping nor Platform name match exists."""
         from netbox_librenms_plugin.utils import find_matching_platform
 
-        DoesNotExist = type("DoesNotExist", (Exception,), {})
-
-        mock_pm_class = MagicMock()
-        mock_pm_class.DoesNotExist = DoesNotExist
-        mock_pm_class.objects.get.side_effect = DoesNotExist
-
-        mock_platform_model = MagicMock()
-        mock_platform_model.DoesNotExist = DoesNotExist
-        mock_platform_model.objects.get.side_effect = DoesNotExist
-
-        with (
-            patch("netbox_librenms_plugin.models.PlatformMapping", mock_pm_class),
-            patch("dcim.models.Platform", mock_platform_model),
-        ):
-            result = find_matching_platform("unknown_os")
+        result = find_matching_platform("unknown_os")
 
         assert result["found"] is False
         assert result["platform"] is None
 
     def test_multiple_platform_mappings_returns_ambiguous(self):
-        """When exact name fails and PlatformMapping.MultipleObjectsReturned, returns ambiguous."""
+        """Case-variant mapping rows for one OS resolve to nothing rather than an arbitrary pick."""
         from netbox_librenms_plugin.utils import find_matching_platform
 
-        DoesNotExist = type("DoesNotExist", (Exception,), {})
-        MultipleObjectsReturned = type("MultipleObjectsReturned", (Exception,), {})
+        self._duplicate_mappings("ios", self._platform("Cisco IOS"))
 
-        mock_pm_class = MagicMock()
-        mock_pm_class.DoesNotExist = DoesNotExist
-        mock_pm_class.MultipleObjectsReturned = MultipleObjectsReturned
-        mock_pm_class.objects.get.side_effect = MultipleObjectsReturned
-
-        mock_platform_model = MagicMock()
-        mock_platform_model.DoesNotExist = DoesNotExist
-        mock_platform_model.objects.get.side_effect = DoesNotExist
-
-        with (
-            patch("netbox_librenms_plugin.models.PlatformMapping", mock_pm_class),
-            patch("dcim.models.Platform", mock_platform_model),
-        ):
-            result = find_matching_platform("ios")
+        result = find_matching_platform("ios")
 
         assert result == {"found": False, "platform": None, "match_type": "ambiguous", "ambiguity_source": "mapping"}
 
     def test_exact_platform_wins_over_existing_mapping(self):
         """When a single Platform exists for the OS string, the exact match wins even if a PlatformMapping also exists."""
+        from netbox_librenms_plugin.models import PlatformMapping
         from netbox_librenms_plugin.utils import find_matching_platform
 
-        DoesNotExist = type("DoesNotExist", (Exception,), {})
-        MultipleObjectsReturned = type("MultipleObjectsReturned", (Exception,), {})
+        exact = self._platform("ios")
+        other = self._platform("Cisco IOS XE")
+        PlatformMapping.objects.create(librenms_os="ios", netbox_platform=other)
 
-        # Both an exact Platform and a PlatformMapping exist for "ios" — they would
-        # resolve to *different* Platform objects. Exact match must win; the mapping
-        # branch must never be consulted.
-        exact_platform = MagicMock(name="exact_platform")
-        mapping_platform = MagicMock(name="mapping_platform")
-        mapping = MagicMock(netbox_platform=mapping_platform)
-
-        mock_pm_class = MagicMock()
-        mock_pm_class.DoesNotExist = DoesNotExist
-        mock_pm_class.MultipleObjectsReturned = MultipleObjectsReturned
-        mock_pm_class.objects.get.return_value = mapping
-
-        mock_platform_model = MagicMock()
-        mock_platform_model.DoesNotExist = DoesNotExist
-        mock_platform_model.MultipleObjectsReturned = MultipleObjectsReturned
-        mock_platform_model.objects.get.return_value = exact_platform
-
-        with (
-            patch("netbox_librenms_plugin.models.PlatformMapping", mock_pm_class),
-            patch("dcim.models.Platform", mock_platform_model),
-        ):
-            result = find_matching_platform("ios")
+        result = find_matching_platform("ios")
 
         assert result["found"] is True
-        assert result["platform"] is exact_platform
+        assert result["platform"] == exact
         assert result["match_type"] == "exact"
-        # Mapping must not be consulted when exact resolves cleanly.
-        mock_pm_class.objects.get.assert_not_called()
 
     def test_ambiguous_platform_falls_through_to_mapping_resolution(self):
-        """When Platform.MultipleObjectsReturned fires, PlatformMapping is consulted; if it resolves, mapping wins (not 'ambiguous')."""
+        """Two Platforms share the name case-insensitively; an explicit mapping breaks the tie."""
+        from netbox_librenms_plugin.models import PlatformMapping
         from netbox_librenms_plugin.utils import find_matching_platform
 
-        DoesNotExist = type("DoesNotExist", (Exception,), {})
-        MultipleObjectsReturned = type("MultipleObjectsReturned", (Exception,), {})
+        # Platform.name is unique case-SENSITIVELY, so these two coexist and name__iexact
+        # matches both — the state the mapping fallback exists to resolve.
+        self._platform("ios")
+        self._platform("IOS", slug="ios-upper")  # slug is unique; only the NAME collides
+        mapped = self._platform("Cisco IOS")
+        PlatformMapping.objects.create(librenms_os="ios", netbox_platform=mapped)
 
-        mapping_platform = MagicMock(name="mapping_platform")
-        mapping = MagicMock(netbox_platform=mapping_platform)
-
-        mock_pm_class = MagicMock()
-        mock_pm_class.DoesNotExist = DoesNotExist
-        mock_pm_class.MultipleObjectsReturned = MultipleObjectsReturned
-        mock_pm_class.objects.get.return_value = mapping
-
-        mock_platform_model = MagicMock()
-        mock_platform_model.DoesNotExist = DoesNotExist
-        mock_platform_model.MultipleObjectsReturned = MultipleObjectsReturned
-        # Exact lookup is ambiguous — but mapping resolves cleanly, so mapping wins.
-        mock_platform_model.objects.get.side_effect = MultipleObjectsReturned
-
-        with (
-            patch("netbox_librenms_plugin.models.PlatformMapping", mock_pm_class),
-            patch("dcim.models.Platform", mock_platform_model),
-        ):
-            result = find_matching_platform("ios")
+        result = find_matching_platform("ios")
 
         assert result["found"] is True
-        assert result["platform"] is mapping_platform
+        assert result["platform"] == mapped
         assert result["match_type"] == "mapping"
 
     def test_ambiguous_platform_with_no_mapping_returns_platform_ambiguous(self):
-        """When Platform.MultipleObjectsReturned fires and PlatformMapping has no entry, ambiguity_source='platform'."""
+        """Two same-name Platforms and no mapping to disambiguate → ambiguity_source='platform'."""
         from netbox_librenms_plugin.utils import find_matching_platform
 
-        DoesNotExist = type("DoesNotExist", (Exception,), {})
-        MultipleObjectsReturned = type("MultipleObjectsReturned", (Exception,), {})
+        self._platform("ios")
+        self._platform("IOS", slug="ios-upper")  # slug is unique; only the NAME collides
 
-        mock_pm_class = MagicMock()
-        mock_pm_class.DoesNotExist = DoesNotExist
-        mock_pm_class.MultipleObjectsReturned = MultipleObjectsReturned
-        mock_pm_class.objects.get.side_effect = DoesNotExist
-
-        mock_platform_model = MagicMock()
-        mock_platform_model.DoesNotExist = DoesNotExist
-        mock_platform_model.MultipleObjectsReturned = MultipleObjectsReturned
-        mock_platform_model.objects.get.side_effect = MultipleObjectsReturned
-
-        with (
-            patch("netbox_librenms_plugin.models.PlatformMapping", mock_pm_class),
-            patch("dcim.models.Platform", mock_platform_model),
-        ):
-            result = find_matching_platform("ios")
+        result = find_matching_platform("ios")
 
         assert result == {"found": False, "platform": None, "match_type": "ambiguous", "ambiguity_source": "platform"}
 

--- a/netbox_librenms_plugin/tests/test_sync_devices.py
+++ b/netbox_librenms_plugin/tests/test_sync_devices.py
@@ -304,5 +304,6 @@ class TestRemoveServerMappingViewWiring:
 
         # required_object_permissions must be scoped to VirtualMachine, not Device
         assert ("change", VirtualMachine) in permissions_at_check.get("POST", [])
+        mock_model.objects.restrict.assert_called_once_with(request.user, "change")
         # Response must redirect to the VM-specific sync URL
         mock_redirect.assert_called_with("plugins:netbox_librenms_plugin:vm_librenms_sync", pk=10)

--- a/netbox_librenms_plugin/tests/test_sync_devices.py
+++ b/netbox_librenms_plugin/tests/test_sync_devices.py
@@ -3,24 +3,7 @@
 from unittest.mock import MagicMock, patch
 
 
-def _bind_and_call(view, request, method, **kwargs):
-    """Call *view*.<method>, binding the request the way ``View.setup()`` does under dispatch().
-
-    A direct ``view.post(request, ...)`` leaves ``self.request`` unset, which the object-scoped
-    lookups read — production always goes through dispatch(), so bind it here too.
-    """
-    view.setup(request)
-    return getattr(view, method)(request, **kwargs)
-
-
-def _post(view, request, **kwargs):
-    """POST into *view* with the request bound (see :func:`_bind_and_call`)."""
-    return _bind_and_call(view, request, "post", **kwargs)
-
-
-def _get(view, request, **kwargs):
-    """GET into *view* with the request bound (see :func:`_bind_and_call`)."""
-    return _bind_and_call(view, request, "get", **kwargs)
+from netbox_librenms_plugin.tests.view_test_helpers import post as _post
 
 
 def _make_view(cls_name, module_path="netbox_librenms_plugin.views.sync.devices"):
@@ -161,7 +144,7 @@ class TestUpdateDeviceLocationView:
         device.get_absolute_url.return_value = "/dcim/devices/1/"
 
         with patch(
-            "netbox_librenms_plugin.views.sync.devices.get_object_or_404",
+            "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
             return_value=device,
         ):
             with patch("netbox_librenms_plugin.views.sync.devices._device_sync_redirect"):
@@ -189,7 +172,7 @@ class TestUpdateDeviceLocationView:
         device.pk = 1
 
         with patch(
-            "netbox_librenms_plugin.views.sync.devices.get_object_or_404",
+            "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
             return_value=device,
         ):
             with patch("netbox_librenms_plugin.views.sync.devices._device_sync_redirect"):

--- a/netbox_librenms_plugin/tests/test_sync_devices.py
+++ b/netbox_librenms_plugin/tests/test_sync_devices.py
@@ -282,6 +282,7 @@ class TestRemoveServerMappingViewWiring:
 
         # Use a mock model class so the select_for_update().get() call doesn't hit the DB
         mock_model = MagicMock()
+        mock_model.objects.restrict.return_value = mock_model.objects
         mock_model.objects.select_for_update.return_value.get.return_value = mock_vm
 
         request = MagicMock()
@@ -298,6 +299,7 @@ class TestRemoveServerMappingViewWiring:
                 PLUGINS_CONFIG={"netbox_librenms_plugin": {}},
             ),
         ):
+            view.request = request
             view.post(request, pk=10)
 
         # required_object_permissions must be scoped to VirtualMachine, not Device

--- a/netbox_librenms_plugin/tests/test_sync_devices.py
+++ b/netbox_librenms_plugin/tests/test_sync_devices.py
@@ -3,6 +3,26 @@
 from unittest.mock import MagicMock, patch
 
 
+def _bind_and_call(view, request, method, **kwargs):
+    """Call *view*.<method>, binding the request the way ``View.setup()`` does under dispatch().
+
+    A direct ``view.post(request, ...)`` leaves ``self.request`` unset, which the object-scoped
+    lookups read — production always goes through dispatch(), so bind it here too.
+    """
+    view.setup(request)
+    return getattr(view, method)(request, **kwargs)
+
+
+def _post(view, request, **kwargs):
+    """POST into *view* with the request bound (see :func:`_bind_and_call`)."""
+    return _bind_and_call(view, request, "post", **kwargs)
+
+
+def _get(view, request, **kwargs):
+    """GET into *view* with the request bound (see :func:`_bind_and_call`)."""
+    return _bind_and_call(view, request, "get", **kwargs)
+
+
 def _make_view(cls_name, module_path="netbox_librenms_plugin.views.sync.devices"):
     import importlib
 
@@ -140,10 +160,13 @@ class TestUpdateDeviceLocationView:
         device.site.name = "London"
         device.get_absolute_url.return_value = "/dcim/devices/1/"
 
-        with patch("netbox_librenms_plugin.views.sync.devices.get_object_or_404", return_value=device):
+        with patch(
+            "netbox_librenms_plugin.views.sync.devices.get_object_or_404",
+            return_value=device,
+        ):
             with patch("netbox_librenms_plugin.views.sync.devices._device_sync_redirect"):
                 with patch("netbox_librenms_plugin.views.sync.devices.messages") as mock_msg:
-                    view.post(view.request, pk=1)
+                    _post(view, view.request, pk=1)
 
         view._librenms_api.update_device_field.assert_called_once_with(
             42,
@@ -165,10 +188,13 @@ class TestUpdateDeviceLocationView:
         device.site = None
         device.pk = 1
 
-        with patch("netbox_librenms_plugin.views.sync.devices.get_object_or_404", return_value=device):
+        with patch(
+            "netbox_librenms_plugin.views.sync.devices.get_object_or_404",
+            return_value=device,
+        ):
             with patch("netbox_librenms_plugin.views.sync.devices._device_sync_redirect"):
                 with patch("netbox_librenms_plugin.views.sync.devices.messages") as mock_msg:
-                    view.post(view.request, pk=1)
+                    _post(view, view.request, pk=1)
 
         view._librenms_api.update_device_field.assert_not_called()
         mock_msg.warning.assert_called_once()
@@ -177,18 +203,21 @@ class TestUpdateDeviceLocationView:
 class TestAddDeviceObjectResolution:
     """Regression tests for AddDeviceToLibreNMSView.get_object()."""
 
-    def test_get_object_uses_get_object_or_404_for_virtualmachine(self):
+    def test_get_object_resolves_a_virtualmachine_through_the_restricted_queryset(self):
         from netbox_librenms_plugin.views.sync.devices import AddDeviceToLibreNMSView
         from virtualization.models import VirtualMachine
 
         view = object.__new__(AddDeviceToLibreNMSView)
         vm_obj = MagicMock()
 
-        with patch("netbox_librenms_plugin.views.sync.devices.get_object_or_404", return_value=vm_obj) as mock_get_obj:
+        with patch(
+            "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+            return_value=vm_obj,
+        ) as mock_get_obj:
             result = view.get_object(123, object_type="virtualmachine")
 
         assert result is vm_obj
-        mock_get_obj.assert_called_once_with(VirtualMachine, pk=123)
+        mock_get_obj.assert_called_once_with(VirtualMachine, "change", pk=123)
 
 
 class TestUpdateDeviceNameViewWiring:

--- a/netbox_librenms_plugin/tests/test_sync_interfaces.py
+++ b/netbox_librenms_plugin/tests/test_sync_interfaces.py
@@ -4,6 +4,9 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from netbox_librenms_plugin.tests.conftest import make_device, make_interface, make_vm
+from netbox_librenms_plugin.tests.view_test_helpers import make_view
+
 
 class TestUpdateInterfaceAttributes:
     """update_interface_attributes() must set fields respecting exclude_columns."""
@@ -248,75 +251,81 @@ class TestUpdateInterfaceAttributes:
         mock_mac.assert_not_called()
 
 
+@pytest.mark.django_db
 class TestHandleMacAddress:
     """
     handle_mac_address() must work for both Interface (has primary_mac_address)
     and VMInterface (does not have primary_mac_address)."""
 
     @pytest.fixture
-    def view(self, mock_librenms_api):
-        """Return a SyncInterfacesView wired to the shared mock API fixture."""
+    def view(self):
+        """The real SyncInterfacesView; only the LibreNMS client is stubbed."""
         from netbox_librenms_plugin.views.sync.interfaces import SyncInterfacesView
 
-        v = object.__new__(SyncInterfacesView)
-        v._librenms_api = mock_librenms_api
-        v.request = MagicMock()
+        v = make_view(SyncInterfacesView)
         v._lookup_maps = {}
         return v
 
     def test_creates_new_mac_and_adds_to_interface(self, view):
-        iface = MagicMock()
-        iface.mac_addresses = MagicMock()
-        iface.mac_addresses.filter.return_value.first.return_value = None
-        new_mac = MagicMock()
+        from dcim.models import MACAddress
 
-        with patch("netbox_librenms_plugin.views.sync.interfaces.MACAddress") as mock_cls:
-            mock_cls.objects.create.return_value = new_mac
-            view.handle_mac_address(iface, "aa:bb:cc:dd:ee:ff")
+        iface = make_interface(make_device("mac-create"), "Gi0/1")
 
-        mock_cls.objects.create.assert_called_once_with(mac_address="aa:bb:cc:dd:ee:ff")
-        iface.mac_addresses.add.assert_called_once_with(new_mac)
+        view.handle_mac_address(iface, "aa:bb:cc:dd:ee:ff")
+
+        mac = MACAddress.objects.get(mac_address="aa:bb:cc:dd:ee:ff")
+        assert list(iface.mac_addresses.all()) == [mac]
 
     def test_reuses_existing_mac(self, view):
-        existing_mac = MagicMock()
-        iface = MagicMock()
-        iface.mac_addresses = MagicMock()
-        iface.mac_addresses.filter.return_value.first.return_value = existing_mac
+        from dcim.models import MACAddress
 
-        with patch("netbox_librenms_plugin.views.sync.interfaces.MACAddress") as mock_cls:
-            view.handle_mac_address(iface, "aa:bb:cc:dd:ee:ff")
+        iface = make_interface(make_device("mac-reuse"), "Gi0/1")
+        existing = MACAddress.objects.create(mac_address="aa:bb:cc:dd:ee:ff")
+        iface.mac_addresses.add(existing)
 
-        mock_cls.objects.create.assert_not_called()
-        iface.mac_addresses.add.assert_called_once_with(existing_mac)
+        view.handle_mac_address(iface, "aa:bb:cc:dd:ee:ff")
+
+        assert MACAddress.objects.filter(mac_address="aa:bb:cc:dd:ee:ff").count() == 1
+        assert list(iface.mac_addresses.all()) == [existing]
 
     def test_sets_primary_mac_when_attribute_present(self, view):
-        mac_obj = MagicMock()
-        iface = MagicMock(spec=["mac_addresses", "primary_mac_address"])
-        iface.mac_addresses = MagicMock()
-        iface.mac_addresses.filter.return_value.first.return_value = None
+        from dcim.models import Interface, MACAddress
 
-        with patch("netbox_librenms_plugin.views.sync.interfaces.MACAddress") as mock_cls:
-            mock_cls.objects.create.return_value = mac_obj
-            view.handle_mac_address(iface, "aa:bb:cc:dd:ee:ff")
+        iface = make_interface(make_device("mac-primary"), "Gi0/1")
 
-        assert iface.primary_mac_address is mac_obj
+        view.handle_mac_address(iface, "aa:bb:cc:dd:ee:ff")
+        iface.save()
 
-    def test_no_error_when_primary_mac_attribute_absent(self, view):
-        """VMInterface does not have primary_mac_address — handle_mac_address must not raise."""
-        mac_obj = MagicMock()
-        iface = MagicMock(spec=["mac_addresses"])  # no primary_mac_address attr
-        iface.mac_addresses = MagicMock()
-        iface.mac_addresses.filter.return_value.first.return_value = None
+        mac = MACAddress.objects.get(mac_address="aa:bb:cc:dd:ee:ff")
+        assert Interface.objects.get(pk=iface.pk).primary_mac_address == mac
 
-        with patch("netbox_librenms_plugin.views.sync.interfaces.MACAddress") as mock_cls:
-            mock_cls.objects.create.return_value = mac_obj
-            # Must not raise AttributeError
-            view.handle_mac_address(iface, "aa:bb:cc:dd:ee:ff")
+    def test_vm_interface_also_gets_its_primary_mac_set(self, view):
+        """VMInterface carries primary_mac_address in this NetBox version, same as Interface.
+
+        The old mock built the VM interface with ``spec=["mac_addresses"]``, fabricating an
+        absence NetBox no longer has, so it pinned a fact that had stopped being true. The
+        ``hasattr`` guard in handle_mac_address is now dead for both interface models.
+        """
+        from dcim.models import MACAddress
+        from virtualization.models import VMInterface
+
+        vm = make_vm("mac-vm")
+        vmiface = VMInterface.objects.create(virtual_machine=vm, name="eth0")
+
+        view.handle_mac_address(vmiface, "aa:bb:cc:dd:ee:ff")
+        vmiface.save()
+
+        mac = MACAddress.objects.get(mac_address="aa:bb:cc:dd:ee:ff")
+        assert list(vmiface.mac_addresses.all()) == [mac]
+        assert VMInterface.objects.get(pk=vmiface.pk).primary_mac_address == mac
 
     def test_noop_when_mac_address_is_falsy(self, view):
-        iface = MagicMock()
-        with patch("netbox_librenms_plugin.views.sync.interfaces.MACAddress") as mock_cls:
-            view.handle_mac_address(iface, "")
-            view.handle_mac_address(iface, None)
+        from dcim.models import MACAddress
 
-        mock_cls.objects.create.assert_not_called()
+        iface = make_interface(make_device("mac-falsy"), "Gi0/1")
+
+        view.handle_mac_address(iface, "")
+        view.handle_mac_address(iface, None)
+
+        assert not MACAddress.objects.exists()
+        assert not iface.mac_addresses.exists()

--- a/netbox_librenms_plugin/tests/test_sync_interfaces.py
+++ b/netbox_librenms_plugin/tests/test_sync_interfaces.py
@@ -254,8 +254,8 @@ class TestUpdateInterfaceAttributes:
 @pytest.mark.django_db
 class TestHandleMacAddress:
     """
-    handle_mac_address() must work for both Interface (has primary_mac_address)
-    and VMInterface (does not have primary_mac_address)."""
+    handle_mac_address() must work for both Interface and VMInterface. Both carry
+    primary_mac_address in the NetBox versions this plugin supports."""
 
     @pytest.fixture
     def view(self):
@@ -277,16 +277,21 @@ class TestHandleMacAddress:
         assert list(iface.mac_addresses.all()) == [mac]
 
     def test_reuses_existing_mac(self, view):
-        from dcim.models import MACAddress
+        """The already-attached MAC is reused AND promoted to primary, not re-created."""
+        from dcim.models import Interface, MACAddress
 
         iface = make_interface(make_device("mac-reuse"), "Gi0/1")
         existing = MACAddress.objects.create(mac_address="aa:bb:cc:dd:ee:ff")
         iface.mac_addresses.add(existing)
+        assert iface.primary_mac_address is None  # the branch has done nothing yet
 
         view.handle_mac_address(iface, "aa:bb:cc:dd:ee:ff")
+        iface.save()
 
         assert MACAddress.objects.filter(mac_address="aa:bb:cc:dd:ee:ff").count() == 1
         assert list(iface.mac_addresses.all()) == [existing]
+        # Without this the test would pass on an early return: the m2m link predates the call.
+        assert Interface.objects.get(pk=iface.pk).primary_mac_address == existing
 
     def test_sets_primary_mac_when_attribute_present(self, view):
         from dcim.models import Interface, MACAddress

--- a/netbox_librenms_plugin/tests/test_sync_modules.py
+++ b/netbox_librenms_plugin/tests/test_sync_modules.py
@@ -13,24 +13,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 
-def _bind_and_call(view, request, method, **kwargs):
-    """Call *view*.<method>, binding the request the way ``View.setup()`` does under dispatch().
-
-    A direct ``view.post(request, ...)`` leaves ``self.request`` unset, which the object-scoped
-    lookups read — production always goes through dispatch(), so bind it here too.
-    """
-    view.setup(request)
-    return getattr(view, method)(request, **kwargs)
-
-
-def _post(view, request, **kwargs):
-    """POST into *view* with the request bound (see :func:`_bind_and_call`)."""
-    return _bind_and_call(view, request, "post", **kwargs)
-
-
-def _get(view, request, **kwargs):
-    """GET into *view* with the request bound (see :func:`_bind_and_call`)."""
-    return _bind_and_call(view, request, "get", **kwargs)
+from netbox_librenms_plugin.tests.view_test_helpers import get as _get, post as _post
 
 
 @contextmanager

--- a/netbox_librenms_plugin/tests/test_sync_modules.py
+++ b/netbox_librenms_plugin/tests/test_sync_modules.py
@@ -856,7 +856,6 @@ class TestInstallSingleStatus:
         locked_bay.installed_module = None
         locked_bay.pk = bay.pk
         locked_bay.module_id = None
-        ModuleBay.objects.restrict.return_value = ModuleBay.objects
         ModuleBay.objects.select_for_update.return_value.select_related.return_value.get.return_value = locked_bay
         ModuleType = MagicMock()
         Module = MagicMock()
@@ -1062,7 +1061,6 @@ class TestInstallSingleStatus:
         locked_bay.pk = bay.pk
         locked_bay.module_id = None
         locked_bay.installed_module = None
-        ModuleBay.objects.restrict.return_value = ModuleBay.objects
         ModuleBay.objects.select_for_update.return_value.select_related.return_value.get.return_value = locked_bay
 
         module_instance = MagicMock()
@@ -4358,8 +4356,6 @@ class TestInstallModuleViewBehavior:
             mock_tx.atomic = noop_atomic
             # The module is read through restrict(user, "change"), so hand back the same manager.
             mock_objects.restrict.return_value = mock_objects
-            # The locked re-fetch goes through restrict(user, ...), so hand back the same manager.
-            mock_objects.restrict.return_value = mock_objects
             mock_objects.select_for_update.return_value = mock_qs
             view.request = request
             view.post(request, pk=24)
@@ -4388,7 +4384,6 @@ class TestInstallModuleViewBehavior:
             yield
 
         mock_qs = MagicMock()
-        mock_qs.get.side_effect = ModuleBay.DoesNotExist
         mock_qs.filter.return_value.first.return_value = None
 
         with (
@@ -4537,8 +4532,6 @@ class TestUpdateModuleSerialViewBehavior:
         ):
             mock_tx.atomic = noop_atomic
             # The module is read through restrict(user, "change"), so hand back the same manager.
-            mock_objects.restrict.return_value = mock_objects
-            # The locked re-fetch goes through restrict(user, ...), so hand back the same manager.
             mock_objects.restrict.return_value = mock_objects
             mock_objects.select_for_update.return_value = mock_qs
             view.request = request

--- a/netbox_librenms_plugin/tests/test_sync_modules.py
+++ b/netbox_librenms_plugin/tests/test_sync_modules.py
@@ -751,6 +751,7 @@ class TestMatchModuleBayExactFallback:
             "netbox_librenms_plugin.utils.apply_normalization_rules", side_effect=lambda name, scope, **kw: name
         ):
             with patch("netbox_librenms_plugin.models.ModuleBayMapping") as mock_mbm:
+                mock_mbm.objects.restrict.return_value = mock_mbm.objects
                 mock_mbm.objects.filter.return_value.first.return_value = None
 
                 # Also patch _lookup_regex_bay_mapping to return None
@@ -779,6 +780,7 @@ class TestMatchModuleBayExactFallback:
             "netbox_librenms_plugin.utils.apply_normalization_rules", side_effect=lambda name, scope, **kw: name
         ):
             with patch("netbox_librenms_plugin.models.ModuleBayMapping") as mock_mbm:
+                mock_mbm.objects.restrict.return_value = mock_mbm.objects
                 mock_mbm.objects.filter.return_value.first.return_value = None
                 with patch.object(BaseModuleTableView, "_lookup_regex_bay_mapping", return_value=None):
                     with patch.object(BaseModuleTableView, "_match_bay_by_position", return_value=None):
@@ -804,6 +806,7 @@ class TestMatchModuleBayExactFallback:
             "netbox_librenms_plugin.utils.apply_normalization_rules", side_effect=lambda name, scope, **kw: name
         ):
             with patch("netbox_librenms_plugin.models.ModuleBayMapping") as mock_mbm:
+                mock_mbm.objects.restrict.return_value = mock_mbm.objects
                 mock_mbm.objects.filter.return_value.first.return_value = None
                 with patch.object(BaseModuleTableView, "_lookup_regex_bay_mapping", return_value=None):
                     with patch.object(BaseModuleTableView, "_match_bay_by_position", return_value=None):
@@ -846,12 +849,14 @@ class TestInstallSingleStatus:
         module_types = {"WS-X4748": mt}
 
         ModuleBay = MagicMock()
+        ModuleBay.objects.restrict.return_value = ModuleBay.objects
         ModuleBay.objects.filter.return_value.select_related.return_value = [bay]
         # Support select_for_update chain used in _install_single
         locked_bay = _bay("Slot 1")
         locked_bay.installed_module = None
         locked_bay.pk = bay.pk
         locked_bay.module_id = None
+        ModuleBay.objects.restrict.return_value = ModuleBay.objects
         ModuleBay.objects.select_for_update.return_value.select_related.return_value.get.return_value = locked_bay
         ModuleType = MagicMock()
         Module = MagicMock()
@@ -1050,12 +1055,14 @@ class TestInstallSingleStatus:
 
         bay.name = "SFP 1"
         bay.module_id = None
+        ModuleBay.objects.restrict.return_value = ModuleBay.objects
         ModuleBay.objects.filter.return_value.select_related.return_value = [bay]
 
         locked_bay = _bay("SFP 1")
         locked_bay.pk = bay.pk
         locked_bay.module_id = None
         locked_bay.installed_module = None
+        ModuleBay.objects.restrict.return_value = ModuleBay.objects
         ModuleBay.objects.select_for_update.return_value.select_related.return_value.get.return_value = locked_bay
 
         module_instance = MagicMock()
@@ -1103,6 +1110,7 @@ class TestInstallSingleStatus:
         )
 
         # No bays under parent module scope.
+        ModuleBay.objects.restrict.return_value = ModuleBay.objects
         ModuleBay.objects.filter.return_value.select_related.return_value = []
         ModuleBay.objects.filter.return_value.first.return_value = None
 
@@ -1262,6 +1270,7 @@ class TestAdoptExistingTemplateInterfaces:
             patch("netbox_librenms_plugin.views.sync.modules.transaction") as mock_tx,
         ):
             mock_tx.atomic = noop_atomic
+            mock_interface_model.objects.restrict.return_value = mock_interface_model.objects
             mock_interface_model.objects.filter.return_value = [iface_a, iface_b]
             result = _adopt_existing_template_interfaces(device, module)
 
@@ -1307,6 +1316,7 @@ class TestAdoptExistingTemplateInterfaces:
             patch("netbox_librenms_plugin.views.sync.modules.transaction") as mock_tx,
         ):
             mock_tx.atomic = tracking_atomic
+            mock_interface_model.objects.restrict.return_value = mock_interface_model.objects
             mock_interface_model.objects.filter.return_value = [iface_a, iface_b]
 
             try:
@@ -1347,6 +1357,7 @@ class TestAdoptExistingTemplateInterfaces:
             patch("netbox_librenms_plugin.views.sync.modules.transaction") as mock_tx,
         ):
             mock_tx.atomic = noop_atomic
+            mock_interface_model.objects.restrict.return_value = mock_interface_model.objects
             mock_interface_model.objects.filter.return_value = [iface]
             result = _adopt_existing_template_interfaces(device, module)
 
@@ -1381,6 +1392,7 @@ class TestAdoptExistingTemplateInterfaces:
             patch("netbox_librenms_plugin.views.sync.modules.get_librenms_device_id", return_value=None),
             patch("netbox_librenms_plugin.views.sync.modules.set_librenms_device_id") as mock_set,
         ):
+            mock_interface_model.objects.restrict.return_value = mock_interface_model.objects
             mock_interface_model.objects.filter.side_effect = [by_name_qs, module_qs]
             result = _bind_interface_librenms_id(
                 device,
@@ -1418,6 +1430,7 @@ class TestAdoptExistingTemplateInterfaces:
             patch("netbox_librenms_plugin.views.sync.modules.get_librenms_device_id", return_value=None),
             patch("netbox_librenms_plugin.views.sync.modules.set_librenms_device_id") as mock_set,
         ):
+            mock_interface_model.objects.restrict.return_value = mock_interface_model.objects
             mock_interface_model.objects.filter.side_effect = [by_name_qs, module_qs]
             result = _bind_interface_librenms_id(
                 device,
@@ -1502,6 +1515,7 @@ class TestAdoptExistingTemplateInterfaces:
             patch("netbox_librenms_plugin.views.sync.modules.get_librenms_device_id", return_value=None),
             patch("netbox_librenms_plugin.views.sync.modules.set_librenms_device_id") as mock_set,
         ):
+            mock_interface_model.objects.restrict.return_value = mock_interface_model.objects
             mock_interface_model.objects.filter.return_value = by_name_qs
             result = _bind_interface_librenms_id(
                 device,
@@ -1548,6 +1562,7 @@ class TestAdoptExistingTemplateInterfaces:
             patch("netbox_librenms_plugin.views.sync.modules.get_librenms_device_id", return_value=None),
             patch("netbox_librenms_plugin.views.sync.modules.set_librenms_device_id") as mock_set,
         ):
+            mock_interface_model.objects.restrict.return_value = mock_interface_model.objects
             mock_interface_model.objects.filter.side_effect = [by_name_qs, module_qs]
             result = _bind_interface_librenms_id(
                 device,
@@ -1590,6 +1605,7 @@ class TestAdoptExistingTemplateInterfaces:
             patch("dcim.models.Interface") as mock_interface_model,
             patch("netbox_librenms_plugin.views.sync.modules.find_by_librenms_id", return_value=None),
         ):
+            mock_interface_model.objects.restrict.return_value = mock_interface_model.objects
             mock_interface_model.objects.filter.side_effect = [by_name_qs, module_qs]
             result = _bind_interface_librenms_id(
                 device,
@@ -1767,6 +1783,8 @@ class TestSingleInstallInterfaceBinding:
         ):
             mock_tx.atomic = noop_atomic
             mock_module_cls.return_value = new_module
+            # The locked re-fetch goes through restrict(user, ...), so hand back the same manager.
+            mock_objects.restrict.return_value = mock_objects
             mock_objects.select_for_update.return_value = mock_qs
             # Mismatched cache context triggers posted fallback path.
             mock_cache.get.return_value = {
@@ -1779,6 +1797,7 @@ class TestSingleInstallInterfaceBinding:
                     }
                 ],
             }
+            view.request = request
             view.post(request, pk=24)
 
         assert any(
@@ -1848,6 +1867,8 @@ class TestSingleInstallInterfaceBinding:
         ):
             mock_tx.atomic = noop_atomic
             mock_module_cls.return_value = new_module
+            # The locked re-fetch goes through restrict(user, ...), so hand back the same manager.
+            mock_objects.restrict.return_value = mock_objects
             mock_objects.select_for_update.return_value = mock_qs
             mock_cache.get.return_value = {
                 "inventory": [
@@ -1858,6 +1879,7 @@ class TestSingleInstallInterfaceBinding:
                     }
                 ]
             }
+            view.request = request
             view.post(request, pk=24)
 
         mock_bind.assert_called_once()
@@ -1934,6 +1956,8 @@ class TestSingleInstallInterfaceBinding:
         ):
             mock_tx.atomic = noop_atomic
             mock_module_cls.return_value = new_module
+            # The locked re-fetch goes through restrict(user, ...), so hand back the same manager.
+            mock_objects.restrict.return_value = mock_objects
             mock_objects.select_for_update.return_value = mock_qs
             mock_cache.get.return_value = {
                 "inventory": [
@@ -1944,6 +1968,7 @@ class TestSingleInstallInterfaceBinding:
                     }
                 ]
             }
+            view.request = request
             view.post(request, pk=24)
 
         # The bind must run and be scoped to the active server the blank key fell back to.
@@ -1979,6 +2004,7 @@ class TestSingleInstallInterfaceBinding:
             patch("netbox_librenms_plugin.views.sync.modules.messages") as mock_messages,
             patch("netbox_librenms_plugin.views.sync.modules.redirect") as mock_redirect,
         ):
+            view.request = request
             view.post(request, pk=24)
 
         mock_messages.error.assert_called_once()
@@ -2030,6 +2056,7 @@ class TestSingleInstallInterfaceBinding:
                 "inventory": [{"entPhysicalIndex": 77, "_librenms_port_id": 42, "_librenms_ifname": "Te1/1/1"}],
                 "librenms_id": 999,
             }
+            view.request = request
             response = view.post(request, pk=24)
 
         mock_bind.assert_called_once()
@@ -2079,6 +2106,7 @@ class TestSingleInstallInterfaceBinding:
                 "inventory": [{"entPhysicalIndex": 78, "_librenms_port_id": 43, "_librenms_ifname": "Te1/1/2"}],
                 "librenms_id": 999,
             }
+            view.request = request
             response = view.post(request, pk=24)
 
         mock_messages.success.assert_called_once()
@@ -2133,6 +2161,7 @@ class TestSingleInstallInterfaceBinding:
                 "inventory": [{"entPhysicalIndex": 77, "entPhysicalName": "Slot 1"}],
                 "librenms_id": 999,
             }
+            view.request = request
             response = view.post(request, pk=24)
 
         mock_bind.assert_called_once()
@@ -2188,6 +2217,7 @@ class TestSingleInstallInterfaceBinding:
                 "inventory": [{"entPhysicalIndex": 77, "_librenms_port_id": 42, "_librenms_ifname": "Te1/1/1"}],
                 "librenms_id": 999,
             }
+            view.request = request
             response = view.post(request, pk=24)
 
         mock_bind.assert_called_once()
@@ -2242,6 +2272,7 @@ class TestSingleInstallInterfaceBinding:
             patch("netbox_librenms_plugin.views.sync.modules._modules_redirect_response", return_value="redirected"),
         ):
             mock_cache.get.return_value = {"inventory": [], "librenms_id": 999}
+            view.request = request
             response = view.post(request, pk=24)
 
         mock_bind.assert_not_called()  # no server context → bind never attempted
@@ -2295,6 +2326,7 @@ class TestSingleInstallInterfaceBinding:
                 "inventory": [{"entPhysicalIndex": 77, "_librenms_port_id": 587, "_librenms_ifname": "2/x1/1/c2"}],
                 "librenms_id": 999,
             }
+            view.request = request
             response = view.post(request, pk=24)
 
         # Bind no-op'd on the already-bound interface, but adoption still ran...
@@ -2348,6 +2380,7 @@ class TestSingleInstallInterfaceBinding:
                 "inventory": [{"entPhysicalIndex": 77, "_librenms_port_id": 587, "_librenms_ifname": "2/x1/1/c2"}],
                 "librenms_id": 999,
             }
+            view.request = request
             view.post(request, pk=24)
 
         mock_adopt.assert_not_called()
@@ -2438,6 +2471,7 @@ class TestSingleInstallInterfaceBinding:
             }
             mock_module_cls.return_value = new_module
             mock_module_cls.objects.select_related.return_value = MagicMock()
+            mock_module_cls.objects.restrict.return_value = mock_module_cls.objects
             mock_module_cls.objects.select_for_update.return_value.filter.side_effect = [
                 installed_filter_qs,
                 conflict_filter_qs,
@@ -2515,6 +2549,7 @@ class TestVCMemberInterfaceNormalization:
         conflict_qs.exclude.return_value.first.return_value = None
 
         with patch("dcim.models.Interface") as mock_interface:
+            mock_interface.objects.restrict.return_value = mock_interface.objects
             mock_interface.objects.filter.side_effect = [module_qs, conflict_qs]
             result = _normalize_module_interface_names_for_vc_member(device, module)
 
@@ -2545,6 +2580,7 @@ class TestVCMemberInterfaceNormalization:
         conflict_qs.exclude.return_value.first.return_value = existing_iface
 
         with patch("dcim.models.Interface") as mock_interface:
+            mock_interface.objects.restrict.return_value = mock_interface.objects
             mock_interface.objects.filter.side_effect = [module_qs, conflict_qs]
             result = _normalize_module_interface_names_for_vc_member(device, module)
 
@@ -2570,6 +2606,7 @@ class TestVCMemberInterfaceNormalization:
         module_qs.order_by.return_value = [iface]
 
         with patch("dcim.models.Interface") as mock_interface:
+            mock_interface.objects.restrict.return_value = mock_interface.objects
             mock_interface.objects.filter.side_effect = [module_qs]
             result = _normalize_module_interface_names_for_vc_member(device, module)
 
@@ -2878,6 +2915,7 @@ class TestParentRowIdxVsEntityIndex:
         with patch("netbox_librenms_plugin.models.ModuleBayMapping") as mock_mapping:
             mock_mapping.objects.all.return_value = []
             with patch("netbox_librenms_plugin.models.InventoryIgnoreRule") as mock_ignore:
+                mock_ignore.objects.restrict.return_value = mock_ignore.objects
                 mock_ignore.objects.filter.return_value.order_by.return_value = []
                 with patch("netbox_librenms_plugin.utils.preload_normalization_rules", return_value={}):
                     with patch.object(view, "_get_module_bays", return_value=({}, {})):
@@ -2970,7 +3008,10 @@ class TestInstallViewsDoNotDeleteCache:
         ):
             mock_tx.atomic = noop_atomic
             mock_module_cls.return_value = new_module
+            # The locked re-fetch goes through restrict(user, ...), so hand back the same manager.
+            mock_objects.restrict.return_value = mock_objects
             mock_objects.select_for_update.return_value = mock_qs
+            view.request = request
             view.post(request, pk=24)
 
         mock_messages.success.assert_called_once()
@@ -3020,6 +3061,7 @@ class TestInstallViewsDoNotDeleteCache:
         ):
             mock_cache.get.return_value = {"inventory": cached_inventory, "librenms_id": "test"}
             mock_tx.atomic = lambda *a, **kw: MagicMock(__enter__=MagicMock(), __exit__=MagicMock(return_value=False))
+            view.request = request
             view.post(request, pk=24)
 
         mock_messages.success.assert_called_once()
@@ -3072,6 +3114,7 @@ class TestInstallViewsDoNotDeleteCache:
         ):
             mock_cache.get.return_value = {"inventory": cached_inventory, "librenms_id": "test"}
             mock_tx.atomic = lambda *a, **kw: MagicMock(__enter__=MagicMock(), __exit__=MagicMock(return_value=False))
+            view.request = request
             view.post(request, pk=24)
 
         mock_messages.success.assert_called_once()
@@ -3103,6 +3146,7 @@ class TestInstallViewsDoNotDeleteCache:
             patch.object(InstallBranchView, "_collect_branch") as mock_collect,
         ):
             mock_cache.get.return_value = {"inventory": [{"entPhysicalIndex": 100}], "librenms_id": 555}
+            view.request = request
             view.post(request, pk=24)
 
         mock_collect.assert_not_called()
@@ -3138,6 +3182,7 @@ class TestInstallViewsDoNotDeleteCache:
             patch("netbox_librenms_plugin.views.sync.modules.InstallBranchView._install_single") as mock_install,
         ):
             mock_cache.get.return_value = {"inventory": [{"entPhysicalIndex": 100}], "librenms_id": 555}
+            view.request = request
             view.post(request, pk=24)
 
         mock_install.assert_not_called()
@@ -3186,6 +3231,7 @@ class TestInstallViewsDoNotDeleteCache:
         ):
             mock_cache.get.return_value = {"inventory": cached_inventory, "librenms_id": "test"}
             mock_tx.atomic = lambda: MagicMock(__enter__=MagicMock(), __exit__=MagicMock(return_value=False))
+            view.request = request
             view.post(request, pk=24)
 
         mock_bind.assert_not_called()
@@ -3237,6 +3283,7 @@ class TestInstallViewsDoNotDeleteCache:
         ):
             mock_cache.get.return_value = {"inventory": cached_inventory, "librenms_id": "test"}
             mock_tx.atomic = lambda: MagicMock(__enter__=MagicMock(), __exit__=MagicMock(return_value=False))
+            view.request = request
             view.post(request, pk=24)
 
         mock_bind.assert_not_called()
@@ -3293,6 +3340,7 @@ class TestInstallViewsDoNotDeleteCache:
         ):
             mock_cache.get.return_value = {"inventory": cached_inventory, "librenms_id": "test"}
             mock_tx.atomic = lambda: MagicMock(__enter__=MagicMock(), __exit__=MagicMock(return_value=False))
+            view.request = request
             view.post(request, pk=24)
 
         mock_bind.assert_called_once()
@@ -3353,6 +3401,7 @@ class TestInstallViewsDoNotDeleteCache:
         ):
             mock_cache.get.return_value = {"inventory": cached_inventory, "librenms_id": "test"}
             mock_tx.atomic = lambda: MagicMock(__enter__=MagicMock(), __exit__=MagicMock(return_value=False))
+            view.request = request
             view.post(request, pk=24)
 
         mock_bind.assert_called_once()
@@ -4176,6 +4225,7 @@ class TestPKValidationErrorPaths:
             patch("netbox_librenms_plugin.views.sync.modules.messages") as mock_msg,
             patch("netbox_librenms_plugin.views.sync.modules.redirect") as mock_redirect,
         ):
+            view.request = request
             view.post(request, pk=24)
 
         mock_msg.error.assert_called_once()
@@ -4209,6 +4259,7 @@ class TestPKValidationErrorPaths:
             patch("netbox_librenms_plugin.views.sync.modules.messages") as mock_msg,
             patch("netbox_librenms_plugin.views.sync.modules.redirect") as mock_redirect,
         ):
+            view.request = request
             view.post(request, pk=24)
 
         mock_msg.error.assert_called_once()
@@ -4241,6 +4292,7 @@ class TestPKValidationErrorPaths:
             patch("netbox_librenms_plugin.views.sync.modules.messages") as mock_msg,
             patch("netbox_librenms_plugin.views.sync.modules.redirect") as mock_redirect,
         ):
+            view.request = request
             view.post(request, pk=24)
 
         mock_msg.error.assert_called_once()
@@ -4280,6 +4332,7 @@ class TestPKValidationErrorPaths:
             patch("netbox_librenms_plugin.views.sync.modules.redirect") as mock_redirect,
         ):
             mock_cache.get.return_value = {"inventory": cached, "librenms_id": "test"}
+            view.request = request
             view.post(request, pk=24)
 
         mock_msg.error.assert_called_once()
@@ -4348,7 +4401,12 @@ class TestInstallModuleViewBehavior:
             patch.object(ModuleBay, "objects") as mock_objects,
         ):
             mock_tx.atomic = noop_atomic
+            # The module is read through restrict(user, "change"), so hand back the same manager.
+            mock_objects.restrict.return_value = mock_objects
+            # The locked re-fetch goes through restrict(user, ...), so hand back the same manager.
+            mock_objects.restrict.return_value = mock_objects
             mock_objects.select_for_update.return_value = mock_qs
+            view.request = request
             view.post(request, pk=24)
 
         mock_msg.warning.assert_called_once()
@@ -4405,7 +4463,10 @@ class TestInstallModuleViewBehavior:
         ):
             mock_tx.atomic = noop_atomic
             mock_module_cls.return_value = new_module
+            # The locked re-fetch goes through restrict(user, ...), so hand back the same manager.
+            mock_objects.restrict.return_value = mock_objects
             mock_objects.select_for_update.return_value = mock_qs
+            view.request = request
             view.post(request, pk=24)
 
         new_module.full_clean.assert_called_once()
@@ -4475,7 +4536,12 @@ class TestUpdateModuleSerialViewBehavior:
             patch.object(Module, "objects") as mock_objects,
         ):
             mock_tx.atomic = noop_atomic
+            # The module is read through restrict(user, "change"), so hand back the same manager.
+            mock_objects.restrict.return_value = mock_objects
+            # The locked re-fetch goes through restrict(user, ...), so hand back the same manager.
+            mock_objects.restrict.return_value = mock_objects
             mock_objects.select_for_update.return_value = mock_qs
+            view.request = request
             view.post(request, pk=24)
 
         assert module.serial == "NEW-SN"
@@ -4685,6 +4751,7 @@ class TestAddBayTemplateViewPostValidation:
                 "netbox_librenms_plugin.views.sync.modules._modules_redirect_response", return_value="REDIR"
             ) as mock_redir,
         ):
+            view.request = req
             result = view.post(req, pk=1)
         assert result == "REDIR"
         assert mock_messages.error.called
@@ -4703,6 +4770,7 @@ class TestAddBayTemplateViewPostValidation:
             patch("netbox_librenms_plugin.views.sync.modules.messages") as mock_messages,
             patch("netbox_librenms_plugin.views.sync.modules._modules_redirect_response", return_value="REDIR"),
         ):
+            view.request = req
             view.post(req, pk=1)
         assert "target_pk" in mock_messages.error.call_args[0][1]
 
@@ -4718,6 +4786,7 @@ class TestAddBayTemplateViewPostValidation:
             patch("netbox_librenms_plugin.views.sync.modules.messages") as mock_messages,
             patch("netbox_librenms_plugin.views.sync.modules._modules_redirect_response", return_value="REDIR"),
         ):
+            view.request = req
             view.post(req, pk=1)
         assert "name is required" in mock_messages.error.call_args[0][1]
 
@@ -4825,6 +4894,7 @@ class TestAddBayTemplateViewMappingCheckbox:
             patch("netbox_librenms_plugin.views.sync.modules.render", return_value="R") as mock_render,
             patch("netbox_librenms_plugin.models.ModuleBayMapping") as mock_mapping_cls,
         ):
+            mock_mapping_cls.objects.restrict.return_value = mock_mapping_cls.objects
             mock_mapping_cls.objects.filter.return_value.filter.return_value.exists.return_value = False
             view.get(req, pk=42)
         ctx = mock_render.call_args[0][2]
@@ -4853,6 +4923,7 @@ class TestAddBayTemplateViewMappingCheckbox:
             patch("netbox_librenms_plugin.views.sync.modules.render", return_value="R") as mock_render,
             patch("netbox_librenms_plugin.models.ModuleBayMapping") as mock_mapping_cls,
         ):
+            mock_mapping_cls.objects.restrict.return_value = mock_mapping_cls.objects
             mock_mapping_cls.objects.filter.return_value.filter.return_value.exists.return_value = True
             view.get(req, pk=42)
         ctx = mock_render.call_args[0][2]
@@ -4877,6 +4948,7 @@ class TestAddBayTemplateViewMappingCheckbox:
             patch("netbox_librenms_plugin.views.sync.modules.render", return_value="R") as mock_render,
             patch("netbox_librenms_plugin.models.ModuleBayMapping") as mock_mapping_cls,
         ):
+            mock_mapping_cls.objects.restrict.return_value = mock_mapping_cls.objects
             mock_mapping_cls.objects.filter.return_value.filter.return_value.exists.return_value = False
             view.get(req, pk=42)
         ctx = mock_render.call_args[0][2]
@@ -4914,9 +4986,11 @@ class TestAddBayTemplateViewMappingCheckbox:
             mock_tx.atomic.return_value.__exit__ = MagicMock(return_value=False)
             mock_bt_cls.return_value = MagicMock()
             # No existing mapping
+            mock_mapping_cls.objects.restrict.return_value = mock_mapping_cls.objects
             mock_mapping_cls.objects.filter.return_value.filter.return_value.exists.return_value = False
             mapping_instance = MagicMock()
             mock_mapping_cls.return_value = mapping_instance
+            view.request = req
             view.post(req, pk=1)
         # ModuleBayMapping was constructed with the right field values
         call_kwargs = mock_mapping_cls.call_args.kwargs
@@ -4958,6 +5032,7 @@ class TestAddBayTemplateViewMappingCheckbox:
             mock_tx.atomic.return_value.__enter__ = lambda s: s
             mock_tx.atomic.return_value.__exit__ = MagicMock(return_value=False)
             mock_bt_cls.return_value = MagicMock()
+            view.request = req
             view.post(req, pk=1)
         # Mapping must not be instantiated when names match
         mock_mapping_cls.assert_not_called()
@@ -4990,6 +5065,7 @@ class TestAddBayTemplateViewMappingCheckbox:
             mock_tx.atomic.return_value.__enter__ = lambda s: s
             mock_tx.atomic.return_value.__exit__ = MagicMock(return_value=False)
             mock_bt_cls.return_value = MagicMock()
+            view.request = req
             view.post(req, pk=1)
         mock_mapping_cls.assert_not_called()
 
@@ -5012,7 +5088,9 @@ class TestAddBayTemplateViewInstantiation:
             patch("dcim.models.Module") as mock_module_cls,
             patch("dcim.models.ModuleBay") as mock_bay_cls,
         ):
+            mock_device_cls.objects.restrict.return_value = mock_device_cls.objects
             mock_device_cls.objects.filter.return_value = [dev_a, dev_b]
+            mock_bay_cls.objects.restrict.return_value = mock_bay_cls.objects
             mock_bay_cls.objects.filter.return_value.exists.return_value = False
             count = AddBayTemplateView._instantiate_template_on_existing(bay_template, "device_type", device_type)
         assert count == 2
@@ -5035,8 +5113,10 @@ class TestAddBayTemplateViewInstantiation:
             patch("dcim.models.Module"),
             patch("dcim.models.ModuleBay") as mock_bay_cls,
         ):
+            mock_device_cls.objects.restrict.return_value = mock_device_cls.objects
             mock_device_cls.objects.filter.return_value = [MagicMock()]
             # Bay already exists on the device
+            mock_bay_cls.objects.restrict.return_value = mock_bay_cls.objects
             mock_bay_cls.objects.filter.return_value.exists.return_value = True
             count = AddBayTemplateView._instantiate_template_on_existing(bay_template, "device_type", device_type)
         assert count == 0
@@ -5054,7 +5134,9 @@ class TestAddBayTemplateViewInstantiation:
             patch("dcim.models.Module") as mock_module_cls,
             patch("dcim.models.ModuleBay") as mock_bay_cls,
         ):
+            mock_module_cls.objects.restrict.return_value = mock_module_cls.objects
             mock_module_cls.objects.filter.return_value.select_related.return_value = [module_a]
+            mock_bay_cls.objects.restrict.return_value = mock_bay_cls.objects
             mock_bay_cls.objects.filter.return_value.exists.return_value = False
             count = AddBayTemplateView._instantiate_template_on_existing(bay_template, "module_type", module_type)
         assert count == 1
@@ -5210,6 +5292,7 @@ class TestAddBayTemplateViewRegexMapping:
             patch("netbox_librenms_plugin.views.sync.modules.render", return_value="R") as mock_render,
             patch("netbox_librenms_plugin.models.ModuleBayMapping") as mock_mapping_cls,
         ):
+            mock_mapping_cls.objects.restrict.return_value = mock_mapping_cls.objects
             mock_mapping_cls.objects.filter.return_value.filter.return_value.exists.return_value = False
             mock_mapping_cls.objects.filter.return_value.filter.return_value.only.return_value = []
             view.get(req, pk=42)
@@ -5238,6 +5321,7 @@ class TestAddBayTemplateViewRegexMapping:
             patch("netbox_librenms_plugin.views.sync.modules.render", return_value="R") as mock_render,
             patch("netbox_librenms_plugin.models.ModuleBayMapping") as mock_mapping_cls,
         ):
+            mock_mapping_cls.objects.restrict.return_value = mock_mapping_cls.objects
             mock_mapping_cls.objects.filter.return_value.filter.return_value.exists.return_value = False
             mock_mapping_cls.objects.filter.return_value.filter.return_value.only.return_value = []
             view.get(req, pk=42)
@@ -5268,6 +5352,7 @@ class TestAddBayTemplateViewRegexMapping:
             patch("netbox_librenms_plugin.models.ModuleBayMapping") as mock_mapping_cls,
         ):
             # No exact mapping, but a covering regex row exists.
+            mock_mapping_cls.objects.restrict.return_value = mock_mapping_cls.objects
             mock_mapping_cls.objects.filter.return_value.filter.return_value.exists.return_value = False
             mock_mapping_cls.objects.filter.return_value.filter.return_value.only.return_value = [existing]
             view.get(req, pk=42)
@@ -5314,9 +5399,11 @@ class TestAddBayTemplateViewRegexMapping:
             mock_tx.atomic.return_value.__exit__ = MagicMock(return_value=False)
             mock_bt_cls.return_value = MagicMock()
             # No existing exact or regex coverage.
+            mock_mapping_cls.objects.restrict.return_value = mock_mapping_cls.objects
             mock_mapping_cls.objects.filter.return_value.filter.return_value.exists.return_value = False
             mock_mapping_cls.objects.filter.return_value.filter.return_value.only.return_value = []
             mock_mapping_cls.return_value = MagicMock()
+            view.request = req
             view.post(req, pk=1)
         kwargs = mock_mapping_cls.call_args.kwargs
         assert kwargs["is_regex"] is True
@@ -5352,9 +5439,11 @@ class TestAddBayTemplateViewRegexMapping:
             mock_tx.atomic.return_value.__enter__ = lambda s: s
             mock_tx.atomic.return_value.__exit__ = MagicMock(return_value=False)
             mock_bt_cls.return_value = MagicMock()
+            mock_mapping_cls.objects.restrict.return_value = mock_mapping_cls.objects
             mock_mapping_cls.objects.filter.return_value.filter.return_value.exists.return_value = False
             mock_mapping_cls.objects.filter.return_value.filter.return_value.only.return_value = []
             mock_mapping_cls.return_value = MagicMock()
+            view.request = req
             view.post(req, pk=1)
         kwargs = mock_mapping_cls.call_args.kwargs
         assert kwargs["is_regex"] is False
@@ -5389,9 +5478,11 @@ class TestAddBayTemplateViewRegexMapping:
             mock_tx.atomic.return_value.__enter__ = lambda s: s
             mock_tx.atomic.return_value.__exit__ = MagicMock(return_value=False)
             mock_bt_cls.return_value = MagicMock()
+            mock_mapping_cls.objects.restrict.return_value = mock_mapping_cls.objects
             mock_mapping_cls.objects.filter.return_value.filter.return_value.exists.return_value = False
             mock_mapping_cls.objects.filter.return_value.filter.return_value.only.return_value = []
             mock_mapping_cls.return_value = MagicMock()
+            view.request = req
             view.post(req, pk=1)
         kwargs = mock_mapping_cls.call_args.kwargs
         assert kwargs["is_regex"] is False
@@ -5426,8 +5517,10 @@ class TestAddBayTemplateViewRegexMapping:
             mock_tx.atomic.return_value.__enter__ = lambda s: s
             mock_tx.atomic.return_value.__exit__ = MagicMock(return_value=False)
             mock_bt_cls.return_value = MagicMock()
+            mock_mapping_cls.objects.restrict.return_value = mock_mapping_cls.objects
             mock_mapping_cls.objects.filter.return_value.filter.return_value.exists.return_value = False
             mock_mapping_cls.objects.filter.return_value.filter.return_value.only.return_value = [existing]
+            view.request = req
             view.post(req, pk=1)
         # Coverage already exists → no new ModuleBayMapping instantiated.
         mock_mapping_cls.assert_not_called()
@@ -6005,6 +6098,7 @@ class TestReplaceModuleRedirectServerKey:
             patch("netbox_librenms_plugin.views.sync.modules.reverse", return_value="/sync/url/"),
             patch("netbox_librenms_plugin.views.sync.modules.messages"),
         ):
+            view.request = request
             return view.post(request, pk=1)
 
     def test_missing_module_id_redirect_preserves_fallback_server_key(self):
@@ -6054,6 +6148,7 @@ class TestUpdateModuleInterfaceRedirectServerKey:
             patch("netbox_librenms_plugin.views.sync.modules.reverse", return_value="/sync/url/"),
             patch("netbox_librenms_plugin.views.sync.modules.messages"),
         ):
+            view.request = request
             response = view.post(request, pk=device.pk)
 
         assert "server_key=prod" in response["HX-Redirect"]
@@ -6088,6 +6183,7 @@ class TestUpdateModuleInterfaceRedirectServerKey:
             patch("netbox_librenms_plugin.views.sync.modules.reverse", return_value="/sync/url/"),
             patch("netbox_librenms_plugin.views.sync.modules.messages"),
         ):
+            view.request = request
             response = view.post(request, pk=device.pk)
 
         assert "server_key=prod" in response["HX-Redirect"]

--- a/netbox_librenms_plugin/tests/test_sync_modules.py
+++ b/netbox_librenms_plugin/tests/test_sync_modules.py
@@ -1759,7 +1759,7 @@ class TestSingleInstallInterfaceBinding:
             yield
 
         mock_qs = MagicMock()
-        mock_qs.get.return_value = module_bay
+        mock_qs.filter.return_value.first.return_value = module_bay
 
         with (
             patch.object(view, "require_all_permissions", return_value=None),
@@ -1844,7 +1844,7 @@ class TestSingleInstallInterfaceBinding:
             yield
 
         mock_qs = MagicMock()
-        mock_qs.get.return_value = module_bay
+        mock_qs.filter.return_value.first.return_value = module_bay
 
         with (
             patch.object(view, "require_all_permissions", return_value=None),
@@ -1933,7 +1933,7 @@ class TestSingleInstallInterfaceBinding:
             yield
 
         mock_qs = MagicMock()
-        mock_qs.get.return_value = module_bay
+        mock_qs.filter.return_value.first.return_value = module_bay
 
         with (
             patch.object(view, "require_all_permissions", return_value=None),
@@ -2386,117 +2386,72 @@ class TestSingleInstallInterfaceBinding:
         mock_adopt.assert_not_called()
         mock_messages.warning.assert_called_once()
 
+    @pytest.mark.django_db
     def test_replace_module_view_binds_interface_after_replace(self):
+        from dcim.models import Module
+        from django.core.cache import cache
+
+        from netbox_librenms_plugin.tests.conftest import (
+            make_device,
+            make_interface,
+            make_module_bay,
+            make_module_type,
+        )
+        from netbox_librenms_plugin.tests.view_test_helpers import make_request, make_view, message_texts
+        from netbox_librenms_plugin.utils import get_librenms_device_id
         from netbox_librenms_plugin.views.sync.modules import ReplaceModuleView
 
-        view = object.__new__(ReplaceModuleView)
-        view.required_object_permissions = {}
-        view._librenms_api = MagicMock(server_key="production")
-        device = _make_device()
-
-        target_bay = MagicMock()
-        target_bay.name = "SFP 1"
-
-        installed_module = MagicMock()
-        installed_module.pk = 321
-        installed_module.module_type.model = "OLD-SFP"
-        installed_module.module_bay = target_bay
-
-        matched_type = MagicMock()
-        matched_type.model = "NEW-SFP"
-
-        new_module = MagicMock()
-        new_module.pk = 654
-
-        request = _make_request(
-            "POST",
-            data={
-                "module_id": "321",
+        device = make_device("replace-bind-device")
+        old_type = make_module_type("OLD-SFP-BIND")
+        new_type = make_module_type("NEW-SFP-BIND")
+        target_bay = make_module_bay(device, "SFP 1")
+        installed_module = Module.objects.create(
+            device=device,
+            module_bay=target_bay,
+            module_type=old_type,
+            serial="SN-OLD-BIND",
+        )
+        interface = make_interface(device, "Te1/1/1")
+        request = make_request(
+            "post",
+            {
+                "module_id": str(installed_module.pk),
                 "ent_index": "77",
-                "server_key": "production",
+                "server_key": "default",
             },
         )
-
-        @contextmanager
-        def noop_atomic():
-            yield
-
-        installed_filter_qs = MagicMock()
-        installed_filter_qs.select_related.return_value.first.return_value = installed_module
-
-        conflict_filter_qs = MagicMock()
-        conflict_filter_qs.exclude.return_value.select_related.return_value = []
-
-        with (
-            patch.object(view, "require_all_permissions", return_value=None),
-            patch(
-                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
-                side_effect=[device, installed_module],
-            ),
-            patch("netbox_librenms_plugin.views.sync.modules.reverse", return_value="/sync/"),
-            patch("netbox_librenms_plugin.views.sync.modules.transaction") as mock_tx,
-            patch("netbox_librenms_plugin.views.sync.modules.messages") as mock_messages,
-            patch("netbox_librenms_plugin.views.sync.modules._modules_redirect_response", return_value="redirected"),
-            patch.object(view, "get_cache_key", return_value="inv-key"),
-            patch("netbox_librenms_plugin.views.sync.modules.cache") as mock_cache,
-            patch(
-                "netbox_librenms_plugin.views.sync.modules.get_module_types_indexed",
-                return_value={"NEW-SFP": matched_type},
-            ),
-            patch("netbox_librenms_plugin.utils.resolve_module_type", return_value=matched_type),
-            patch(
-                "netbox_librenms_plugin.views.sync.modules._count_adoptable_interfaces", return_value=2
-            ) as mock_count,
-            patch(
-                "netbox_librenms_plugin.views.sync.modules._normalize_module_interface_names_for_vc_member",
-                return_value={"renamed": 1, "adopted": 0, "removed": 0, "skipped": 0},
-            ) as mock_normalize,
-            patch(
-                "netbox_librenms_plugin.views.sync.modules._bind_interface_librenms_id",
-                return_value={"status": "bound", "interface": "Te1/1/1", "port_id": 42},
-            ) as mock_bind,
-            patch("dcim.models.Module") as mock_module_cls,
-        ):
-            mock_tx.atomic = noop_atomic
-            mock_cache.get.return_value = {
+        view = make_view(ReplaceModuleView, request, librenms_api=MagicMock(server_key="default"))
+        cache_key = view.get_cache_key(device, "inventory", server_key="default")
+        cache.set(
+            cache_key,
+            {
                 "inventory": [
                     {
                         "entPhysicalIndex": 77,
-                        "entPhysicalModelName": "NEW-SFP",
-                        "entPhysicalSerialNum": "SN-42",
+                        "entPhysicalModelName": new_type.model,
+                        "entPhysicalSerialNum": "SN-NEW-BIND",
                         "_librenms_port_id": 42,
-                        "_librenms_ifname": "Te1/1/1",
+                        "_librenms_ifname": interface.name,
                     }
-                ]
-            }
-            mock_module_cls.return_value = new_module
-            mock_module_cls.objects.select_related.return_value = MagicMock()
-            mock_module_cls.objects.restrict.return_value = mock_module_cls.objects
-            mock_module_cls.objects.select_for_update.return_value.filter.side_effect = [
-                installed_filter_qs,
-                conflict_filter_qs,
-            ]
-
-            response = _post(view, request, pk=24)
-
-        mock_count.assert_called_once_with(device, new_module)
-        assert new_module._adopt_components is True
-        mock_normalize.assert_called_once_with(device, new_module)
-        mock_bind.assert_called_once()
-        bind_call = mock_bind.call_args
-        assert bind_call.args[0] is device
-        assert bind_call.args[1]["_librenms_port_id"] == 42
-        assert bind_call.args[2] == 654
-        assert bind_call.args[3] == "production"
-        mock_messages.success.assert_called_once()
-        warning_messages = [call.args[1] for call in mock_messages.warning.call_args_list]
-        assert (
-            "Module sync authority applied: adopted 2 existing standalone interface(s) into the module."
-            in warning_messages
+                ],
+                "librenms_id": 1,
+            },
         )
-        assert "VC member interface normalization applied: renamed 1." in warning_messages
-        mock_messages.info.assert_called()
-        assert response == "redirected"
+        try:
+            response = _post(view, request, pk=device.pk)
+        finally:
+            cache.delete(cache_key)
+
+        assert response.status_code == 302
+        assert not Module.objects.filter(pk=installed_module.pk).exists()
+        replacement = Module.objects.get(device=device, module_bay=target_bay)
+        assert replacement.module_type == new_type
+        assert replacement.serial == "SN-NEW-BIND"
+        interface.refresh_from_db()
+        assert interface.module_id == replacement.pk
+        assert get_librenms_device_id(interface, "default") == 42
+        assert any("Replaced OLD-SFP-BIND with NEW-SFP-BIND" in text for text in message_texts(request, "success"))
+        assert any("Bound Te1/1/1 to LibreNMS port_id 42" in text for text in message_texts(request, "info"))
 
 
 class TestVCMemberInterfaceNormalization:
@@ -2990,7 +2945,7 @@ class TestInstallViewsDoNotDeleteCache:
             yield
 
         mock_qs = MagicMock()
-        mock_qs.get.return_value = module_bay
+        mock_qs.filter.return_value.first.return_value = module_bay
 
         with (
             patch.object(view, "require_all_permissions", return_value=None),
@@ -4386,7 +4341,7 @@ class TestInstallModuleViewBehavior:
             yield
 
         mock_qs = MagicMock()
-        mock_qs.get.return_value = module_bay  # locked re-fetch returns same occupied bay
+        mock_qs.filter.return_value.first.return_value = module_bay  # locked re-fetch returns same occupied bay
 
         with (
             patch.object(view, "require_all_permissions", return_value=None),
@@ -4411,6 +4366,50 @@ class TestInstallModuleViewBehavior:
 
         mock_msg.warning.assert_called_once()
         assert "already has a module" in mock_msg.warning.call_args[0][1]
+        mock_redirect.assert_called_once()
+
+    def test_bay_deleted_before_lock_reports_error(self):
+        """A bay removed after the first lookup must not cause an uncaught exception."""
+        from contextlib import contextmanager
+
+        from dcim.models import ModuleBay
+
+        view = self._view()
+        device = _make_device()
+        module_bay = MagicMock()
+        module_type = MagicMock()
+        request = _make_request(
+            "POST",
+            data={"module_bay_id": "10", "module_type_id": "5", "serial": "SN1"},
+        )
+
+        @contextmanager
+        def noop_atomic():
+            yield
+
+        mock_qs = MagicMock()
+        mock_qs.get.side_effect = ModuleBay.DoesNotExist
+        mock_qs.filter.return_value.first.return_value = None
+
+        with (
+            patch.object(view, "require_all_permissions", return_value=None),
+            patch(
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+                side_effect=[device, module_bay, module_type],
+            ),
+            patch("netbox_librenms_plugin.views.sync.modules.reverse", return_value="/sync/"),
+            patch("netbox_librenms_plugin.views.sync.modules.transaction") as mock_tx,
+            patch("netbox_librenms_plugin.views.sync.modules.messages") as mock_msg,
+            patch("netbox_librenms_plugin.views.sync.modules.redirect") as mock_redirect,
+            patch.object(ModuleBay, "objects") as mock_objects,
+        ):
+            mock_tx.atomic = noop_atomic
+            mock_objects.restrict.return_value = mock_objects
+            mock_objects.select_for_update.return_value = mock_qs
+            view.request = request
+            view.post(request, pk=24)
+
+        mock_msg.error.assert_called_once_with(request, "Module bay no longer exists.")
         mock_redirect.assert_called_once()
 
     def test_successful_install(self):
@@ -4446,7 +4445,7 @@ class TestInstallModuleViewBehavior:
             yield
 
         mock_qs = MagicMock()
-        mock_qs.get.return_value = module_bay  # locked re-fetch returns same bay
+        mock_qs.filter.return_value.first.return_value = module_bay  # locked re-fetch returns same bay
 
         with (
             patch.object(view, "require_all_permissions", return_value=None),

--- a/netbox_librenms_plugin/tests/test_sync_modules.py
+++ b/netbox_librenms_plugin/tests/test_sync_modules.py
@@ -13,6 +13,26 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 
+def _bind_and_call(view, request, method, **kwargs):
+    """Call *view*.<method>, binding the request the way ``View.setup()`` does under dispatch().
+
+    A direct ``view.post(request, ...)`` leaves ``self.request`` unset, which the object-scoped
+    lookups read — production always goes through dispatch(), so bind it here too.
+    """
+    view.setup(request)
+    return getattr(view, method)(request, **kwargs)
+
+
+def _post(view, request, **kwargs):
+    """POST into *view* with the request bound (see :func:`_bind_and_call`)."""
+    return _bind_and_call(view, request, "post", **kwargs)
+
+
+def _get(view, request, **kwargs):
+    """GET into *view* with the request bound (see :func:`_bind_and_call`)."""
+    return _bind_and_call(view, request, "get", **kwargs)
+
+
 @contextmanager
 def _patch_build_row_deps(view, match_bay_return=None):
     """Patch all utility imports used by _build_row to isolate bay/type matching tests."""
@@ -1745,7 +1765,7 @@ class TestSingleInstallInterfaceBinding:
         with (
             patch.object(view, "require_all_permissions", return_value=None),
             patch(
-                "netbox_librenms_plugin.views.sync.modules.get_object_or_404",
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
                 side_effect=[device, module_bay, module_type],
             ),
             patch("netbox_librenms_plugin.views.sync.modules.reverse", return_value="/sync/"),
@@ -1827,7 +1847,7 @@ class TestSingleInstallInterfaceBinding:
         with (
             patch.object(view, "require_all_permissions", return_value=None),
             patch(
-                "netbox_librenms_plugin.views.sync.modules.get_object_or_404",
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
                 side_effect=[device, module_bay, module_type],
             ),
             patch("netbox_librenms_plugin.views.sync.modules.reverse", return_value="/sync/"),
@@ -1913,7 +1933,7 @@ class TestSingleInstallInterfaceBinding:
         with (
             patch.object(view, "require_all_permissions", return_value=None),
             patch(
-                "netbox_librenms_plugin.views.sync.modules.get_object_or_404",
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
                 side_effect=[device, module_bay, module_type],
             ),
             patch("netbox_librenms_plugin.views.sync.modules.reverse", return_value="/sync/"),
@@ -1968,7 +1988,10 @@ class TestSingleInstallInterfaceBinding:
 
         with (
             patch.object(view, "require_all_permissions", return_value=None),
-            patch("netbox_librenms_plugin.views.sync.modules.get_object_or_404", return_value=device),
+            patch(
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+                return_value=device,
+            ),
             patch("netbox_librenms_plugin.views.sync.modules.reverse", return_value="/sync/"),
             patch("netbox_librenms_plugin.views.sync.modules.messages") as mock_messages,
             patch("netbox_librenms_plugin.views.sync.modules.redirect") as mock_redirect,
@@ -2004,7 +2027,7 @@ class TestSingleInstallInterfaceBinding:
         with (
             patch.object(view, "require_all_permissions", return_value=None),
             patch(
-                "netbox_librenms_plugin.views.sync.modules.get_object_or_404",
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
                 side_effect=[device, module],
             ),
             patch("netbox_librenms_plugin.views.sync.modules.reverse", return_value="/sync/"),
@@ -2051,7 +2074,7 @@ class TestSingleInstallInterfaceBinding:
         with (
             patch.object(view, "require_all_permissions", return_value=None),
             patch(
-                "netbox_librenms_plugin.views.sync.modules.get_object_or_404",
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
                 side_effect=[device, module],
             ),
             patch("netbox_librenms_plugin.views.sync.modules.reverse", return_value="/sync/"),
@@ -2105,7 +2128,7 @@ class TestSingleInstallInterfaceBinding:
         with (
             patch.object(view, "require_all_permissions", return_value=None),
             patch(
-                "netbox_librenms_plugin.views.sync.modules.get_object_or_404",
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
                 side_effect=[device, module],
             ),
             patch("netbox_librenms_plugin.views.sync.modules.reverse", return_value="/sync/"),
@@ -2157,7 +2180,7 @@ class TestSingleInstallInterfaceBinding:
         with (
             patch.object(view, "require_all_permissions", return_value=None),
             patch(
-                "netbox_librenms_plugin.views.sync.modules.get_object_or_404",
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
                 side_effect=[device, module],
             ),
             patch("netbox_librenms_plugin.views.sync.modules.reverse", return_value="/sync/"),
@@ -2219,7 +2242,7 @@ class TestSingleInstallInterfaceBinding:
         with (
             patch.object(view, "require_all_permissions", return_value=None),
             patch(
-                "netbox_librenms_plugin.views.sync.modules.get_object_or_404",
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
                 side_effect=[device, module],
             ),
             patch("netbox_librenms_plugin.views.sync.modules.reverse", return_value="/sync/"),
@@ -2267,7 +2290,7 @@ class TestSingleInstallInterfaceBinding:
         with (
             patch.object(view, "require_all_permissions", return_value=None),
             patch(
-                "netbox_librenms_plugin.views.sync.modules.get_object_or_404",
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
                 side_effect=[device, module],
             ),
             patch("netbox_librenms_plugin.views.sync.modules.reverse", return_value="/sync/"),
@@ -2321,7 +2344,7 @@ class TestSingleInstallInterfaceBinding:
         with (
             patch.object(view, "require_all_permissions", return_value=None),
             patch(
-                "netbox_librenms_plugin.views.sync.modules.get_object_or_404",
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
                 side_effect=[device, module],
             ),
             patch("netbox_librenms_plugin.views.sync.modules.reverse", return_value="/sync/"),
@@ -2391,7 +2414,7 @@ class TestSingleInstallInterfaceBinding:
         with (
             patch.object(view, "require_all_permissions", return_value=None),
             patch(
-                "netbox_librenms_plugin.views.sync.modules.get_object_or_404",
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
                 side_effect=[device, installed_module],
             ),
             patch("netbox_librenms_plugin.views.sync.modules.reverse", return_value="/sync/"),
@@ -2437,7 +2460,7 @@ class TestSingleInstallInterfaceBinding:
                 conflict_filter_qs,
             ]
 
-            response = view.post(request, pk=24)
+            response = _post(view, request, pk=24)
 
         mock_count.assert_called_once_with(device, new_module)
         assert new_module._adopt_components is True
@@ -2951,7 +2974,7 @@ class TestInstallViewsDoNotDeleteCache:
         with (
             patch.object(view, "require_all_permissions", return_value=None),
             patch(
-                "netbox_librenms_plugin.views.sync.modules.get_object_or_404",
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
                 side_effect=[device, module_bay, module_type],
             ),
             patch("netbox_librenms_plugin.views.sync.modules.reverse", return_value="/sync/"),
@@ -2995,7 +3018,10 @@ class TestInstallViewsDoNotDeleteCache:
 
         with (
             patch.object(view, "require_all_permissions", return_value=None),
-            patch("netbox_librenms_plugin.views.sync.modules.get_object_or_404", return_value=device),
+            patch(
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+                return_value=device,
+            ),
             patch("netbox_librenms_plugin.views.sync.modules.reverse", return_value="/sync/"),
             patch("netbox_librenms_plugin.views.sync.modules.cache") as mock_cache,
             patch.object(view, "get_cache_key", return_value="test-key"),
@@ -3045,7 +3071,10 @@ class TestInstallViewsDoNotDeleteCache:
 
         with (
             patch.object(view, "require_all_permissions", return_value=None),
-            patch("netbox_librenms_plugin.views.sync.modules.get_object_or_404", return_value=device),
+            patch(
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+                return_value=device,
+            ),
             patch("netbox_librenms_plugin.views.sync.modules.reverse", return_value="/sync/"),
             patch("netbox_librenms_plugin.views.sync.modules.cache") as mock_cache,
             patch.object(view, "get_cache_key", return_value="test-key"),
@@ -3078,7 +3107,10 @@ class TestInstallViewsDoNotDeleteCache:
 
         with (
             patch.object(view, "require_all_permissions", return_value=None),
-            patch("netbox_librenms_plugin.views.sync.modules.get_object_or_404", return_value=device),
+            patch(
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+                return_value=device,
+            ),
             patch("netbox_librenms_plugin.views.sync.modules.reverse", return_value="/sync/"),
             patch("netbox_librenms_plugin.views.sync.modules.cache") as mock_cache,
             patch.object(view, "get_cache_key", return_value="test-key"),
@@ -3110,7 +3142,10 @@ class TestInstallViewsDoNotDeleteCache:
 
         with (
             patch.object(view, "require_all_permissions", return_value=None),
-            patch("netbox_librenms_plugin.views.sync.modules.get_object_or_404", return_value=device),
+            patch(
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+                return_value=device,
+            ),
             patch("netbox_librenms_plugin.views.sync.modules.reverse", return_value="/sync/"),
             patch("netbox_librenms_plugin.views.sync.modules.cache") as mock_cache,
             patch.object(view, "get_cache_key", return_value="test-key"),
@@ -3148,7 +3183,10 @@ class TestInstallViewsDoNotDeleteCache:
 
         with (
             patch.object(view, "require_all_permissions", return_value=None),
-            patch("netbox_librenms_plugin.views.sync.modules.get_object_or_404", return_value=device),
+            patch(
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+                return_value=device,
+            ),
             patch("netbox_librenms_plugin.views.sync.modules.reverse", return_value="/sync/"),
             patch("netbox_librenms_plugin.views.sync.modules.cache") as mock_cache,
             patch.object(view, "get_cache_key", return_value="test-key"),
@@ -3197,7 +3235,10 @@ class TestInstallViewsDoNotDeleteCache:
 
         with (
             patch.object(view, "require_all_permissions", return_value=None),
-            patch("netbox_librenms_plugin.views.sync.modules.get_object_or_404", return_value=device),
+            patch(
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+                return_value=device,
+            ),
             patch("netbox_librenms_plugin.views.sync.modules.reverse", return_value="/sync/"),
             patch("netbox_librenms_plugin.views.sync.modules.cache") as mock_cache,
             patch.object(view, "get_cache_key", return_value="test-key"),
@@ -3246,7 +3287,10 @@ class TestInstallViewsDoNotDeleteCache:
 
         with (
             patch.object(view, "require_all_permissions", return_value=None),
-            patch("netbox_librenms_plugin.views.sync.modules.get_object_or_404", return_value=device),
+            patch(
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+                return_value=device,
+            ),
             patch("netbox_librenms_plugin.views.sync.modules.reverse", return_value="/sync/"),
             patch("netbox_librenms_plugin.views.sync.modules.cache") as mock_cache,
             patch.object(view, "get_cache_key", return_value="test-key"),
@@ -3304,7 +3348,10 @@ class TestInstallViewsDoNotDeleteCache:
 
         with (
             patch.object(view, "require_all_permissions", return_value=None),
-            patch("netbox_librenms_plugin.views.sync.modules.get_object_or_404", return_value=device),
+            patch(
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+                return_value=device,
+            ),
             patch("netbox_librenms_plugin.views.sync.modules.reverse", return_value="/sync/"),
             patch("netbox_librenms_plugin.views.sync.modules.cache") as mock_cache,
             patch.object(view, "get_cache_key", return_value="test-key"),
@@ -4138,7 +4185,10 @@ class TestPKValidationErrorPaths:
 
         with (
             patch.object(view, "require_all_permissions", return_value=None),
-            patch("netbox_librenms_plugin.views.sync.modules.get_object_or_404", return_value=device),
+            patch(
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+                return_value=device,
+            ),
             patch("netbox_librenms_plugin.views.sync.modules.reverse", return_value="/sync/"),
             patch("netbox_librenms_plugin.views.sync.modules.messages") as mock_msg,
             patch("netbox_librenms_plugin.views.sync.modules.redirect") as mock_redirect,
@@ -4168,7 +4218,10 @@ class TestPKValidationErrorPaths:
 
         with (
             patch.object(view, "require_all_permissions", return_value=None),
-            patch("netbox_librenms_plugin.views.sync.modules.get_object_or_404", return_value=device),
+            patch(
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+                return_value=device,
+            ),
             patch("netbox_librenms_plugin.views.sync.modules.reverse", return_value="/sync/"),
             patch("netbox_librenms_plugin.views.sync.modules.messages") as mock_msg,
             patch("netbox_librenms_plugin.views.sync.modules.redirect") as mock_redirect,
@@ -4197,7 +4250,10 @@ class TestPKValidationErrorPaths:
 
         with (
             patch.object(view, "require_all_permissions", return_value=None),
-            patch("netbox_librenms_plugin.views.sync.modules.get_object_or_404", return_value=device),
+            patch(
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+                return_value=device,
+            ),
             patch("netbox_librenms_plugin.views.sync.modules.reverse", return_value="/sync/"),
             patch("netbox_librenms_plugin.views.sync.modules.messages") as mock_msg,
             patch("netbox_librenms_plugin.views.sync.modules.redirect") as mock_redirect,
@@ -4230,7 +4286,10 @@ class TestPKValidationErrorPaths:
 
         with (
             patch.object(view, "require_all_permissions", return_value=None),
-            patch("netbox_librenms_plugin.views.sync.modules.get_object_or_404", return_value=device),
+            patch(
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+                return_value=device,
+            ),
             patch("netbox_librenms_plugin.views.sync.modules.reverse", return_value="/sync/"),
             patch.object(view, "get_cache_key", return_value="ck"),
             patch("netbox_librenms_plugin.views.sync.modules.cache") as mock_cache,
@@ -4296,7 +4355,7 @@ class TestInstallModuleViewBehavior:
         with (
             patch.object(view, "require_all_permissions", return_value=None),
             patch(
-                "netbox_librenms_plugin.views.sync.modules.get_object_or_404",
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
                 side_effect=[device, module_bay, module_type],
             ),
             patch("netbox_librenms_plugin.views.sync.modules.reverse", return_value="/sync/"),
@@ -4351,7 +4410,7 @@ class TestInstallModuleViewBehavior:
         with (
             patch.object(view, "require_all_permissions", return_value=None),
             patch(
-                "netbox_librenms_plugin.views.sync.modules.get_object_or_404",
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
                 side_effect=[device, module_bay, module_type],
             ),
             patch("netbox_librenms_plugin.views.sync.modules.reverse", return_value="/sync/"),
@@ -4423,7 +4482,7 @@ class TestUpdateModuleSerialViewBehavior:
         with (
             patch.object(view, "require_all_permissions", return_value=None),
             patch(
-                "netbox_librenms_plugin.views.sync.modules.get_object_or_404",
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
                 return_value=device,
             ),
             patch("netbox_librenms_plugin.views.sync.modules.reverse", return_value="/sync/"),
@@ -4633,7 +4692,10 @@ class TestAddBayTemplateViewPostValidation:
         view = self._make_view()
         req = self._make_request({"target_kind": "bogus", "target_pk": "1", "name": "Slot 1"})
         with (
-            patch("netbox_librenms_plugin.views.sync.modules.get_object_or_404", return_value=MagicMock()),
+            patch(
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+                return_value=MagicMock(),
+            ),
             patch("netbox_librenms_plugin.views.sync.modules.reverse", return_value="/sync/"),
             patch("netbox_librenms_plugin.views.sync.modules.messages") as mock_messages,
             patch(
@@ -4650,7 +4712,10 @@ class TestAddBayTemplateViewPostValidation:
         view = self._make_view()
         req = self._make_request({"target_kind": "device_type", "target_pk": "", "name": "Slot 1"})
         with (
-            patch("netbox_librenms_plugin.views.sync.modules.get_object_or_404", return_value=MagicMock()),
+            patch(
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+                return_value=MagicMock(),
+            ),
             patch("netbox_librenms_plugin.views.sync.modules.reverse", return_value="/sync/"),
             patch("netbox_librenms_plugin.views.sync.modules.messages") as mock_messages,
             patch("netbox_librenms_plugin.views.sync.modules._modules_redirect_response", return_value="REDIR"),
@@ -4662,7 +4727,10 @@ class TestAddBayTemplateViewPostValidation:
         view = self._make_view()
         req = self._make_request({"target_kind": "module_type", "target_pk": "5", "name": "  "})
         with (
-            patch("netbox_librenms_plugin.views.sync.modules.get_object_or_404", return_value=MagicMock()),
+            patch(
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+                return_value=MagicMock(),
+            ),
             patch("netbox_librenms_plugin.views.sync.modules.reverse", return_value="/sync/"),
             patch("netbox_librenms_plugin.views.sync.modules.messages") as mock_messages,
             patch("netbox_librenms_plugin.views.sync.modules._modules_redirect_response", return_value="REDIR"),
@@ -4685,7 +4753,10 @@ class TestAddBayTemplateViewGetValidation:
         view = self._make_view()
         req = MagicMock()
         req.GET = {"target_kind": "nope", "target_pk": "1"}
-        with patch("netbox_librenms_plugin.views.sync.modules.get_object_or_404", return_value=MagicMock()):
+        with patch(
+            "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+            return_value=MagicMock(),
+        ):
             response = view.get(req, pk=1)
         assert response.status_code == 400
 
@@ -4693,7 +4764,10 @@ class TestAddBayTemplateViewGetValidation:
         view = self._make_view()
         req = MagicMock()
         req.GET = {"target_kind": "device_type", "target_pk": "abc"}
-        with patch("netbox_librenms_plugin.views.sync.modules.get_object_or_404", return_value=MagicMock()):
+        with patch(
+            "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+            return_value=MagicMock(),
+        ):
             response = view.get(req, pk=1)
         assert response.status_code == 400
 
@@ -4708,7 +4782,10 @@ class TestAddBayTemplateViewGetValidation:
             "suggested_label": "Fan Controller",
         }
         with (
-            patch("netbox_librenms_plugin.views.sync.modules.get_object_or_404", return_value=MagicMock()),
+            patch(
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+                return_value=MagicMock(),
+            ),
             patch("netbox_librenms_plugin.views.sync.modules.render", return_value="RENDERED") as mock_render,
         ):
             response = view.get(req, pk=42)
@@ -4758,7 +4835,10 @@ class TestAddBayTemplateViewMappingCheckbox:
         }
         req.user.has_perm.return_value = True
         with (
-            patch("netbox_librenms_plugin.views.sync.modules.get_object_or_404", return_value=device),
+            patch(
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+                return_value=device,
+            ),
             patch("netbox_librenms_plugin.views.sync.modules.render", return_value="R") as mock_render,
             patch("netbox_librenms_plugin.models.ModuleBayMapping") as mock_mapping_cls,
         ):
@@ -4783,7 +4863,10 @@ class TestAddBayTemplateViewMappingCheckbox:
         }
         req.user.has_perm.return_value = True
         with (
-            patch("netbox_librenms_plugin.views.sync.modules.get_object_or_404", return_value=device),
+            patch(
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+                return_value=device,
+            ),
             patch("netbox_librenms_plugin.views.sync.modules.render", return_value="R") as mock_render,
             patch("netbox_librenms_plugin.models.ModuleBayMapping") as mock_mapping_cls,
         ):
@@ -4804,7 +4887,10 @@ class TestAddBayTemplateViewMappingCheckbox:
         }
         req.user.has_perm.return_value = False  # lacks add_modulebaymapping
         with (
-            patch("netbox_librenms_plugin.views.sync.modules.get_object_or_404", return_value=device),
+            patch(
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+                return_value=device,
+            ),
             patch("netbox_librenms_plugin.views.sync.modules.render", return_value="R") as mock_render,
             patch("netbox_librenms_plugin.models.ModuleBayMapping") as mock_mapping_cls,
         ):
@@ -4830,7 +4916,10 @@ class TestAddBayTemplateViewMappingCheckbox:
         req.user.has_perm.return_value = True
         target = MagicMock()
         with (
-            patch("netbox_librenms_plugin.views.sync.modules.get_object_or_404", side_effect=[device, target]),
+            patch(
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+                side_effect=[device, target],
+            ),
             patch("netbox_librenms_plugin.views.sync.modules.reverse", return_value="/sync/"),
             patch("netbox_librenms_plugin.views.sync.modules.transaction") as mock_tx,
             patch("netbox_librenms_plugin.views.sync.modules.messages") as mock_msg,
@@ -4872,7 +4961,10 @@ class TestAddBayTemplateViewMappingCheckbox:
         }
         req.user.has_perm.return_value = True
         with (
-            patch("netbox_librenms_plugin.views.sync.modules.get_object_or_404", side_effect=[device, MagicMock()]),
+            patch(
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+                side_effect=[device, MagicMock()],
+            ),
             patch("netbox_librenms_plugin.views.sync.modules.reverse", return_value="/sync/"),
             patch("netbox_librenms_plugin.views.sync.modules.transaction") as mock_tx,
             patch("netbox_librenms_plugin.views.sync.modules.messages"),
@@ -4901,7 +4993,10 @@ class TestAddBayTemplateViewMappingCheckbox:
         }
         req.user.has_perm.return_value = True
         with (
-            patch("netbox_librenms_plugin.views.sync.modules.get_object_or_404", side_effect=[device, MagicMock()]),
+            patch(
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+                side_effect=[device, MagicMock()],
+            ),
             patch("netbox_librenms_plugin.views.sync.modules.reverse", return_value="/sync/"),
             patch("netbox_librenms_plugin.views.sync.modules.transaction") as mock_tx,
             patch("netbox_librenms_plugin.views.sync.modules.messages"),
@@ -5125,7 +5220,10 @@ class TestAddBayTemplateViewRegexMapping:
         }
         req.user.has_perm.return_value = True
         with (
-            patch("netbox_librenms_plugin.views.sync.modules.get_object_or_404", return_value=device),
+            patch(
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+                return_value=device,
+            ),
             patch("netbox_librenms_plugin.views.sync.modules.render", return_value="R") as mock_render,
             patch("netbox_librenms_plugin.models.ModuleBayMapping") as mock_mapping_cls,
         ):
@@ -5150,7 +5248,10 @@ class TestAddBayTemplateViewRegexMapping:
         }
         req.user.has_perm.return_value = True
         with (
-            patch("netbox_librenms_plugin.views.sync.modules.get_object_or_404", return_value=device),
+            patch(
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+                return_value=device,
+            ),
             patch("netbox_librenms_plugin.views.sync.modules.render", return_value="R") as mock_render,
             patch("netbox_librenms_plugin.models.ModuleBayMapping") as mock_mapping_cls,
         ):
@@ -5176,7 +5277,10 @@ class TestAddBayTemplateViewRegexMapping:
         }
         req.user.has_perm.return_value = True
         with (
-            patch("netbox_librenms_plugin.views.sync.modules.get_object_or_404", return_value=device),
+            patch(
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+                return_value=device,
+            ),
             patch("netbox_librenms_plugin.views.sync.modules.render", return_value="R") as mock_render,
             patch("netbox_librenms_plugin.models.ModuleBayMapping") as mock_mapping_cls,
         ):
@@ -5212,7 +5316,10 @@ class TestAddBayTemplateViewRegexMapping:
             }
         )
         with (
-            patch("netbox_librenms_plugin.views.sync.modules.get_object_or_404", side_effect=[device, target]),
+            patch(
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+                side_effect=[device, target],
+            ),
             patch("netbox_librenms_plugin.views.sync.modules.reverse", return_value="/sync/"),
             patch("netbox_librenms_plugin.views.sync.modules.transaction") as mock_tx,
             patch("netbox_librenms_plugin.views.sync.modules.messages"),
@@ -5248,7 +5355,10 @@ class TestAddBayTemplateViewRegexMapping:
             }
         )
         with (
-            patch("netbox_librenms_plugin.views.sync.modules.get_object_or_404", side_effect=[device, target]),
+            patch(
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+                side_effect=[device, target],
+            ),
             patch("netbox_librenms_plugin.views.sync.modules.reverse", return_value="/sync/"),
             patch("netbox_librenms_plugin.views.sync.modules.transaction") as mock_tx,
             patch("netbox_librenms_plugin.views.sync.modules.messages"),
@@ -5282,7 +5392,10 @@ class TestAddBayTemplateViewRegexMapping:
             }
         )
         with (
-            patch("netbox_librenms_plugin.views.sync.modules.get_object_or_404", side_effect=[device, target]),
+            patch(
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+                side_effect=[device, target],
+            ),
             patch("netbox_librenms_plugin.views.sync.modules.reverse", return_value="/sync/"),
             patch("netbox_librenms_plugin.views.sync.modules.transaction") as mock_tx,
             patch("netbox_librenms_plugin.views.sync.modules.messages"),
@@ -5316,7 +5429,10 @@ class TestAddBayTemplateViewRegexMapping:
         existing = MagicMock()
         existing.librenms_name = r"^Sfm (\d+)$"
         with (
-            patch("netbox_librenms_plugin.views.sync.modules.get_object_or_404", side_effect=[device, target]),
+            patch(
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+                side_effect=[device, target],
+            ),
             patch("netbox_librenms_plugin.views.sync.modules.reverse", return_value="/sync/"),
             patch("netbox_librenms_plugin.views.sync.modules.transaction") as mock_tx,
             patch("netbox_librenms_plugin.views.sync.modules.messages"),
@@ -5474,7 +5590,7 @@ class TestVCNormalizationReportView:
         with (
             patch.object(view, "require_object_permissions", return_value=None),
             patch(
-                "netbox_librenms_plugin.views.sync.modules.get_object_or_404",
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
                 return_value=device,
             ),
         ):
@@ -5495,7 +5611,7 @@ class TestVCNormalizationReportView:
         request = _make_request("GET", data={"module_id": str(module.pk)})
 
         with patch.object(view, "require_object_permissions", return_value=None):
-            response = view.get(request, pk=device.pk)
+            response = _get(view, request, pk=device.pk)
 
         assert response.status_code == 400
         assert b"nothing to report" in response.content.lower()
@@ -5520,7 +5636,7 @@ class TestVCNormalizationReportView:
                 return_value="rendered",
             ) as mock_render,
         ):
-            response = view.get(request, pk=device.pk)
+            response = _get(view, request, pk=device.pk)
 
         assert response == "rendered"
         ctx = mock_render.call_args[0][2]
@@ -5542,7 +5658,7 @@ class TestVCNormalizationReportView:
         with (
             patch.object(view, "require_object_permissions", return_value=None),
             patch(
-                "netbox_librenms_plugin.views.sync.modules.get_object_or_404",
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
                 side_effect=[device, module],
             ),
             patch(
@@ -5557,7 +5673,7 @@ class TestVCNormalizationReportView:
                 return_value=None,
             ),
         ):
-            response = view.get(request, pk=24)
+            response = _get(view, request, pk=24)
 
         mock_warn.assert_called_once_with(request)
         assert response.status_code == 400
@@ -5574,7 +5690,7 @@ class TestVCNormalizationReportView:
         with (
             patch.object(view, "require_object_permissions", return_value=None),
             patch(
-                "netbox_librenms_plugin.views.sync.modules.get_object_or_404",
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
                 return_value=device,
             ),
         ):
@@ -5895,7 +6011,10 @@ class TestReplaceModuleRedirectServerKey:
 
         with (
             patch.object(type(view), "librenms_api", new_callable=lambda: property(lambda s: mock_api)),
-            patch("netbox_librenms_plugin.views.sync.modules.get_object_or_404", return_value=MagicMock(pk=1)),
+            patch(
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+                return_value=MagicMock(pk=1),
+            ),
             patch(
                 "netbox_librenms_plugin.views.sync.modules._resolve_target_device_with_validation",
                 return_value=(MagicMock(), False),
@@ -5937,7 +6056,10 @@ class TestUpdateModuleInterfaceRedirectServerKey:
 
         with (
             patch.object(view, "require_all_permissions", return_value=None),
-            patch("netbox_librenms_plugin.views.sync.modules.get_object_or_404", return_value=device),
+            patch(
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
+                return_value=device,
+            ),
             patch(
                 "netbox_librenms_plugin.views.sync.modules._resolve_target_device_with_validation",
                 return_value=(device, False),
@@ -5965,7 +6087,7 @@ class TestUpdateModuleInterfaceRedirectServerKey:
         with (
             patch.object(view, "require_all_permissions", return_value=None),
             patch(
-                "netbox_librenms_plugin.views.sync.modules.get_object_or_404",
+                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
                 side_effect=[device, module],
             ),
             patch(

--- a/netbox_librenms_plugin/tests/test_sync_modules.py
+++ b/netbox_librenms_plugin/tests/test_sync_modules.py
@@ -2808,15 +2808,21 @@ class TestAncestorWalkGenericContainerModel:
         assert top == [parent]
 
     def test_unknown_model_remains_visible_for_no_type_diagnosis(self):
-        """Placeholder policy stays unchanged: Unknown is not a generic container model."""
-        item = {
+        """Unknown is a real ancestor model, so its child stays nested below it."""
+        parent = {
             "entPhysicalIndex": 1,
             "entPhysicalClass": "module",
             "entPhysicalModelName": "Unknown",
             "entPhysicalContainedIn": 0,
         }
+        child = {
+            "entPhysicalIndex": 2,
+            "entPhysicalClass": "module",
+            "entPhysicalModelName": "CHILD-MODULE",
+            "entPhysicalContainedIn": 1,
+        }
 
-        assert self._run_top_items([item]) == [item]
+        assert self._run_top_items([parent, child]) == [parent]
 
 
 # ---------------------------------------------------------------------------

--- a/netbox_librenms_plugin/tests/test_sync_modules.py
+++ b/netbox_librenms_plugin/tests/test_sync_modules.py
@@ -2788,6 +2788,36 @@ class TestAncestorWalkGenericContainerModel:
         assert 1 in indices
         assert 2 not in indices, "Child module under real parent must remain a descendant"
 
+    def test_numeric_models_are_classified_without_crashing(self):
+        """Numeric child and ancestor models still participate in top-level classification."""
+        parent = {
+            "entPhysicalIndex": 1,
+            "entPhysicalClass": "module",
+            "entPhysicalModelName": 123456,
+            "entPhysicalContainedIn": 0,
+        }
+        child = {
+            "entPhysicalIndex": 2,
+            "entPhysicalClass": "module",
+            "entPhysicalModelName": 654321,
+            "entPhysicalContainedIn": 1,
+        }
+
+        top = self._run_top_items([parent, child])
+
+        assert top == [parent]
+
+    def test_unknown_model_remains_visible_for_no_type_diagnosis(self):
+        """Placeholder policy stays unchanged: Unknown is not a generic container model."""
+        item = {
+            "entPhysicalIndex": 1,
+            "entPhysicalClass": "module",
+            "entPhysicalModelName": "Unknown",
+            "entPhysicalContainedIn": 0,
+        }
+
+        assert self._run_top_items([item]) == [item]
+
 
 # ---------------------------------------------------------------------------
 # Regression: parent_row_idx (table index) must not alias entPhysicalIndex

--- a/netbox_librenms_plugin/tests/test_sync_modules.py
+++ b/netbox_librenms_plugin/tests/test_sync_modules.py
@@ -4410,6 +4410,7 @@ class TestInstallModuleViewBehavior:
             view.post(request, pk=24)
 
         mock_msg.error.assert_called_once_with(request, "Module bay no longer exists.")
+        mock_qs.filter.assert_called_once_with(pk=10, device=device)
         mock_redirect.assert_called_once()
 
     def test_successful_install(self):

--- a/netbox_librenms_plugin/tests/test_utils.py
+++ b/netbox_librenms_plugin/tests/test_utils.py
@@ -1513,6 +1513,7 @@ class TestNormalizeDeviceSerialsMigration:
         with connection.cursor() as cursor:
             cursor.execute("SELECT to_regclass(%s)::oid", ["nblp_dcim_device_serial_idx"])
             original_oid = cursor.fetchone()[0]
+        assert original_oid is not None, "0012 must have created nblp_dcim_device_serial_idx"
 
         with connection.schema_editor(atomic=False) as schema_editor:
             module.ensure_device_serial_index(apps, schema_editor)

--- a/netbox_librenms_plugin/tests/test_utils.py
+++ b/netbox_librenms_plugin/tests/test_utils.py
@@ -782,6 +782,20 @@ class TestPaginationHelpers:
 
         assert result == 50
 
+    @pytest.mark.parametrize("disabled_max", [0, None])
+    @patch("netbox_librenms_plugin.utils.get_config")
+    @patch("netbox_librenms_plugin.utils.netbox_get_paginate_count")
+    def test_get_table_paginate_count_no_clamp_when_max_disabled(self, mock_netbox_paginate, mock_config, disabled_max):
+        """MAX_PAGE_SIZE 0/None disables the NetBox ceiling; per_page must pass through unclamped."""
+        # min(per_page, 0) would silently return 0 rows per page; min(per_page, None) TypeErrors.
+        from netbox_librenms_plugin.utils import get_table_paginate_count
+
+        mock_config.return_value.MAX_PAGE_SIZE = disabled_max
+        mock_request = MagicMock()
+        mock_request.GET = {"table1_per_page": "500"}
+
+        assert get_table_paginate_count(mock_request, "table1_") == 500
+
     @patch("netbox_librenms_plugin.utils.get_config")
     @patch("netbox_librenms_plugin.utils.netbox_get_paginate_count")
     def test_get_table_paginate_count_default(self, mock_netbox_paginate, mock_config):

--- a/netbox_librenms_plugin/tests/test_utils.py
+++ b/netbox_librenms_plugin/tests/test_utils.py
@@ -1719,3 +1719,33 @@ class TestGetVirtualChassisMemberNoneName:
         dev.refresh_from_db()
 
         assert get_virtual_chassis_member(dev, None) is dev
+
+
+class TestCoercePositiveInt:
+    """coerce_positive_int accepts only positive int / int-string and rejects non-integer types (no float truncation)."""
+
+    @pytest.mark.parametrize(
+        "value,expected",
+        [
+            (5, 5),
+            ("7", 7),
+            (1, 1),
+            (0, None),
+            (-3, None),
+            ("0", None),
+            ("-3", None),
+            (None, None),
+            (True, None),  # bool is an int subclass — must not become 1
+            (False, None),
+            (1.9, None),  # float must NOT int()-truncate to 1
+            (1.0, None),  # even a whole float is rejected (non-integer type)
+            ("1.9", None),  # non-integer string
+            ("abc", None),
+            ([], None),
+            ({}, None),
+        ],
+    )
+    def test_coercion(self, value, expected):
+        from netbox_librenms_plugin.utils import coerce_positive_int
+
+        assert coerce_positive_int(value) == expected

--- a/netbox_librenms_plugin/tests/test_utils_shared_helpers.py
+++ b/netbox_librenms_plugin/tests/test_utils_shared_helpers.py
@@ -10,7 +10,12 @@ Both are pure functions, so these exercise the real implementations directly wit
 
 import pytest
 
-from netbox_librenms_plugin.utils import cached_row_matches, is_valid_ports_payload, resolve_server_mapping_display_id
+from netbox_librenms_plugin.utils import (
+    cached_row_matches,
+    is_valid_ports_payload,
+    resolve_server_mapping_display_id,
+    row_identity_matches,
+)
 
 
 class TestCachedRowMatches:
@@ -36,6 +41,41 @@ class TestCachedRowMatches:
         # Pre-existing behavior preserved by the extraction: a non-dict payload has no readable
         # device_id, so it is left trusted (downstream shape gates reject it where it matters).
         assert cached_row_matches(["not-a-dict"], 12) is True
+
+    def test_two_invalid_ids_do_not_match(self):
+        # Both ids un-coercible must not compare equal as None == None; fail closed.
+        assert cached_row_matches({"device_id": "abc"}, "xyz") is False
+
+    def test_invalid_requested_id_rejects_even_a_trusted_row(self):
+        # An un-coercible requested id can't be identity-checked at all, so nothing matches it.
+        assert cached_row_matches({"hostname": "a"}, "xyz") is False
+
+
+class TestRowIdentityMatches:
+    """The strict identity rule for the collision pre-check and the single-row fetch fallback."""
+
+    def test_matching_dict_row(self):
+        assert row_identity_matches({"device_id": 5, "hostname": "a"}, 5) is True
+
+    def test_string_and_int_ids_normalize_equal(self):
+        assert row_identity_matches({"device_id": "5"}, 5) is True
+
+    def test_contradicting_id_fails(self):
+        assert row_identity_matches({"device_id": 6}, 5) is False
+
+    def test_row_without_device_id_fails(self):
+        # Unlike cached_row_matches, a fetched row MUST carry its own id — fail closed.
+        assert row_identity_matches({"hostname": "a"}, 5) is False
+
+    def test_non_dict_payload_fails(self):
+        assert row_identity_matches(["not-a-dict"], 5) is False
+
+    def test_none_payload_fails(self):
+        assert row_identity_matches(None, 5) is False
+
+    def test_two_invalid_ids_do_not_match(self):
+        # None == None must not read as a verified identity.
+        assert row_identity_matches({"device_id": "abc"}, "abc") is False
 
 
 class TestIsValidPortsPayload:

--- a/netbox_librenms_plugin/tests/test_utils_shared_helpers.py
+++ b/netbox_librenms_plugin/tests/test_utils_shared_helpers.py
@@ -37,10 +37,8 @@ class TestCachedRowMatches:
     def test_none_row_never_matches(self):
         assert cached_row_matches(None, 12) is False
 
-    def test_non_dict_row_stays_trusted(self):
-        # Pre-existing behavior preserved by the extraction: a non-dict payload has no readable
-        # device_id, so it is left trusted (downstream shape gates reject it where it matters).
-        assert cached_row_matches(["not-a-dict"], 12) is True
+    def test_non_dict_row_is_rejected(self):
+        assert cached_row_matches(["not-a-dict"], 12) is False
 
     def test_two_invalid_ids_do_not_match(self):
         # Both ids un-coercible must not compare equal as None == None; fail closed.

--- a/netbox_librenms_plugin/tests/test_utils_shared_helpers.py
+++ b/netbox_librenms_plugin/tests/test_utils_shared_helpers.py
@@ -10,7 +10,32 @@ Both are pure functions, so these exercise the real implementations directly wit
 
 import pytest
 
-from netbox_librenms_plugin.utils import is_valid_ports_payload, resolve_server_mapping_display_id
+from netbox_librenms_plugin.utils import cached_row_matches, is_valid_ports_payload, resolve_server_mapping_display_id
+
+
+class TestCachedRowMatches:
+    """The single- and bulk-import cache reads share this acceptance rule (can't drift)."""
+
+    def test_matching_id_is_served(self):
+        assert cached_row_matches({"device_id": 12, "hostname": "a"}, 12) is True
+
+    def test_string_and_int_ids_normalize_equal(self):
+        assert cached_row_matches({"device_id": "12"}, 12) is True
+
+    def test_contradicting_id_is_rejected(self):
+        # A mis-keyed/stale entry (another device's row under this key) must not be served.
+        assert cached_row_matches({"device_id": 99}, 12) is False
+
+    def test_row_without_device_id_stays_trusted(self):
+        assert cached_row_matches({"hostname": "a"}, 12) is True
+
+    def test_none_row_never_matches(self):
+        assert cached_row_matches(None, 12) is False
+
+    def test_non_dict_row_stays_trusted(self):
+        # Pre-existing behavior preserved by the extraction: a non-dict payload has no readable
+        # device_id, so it is left trusted (downstream shape gates reject it where it matters).
+        assert cached_row_matches(["not-a-dict"], 12) is True
 
 
 class TestIsValidPortsPayload:

--- a/netbox_librenms_plugin/tests/test_validation_template_server_key.py
+++ b/netbox_librenms_plugin/tests/test_validation_template_server_key.py
@@ -55,5 +55,8 @@ def test_mapping_writing_conflict_forms_include_server_key():
     mapping_forms = [f for f in forms if _form_actions(f) & MAPPING_ACTIONS]
     assert mapping_forms, "expected mapping-writing device_conflict_action forms in the template"
 
-    missing = [sorted(_form_actions(f)) for f in mapping_forms if 'name="server_key"' not in f]
+    hidden_include = '{% include "netbox_librenms_plugin/inc/_hidden_server_key.html" %}'
+    missing = [
+        sorted(_form_actions(f)) for f in mapping_forms if 'name="server_key"' not in f and hidden_include not in f
+    ]
     assert not missing, f"mapping-writing forms missing a server_key hidden input: {missing}"

--- a/netbox_librenms_plugin/tests/test_validation_template_server_key.py
+++ b/netbox_librenms_plugin/tests/test_validation_template_server_key.py
@@ -17,6 +17,9 @@ TEMPLATE = "netbox_librenms_plugin/htmx/device_validation_details.html"
 
 # Actions that persist a server-scoped librenms_id mapping (need the active server_key).
 MAPPING_ACTIONS = {"link", "update", "update_serial", "migrate_librenms_id"}
+HIDDEN_SERVER_KEY_INCLUDE = re.compile(
+    r'{%\s*include\s+["\']netbox_librenms_plugin/inc/_hidden_server_key\.html["\']\s*%}'
+)
 
 
 def _form_actions(form_html):
@@ -55,8 +58,9 @@ def test_mapping_writing_conflict_forms_include_server_key():
     mapping_forms = [f for f in forms if _form_actions(f) & MAPPING_ACTIONS]
     assert mapping_forms, "expected mapping-writing device_conflict_action forms in the template"
 
-    hidden_include = '{% include "netbox_librenms_plugin/inc/_hidden_server_key.html" %}'
     missing = [
-        sorted(_form_actions(f)) for f in mapping_forms if 'name="server_key"' not in f and hidden_include not in f
+        sorted(_form_actions(f))
+        for f in mapping_forms
+        if 'name="server_key"' not in f and not HIDDEN_SERVER_KEY_INCLUDE.search(f)
     ]
     assert not missing, f"mapping-writing forms missing a server_key hidden input: {missing}"

--- a/netbox_librenms_plugin/tests/test_validation_template_server_key.py
+++ b/netbox_librenms_plugin/tests/test_validation_template_server_key.py
@@ -20,10 +20,21 @@ MAPPING_ACTIONS = {"link", "update", "update_serial", "migrate_librenms_id"}
 
 
 def _form_actions(form_html):
-    return set(
-        re.findall(r'name="action"\s+value="([^"]+)"', form_html)
-        + re.findall(r'value="([^"]+)"\s+name="action"', form_html)
-    )
+    actions = set()
+    for tag in re.findall(r"<(?:input|button)\b[^>]*>", form_html, re.DOTALL | re.IGNORECASE):
+        if not re.search(r"\bname\s*=\s*(['\"])action\1", tag, re.IGNORECASE):
+            continue
+        value = re.search(r"\bvalue\s*=\s*(['\"])(.*?)\1", tag, re.DOTALL | re.IGNORECASE)
+        if value:
+            actions.add(value.group(2))
+    return actions
+
+
+def test_form_actions_accepts_attributes_between_name_and_value():
+    """An action input stays visible to the server-key scan when it gains another attribute."""
+    form = '<input type="hidden" name="action" class="mapping-action" value="link">'
+
+    assert _form_actions(form) == {"link"}
 
 
 def test_mapping_writing_conflict_forms_include_server_key():

--- a/netbox_librenms_plugin/tests/test_validation_template_server_key.py
+++ b/netbox_librenms_plugin/tests/test_validation_template_server_key.py
@@ -53,6 +53,9 @@ def test_form_actions_ignores_data_attributes():
 
 def test_mapping_writing_conflict_forms_include_server_key():
     src = pathlib.Path(get_template(TEMPLATE).origin.name).read_text()
+    partial = pathlib.Path(get_template("netbox_librenms_plugin/inc/_hidden_server_key.html").origin.name).read_text()
+    assert 'name="server_key"' in partial
+
     forms = [f for f in re.findall(r"<form\b.*?</form>", src, re.DOTALL) if "device_conflict_action" in f]
 
     mapping_forms = [f for f in forms if _form_actions(f) & MAPPING_ACTIONS]

--- a/netbox_librenms_plugin/tests/test_validation_template_server_key.py
+++ b/netbox_librenms_plugin/tests/test_validation_template_server_key.py
@@ -22,11 +22,16 @@ HIDDEN_SERVER_KEY_INCLUDE = re.compile(
 )
 
 
+def _named_control_tags(form_html, name):
+    for tag in re.findall(r"<(?:input|button)\b[^>]*>", form_html, re.DOTALL | re.IGNORECASE):
+        name_pattern = rf"(?:^|\s)name\s*=\s*(['\"]){re.escape(name)}\1(?=\s|/?>)"
+        if re.search(name_pattern, tag, re.IGNORECASE):
+            yield tag
+
+
 def _form_actions(form_html):
     actions = set()
-    for tag in re.findall(r"<(?:input|button)\b[^>]*>", form_html, re.DOTALL | re.IGNORECASE):
-        if not re.search(r"(?:^|\s)name\s*=\s*(['\"])action\1(?=\s|/?>)", tag, re.IGNORECASE):
-            continue
+    for tag in _named_control_tags(form_html, "action"):
         value = re.search(
             r"(?:^|\s)value\s*=\s*(['\"])(.*?)\1(?=\s|/?>)",
             tag,
@@ -35,6 +40,10 @@ def _form_actions(form_html):
         if value:
             actions.add(value.group(2))
     return actions
+
+
+def _form_has_named_control(form_html, name):
+    return next(_named_control_tags(form_html, name), None) is not None
 
 
 def test_form_actions_accepts_attributes_between_name_and_value():
@@ -51,6 +60,13 @@ def test_form_actions_ignores_data_attributes():
     assert _form_actions(form) == set()
 
 
+def test_form_named_control_ignores_data_attributes():
+    """A data-name attribute must not satisfy the server-key input scan."""
+    form = '<input type="hidden" data-name="server_key" value="secondary">'
+
+    assert not _form_has_named_control(form, "server_key")
+
+
 def test_mapping_writing_conflict_forms_include_server_key():
     src = pathlib.Path(get_template(TEMPLATE).origin.name).read_text()
     partial = pathlib.Path(get_template("netbox_librenms_plugin/inc/_hidden_server_key.html").origin.name).read_text()
@@ -64,6 +80,6 @@ def test_mapping_writing_conflict_forms_include_server_key():
     missing = [
         sorted(_form_actions(f))
         for f in mapping_forms
-        if 'name="server_key"' not in f and not HIDDEN_SERVER_KEY_INCLUDE.search(f)
+        if not _form_has_named_control(f, "server_key") and not HIDDEN_SERVER_KEY_INCLUDE.search(f)
     ]
     assert not missing, f"mapping-writing forms missing a server_key hidden input: {missing}"

--- a/netbox_librenms_plugin/tests/test_validation_template_server_key.py
+++ b/netbox_librenms_plugin/tests/test_validation_template_server_key.py
@@ -70,7 +70,7 @@ def test_form_named_control_ignores_data_attributes():
 def test_mapping_writing_conflict_forms_include_server_key():
     src = pathlib.Path(get_template(TEMPLATE).origin.name).read_text()
     partial = pathlib.Path(get_template("netbox_librenms_plugin/inc/_hidden_server_key.html").origin.name).read_text()
-    assert 'name="server_key"' in partial
+    assert _form_has_named_control(partial, "server_key")
 
     forms = [f for f in re.findall(r"<form\b.*?</form>", src, re.DOTALL) if "device_conflict_action" in f]
 

--- a/netbox_librenms_plugin/tests/test_validation_template_server_key.py
+++ b/netbox_librenms_plugin/tests/test_validation_template_server_key.py
@@ -22,9 +22,13 @@ MAPPING_ACTIONS = {"link", "update", "update_serial", "migrate_librenms_id"}
 def _form_actions(form_html):
     actions = set()
     for tag in re.findall(r"<(?:input|button)\b[^>]*>", form_html, re.DOTALL | re.IGNORECASE):
-        if not re.search(r"\bname\s*=\s*(['\"])action\1", tag, re.IGNORECASE):
+        if not re.search(r"(?:^|\s)name\s*=\s*(['\"])action\1(?=\s|/?>)", tag, re.IGNORECASE):
             continue
-        value = re.search(r"\bvalue\s*=\s*(['\"])(.*?)\1", tag, re.DOTALL | re.IGNORECASE)
+        value = re.search(
+            r"(?:^|\s)value\s*=\s*(['\"])(.*?)\1(?=\s|/?>)",
+            tag,
+            re.DOTALL | re.IGNORECASE,
+        )
         if value:
             actions.add(value.group(2))
     return actions
@@ -35,6 +39,13 @@ def test_form_actions_accepts_attributes_between_name_and_value():
     form = '<input type="hidden" name="action" class="mapping-action" value="link">'
 
     assert _form_actions(form) == {"link"}
+
+
+def test_form_actions_ignores_data_attributes():
+    """Metadata attributes must not make a non-action input look like an action control."""
+    form = '<input type="hidden" data-name="action" data-value="link">'
+
+    assert _form_actions(form) == set()
 
 
 def test_mapping_writing_conflict_forms_include_server_key():

--- a/netbox_librenms_plugin/tests/test_view_seam.py
+++ b/netbox_librenms_plugin/tests/test_view_seam.py
@@ -1,0 +1,190 @@
+"""The shared real-request/real-user drivers in view_test_helpers must work end to end.
+
+These are the seam every de-mocked view test stands on: if ``make_request`` silently failed to
+attach message storage, or ``grant`` produced a permission the NetBox backend ignores, the
+converted tests would pass for the wrong reason. Each assertion here pins one of those.
+"""
+
+import pytest
+
+from netbox_librenms_plugin.tests.conftest import make_device
+from netbox_librenms_plugin.tests.view_test_helpers import (
+    grant,
+    make_request,
+    make_superuser,
+    make_user_with_perms,
+    make_view,
+    message_texts,
+    messages_on,
+    post,
+)
+
+
+@pytest.mark.django_db
+class TestRealRequest:
+    def test_messages_are_recorded_for_real(self):
+        """A patched ``messages`` module proves nothing about what the user is told; this records."""
+        from django.contrib import messages
+
+        request = make_request()
+        messages.error(request, "boom")
+        messages.success(request, "ok")
+
+        assert messages_on(request) == [("error", "boom"), ("success", "ok")]
+
+    def test_message_texts_filters_by_level(self):
+        from django.contrib import messages
+
+        request = make_request()
+        messages.warning(request, "careful")
+        messages.error(request, "boom")
+
+        assert message_texts(request, "warning") == ["careful"]
+
+    def test_error_filtering_survives_netboxs_danger_tag(self):
+        """NetBox remaps ERROR's tag to "danger"; filtering by tag string would match nothing."""
+        from django.contrib import messages
+        from django.contrib.messages import get_messages
+
+        request = make_request()
+        messages.error(request, "boom")
+
+        assert [m.level_tag for m in get_messages(request)] == ["danger"]  # the trap
+        assert message_texts(request, "error") == ["boom"]
+
+    def test_an_unknown_level_name_is_rejected_not_silently_empty(self):
+        """A typo'd level must fail loudly, or `assert not message_texts(...)` passes vacuously."""
+        request = make_request()
+
+        with pytest.raises(ValueError):
+            message_texts(request, "eror")
+
+    def test_post_data_reaches_request_post(self):
+        request = make_request("post", {"server_key": "default", "platform_name": "ios"})
+
+        assert request.POST.get("platform_name") == "ios"
+
+    def test_default_user_is_a_real_active_superuser(self):
+        request = make_request()
+
+        assert request.user.is_superuser and request.user.is_active
+        assert request.user.pk is not None
+
+
+@pytest.mark.django_db
+class TestRealGrants:
+    def test_grant_is_honored_by_netbox_has_perm(self):
+        """NetBox's ObjectPermissionBackend ignores the user_permissions m2m — only these count."""
+        from dcim.models import Device
+
+        user = make_user_with_perms("seam-grantee", [("change", Device)])
+
+        assert user.has_perm("dcim.change_device")
+        assert not user.has_perm("dcim.delete_device")
+
+    def test_plugin_write_perms_are_granted_by_default(self):
+        user = make_user_with_perms("seam-plugin", [])
+
+        assert user.has_perm("netbox_librenms_plugin.view_librenmssettings")
+        assert user.has_perm("netbox_librenms_plugin.change_librenmssettings")
+
+    def test_plugin_write_can_be_withheld(self):
+        user = make_user_with_perms("seam-noplugin", [], plugin_write=False)
+
+        assert not user.has_perm("netbox_librenms_plugin.change_librenmssettings")
+
+    def test_a_constrained_grant_passes_has_perm_but_narrows_restrict(self):
+        """The exact shape the object-scoped lookups defend against: model-level yes, row-level no."""
+        from dcim.models import Device
+
+        mine = make_device("seam-mine")
+        theirs = make_device("seam-theirs")
+        user = make_user_with_perms("seam-constrained", [("change", Device)], constraints={"name": "seam-mine"})
+
+        assert user.has_perm("dcim.change_device")  # asked without an instance — passes
+        visible = Device.objects.restrict(user, "change")
+        assert list(visible.values_list("pk", flat=True)) == [mine.pk]
+        assert theirs.pk not in set(visible.values_list("pk", flat=True))
+
+    def test_restrict_returns_none_without_the_model_grant(self):
+        """Scoping a read the gate never covered would silently drop every row — pin that."""
+        from dcim.models import Device
+
+        make_device("seam-ungranted")
+        user = make_user_with_perms("seam-nodevice", [])
+
+        assert not Device.objects.restrict(user, "change").exists()
+
+    def test_grant_reloads_the_permission_cache(self):
+        """A user object cached before the grant would report the stale answer."""
+        from dcim.models import Device
+        from django.contrib.auth import get_user_model
+
+        user = get_user_model().objects.create_user(username="seam-cache", password="x")
+        assert not user.has_perm("dcim.change_device")  # primes the cache
+
+        user = grant(user, "change", Device)
+
+        assert user.has_perm("dcim.change_device")
+
+
+@pytest.mark.django_db
+class TestRealView:
+    def test_make_view_binds_the_request_and_runs_the_real_gate(self):
+        """A superuser drives the real permission gate to a real DB write — no ORM mock in sight."""
+        from dcim.models import Device
+
+        from netbox_librenms_plugin.views.sync.device_fields import UpdateDeviceSerialView
+
+        dev = make_device("seam-serial")
+        request = make_request("post")
+        view = make_view(UpdateDeviceSerialView, request)
+        view._librenms_api.get_librenms_id.return_value = 42
+        view._librenms_api.get_device_info.return_value = (True, {"serial": "SN-SEAM"})
+
+        post(view, request, pk=dev.pk)
+
+        assert Device.objects.get(pk=dev.pk).serial == "SN-SEAM"
+
+    def test_the_real_gate_denies_a_user_without_the_change_grant(self):
+        """No mocked ``require_all_permissions``: the denial comes from a real missing grant."""
+        from dcim.models import Device
+
+        from netbox_librenms_plugin.views.sync.device_fields import UpdateDeviceSerialView
+
+        dev = make_device("seam-denied")
+        user = make_user_with_perms("seam-viewer", [("view", Device)])
+        request = make_request("post", user=user)
+        view = make_view(UpdateDeviceSerialView, request)
+        view._librenms_api.get_librenms_id.return_value = 42
+        view._librenms_api.get_device_info.return_value = (True, {"serial": "SN-DENIED"})
+
+        post(view, request, pk=dev.pk)
+
+        assert Device.objects.get(pk=dev.pk).serial == ""
+        assert any("Missing permissions" in t for t in message_texts(request, "error"))
+
+    def test_a_constrained_grant_404s_on_a_device_outside_it(self):
+        """The scoped lookup must fail closed, not fall through to the plain manager."""
+        from django.http import Http404
+
+        from netbox_librenms_plugin.views.sync.device_fields import UpdateDeviceSerialView
+        from dcim.models import Device
+
+        mine = make_device("seam-scoped-mine")
+        theirs = make_device("seam-scoped-theirs")
+        user = make_user_with_perms("seam-scoped", [("change", Device)], constraints={"name": "seam-scoped-mine"})
+        request = make_request("post", user=user)
+        view = make_view(UpdateDeviceSerialView, request)
+        view._librenms_api.get_librenms_id.return_value = 42
+        view._librenms_api.get_device_info.return_value = (True, {"serial": "SN-X"})
+
+        with pytest.raises(Http404):
+            post(view, request, pk=theirs.pk)
+
+        post(view, request, pk=mine.pk)
+        assert Device.objects.get(pk=mine.pk).serial == "SN-X"
+
+    def test_superuser_helper_returns_the_same_row_across_calls(self):
+        """Two builders in one test must not race the unique-username constraint."""
+        assert make_superuser().pk == make_superuser().pk

--- a/netbox_librenms_plugin/tests/test_view_wiring.py
+++ b/netbox_librenms_plugin/tests/test_view_wiring.py
@@ -888,6 +888,10 @@ class TestImportMappingPermissionOrder:
             for assignment in ast.walk(tree)
             if isinstance(assignment, ast.Assign)
             and any(
+                getattr(target, "id", getattr(target, "attr", "")) == "required_object_permissions"
+                for target in assignment.targets
+            )
+            and any(
                 isinstance(node, ast.Tuple)
                 and len(node.elts) == 2
                 and isinstance(node.elts[0], ast.Constant)

--- a/netbox_librenms_plugin/tests/test_view_wiring.py
+++ b/netbox_librenms_plugin/tests/test_view_wiring.py
@@ -883,17 +883,21 @@ class TestImportMappingPermissionOrder:
             and node.func.value.args
             and getattr(node.func.value.args[0], "id", "") == target_model
         )
-        declared_read = any(
-            isinstance(node, ast.Tuple)
-            and len(node.elts) == 2
-            and isinstance(node.elts[0], ast.Constant)
-            and node.elts[0].value == "view"
-            and getattr(node.elts[1], "id", "") == target_model
-            for node in ast.walk(tree)
+        declaration_line = min(
+            assignment.lineno
+            for assignment in ast.walk(tree)
+            if isinstance(assignment, ast.Assign)
+            and any(
+                isinstance(node, ast.Tuple)
+                and len(node.elts) == 2
+                and isinstance(node.elts[0], ast.Constant)
+                and node.elts[0].value == "view"
+                and getattr(node.elts[1], "id", "") == target_model
+                for node in ast.walk(assignment.value)
+            )
         )
 
-        assert declared_read
-        assert gate_line < target_lookup_line
+        assert declaration_line < gate_line < target_lookup_line
 
 
 class TestScopedRowLocks:

--- a/netbox_librenms_plugin/tests/test_view_wiring.py
+++ b/netbox_librenms_plugin/tests/test_view_wiring.py
@@ -484,17 +484,34 @@ class TestGatedViewsResolveThroughRestrictedQuerysets:
         """Return {(label, class, line)} for gated classes in *tree* that resolve by raw pk."""
         import ast
 
+        def _call_chain(node):
+            """Yield calls in a queryset receiver chain, excluding arguments and filters."""
+            cur = node
+            while True:
+                if isinstance(cur, ast.Call):
+                    yield cur
+                    if not isinstance(cur.func, ast.Attribute):
+                        return
+                    cur = cur.func.value
+                elif isinstance(cur, ast.Attribute):
+                    cur = cur.value
+                else:
+                    return
+
         def _is_scoped(node):
             """Whether the queryset came from restricted_queryset(...) / .restrict(...)."""
             # Accepts the chained form too: self.restricted_queryset(Module).select_related(...).
             return any(
-                isinstance(inner, ast.Call) and getattr(inner.func, "attr", "") in ("restricted_queryset", "restrict")
-                for inner in ast.walk(node)
+                getattr(call.func, "attr", "") in ("restricted_queryset", "restrict") for call in _call_chain(node)
             )
 
         def _has_scoped_relationship_filter(call):
             """Whether an ``__in`` relationship value is a restricted queryset."""
-            return any(kw.arg and kw.arg.endswith("__in") and _is_scoped(kw.value) for kw in call.keywords)
+            return any(
+                kw.arg and kw.arg.endswith("__in") and _is_scoped(kw.value)
+                for chain_call in _call_chain(call)
+                for kw in chain_call.keywords
+            )
 
         def _through_manager(node):
             """Whether *node* is an unscoped ``<Model>.objects`` chain."""
@@ -545,7 +562,7 @@ class TestGatedViewsResolveThroughRestrictedQuerysets:
                 if not isinstance(sub, ast.Call):
                     continue
                 if getattr(sub.func, "id", None) == "get_object_or_404":
-                    if not (sub.args and _is_scoped(sub.args[0])):
+                    if not (sub.args and (_is_scoped(sub.args[0]) or _has_scoped_relationship_filter(sub.args[0]))):
                         offenders.add((label, node.name, sub.lineno))
                     continue
                 if not isinstance(sub.func, ast.Attribute) or sub.func.attr not in cls.RAW_TERMINALS:
@@ -627,6 +644,34 @@ class TestGatedViewsResolveThroughRestrictedQuerysets:
             "    required_object_permissions = {'POST': []}\n"
             "    def post(self, request, pk):\n"
             "        return get_object_or_404(self.restricted_queryset(Device), pk=pk)\n"
+        )
+        assert not self._scan_tree(ast.parse(source), "<fixture>")
+
+    def test_the_scan_rejects_an_unrelated_scope_in_a_primary_queryset(self):
+        """A nested scope call must not bless get_object_or_404's unscoped queryset."""
+        import ast
+
+        source = (
+            "class V:\n"
+            "    required_object_permissions = {'POST': []}\n"
+            "    def post(self, request, pk):\n"
+            "        return get_object_or_404(\n"
+            "            Interface.objects.filter(audit=self.restricted_queryset(Device).count()), pk=remote_pk\n"
+            "        )\n"
+        )
+        assert self._scan_tree(ast.parse(source), "<fixture>"), "an unrelated scope call must not hide a raw lookup"
+
+    def test_the_scan_accepts_a_primary_relationship_scope(self):
+        """An owner ``__in`` filter from a restricted queryset scopes the primary lookup."""
+        import ast
+
+        source = (
+            "class V:\n"
+            "    required_object_permissions = {'POST': []}\n"
+            "    def post(self, request, pk):\n"
+            "        return get_object_or_404(\n"
+            "            Interface.objects.filter(device__in=self.restricted_queryset(Device)), pk=remote_pk\n"
+            "        )\n"
         )
         assert not self._scan_tree(ast.parse(source), "<fixture>")
 

--- a/netbox_librenms_plugin/tests/test_view_wiring.py
+++ b/netbox_librenms_plugin/tests/test_view_wiring.py
@@ -5,6 +5,7 @@ These tests never touch the database or network; they only inspect class
 hierarchies and attribute presence.
 """
 
+import json
 import os
 from pathlib import Path
 
@@ -743,6 +744,98 @@ class TestGatedViewsRefuseOutOfScopeObjects:
         assert foreign_module.device_id == other_device.pk  # not moved
         assert foreign_module.module_bay_id == foreign_bay.pk
 
+    def test_module_move_refuses_to_delete_a_bay_occupant_outside_the_grant(self):
+        """MoveModuleView deletes whatever occupies the target bay; the bay filter proves where that row sits, not that the delete grant covers it."""
+        from dcim.models import Device, Module, ModuleBay
+
+        from netbox_librenms_plugin.tests.conftest import make_device, make_module_bay, make_module_type
+        from netbox_librenms_plugin.views.sync.modules import MoveModuleView
+
+        page_device = make_device("scope-moveocc-page")
+        mtype = make_module_type("MT-scope-moveocc")
+        source_bay = make_module_bay(page_device, "Slot 1")
+        target_bay = make_module_bay(page_device, "Slot 2")
+        conflict_module = Module.objects.create(device=page_device, module_bay=source_bay, module_type=mtype)
+        # The bay's current occupant sits on the page device, so only the delete grant excludes it.
+        occupant = Module.objects.create(device=page_device, module_bay=target_bay, module_type=mtype)
+
+        user = self._user(
+            "scope-moveocc",
+            [
+                (Device, "view", {"pk": page_device.pk}),
+                (ModuleBay, "view", None),
+                (Module, "change", None),  # the module being moved IS covered
+                (Module, "delete", {"pk": conflict_module.pk}),  # the occupant is NOT
+            ],
+        )
+        view = MoveModuleView()
+        request = self._request(
+            user,
+            {
+                "server_key": "default",
+                "conflict_module_id": str(conflict_module.pk),
+                "target_bay_id": str(target_bay.pk),
+                "module_id": str(occupant.pk),
+            },
+        )
+        view.setup(request)
+        view.post(request, pk=page_device.pk)
+
+        assert Module.objects.filter(pk=occupant.pk).exists()  # outside the delete grant, so kept
+
+    def test_interface_delete_refuses_an_interface_outside_the_grant(self):
+        """DeleteNetBoxInterfacesView deletes ids straight from the POST; the device check proves ownership, not the grant."""
+        from dcim.models import Device, Interface
+
+        from netbox_librenms_plugin.tests.conftest import make_device, make_interface
+        from netbox_librenms_plugin.views.sync.interfaces import DeleteNetBoxInterfacesView
+
+        device = make_device("scope-ifdel")
+        granted = make_interface(device, "eth0")
+        # Same device, so every ownership check the view makes passes; only the grant excludes it.
+        outside = make_interface(device, "eth1")
+
+        user = self._user(
+            "scope-ifdel",
+            [
+                (Device, "view", {"pk": device.pk}),
+                (Interface, "delete", {"pk": granted.pk}),
+            ],
+        )
+        view = DeleteNetBoxInterfacesView()
+        request = self._request(user, {"server_key": "default", "interface_ids": [str(outside.pk)]})
+        view.setup(request)
+        response = view.post(request, object_type="device", object_id=device.pk)
+
+        assert Interface.objects.filter(pk=outside.pk).exists()
+        assert json.loads(response.content)["deleted_count"] == 0
+
+    def test_vm_interface_delete_refuses_an_interface_outside_the_grant(self):
+        """The virtual-machine branch of the same view resolves VMInterface ids from the POST too."""
+        from virtualization.models import VirtualMachine, VMInterface
+
+        from netbox_librenms_plugin.tests.conftest import make_vm
+        from netbox_librenms_plugin.views.sync.interfaces import DeleteNetBoxInterfacesView
+
+        vm = make_vm("scope-vmifdel")
+        granted = VMInterface.objects.create(virtual_machine=vm, name="eth0")
+        outside = VMInterface.objects.create(virtual_machine=vm, name="eth1")
+
+        user = self._user(
+            "scope-vmifdel",
+            [
+                (VirtualMachine, "view", {"pk": vm.pk}),
+                (VMInterface, "delete", {"pk": granted.pk}),
+            ],
+        )
+        view = DeleteNetBoxInterfacesView()
+        request = self._request(user, {"server_key": "default", "interface_ids": [str(outside.pk)]})
+        view.setup(request)
+        response = view.post(request, object_type="virtualmachine", object_id=vm.pk)
+
+        assert VMInterface.objects.filter(pk=outside.pk).exists()
+        assert json.loads(response.content)["deleted_count"] == 0
+
     def test_vc_serial_assign_refuses_a_member_outside_the_grant(self):
         """AssignVCSerialView overwrites the member's serial and takes its pk from the POST, guarded only by same-VC membership."""
         from dcim.models import Device
@@ -768,7 +861,7 @@ class TestGatedViewsRefuseOutOfScopeObjects:
         view = AssignVCSerialView()
         request = self._request(
             user,
-            {"server_key": "default", "member_id_0": str(sibling.pk), "serial_0": "HIJACKED"},
+            {"server_key": "default", "member_id_1": str(sibling.pk), "serial_1": "HIJACKED"},
         )
         view.setup(request)
         view.post(request, pk=page_member.pk)

--- a/netbox_librenms_plugin/tests/test_view_wiring.py
+++ b/netbox_librenms_plugin/tests/test_view_wiring.py
@@ -448,9 +448,22 @@ class TestGatedViewsResolveThroughRestrictedQuerysets:
     statically or per-request) OR calls one of the ``require_*_permission(s)`` gates: a view gated
     only by the plugin write permission reaches objects by raw pk just as easily.
 
-    Scope and limits: a raw lookup inherited from an ungated base class is NOT seen, and neither is
-    ``Model.objects.get(pk=...)`` / ``.filter(pk=...)`` — the secondary-lookup form. Both remain a
-    review matter.
+    Two forms are flagged: the PRIMARY lookup (``get_object_or_404(Model, pk=...)``) and the
+    SECONDARY one (``Model.objects.get(pk=...)`` / ``.filter(pk=...)``), which is where the same
+    defect kept reappearing after the primary lookups were scoped — on the module move/serial
+    endpoints, the interface delete targets and the OOB interface reuse.
+
+    What counts is where the id came from. A bare name, ``int(...)`` or a subscript is a CLIENT id
+    and must be scoped. A re-lock keyed by an already-resolved object (``pk=device.pk``,
+    ``pk=donor.oob_ip_id``) is exempt: the scoping happened where that object was resolved, and
+    restricting the re-read would instead demand a permission the view's gate never required —
+    ``restrict()`` returns ``none()`` for a user who lacks the model-level grant, so a change-only
+    caller would silently lose rows out of a lock set and be told the object "no longer exists".
+
+    Scope and limits: a raw lookup inherited from an ungated base class is NOT seen; bulk
+    ``pk__in=<collection>`` locks are not covered (each is built in-function from rows already
+    resolved); and a ``.filter(pk=...).exists()`` probe is exempt — it reads no object data and is how
+    ``_required_perms_for_object`` decides WHICH permission to demand, before any gate has run.
     """
 
     GATE_CALLS = frozenset(
@@ -463,6 +476,8 @@ class TestGatedViewsResolveThroughRestrictedQuerysets:
             "require_all_permissions_json",
         }
     )
+    PK_LOOKUP_KEYS = frozenset({"pk", "id"})
+    RAW_TERMINALS = frozenset({"get", "filter", "get_or_create"})
 
     @classmethod
     def _scan_tree(cls, tree, label):
@@ -470,12 +485,27 @@ class TestGatedViewsResolveThroughRestrictedQuerysets:
         import ast
 
         def _is_scoped(node):
-            """Whether the first get_object_or_404 argument came from restricted_queryset(...)."""
+            """Whether the queryset came from restricted_queryset(...) / .restrict(...)."""
             # Accepts the chained form too: self.restricted_queryset(Module).select_related(...).
             return any(
-                isinstance(inner, ast.Call) and getattr(inner.func, "attr", "") == "restricted_queryset"
+                isinstance(inner, ast.Call) and getattr(inner.func, "attr", "") in ("restricted_queryset", "restrict")
                 for inner in ast.walk(node)
             )
+
+        def _through_manager(node):
+            """Whether *node* is an unscoped ``<Model>.objects`` chain."""
+            saw_objects = False
+            cur = node
+            while True:
+                if isinstance(cur, ast.Call):
+                    if getattr(cur.func, "attr", "") in ("restricted_queryset", "restrict"):
+                        return False
+                    cur = cur.func
+                elif isinstance(cur, ast.Attribute):
+                    saw_objects = saw_objects or cur.attr == "objects"
+                    cur = cur.value
+                else:
+                    return saw_objects
 
         def _declares_gate(class_node):
             for sub in ast.walk(class_node):
@@ -498,10 +528,37 @@ class TestGatedViewsResolveThroughRestrictedQuerysets:
             # The mixin that DEFINES restrict_object_or_404 is where the raw call belongs.
             if any(isinstance(sub, ast.FunctionDef) and sub.name == "restrict_object_or_404" for sub in node.body):
                 continue
+            # `<qs>.exists()` reads no object data — see the class docstring.
+            exempt = {
+                sub.func.value
+                for sub in ast.walk(node)
+                if isinstance(sub, ast.Call)
+                and isinstance(sub.func, ast.Attribute)
+                and sub.func.attr == "exists"
+                and isinstance(sub.func.value, ast.Call)
+            }
             for sub in ast.walk(node):
-                if not (isinstance(sub, ast.Call) and getattr(sub.func, "id", None) == "get_object_or_404"):
+                if not isinstance(sub, ast.Call):
                     continue
-                if not (sub.args and _is_scoped(sub.args[0])):
+                if getattr(sub.func, "id", None) == "get_object_or_404":
+                    if not (sub.args and _is_scoped(sub.args[0])):
+                        offenders.add((label, node.name, sub.lineno))
+                    continue
+                if not isinstance(sub.func, ast.Attribute) or sub.func.attr not in cls.RAW_TERMINALS:
+                    continue
+                if sub in exempt:
+                    continue
+                pk_kwargs = [kw for kw in sub.keywords if kw.arg in cls.PK_LOOKUP_KEYS]
+                # `pk=obj.pk` / `pk=obj.foo_id` is a re-lock, not a client id — see the docstring.
+                if not pk_kwargs or all(
+                    isinstance(kw.value, ast.Attribute) and (kw.value.attr == "pk" or kw.value.attr.endswith("_id"))
+                    for kw in pk_kwargs
+                ):
+                    continue
+                # A scoped queryset can also arrive as an ARGUMENT rather than the receiver:
+                # `Port.objects.filter(pk=..., device__in=self.restricted_queryset(Device))`
+                # constrains by owner visibility, which is a deliberate and sufficient scoping.
+                if _through_manager(sub.func.value) and not _is_scoped(sub):
                     offenders.add((label, node.name, sub.lineno))
         return offenders
 
@@ -562,6 +619,79 @@ class TestGatedViewsResolveThroughRestrictedQuerysets:
             "    required_object_permissions = {'POST': []}\n"
             "    def post(self, request, pk):\n"
             "        return get_object_or_404(self.restricted_queryset(Device), pk=pk)\n"
+        )
+        assert not self._scan_tree(ast.parse(source), "<fixture>")
+
+    @pytest.mark.parametrize(
+        "lookup",
+        [
+            "Module.objects.get(pk=module_id)",
+            "Module.objects.filter(pk=module_id, device=d).first()",
+            "Module.objects.select_for_update().filter(pk=module_id).first()",
+            "Interface.objects.get(id=iface_id)",
+        ],
+    )
+    def test_the_scan_flags_a_secondary_raw_lookup(self, lookup):
+        """The secondary form is the one that kept slipping through — every shape of it must be flagged."""
+        import ast
+
+        source = (
+            "class V:\n"
+            "    required_object_permissions = {'POST': []}\n"
+            "    def post(self, request, pk):\n"
+            f"        return {lookup}\n"
+        )
+        assert self._scan_tree(ast.parse(source), "<fixture>"), f"not flagged: {lookup}"
+
+    def test_the_scan_accepts_a_scoped_secondary_lookup(self):
+        """Both scoping spellings clear it: the mixin helper and the bare manager restrict()."""
+        import ast
+
+        source = (
+            "class V:\n"
+            "    required_object_permissions = {'POST': []}\n"
+            "    def post(self, request, pk):\n"
+            "        a = self.restricted_queryset(Module, 'change').select_for_update().filter(pk=module_id)\n"
+            "        return Interface.objects.restrict(request.user, 'view').get(pk=iface_id)\n"
+        )
+        assert not self._scan_tree(ast.parse(source), "<fixture>")
+
+    def test_the_scan_accepts_scoping_passed_as_an_argument(self):
+        """Constraining by owner visibility scopes the row just as well as scoping its own manager."""
+        import ast
+
+        source = (
+            "class V:\n"
+            "    required_object_permissions = {'POST': []}\n"
+            "    def post(self, request, pk):\n"
+            "        return Interface.objects.filter(\n"
+            "            pk=remote_pk, device__in=self.restricted_queryset(Device)\n"
+            "        ).first()\n"
+        )
+        assert not self._scan_tree(ast.parse(source), "<fixture>")
+
+    def test_the_scan_exempts_a_relock_of_an_already_resolved_object(self):
+        """Re-locking a row already resolved through a scoped queryset must not demand a new permission."""
+        import ast
+
+        source = (
+            "class V:\n"
+            "    required_object_permissions = {'POST': []}\n"
+            "    def post(self, request, pk):\n"
+            "        a = Device.objects.select_for_update().get(pk=existing_device.pk)\n"
+            "        return IPAddress.objects.select_for_update().filter(pk=donor.oob_ip_id).first()\n"
+        )
+        assert not self._scan_tree(ast.parse(source), "<fixture>")
+
+    def test_the_scan_exempts_an_exists_probe(self):
+        """A .exists() probe reads no object data and picks WHICH permission to demand."""
+        import ast
+
+        source = (
+            "class V:\n"
+            "    required_object_permissions = {'POST': []}\n"
+            "    def post(self, request, pk):\n"
+            "        return Device.objects.filter(pk=object_id).exists()\n"
         )
         assert not self._scan_tree(ast.parse(source), "<fixture>")
 
@@ -743,6 +873,84 @@ class TestGatedViewsRefuseOutOfScopeObjects:
         foreign_module.refresh_from_db()
         assert foreign_module.device_id == other_device.pk  # not moved
         assert foreign_module.module_bay_id == foreign_bay.pk
+
+    def test_module_serial_update_refuses_a_module_outside_the_grant(self):
+        """UpdateModuleSerialView writes the serial of a module whose pk comes from the POST, filtered only by device."""
+        from dcim.models import Device, Module
+
+        from netbox_librenms_plugin.tests.conftest import make_device, make_module_bay, make_module_type
+        from netbox_librenms_plugin.views.sync.modules import UpdateModuleSerialView
+
+        page_device = make_device("scope-modserial-page")
+        mtype = make_module_type("MT-scope-modserial")
+        bay = make_module_bay(page_device, "Slot 1")
+        # On the page device, so the view's device filter passes; only the grant excludes it.
+        module = Module.objects.create(device=page_device, module_bay=bay, module_type=mtype, serial="ORIGINAL")
+        decoy = Module.objects.create(
+            device=page_device, module_bay=make_module_bay(page_device, "Slot 2"), module_type=mtype
+        )
+
+        user = self._user(
+            "scope-modserial",
+            [
+                (Device, "view", {"pk": page_device.pk}),
+                (Module, "change", {"pk": decoy.pk}),
+            ],
+        )
+        view = UpdateModuleSerialView()
+        request = self._request(
+            user,
+            {"server_key": "default", "module_id": str(module.pk), "serial": "HIJACKED"},
+        )
+        view.setup(request)
+        view.post(request, pk=page_device.pk)
+
+        module.refresh_from_db()
+        assert module.serial == "ORIGINAL"
+
+    def test_site_location_push_refuses_a_site_outside_the_grant(self):
+        """SyncSiteLocationView is gated by the plugin write permission alone and takes the site pk from the POST body."""
+        from dcim.models import Site
+
+        from netbox_librenms_plugin.views.sync.locations import SyncSiteLocationView
+
+        in_scope = Site.objects.create(name="scope-site-in", slug="scope-site-in")
+        out_of_scope = Site.objects.create(name="scope-site-out", slug="scope-site-out")
+        user = self._user("scope-site", [(Site, "view", {"pk": in_scope.pk})])
+
+        view = SyncSiteLocationView()
+        request = self._request(user, {"action": "update", "pk": str(out_of_scope.pk)})
+        view.setup(request)
+
+        # Bounces on "Site not found" before any LibreNMS call, so no API stub is needed.
+        assert view.get_site_by_pk(out_of_scope.pk) is None
+        assert view.get_site_by_pk(in_scope.pk) == in_scope  # the grant DOES still resolve
+
+    def test_oob_interface_reuse_refuses_an_interface_outside_the_grant(self):
+        """AddAsOOBView reuses an interface whose pk comes from the OOB form, filtered only by device."""
+        from dcim.models import Device, Interface
+        from django.db import transaction
+
+        from netbox_librenms_plugin.tests.conftest import make_device, make_interface
+        from netbox_librenms_plugin.views.imports.actions import AddAsOOBView
+
+        device = make_device("scope-oobiface")
+        granted = make_interface(device, "eth0")
+        # Same device, so the view's device filter passes; only the grant excludes it.
+        outside = make_interface(device, "idrac0")
+
+        user = self._user(
+            "scope-oobiface",
+            [
+                (Device, "view", {"pk": device.pk}),
+                (Interface, "view", {"pk": granted.pk}),
+            ],
+        )
+        request = self._request(user, {"oob_interface_id": str(outside.pk)})
+
+        with transaction.atomic():
+            resolved, _reason = AddAsOOBView._resolve_oob_interface(request, device)
+        assert resolved is None  # outside the grant, so it is not handed back for the OOB attach
 
     def test_module_move_refuses_to_delete_a_bay_occupant_outside_the_grant(self):
         """MoveModuleView deletes whatever occupies the target bay; the bay filter proves where that row sits, not that the delete grant covers it."""

--- a/netbox_librenms_plugin/tests/test_view_wiring.py
+++ b/netbox_librenms_plugin/tests/test_view_wiring.py
@@ -434,27 +434,39 @@ class TestSingleCableVerifyServerKey:
 
 
 class TestGatedViewsResolveThroughRestrictedQuerysets:
-    """A view that declares required_object_permissions must not resolve an object by raw pk.
+    """A gated view must not resolve an object by raw pk.
 
     NetBoxObjectPermissionMixin asks ``has_perm`` WITHOUT an instance, so a CONSTRAINED grant (a
     site-scoped change_device, say) clears the gate; a plain ``get_object_or_404`` behind it then
     reads or writes an object outside that grant. This is a RECURRING defect class — the same
-    finding has landed on the cable remote picker, the LAG/parent relationship sync and the
-    move-to-winner endpoints — so it is enforced mechanically here instead of case by case.
+    finding has landed on the cable remote picker, the LAG/parent relationship sync, the
+    move-to-winner endpoints and the LibreNMS location push — so it is enforced mechanically here
+    instead of case by case.
 
-    Scope and limits: the scan flags ``get_object_or_404`` inside classes that assign
-    required_object_permissions themselves (statically or per-request). A raw lookup inherited from
-    an ungated base class is NOT seen, and neither is ``Model.objects.get(pk=...)``; both remain a
+    "Gated" means the class declares ``required_object_permissions`` (by assignment or annotation,
+    statically or per-request) OR calls one of the ``require_*_permission(s)`` gates: a view gated
+    only by the plugin write permission reaches objects by raw pk just as easily.
+
+    Scope and limits: a raw lookup inherited from an ungated base class is NOT seen, and neither is
+    ``Model.objects.get(pk=...)`` / ``.filter(pk=...)`` — the secondary-lookup form. Both remain a
     review matter.
     """
 
-    @staticmethod
-    def _scan():
-        """Return {(module, class, line)} for gated view classes that resolve an object by raw pk."""
-        import ast
-        import pathlib
+    GATE_CALLS = frozenset(
+        {
+            "require_write_permission",
+            "require_write_permission_json",
+            "require_object_permissions",
+            "require_object_permissions_json",
+            "require_all_permissions",
+            "require_all_permissions_json",
+        }
+    )
 
-        import netbox_librenms_plugin
+    @classmethod
+    def _scan_tree(cls, tree, label):
+        """Return {(label, class, line)} for gated classes in *tree* that resolve by raw pk."""
+        import ast
 
         def _is_scoped(node):
             """Whether the first get_object_or_404 argument came from restricted_queryset(...)."""
@@ -464,33 +476,47 @@ class TestGatedViewsResolveThroughRestrictedQuerysets:
                 for inner in ast.walk(node)
             )
 
+        def _declares_gate(class_node):
+            for sub in ast.walk(class_node):
+                if isinstance(sub, ast.Assign):
+                    for target in sub.targets:
+                        if getattr(target, "id", getattr(target, "attr", "")) == "required_object_permissions":
+                            return True
+                elif isinstance(sub, ast.AnnAssign):
+                    target = sub.target
+                    if getattr(target, "id", getattr(target, "attr", "")) == "required_object_permissions":
+                        return True
+                elif isinstance(sub, ast.Call) and getattr(sub.func, "attr", "") in cls.GATE_CALLS:
+                    return True
+            return False
+
+        offenders = set()
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.ClassDef) or not _declares_gate(node):
+                continue
+            # The mixin that DEFINES restrict_object_or_404 is where the raw call belongs.
+            if any(isinstance(sub, ast.FunctionDef) and sub.name == "restrict_object_or_404" for sub in node.body):
+                continue
+            for sub in ast.walk(node):
+                if not (isinstance(sub, ast.Call) and getattr(sub.func, "id", None) == "get_object_or_404"):
+                    continue
+                if not (sub.args and _is_scoped(sub.args[0])):
+                    offenders.add((label, node.name, sub.lineno))
+        return offenders
+
+    @classmethod
+    def _scan(cls):
+        """Run :meth:`_scan_tree` over every view module."""
+        import ast
+        import pathlib
+
+        import netbox_librenms_plugin
+
         views_root = pathlib.Path(netbox_librenms_plugin.__file__).parent / "views"
         offenders = set()
         for path in sorted(views_root.rglob("*.py")):
             tree = ast.parse(path.read_text(encoding="utf-8"), str(path))
-            for node in ast.walk(tree):
-                if not isinstance(node, ast.ClassDef):
-                    continue
-                declares_gate = any(
-                    (isinstance(target, ast.Name) and target.id == "required_object_permissions")
-                    or (isinstance(target, ast.Attribute) and target.attr == "required_object_permissions")
-                    for sub in ast.walk(node)
-                    if isinstance(sub, ast.Assign)
-                    for target in sub.targets
-                )
-                if not declares_gate:
-                    continue
-                # The mixin that DEFINES restrict_object_or_404 is where the raw call belongs.
-                defines_helper = any(
-                    isinstance(sub, ast.FunctionDef) and sub.name == "restrict_object_or_404" for sub in node.body
-                )
-                if defines_helper:
-                    continue
-                for sub in ast.walk(node):
-                    if not (isinstance(sub, ast.Call) and getattr(sub.func, "id", None) == "get_object_or_404"):
-                        continue
-                    if not (sub.args and _is_scoped(sub.args[0])):
-                        offenders.add((str(path.relative_to(views_root)), node.name, sub.lineno))
+            offenders |= cls._scan_tree(tree, str(path.relative_to(views_root)))
         return offenders
 
     def test_no_gated_view_resolves_an_object_by_raw_pk(self):
@@ -501,8 +527,8 @@ class TestGatedViewsResolveThroughRestrictedQuerysets:
             f"then reaches objects outside it; use restrict_object_or_404: {offenders}"
         )
 
-    def test_the_scan_recognizes_a_raw_lookup(self):
-        """Guard the guard: the scan must still flag the pattern it exists to catch."""
+    def test_the_scan_flags_a_raw_lookup(self):
+        """Guard the guard: the REAL scan must still flag the pattern it exists to catch."""
         import ast
 
         source = (
@@ -511,16 +537,32 @@ class TestGatedViewsResolveThroughRestrictedQuerysets:
             "    def post(self, request, pk):\n"
             "        return get_object_or_404(Device, pk=pk)\n"
         )
-        tree = ast.parse(source)
-        calls = [n for n in ast.walk(tree) if isinstance(n, ast.Call) and getattr(n.func, "id", None)]
-        assert calls, "the fixture must contain a get_object_or_404 call"
-        scoped = any(
-            isinstance(inner, ast.Call) and getattr(inner.func, "attr", "") == "restricted_queryset"
-            for call in calls
-            for inner in ast.walk(call.args[0])
-            if call.args
+        assert self._scan_tree(ast.parse(source), "<fixture>"), "the scan no longer flags a raw pk lookup"
+
+    def test_the_scan_flags_a_view_gated_only_by_the_write_permission(self):
+        """A view gated by require_write_permission alone reaches objects by raw pk just as easily."""
+        import ast
+
+        source = (
+            "class V:\n"
+            "    def post(self, request, pk):\n"
+            "        if error := self.require_write_permission():\n"
+            "            return error\n"
+            "        return get_object_or_404(Device, pk=pk)\n"
         )
-        assert not scoped  # a bare model argument is exactly what the scan must reject
+        assert self._scan_tree(ast.parse(source), "<fixture>"), "a write-gated raw lookup must be flagged"
+
+    def test_the_scan_accepts_a_scoped_lookup(self):
+        """The positive control: a lookup already routed through restricted_queryset is not flagged."""
+        import ast
+
+        source = (
+            "class V:\n"
+            "    required_object_permissions = {'POST': []}\n"
+            "    def post(self, request, pk):\n"
+            "        return get_object_or_404(self.restricted_queryset(Device), pk=pk)\n"
+        )
+        assert not self._scan_tree(ast.parse(source), "<fixture>")
 
 
 @pytest.mark.django_db
@@ -641,6 +683,99 @@ class TestGatedViewsRefuseOutOfScopeObjects:
         with pytest.raises(Http404):
             view.post(request, pk=out_of_scope.pk)
 
+    def test_location_push_404s_a_device_outside_the_grant(self):
+        """UpdateDeviceLocationView is gated by the plugin write permission and reads the device by URL pk, so it must scope that read too."""
+        from dcim.models import Device
+        from django.http import Http404
+
+        from netbox_librenms_plugin.tests.conftest import make_device
+        from netbox_librenms_plugin.views.sync.devices import UpdateDeviceLocationView
+
+        in_scope = make_device("scope-loc-in")
+        out_of_scope = make_device("scope-loc-out")
+        user = self._user("scope-loc", [(Device, "view", {"pk": in_scope.pk})])
+
+        view = UpdateDeviceLocationView()
+        request = self._request(user, {"server_key": "default"})
+        view.setup(request)
+        with pytest.raises(Http404):
+            view.post(request, pk=out_of_scope.pk)
+
+    def test_module_move_refuses_a_conflict_module_outside_the_grant(self):
+        """MoveModuleView reassigns the conflict module's bay/device, and its pk comes from the POST — a secondary lookup the primary scoping does not cover."""
+        from dcim.models import Device, Module, ModuleBay, ModuleType
+        from dcim.models import Manufacturer
+
+        from netbox_librenms_plugin.tests.conftest import make_device
+        from netbox_librenms_plugin.views.sync.modules import MoveModuleView
+
+        page_device = make_device("scope-move-page")
+        other_device = make_device("scope-move-other")
+        mfr, _ = Manufacturer.objects.get_or_create(name="Mfr-scope-move", slug="mfr-scope-move")
+        mtype = ModuleType.objects.create(manufacturer=mfr, model="MT-scope-move")
+        target_bay = ModuleBay.objects.create(device=page_device, name="Slot 1")
+        foreign_bay = ModuleBay.objects.create(device=other_device, name="Slot 9")
+        # The module the caller names lives on a device the grant does NOT cover.
+        foreign_module = Module.objects.create(device=other_device, module_bay=foreign_bay, module_type=mtype)
+
+        user = self._user(
+            "scope-move",
+            [
+                (Device, "view", {"pk": page_device.pk}),
+                (ModuleBay, "view", None),  # so the run reaches the conflict-module lookup under test
+                (Module, "change", {"device__name": "scope-move-page"}),
+                (Module, "delete", {"device__name": "scope-move-page"}),
+            ],
+        )
+        view = MoveModuleView()
+        request = self._request(
+            user,
+            {
+                "server_key": "default",
+                "conflict_module_id": str(foreign_module.pk),
+                "target_bay_id": str(target_bay.pk),
+            },
+        )
+        view.setup(request)
+        view.post(request, pk=page_device.pk)
+
+        foreign_module.refresh_from_db()
+        assert foreign_module.device_id == other_device.pk  # not moved
+        assert foreign_module.module_bay_id == foreign_bay.pk
+
+    def test_vc_serial_assign_refuses_a_member_outside_the_grant(self):
+        """AssignVCSerialView overwrites the member's serial and takes its pk from the POST, guarded only by same-VC membership."""
+        from dcim.models import Device
+
+        from dcim.models import VirtualChassis
+
+        from netbox_librenms_plugin.tests.conftest import make_device
+        from netbox_librenms_plugin.views.sync.device_fields import AssignVCSerialView
+
+        vc = VirtualChassis.objects.create(name="VC-scope-vcser")
+        page_member = make_device("scope-vcser-1")
+        sibling = make_device("scope-vcser-2")
+        for position, member in ((1, page_member), (2, sibling)):
+            member.virtual_chassis = vc
+            member.vc_position = position
+            member.save()
+        vc.master = page_member
+        vc.save()
+        sibling.serial = "ORIGINAL"
+        sibling.save()
+
+        user = self._user("scope-vcser", [(Device, "change", {"pk": page_member.pk})])
+        view = AssignVCSerialView()
+        request = self._request(
+            user,
+            {"server_key": "default", "member_id_0": str(sibling.pk), "serial_0": "HIJACKED"},
+        )
+        view.setup(request)
+        view.post(request, pk=page_member.pk)
+
+        sibling.refresh_from_db()
+        assert sibling.serial == "ORIGINAL"  # a sibling outside the grant keeps its serial
+
     def test_in_scope_object_still_resolves(self):
         """The device the grant DOES cover passes the lookup — the scoping must not over-block."""
         from dcim.models import Device
@@ -670,6 +805,11 @@ class TestCacheKeysAreServerScoped:
 
     The helpers take ``server_key`` last, so a call is scoped when it passes the keyword or enough
     positional arguments to reach it.
+
+    Scope and limits: only direct attribute calls are matched, so a helper passed as a callable and
+    invoked under a local name (``modules.py`` hands ``self.get_cache_key`` to
+    ``_resolve_single_install_binding_item``) escapes the scan, and a call forwarding ``**kwargs``
+    is taken on trust — its contents are not inspected. Both remain a review matter.
     """
 
     # helper name -> number of positional args needed to reach server_key
@@ -695,7 +835,10 @@ class TestCacheKeysAreServerScoped:
                 helper = getattr(node.func, "attr", "")
                 if helper not in cls.HELPERS:
                     continue
-                keyed = any(kw.arg == "server_key" for kw in node.keywords) or len(node.args) >= cls.HELPERS[helper]
+                # kw.arg is None for **kwargs forwarding, which may carry server_key: not a miss.
+                keyed = (
+                    any(kw.arg in ("server_key", None) for kw in node.keywords) or len(node.args) >= cls.HELPERS[helper]
+                )
                 if not keyed:
                     unscoped.append(f"{path.relative_to(package_root)}:{node.lineno} {helper}")
         return unscoped

--- a/netbox_librenms_plugin/tests/test_view_wiring.py
+++ b/netbox_librenms_plugin/tests/test_view_wiring.py
@@ -1111,7 +1111,9 @@ class TestViewTestHelpers:
                 assert self.kwargs == kwargs
                 return HttpResponse()
 
-        bind_and_call(KwargView(), RequestFactory().post("/"), "post", pk=17)
+        response = bind_and_call(KwargView(), RequestFactory().post("/"), "post", pk=17)
+
+        assert isinstance(response, HttpResponse)
 
     def test_message_level_rejects_non_level_message_attributes(self):
         from netbox_librenms_plugin.tests.view_test_helpers import _message_level

--- a/netbox_librenms_plugin/tests/test_view_wiring.py
+++ b/netbox_librenms_plugin/tests/test_view_wiring.py
@@ -431,3 +431,291 @@ class TestSingleCableVerifyServerKey:
             assert mock_sync_device.call_args[1]["server_key"] == "fallback-server"
             cache_key_arg = mock_cache.get.call_args[0][0]
             assert "fallback-server" in cache_key_arg
+
+
+class TestGatedViewsResolveThroughRestrictedQuerysets:
+    """A view that declares required_object_permissions must not resolve an object by raw pk.
+
+    NetBoxObjectPermissionMixin asks ``has_perm`` WITHOUT an instance, so a CONSTRAINED grant (a
+    site-scoped change_device, say) clears the gate; a plain ``get_object_or_404`` behind it then
+    reads or writes an object outside that grant. This is a RECURRING defect class — the same
+    finding has landed on the cable remote picker, the LAG/parent relationship sync and the
+    move-to-winner endpoints — so it is enforced mechanically here instead of case by case.
+
+    Scope and limits: the scan flags ``get_object_or_404`` inside classes that assign
+    required_object_permissions themselves (statically or per-request). A raw lookup inherited from
+    an ungated base class is NOT seen, and neither is ``Model.objects.get(pk=...)``; both remain a
+    review matter.
+    """
+
+    @staticmethod
+    def _scan():
+        """Return {(module, class, line)} for gated view classes that resolve an object by raw pk."""
+        import ast
+        import pathlib
+
+        import netbox_librenms_plugin
+
+        def _is_scoped(node):
+            """Whether the first get_object_or_404 argument came from restricted_queryset(...)."""
+            # Accepts the chained form too: self.restricted_queryset(Module).select_related(...).
+            return any(
+                isinstance(inner, ast.Call) and getattr(inner.func, "attr", "") == "restricted_queryset"
+                for inner in ast.walk(node)
+            )
+
+        views_root = pathlib.Path(netbox_librenms_plugin.__file__).parent / "views"
+        offenders = set()
+        for path in sorted(views_root.rglob("*.py")):
+            tree = ast.parse(path.read_text(encoding="utf-8"), str(path))
+            for node in ast.walk(tree):
+                if not isinstance(node, ast.ClassDef):
+                    continue
+                declares_gate = any(
+                    (isinstance(target, ast.Name) and target.id == "required_object_permissions")
+                    or (isinstance(target, ast.Attribute) and target.attr == "required_object_permissions")
+                    for sub in ast.walk(node)
+                    if isinstance(sub, ast.Assign)
+                    for target in sub.targets
+                )
+                if not declares_gate:
+                    continue
+                # The mixin that DEFINES restrict_object_or_404 is where the raw call belongs.
+                defines_helper = any(
+                    isinstance(sub, ast.FunctionDef) and sub.name == "restrict_object_or_404" for sub in node.body
+                )
+                if defines_helper:
+                    continue
+                for sub in ast.walk(node):
+                    if not (isinstance(sub, ast.Call) and getattr(sub.func, "id", None) == "get_object_or_404"):
+                        continue
+                    if not (sub.args and _is_scoped(sub.args[0])):
+                        offenders.add((str(path.relative_to(views_root)), node.name, sub.lineno))
+        return offenders
+
+    def test_no_gated_view_resolves_an_object_by_raw_pk(self):
+        """Every gated view resolves through restrict_object_or_404 / restricted_queryset, never a raw pk lookup."""
+        offenders = sorted(self._scan())
+        assert not offenders, (
+            "gated view(s) resolving an object by raw pk — a constrained grant clears the gate and "
+            f"then reaches objects outside it; use restrict_object_or_404: {offenders}"
+        )
+
+    def test_the_scan_recognizes_a_raw_lookup(self):
+        """Guard the guard: the scan must still flag the pattern it exists to catch."""
+        import ast
+
+        source = (
+            "class V:\n"
+            "    required_object_permissions = {'POST': []}\n"
+            "    def post(self, request, pk):\n"
+            "        return get_object_or_404(Device, pk=pk)\n"
+        )
+        tree = ast.parse(source)
+        calls = [n for n in ast.walk(tree) if isinstance(n, ast.Call) and getattr(n.func, "id", None)]
+        assert calls, "the fixture must contain a get_object_or_404 call"
+        scoped = any(
+            isinstance(inner, ast.Call) and getattr(inner.func, "attr", "") == "restricted_queryset"
+            for call in calls
+            for inner in ast.walk(call.args[0])
+            if call.args
+        )
+        assert not scoped  # a bare model argument is exactly what the scan must reject
+
+
+@pytest.mark.django_db
+class TestGatedViewsRefuseOutOfScopeObjects:
+    """The behavioural half of the guard above: a CONSTRAINED grant must not reach another object.
+
+    One representative view per family (device-field write, owner-scoped sync, module install) is
+    driven through the REAL gate and the REAL restrict(), so the structural scan cannot pass while
+    the runtime behaviour is broken.
+    """
+
+    @staticmethod
+    def _user(username, model_grants):
+        """A real non-superuser with plugin write plus ``model_grants`` = [(model, action, constraints)]."""
+        from core.models import ObjectType
+        from django.apps import apps
+        from django.contrib.auth import get_user_model
+        from users.models import ObjectPermission
+
+        LibreNMSSettings = apps.get_model("netbox_librenms_plugin", "LibreNMSSettings")
+
+        user = get_user_model().objects.create_user(username=username, password="x")
+        plugin = ObjectPermission.objects.create(name=f"{username}-plugin", actions=["view", "change"])
+        plugin.object_types.set([ObjectType.objects.get_for_model(LibreNMSSettings)])
+        plugin.users.set([user])
+        for i, (model, action, constraints) in enumerate(model_grants):
+            perm = ObjectPermission.objects.create(
+                name=f"{username}-{action}-{i}", actions=[action], constraints=constraints
+            )
+            perm.object_types.set([ObjectType.objects.get_for_model(model)])
+            perm.users.set([user])
+        return get_user_model().objects.get(pk=user.pk)  # reload to clear the perm cache
+
+    @staticmethod
+    def _request(user, data, method="post"):
+        from django.contrib.messages.storage.fallback import FallbackStorage
+        from django.test import RequestFactory
+
+        factory = RequestFactory()
+        request = getattr(factory, method)("/x/", data)
+        request.user = user
+        request.session = {}
+        request._messages = FallbackStorage(request)
+        return request
+
+    def test_device_field_write_404s_a_device_outside_the_grant(self):
+        """UpdateDeviceNameView writes the device itself, so a pk-constrained change_device must not reach another one."""
+        from dcim.models import Device
+        from django.http import Http404
+
+        from netbox_librenms_plugin.tests.conftest import make_device
+        from netbox_librenms_plugin.views.sync.device_fields import UpdateDeviceNameView
+
+        in_scope = make_device("scope-devfield-in")
+        out_of_scope = make_device("scope-devfield-out")
+        original_name = out_of_scope.name
+        user = self._user("scope-devfield", [(Device, "change", {"pk": in_scope.pk})])
+
+        view = UpdateDeviceNameView()
+        request = self._request(user, {"server_key": "default"})
+        view.setup(request)
+        with pytest.raises(Http404):
+            view.post(request, pk=out_of_scope.pk)
+
+        out_of_scope.refresh_from_db()
+        assert out_of_scope.name == original_name  # untouched
+
+    def test_ip_sync_404s_an_owner_outside_the_grant(self):
+        """SyncIPAddressesView resolves the owner device by URL pk; a scoped view_device must not reach another."""
+        from dcim.models import Device
+        from django.http import Http404
+        from ipam.models import IPAddress
+
+        from netbox_librenms_plugin.tests.conftest import make_device
+        from netbox_librenms_plugin.views.sync.ip_addresses import SyncIPAddressesView
+
+        in_scope = make_device("scope-ipsync-in")
+        out_of_scope = make_device("scope-ipsync-out")
+        user = self._user(
+            "scope-ipsync",
+            [
+                (Device, "view", {"pk": in_scope.pk}),
+                (IPAddress, "add", None),
+                (IPAddress, "change", None),
+            ],
+        )
+
+        view = SyncIPAddressesView()
+        request = self._request(user, {"server_key": "default", "select": ["10.0.0.1"]})
+        view.setup(request)
+        with pytest.raises(Http404):
+            view.post(request, object_type="device", pk=out_of_scope.pk)
+
+    def test_module_install_404s_a_page_device_outside_the_grant(self):
+        """InstallModuleView resolves the page device by URL pk before touching modules."""
+        from dcim.models import Device, Interface, Module
+        from django.http import Http404
+
+        from netbox_librenms_plugin.tests.conftest import make_device
+        from netbox_librenms_plugin.views.sync.modules import InstallModuleView
+
+        in_scope = make_device("scope-modinstall-in")
+        out_of_scope = make_device("scope-modinstall-out")
+        user = self._user(
+            "scope-modinstall",
+            [
+                (Device, "view", {"pk": in_scope.pk}),
+                (Module, "add", None),
+                (Interface, "add", None),
+                (Interface, "change", None),
+                (Interface, "delete", None),
+            ],
+        )
+
+        view = InstallModuleView()
+        request = self._request(user, {"server_key": "default"})
+        view.setup(request)
+        with pytest.raises(Http404):
+            view.post(request, pk=out_of_scope.pk)
+
+    def test_in_scope_object_still_resolves(self):
+        """The device the grant DOES cover passes the lookup — the scoping must not over-block."""
+        from dcim.models import Device
+
+        from netbox_librenms_plugin.tests.conftest import make_device
+        from netbox_librenms_plugin.views.sync.device_fields import UpdateDeviceNameView
+
+        device = make_device("scope-devfield-ok")
+        user = self._user("scope-devfield-ok", [(Device, "change", {"pk": device.pk})])
+
+        view = UpdateDeviceNameView()
+        request = self._request(user, {"server_key": "default"})
+        view.setup(request)
+        # No LibreNMS mapping on this device, so the view refuses on its MERITS (a flash message +
+        # redirect), not with a 404 at the lookup — proof the restricted queryset resolved it.
+        response = view.post(request, pk=device.pk)
+        assert response.status_code in (200, 302)
+
+
+class TestCacheKeysAreServerScoped:
+    """Every production cache key is namespaced by the LibreNMS server it belongs to.
+
+    Multi-server scoping is the most repeated finding class in this stack's review history: a
+    reader or writer that drops ``server_key`` silently addresses the DEFAULT server's namespace,
+    so a refresh on server B renders an empty table, or one server's snapshot lands where another
+    server's readers look. Every site was fixed one at a time; this keeps the class from returning.
+
+    The helpers take ``server_key`` last, so a call is scoped when it passes the keyword or enough
+    positional arguments to reach it.
+    """
+
+    # helper name -> number of positional args needed to reach server_key
+    HELPERS = {"get_cache_key": 3, "get_last_fetched_key": 3, "get_vlan_overrides_key": 2}
+
+    @classmethod
+    def _scan(cls):
+        """Return ["<file>:<line> <helper>"] for production cache-key calls with no server_key."""
+        import ast
+        import pathlib
+
+        import netbox_librenms_plugin
+
+        package_root = pathlib.Path(netbox_librenms_plugin.__file__).parent
+        unscoped = []
+        for path in sorted(package_root.rglob("*.py")):
+            if "tests" in path.parts:
+                continue
+            tree = ast.parse(path.read_text(encoding="utf-8"), str(path))
+            for node in ast.walk(tree):
+                if not isinstance(node, ast.Call):
+                    continue
+                helper = getattr(node.func, "attr", "")
+                if helper not in cls.HELPERS:
+                    continue
+                keyed = any(kw.arg == "server_key" for kw in node.keywords) or len(node.args) >= cls.HELPERS[helper]
+                if not keyed:
+                    unscoped.append(f"{path.relative_to(package_root)}:{node.lineno} {helper}")
+        return unscoped
+
+    def test_every_cache_key_call_passes_a_server_key(self):
+        """A cache key built without server_key addresses the default server's namespace."""
+        unscoped = self._scan()
+        assert not unscoped, (
+            "cache key(s) built without a server_key — they address the default server's namespace, "
+            f"so another server's readers never see the entry: {unscoped}"
+        )
+
+    def test_the_helpers_still_take_server_key_last(self):
+        """Guard the guard: the positional-arity assumption above must match the real signatures."""
+        import inspect
+
+        from netbox_librenms_plugin.views.mixins import CacheMixin
+
+        for helper, position in self.HELPERS.items():
+            params = list(inspect.signature(getattr(CacheMixin, helper)).parameters)
+            assert params[-1] == "server_key", f"{helper} no longer takes server_key last: {params}"
+            # params includes self, so the positional count to reach server_key is len(params) - 1.
+            assert len(params) - 1 == position, f"{helper} arity changed — update HELPERS: {params}"

--- a/netbox_librenms_plugin/tests/test_view_wiring.py
+++ b/netbox_librenms_plugin/tests/test_view_wiring.py
@@ -779,6 +779,226 @@ class TestGatedViewsResolveThroughRestrictedQuerysets:
         assert not self._scan_tree(ast.parse(source), "<fixture>")
 
 
+class TestPostedSelectionsFailClosed:
+    """Prevent an explicit object selection from degrading to an absent selection."""
+
+    LOOKUP_ERRORS = frozenset({"DoesNotExist", "ObjectDoesNotExist", "TypeError", "ValueError"})
+
+    @staticmethod
+    def _exception_names(node):
+        """Return the exception names handled by an except clause."""
+        import ast
+
+        if isinstance(node, ast.Tuple):
+            return {name for element in node.elts for name in TestPostedSelectionsFailClosed._exception_names(element)}
+        if isinstance(node, ast.Name):
+            return {node.id}
+        if isinstance(node, ast.Attribute):
+            return {node.attr}
+        return set()
+
+    @staticmethod
+    def _is_post_get(node):
+        """Whether *node* reads a value from request.POST."""
+        import ast
+
+        return (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "get"
+            and isinstance(node.func.value, ast.Attribute)
+            and node.func.value.attr == "POST"
+        )
+
+    @staticmethod
+    def _is_restricted_get(node):
+        """Whether *node* gets one object from a permission-restricted queryset."""
+        import ast
+
+        return (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "get"
+            and any(
+                isinstance(call, ast.Call)
+                and isinstance(call.func, ast.Attribute)
+                and call.func.attr == "restricted_queryset"
+                for call in ast.walk(node.func.value)
+            )
+        )
+
+    @staticmethod
+    def _returns_none(statement):
+        """Whether *statement* is ``return None``."""
+        import ast
+
+        return isinstance(statement, ast.Return) and (
+            statement.value is None or isinstance(statement.value, ast.Constant) and statement.value.value is None
+        )
+
+    @staticmethod
+    def _is_none_guard(node, name):
+        """Whether *node* checks that *name* is None."""
+        import ast
+
+        return (
+            isinstance(node, ast.Compare)
+            and isinstance(node.left, ast.Name)
+            and node.left.id == name
+            and len(node.ops) == 1
+            and isinstance(node.ops[0], ast.Is)
+            and len(node.comparators) == 1
+            and isinstance(node.comparators[0], ast.Constant)
+            and node.comparators[0].value is None
+        )
+
+    @staticmethod
+    def _stops_current_path(statements):
+        """Whether *statements* stop the current path before the selected object can be used."""
+        import ast
+
+        return bool(statements) and isinstance(statements[-1], (ast.Break, ast.Continue, ast.Raise, ast.Return))
+
+    @classmethod
+    def _statement_lists(cls, node):
+        """Yield each ordered statement list nested below *node*."""
+        import ast
+
+        for _field, value in ast.iter_fields(node):
+            if isinstance(value, list) and value and all(isinstance(item, ast.stmt) for item in value):
+                yield value
+                for statement in value:
+                    yield from cls._statement_lists(statement)
+            elif isinstance(value, ast.AST):
+                yield from cls._statement_lists(value)
+
+    @classmethod
+    def _calls_reject_none(cls, tree, helper_name):
+        """Whether every local call to *helper_name* stops when its result is None."""
+        import ast
+
+        found_call = False
+        for statements in cls._statement_lists(tree):
+            for index, statement in enumerate(statements):
+                if not isinstance(statement, ast.Assign) or not isinstance(statement.value, ast.Call):
+                    continue
+                function = statement.value.func
+                if not isinstance(function, ast.Attribute) or function.attr != helper_name:
+                    continue
+                found_call = True
+                if len(statement.targets) != 1 or not isinstance(statement.targets[0], ast.Name):
+                    return False
+                if index + 1 >= len(statements):
+                    return False
+                guard = statements[index + 1]
+                if not isinstance(guard, ast.If) or not cls._is_none_guard(guard.test, statement.targets[0].id):
+                    return False
+                if not cls._stops_current_path(guard.body):
+                    return False
+        return found_call
+
+    @classmethod
+    def _scan_tree(cls, tree, label):
+        """Return posted restricted lookups whose failure becomes no selection."""
+        import ast
+
+        offenders = set()
+        for function in (node for node in ast.walk(tree) if isinstance(node, ast.FunctionDef)):
+            posted_names = {
+                target.id
+                for assignment in ast.walk(function)
+                if isinstance(assignment, ast.Assign) and cls._is_post_get(assignment.value)
+                for target in assignment.targets
+                if isinstance(target, ast.Name)
+            }
+            if not posted_names:
+                continue
+
+            terminal_none = bool(function.body and cls._returns_none(function.body[-1]))
+            for try_node in (node for node in ast.walk(function) if isinstance(node, ast.Try)):
+                restricted_gets = [
+                    call
+                    for statement in try_node.body
+                    for call in ast.walk(statement)
+                    if cls._is_restricted_get(call)
+                    and any(isinstance(node, ast.Name) and node.id in posted_names for node in ast.walk(call))
+                ]
+                if not restricted_gets:
+                    continue
+
+                for handler in try_node.handlers:
+                    catches_lookup_error = bool(cls._exception_names(handler.type) & cls.LOOKUP_ERRORS)
+                    passes_to_terminal_none = (
+                        terminal_none and len(handler.body) == 1 and isinstance(handler.body[0], ast.Pass)
+                    )
+                    returns_none = len(handler.body) == 1 and cls._returns_none(handler.body[0])
+                    if catches_lookup_error and (passes_to_terminal_none or returns_none):
+                        if not cls._calls_reject_none(tree, function.name):
+                            offenders.add((label, function.name, restricted_gets[0].lineno))
+
+        return offenders
+
+    @classmethod
+    def _scan(cls):
+        """Run the fail-open selection scan over every view module."""
+        import ast
+        import pathlib
+
+        import netbox_librenms_plugin
+
+        views_root = pathlib.Path(netbox_librenms_plugin.__file__).parent / "views"
+        offenders = set()
+        for path in sorted(views_root.rglob("*.py")):
+            tree = ast.parse(path.read_text(encoding="utf-8"), str(path))
+            offenders |= cls._scan_tree(tree, str(path.relative_to(views_root)))
+        return offenders
+
+    def test_no_posted_restricted_selection_fails_open(self):
+        offenders = sorted(self._scan())
+        assert not offenders, (
+            "posted object selection(s) degrade to no selection after a restricted lookup fails; "
+            f"raise or report the invalid selection instead: {offenders}"
+        )
+
+    def test_the_scan_flags_the_old_vrf_pattern(self):
+        """Guard the guard with the fail-open structure that caused the VRF defect."""
+        import ast
+
+        source = (
+            "class V:\n"
+            "    def get_selection(self, request):\n"
+            "        selected_id = request.POST.get('selection')\n"
+            "        if selected_id:\n"
+            "            try:\n"
+            "                return self.restricted_queryset(VRF).get(pk=selected_id)\n"
+            "            except (VRF.DoesNotExist, TypeError, ValueError):\n"
+            "                pass\n"
+            "        return None\n"
+        )
+        assert self._scan_tree(ast.parse(source), "<fixture>")
+
+    def test_the_scan_accepts_an_explicit_invalid_selection_sentinel(self):
+        """A None sentinel is safe when every caller stops before it can reach a write."""
+        import ast
+
+        source = (
+            "class V:\n"
+            "    def get_selection(self, request):\n"
+            "        selected_id = request.POST.get('selection')\n"
+            "        try:\n"
+            "            return self.restricted_queryset(Device).get(pk=selected_id)\n"
+            "        except Device.DoesNotExist:\n"
+            "            return None\n"
+            "    def sync(self, request):\n"
+            "        selected = self.get_selection(request)\n"
+            "        if selected is None:\n"
+            "            self.record_invalid_selection()\n"
+            "            return\n"
+            "        self.write(selected)\n"
+        )
+        assert not self._scan_tree(ast.parse(source), "<fixture>")
+
+
 class TestViewTestHelpers:
     def test_bind_and_call_populates_view_kwargs(self):
         """The direct-call helper must bind URL kwargs exactly as Django dispatch does."""

--- a/netbox_librenms_plugin/tests/test_view_wiring.py
+++ b/netbox_librenms_plugin/tests/test_view_wiring.py
@@ -1337,6 +1337,7 @@ class TestGatedViewsRefuseOutOfScopeObjects:
         assert hidden.module_bay.name not in html
         assert f'name="conflict_module_id" value="{hidden.pk}"' not in html
         assert "cannot view" in html
+        assert "Update Serial Only" not in html
 
     def test_site_location_push_refuses_a_site_outside_the_grant(self):
         """SyncSiteLocationView is gated by the plugin write permission alone and takes the site pk from the POST body."""

--- a/netbox_librenms_plugin/tests/test_view_wiring.py
+++ b/netbox_librenms_plugin/tests/test_view_wiring.py
@@ -1311,7 +1311,7 @@ class TestGatedViewsRefuseOutOfScopeObjects:
 
     def test_ip_sync_404s_an_owner_outside_the_grant(self):
         """SyncIPAddressesView resolves the owner device by URL pk; a scoped view_device must not reach another."""
-        from dcim.models import Device
+        from dcim.models import Device, Interface
         from django.http import Http404
         from ipam.models import IPAddress
 
@@ -1324,6 +1324,7 @@ class TestGatedViewsRefuseOutOfScopeObjects:
             "scope-ipsync",
             [
                 (Device, "view", {"pk": in_scope.pk}),
+                (Interface, "view", None),
                 (IPAddress, "add", None),
                 (IPAddress, "change", None),
             ],

--- a/netbox_librenms_plugin/tests/test_view_wiring.py
+++ b/netbox_librenms_plugin/tests/test_view_wiring.py
@@ -780,7 +780,11 @@ class TestGatedViewsResolveThroughRestrictedQuerysets:
 
 
 class TestPostedSelectionsFailClosed:
-    """Prevent an explicit object selection from degrading to an absent selection."""
+    """Prevent an explicit object selection from degrading to an absent selection.
+
+    The scanner recognizes assignments from ``request.POST.get()`` and attribute-based local
+    helper calls. It does not model subscription reads, ``request.data``, or module-level callers.
+    """
 
     LOOKUP_ERRORS = frozenset({"DoesNotExist", "ObjectDoesNotExist", "TypeError", "ValueError"})
 
@@ -837,6 +841,19 @@ class TestPostedSelectionsFailClosed:
         )
 
     @staticmethod
+    def _reports_rejected_selection(statements):
+        """Whether the handler records the invalid selection before it returns."""
+        import ast
+
+        return any(
+            isinstance(call, ast.Call)
+            and isinstance(call.func, ast.Attribute)
+            and call.func.attr == "_record_skipped_conflict"
+            for statement in statements
+            for call in ast.walk(statement)
+        )
+
+    @staticmethod
     def _is_none_guard(node, name):
         """Whether *node* checks that *name* is None."""
         import ast
@@ -869,6 +886,10 @@ class TestPostedSelectionsFailClosed:
                 yield value
                 for statement in value:
                     yield from cls._statement_lists(statement)
+            elif isinstance(value, list):
+                for item in value:
+                    if isinstance(item, ast.AST):
+                        yield from cls._statement_lists(item)
             elif isinstance(value, ast.AST):
                 yield from cls._statement_lists(value)
 
@@ -903,7 +924,7 @@ class TestPostedSelectionsFailClosed:
         import ast
 
         offenders = set()
-        for function in (node for node in ast.walk(tree) if isinstance(node, ast.FunctionDef)):
+        for function in (node for node in ast.walk(tree) if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))):
             posted_names = {
                 target.id
                 for assignment in ast.walk(function)
@@ -933,11 +954,12 @@ class TestPostedSelectionsFailClosed:
                         or bool(handled & cls.LOOKUP_ERRORS)
                         or bool(handled & {"Exception", "BaseException"})
                     )
-                    passes_to_terminal_none = (
-                        terminal_none and len(handler.body) == 1 and isinstance(handler.body[0], ast.Pass)
-                    )
-                    returns_none = len(handler.body) == 1 and cls._returns_none(handler.body[0])
-                    if catches_lookup_error and (passes_to_terminal_none or returns_none):
+                    last_statement = handler.body[-1] if handler.body else None
+                    passes_to_terminal_none = terminal_none and isinstance(last_statement, ast.Pass)
+                    returns_none = cls._returns_none(last_statement)
+                    rejects_selection = passes_to_terminal_none or returns_none
+                    reports_rejection = cls._reports_rejected_selection(handler.body[:-1])
+                    if catches_lookup_error and rejects_selection and not reports_rejection:
                         if not cls._calls_reject_none(tree, function.name):
                             offenders.add((label, function.name, restricted_gets[0].lineno))
 
@@ -997,6 +1019,61 @@ class TestPostedSelectionsFailClosed:
             "            return None\n"
         )
         assert self._scan_tree(ast.parse(source), "<fixture>")
+
+    def test_the_scan_checks_async_view_helpers(self):
+        """An async helper must not escape the posted-selection scan."""
+        import ast
+
+        source = (
+            "class V:\n"
+            "    async def get_selection(self, request):\n"
+            "        selected_id = request.POST.get('selection')\n"
+            "        try:\n"
+            "            return self.restricted_queryset(Device).get(pk=selected_id)\n"
+            "        except Device.DoesNotExist:\n"
+            "            return None\n"
+        )
+        assert self._scan_tree(ast.parse(source), "<fixture>")
+
+    def test_the_scan_flags_a_logging_handler_that_falls_through(self):
+        """Logging before ``pass`` must not hide a lookup that still degrades to None."""
+        import ast
+
+        source = (
+            "class V:\n"
+            "    def get_selection(self, request):\n"
+            "        selected_id = request.POST.get('selection')\n"
+            "        try:\n"
+            "            return self.restricted_queryset(Device).get(pk=selected_id)\n"
+            "        except Device.DoesNotExist:\n"
+            "            logger.debug('missing')\n"
+            "            pass\n"
+            "        return None\n"
+        )
+        assert self._scan_tree(ast.parse(source), "<fixture>")
+
+    def test_the_scan_finds_a_guarded_helper_call_inside_an_except_block(self):
+        """A helper call inside an except handler must count when its None result stops the path."""
+        import ast
+
+        source = (
+            "class V:\n"
+            "    def get_selection(self, request):\n"
+            "        selected_id = request.POST.get('selection')\n"
+            "        try:\n"
+            "            return self.restricted_queryset(Device).get(pk=selected_id)\n"
+            "        except Device.DoesNotExist:\n"
+            "            return None\n"
+            "    def post(self, request):\n"
+            "        try:\n"
+            "            work()\n"
+            "        except ValueError:\n"
+            "            selected = self.get_selection(request)\n"
+            "            if selected is None:\n"
+            "                return None\n"
+            "        return selected\n"
+        )
+        assert not self._scan_tree(ast.parse(source), "<fixture>")
 
     def test_the_scan_accepts_an_explicit_invalid_selection_sentinel(self):
         """A None sentinel is safe when every caller stops before it can reach a write."""
@@ -1191,36 +1268,24 @@ class TestGatedViewsRefuseOutOfScopeObjects:
     @staticmethod
     def _user(username, model_grants):
         """A real non-superuser with plugin write plus ``model_grants`` = [(model, action, constraints)]."""
-        from core.models import ObjectType
-        from django.apps import apps
-        from django.contrib.auth import get_user_model
-        from users.models import ObjectPermission
+        from netbox_librenms_plugin.tests.view_test_helpers import grant, make_user_with_perms
 
-        LibreNMSSettings = apps.get_model("netbox_librenms_plugin", "LibreNMSSettings")
-
-        user = get_user_model().objects.create_user(username=username, password="x")
-        plugin = ObjectPermission.objects.create(name=f"{username}-plugin", actions=["view", "change"])
-        plugin.object_types.set([ObjectType.objects.get_for_model(LibreNMSSettings)])
-        plugin.users.set([user])
+        user = make_user_with_perms(username, [])
         for i, (model, action, constraints) in enumerate(model_grants):
-            perm = ObjectPermission.objects.create(
-                name=f"{username}-{action}-{i}", actions=[action], constraints=constraints
+            user = grant(
+                user,
+                action,
+                model,
+                constraints=constraints,
+                name=f"{username}-{action}-{i}",
             )
-            perm.object_types.set([ObjectType.objects.get_for_model(model)])
-            perm.users.set([user])
-        return get_user_model().objects.get(pk=user.pk)  # reload to clear the perm cache
+        return user
 
     @staticmethod
     def _request(user, data, method="post"):
-        from django.contrib.messages.storage.fallback import FallbackStorage
-        from django.test import RequestFactory
+        from netbox_librenms_plugin.tests.view_test_helpers import make_request
 
-        factory = RequestFactory()
-        request = getattr(factory, method)("/x/", data)
-        request.user = user
-        request.session = {}
-        request._messages = FallbackStorage(request)
-        return request
+        return make_request(method, data, user=user, path="/x/")
 
     def test_device_field_write_404s_a_device_outside_the_grant(self):
         """UpdateDeviceNameView writes the device itself, so a pk-constrained change_device must not reach another one."""

--- a/netbox_librenms_plugin/tests/test_view_wiring.py
+++ b/netbox_librenms_plugin/tests/test_view_wiring.py
@@ -492,6 +492,10 @@ class TestGatedViewsResolveThroughRestrictedQuerysets:
                 for inner in ast.walk(node)
             )
 
+        def _has_scoped_relationship_filter(call):
+            """Whether an ``__in`` relationship value is a restricted queryset."""
+            return any(kw.arg and kw.arg.endswith("__in") and _is_scoped(kw.value) for kw in call.keywords)
+
         def _through_manager(node):
             """Whether *node* is an unscoped ``<Model>.objects`` chain."""
             saw_objects = False
@@ -558,7 +562,11 @@ class TestGatedViewsResolveThroughRestrictedQuerysets:
                 # A scoped queryset can also arrive as an ARGUMENT rather than the receiver:
                 # `Port.objects.filter(pk=..., device__in=self.restricted_queryset(Device))`
                 # constrains by owner visibility, which is a deliberate and sufficient scoping.
-                if _through_manager(sub.func.value) and not _is_scoped(sub):
+                if (
+                    _through_manager(sub.func.value)
+                    and not _is_scoped(sub.func.value)
+                    and not _has_scoped_relationship_filter(sub)
+                ):
                     offenders.add((label, node.name, sub.lineno))
         return offenders
 
@@ -670,6 +678,20 @@ class TestGatedViewsResolveThroughRestrictedQuerysets:
         )
         assert not self._scan_tree(ast.parse(source), "<fixture>")
 
+    def test_the_scan_rejects_an_unrelated_nested_scope_call(self):
+        """A scope call in an unrelated filter value must not bless a raw primary-key lookup."""
+        import ast
+
+        source = (
+            "class V:\n"
+            "    required_object_permissions = {'POST': []}\n"
+            "    def post(self, request, pk):\n"
+            "        return Interface.objects.filter(\n"
+            "            pk=remote_pk, audit=self.restricted_queryset(Device).count()\n"
+            "        ).first()\n"
+        )
+        assert self._scan_tree(ast.parse(source), "<fixture>"), "an unrelated scope call must not hide a raw lookup"
+
     def test_the_scan_exempts_a_relock_of_an_already_resolved_object(self):
         """Re-locking a row already resolved through a scoped queryset must not demand a new permission."""
         import ast
@@ -694,6 +716,157 @@ class TestGatedViewsResolveThroughRestrictedQuerysets:
             "        return Device.objects.filter(pk=object_id).exists()\n"
         )
         assert not self._scan_tree(ast.parse(source), "<fixture>")
+
+
+class TestViewTestHelpers:
+    def test_bind_and_call_populates_view_kwargs(self):
+        """The direct-call helper must bind URL kwargs exactly as Django dispatch does."""
+        from django.http import HttpResponse
+        from django.test import RequestFactory
+        from django.views import View
+
+        from netbox_librenms_plugin.tests.view_test_helpers import bind_and_call
+
+        class KwargView(View):
+            def post(self, request, **kwargs):
+                assert self.kwargs == kwargs
+                return HttpResponse()
+
+        bind_and_call(KwargView(), RequestFactory().post("/"), "post", pk=17)
+
+    def test_message_level_rejects_non_level_message_attributes(self):
+        from netbox_librenms_plugin.tests.view_test_helpers import _message_level
+
+        with pytest.raises(ValueError, match="unknown message level"):
+            _message_level("add_message")
+
+
+class TestModuleWriteViewPermissionDeclarations:
+    @pytest.mark.parametrize(
+        ("view_name", "expected"),
+        [
+            ("InstallModuleView", ("view", "Device")),
+            ("InstallModuleView", ("view", "ModuleBay")),
+            ("InstallModuleView", ("view", "ModuleType")),
+            ("InstallBranchView", ("view", "Device")),
+            ("InstallSelectedView", ("view", "Device")),
+            ("UpdateModuleSerialView", ("view", "Device")),
+            ("UpdateModuleInterfaceView", ("view", "Device")),
+            ("UpdateModuleInterfaceView", ("view", "Module")),
+            ("ReplaceModuleView", ("view", "Device")),
+            ("MoveModuleView", ("view", "Device")),
+            ("MoveModuleView", ("view", "ModuleBay")),
+        ],
+    )
+    def test_write_gate_declares_each_restricted_read(self, view_name, expected):
+        """Each dynamic gate must declare every model read before the first lookup."""
+        from types import SimpleNamespace
+        from unittest.mock import MagicMock
+
+        from netbox_librenms_plugin.views.sync import modules
+
+        view = getattr(modules, view_name)()
+        denied = object()
+        view.require_all_permissions = MagicMock(return_value=denied)
+        request = SimpleNamespace(POST={})
+
+        assert view.post(request, pk=1) is denied
+        assert any(
+            action == expected[0] and model.__name__ == expected[1]
+            for action, model in view.required_object_permissions["POST"]
+        )
+
+    @pytest.mark.parametrize(
+        ("method", "target_kind", "target_model"),
+        [("get", "device_type", "DeviceType"), ("post", "module_type", "ModuleType")],
+    )
+    def test_add_bay_template_gate_declares_device_and_dynamic_target_reads(self, method, target_kind, target_model):
+        from types import SimpleNamespace
+        from unittest.mock import MagicMock
+
+        from netbox_librenms_plugin.views.sync.modules import AddBayTemplateView
+
+        view = AddBayTemplateView()
+        denied = object()
+        view.require_all_permissions = MagicMock(return_value=denied)
+        request = SimpleNamespace(GET={"target_kind": target_kind}, POST={"target_kind": target_kind})
+
+        assert getattr(view, method)(request, pk=1) is denied
+        declared = {(action, model.__name__) for action, model in view.required_object_permissions[method.upper()]}
+        assert ("view", "Device") in declared
+        assert ("view", target_model) in declared
+
+
+class TestImportMappingPermissionOrder:
+    @pytest.mark.parametrize(
+        ("view_name", "target_model"),
+        [("AddDeviceTypeMappingView", "DeviceType"), ("AddPlatformMappingView", "Platform")],
+    )
+    def test_target_read_is_declared_and_gated_before_restricted_lookup(self, view_name, target_model):
+        """Posted mapping targets must not be resolved before their view-permission gate."""
+        import ast
+        import inspect
+        import textwrap
+
+        from netbox_librenms_plugin.views.imports import actions
+
+        tree = ast.parse(textwrap.dedent(inspect.getsource(getattr(actions, view_name).post)))
+        calls = [node for node in ast.walk(tree) if isinstance(node, ast.Call)]
+        gate_line = min(node.lineno for node in calls if getattr(node.func, "attr", "") == "require_object_permissions")
+        target_lookup_line = min(
+            node.lineno
+            for node in calls
+            if getattr(node.func, "attr", "") == "get"
+            and isinstance(node.func.value, ast.Call)
+            and getattr(node.func.value.func, "attr", "") == "restricted_queryset"
+            and node.func.value.args
+            and getattr(node.func.value.args[0], "id", "") == target_model
+        )
+        declared_read = any(
+            isinstance(node, ast.Tuple)
+            and len(node.elts) == 2
+            and isinstance(node.elts[0], ast.Constant)
+            and node.elts[0].value == "view"
+            and getattr(node.elts[1], "id", "") == target_model
+            for node in ast.walk(tree)
+        )
+
+        assert declared_read
+        assert gate_line < target_lookup_line
+
+
+class TestScopedRowLocks:
+    def test_restricted_queryset_locks_only_the_target_table(self):
+        """Permission joins must not become PostgreSQL row-lock targets."""
+        import ast
+        import pathlib
+
+        import netbox_librenms_plugin
+
+        views_root = pathlib.Path(netbox_librenms_plugin.__file__).parent / "views"
+        offenders = []
+        for path in sorted(views_root.rglob("*.py")):
+            tree = ast.parse(path.read_text(encoding="utf-8"), str(path))
+            for node in ast.walk(tree):
+                if not isinstance(node, ast.Call) or getattr(node.func, "attr", "") != "select_for_update":
+                    continue
+                receiver = node.func.value
+                is_restricted = any(
+                    isinstance(inner, ast.Call)
+                    and getattr(inner.func, "attr", "") in {"restricted_queryset", "restrict"}
+                    for inner in ast.walk(receiver)
+                )
+                if not is_restricted:
+                    continue
+                of_keyword = next((kw for kw in node.keywords if kw.arg == "of"), None)
+                if not (
+                    of_keyword
+                    and isinstance(of_keyword.value, (ast.Tuple, ast.List))
+                    and [getattr(item, "value", None) for item in of_keyword.value.elts] == ["self"]
+                ):
+                    offenders.append((str(path.relative_to(views_root)), node.lineno))
+
+        assert not offenders, f"restricted row locks must use select_for_update(of=('self',)): {offenders}"
 
 
 @pytest.mark.django_db
@@ -789,7 +962,7 @@ class TestGatedViewsRefuseOutOfScopeObjects:
 
     def test_module_install_404s_a_page_device_outside_the_grant(self):
         """InstallModuleView resolves the page device by URL pk before touching modules."""
-        from dcim.models import Device, Interface, Module
+        from dcim.models import Device, Interface, Module, ModuleBay, ModuleType
         from django.http import Http404
 
         from netbox_librenms_plugin.tests.conftest import make_device
@@ -801,6 +974,8 @@ class TestGatedViewsRefuseOutOfScopeObjects:
             "scope-modinstall",
             [
                 (Device, "view", {"pk": in_scope.pk}),
+                (ModuleBay, "view", None),
+                (ModuleType, "view", None),
                 (Module, "add", None),
                 (Interface, "add", None),
                 (Interface, "change", None),

--- a/netbox_librenms_plugin/tests/test_view_wiring.py
+++ b/netbox_librenms_plugin/tests/test_view_wiring.py
@@ -927,7 +927,12 @@ class TestPostedSelectionsFailClosed:
                     continue
 
                 for handler in try_node.handlers:
-                    catches_lookup_error = bool(cls._exception_names(handler.type) & cls.LOOKUP_ERRORS)
+                    handled = cls._exception_names(handler.type)
+                    catches_lookup_error = (
+                        handler.type is None
+                        or bool(handled & cls.LOOKUP_ERRORS)
+                        or bool(handled & {"Exception", "BaseException"})
+                    )
                     passes_to_terminal_none = (
                         terminal_none and len(handler.body) == 1 and isinstance(handler.body[0], ast.Pass)
                     )
@@ -974,6 +979,22 @@ class TestPostedSelectionsFailClosed:
             "            except (VRF.DoesNotExist, TypeError, ValueError):\n"
             "                pass\n"
             "        return None\n"
+        )
+        assert self._scan_tree(ast.parse(source), "<fixture>")
+
+    @pytest.mark.parametrize("handler", ["except:", "except Exception:", "except BaseException:"])
+    def test_the_scan_flags_broad_exception_handlers(self, handler):
+        """Broad handlers must not hide a restricted lookup that fails open."""
+        import ast
+
+        source = (
+            "class V:\n"
+            "    def get_selection(self, request):\n"
+            "        selected_id = request.POST.get('selection')\n"
+            "        try:\n"
+            "            return self.restricted_queryset(Device).get(pk=selected_id)\n"
+            f"        {handler}\n"
+            "            return None\n"
         )
         assert self._scan_tree(ast.parse(source), "<fixture>")
 

--- a/netbox_librenms_plugin/tests/test_view_wiring.py
+++ b/netbox_librenms_plugin/tests/test_view_wiring.py
@@ -8,6 +8,7 @@ hierarchies and attribute presence.
 import json
 import os
 from pathlib import Path
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -506,10 +507,11 @@ class TestGatedViewsResolveThroughRestrictedQuerysets:
             )
 
         def _has_scoped_relationship_filter(call):
-            """Whether an ``__in`` relationship value is a restricted queryset."""
+            """Whether a positive lookup constrains ``__in`` to a restricted queryset."""
             return any(
                 kw.arg and kw.arg.endswith("__in") and _is_scoped(kw.value)
                 for chain_call in _call_chain(call)
+                if getattr(chain_call.func, "attr", "") in cls.RAW_TERMINALS
                 for kw in chain_call.keywords
             )
 
@@ -674,6 +676,20 @@ class TestGatedViewsResolveThroughRestrictedQuerysets:
             "        )\n"
         )
         assert not self._scan_tree(ast.parse(source), "<fixture>")
+
+    def test_the_scan_rejects_a_negated_relationship_scope(self):
+        """An exclusion of permitted owners selects precisely the objects outside the grant."""
+        import ast
+
+        source = (
+            "class V:\n"
+            "    required_object_permissions = {'POST': []}\n"
+            "    def post(self, request, pk):\n"
+            "        return get_object_or_404(\n"
+            "            Interface.objects.exclude(device__in=self.restricted_queryset(Device)), pk=remote_pk\n"
+            "        )\n"
+        )
+        assert self._scan_tree(ast.parse(source), "<fixture>"), "a negated permission scope must be flagged"
 
     @pytest.mark.parametrize(
         "lookup",
@@ -1127,6 +1143,200 @@ class TestGatedViewsRefuseOutOfScopeObjects:
 
         module.refresh_from_db()
         assert module.serial == "ORIGINAL"
+
+    def test_module_replace_refuses_to_delete_the_target_outside_the_delete_grant(self):
+        """Replace deletes its target, so change access alone must not authorize the operation."""
+        from dcim.models import Device, Interface, Module
+        from django.core.cache import cache
+        from django.http import Http404
+
+        from netbox_librenms_plugin.tests.conftest import make_device, make_module_bay, make_module_type
+        from netbox_librenms_plugin.views.sync.modules import ReplaceModuleView
+
+        device = make_device("scope-replace-target")
+        module_type = make_module_type("MT-scope-replace-target")
+        target = Module.objects.create(
+            device=device,
+            module_bay=make_module_bay(device, "Slot 1"),
+            module_type=module_type,
+            serial="OLD-TARGET",
+        )
+        decoy = Module.objects.create(
+            device=device,
+            module_bay=make_module_bay(device, "Slot 2"),
+            module_type=module_type,
+        )
+        user = self._user(
+            "scope-replace-target",
+            [
+                (Device, "view", {"pk": device.pk}),
+                (Module, "add", None),
+                (Module, "change", {"pk": target.pk}),
+                (Module, "delete", {"pk": decoy.pk}),
+                (Interface, "add", None),
+                (Interface, "change", None),
+                (Interface, "delete", None),
+            ],
+        )
+        view = ReplaceModuleView()
+        view._librenms_api = MagicMock(server_key="default")
+        request = self._request(
+            user,
+            {"module_id": str(target.pk), "ent_index": "100"},
+        )
+        view.setup(request)
+        cache_key = view.get_cache_key(device, "inventory", server_key="default")
+        cache.set(
+            cache_key,
+            {
+                "inventory": [
+                    {
+                        "entPhysicalIndex": 100,
+                        "entPhysicalModelName": module_type.model,
+                        "entPhysicalSerialNum": "NEW-TARGET",
+                    }
+                ],
+                "librenms_id": 1,
+            },
+        )
+        try:
+            with pytest.raises(Http404):
+                view.post(request, pk=device.pk)
+        finally:
+            cache.delete(cache_key)
+
+        target.refresh_from_db()
+        assert target.serial == "OLD-TARGET"
+        assert Module.objects.filter(module_bay=target.module_bay).count() == 1
+
+    def test_module_replace_fails_closed_on_a_hidden_serial_conflict(self):
+        """An existing serial outside delete scope must block replacement, not become a duplicate."""
+        from dcim.models import Device, Interface, Module
+        from django.core.cache import cache
+
+        from netbox_librenms_plugin.tests.conftest import make_device, make_module_bay, make_module_type
+        from netbox_librenms_plugin.tests.view_test_helpers import message_texts
+        from netbox_librenms_plugin.views.sync.modules import ReplaceModuleView
+
+        device = make_device("scope-replace-conflict")
+        other_device = make_device("scope-replace-hidden")
+        module_type = make_module_type("MT-scope-replace-conflict")
+        target = Module.objects.create(
+            device=device,
+            module_bay=make_module_bay(device, "Slot 1"),
+            module_type=module_type,
+            serial="OLD-CONFLICT",
+        )
+        hidden = Module.objects.create(
+            device=other_device,
+            module_bay=make_module_bay(other_device, "Secret Slot"),
+            module_type=module_type,
+            serial="INCOMING-CONFLICT",
+        )
+        user = self._user(
+            "scope-replace-conflict",
+            [
+                (Device, "view", {"pk": device.pk}),
+                (Module, "add", None),
+                (Module, "change", {"pk": target.pk}),
+                (Module, "delete", {"pk": target.pk}),
+                (Interface, "add", None),
+                (Interface, "change", None),
+                (Interface, "delete", None),
+            ],
+        )
+        view = ReplaceModuleView()
+        view._librenms_api = MagicMock(server_key="default")
+        request = self._request(user, {"module_id": str(target.pk), "ent_index": "100"})
+        view.setup(request)
+        cache_key = view.get_cache_key(device, "inventory", server_key="default")
+        cache.set(
+            cache_key,
+            {
+                "inventory": [
+                    {
+                        "entPhysicalIndex": 100,
+                        "entPhysicalModelName": module_type.model,
+                        "entPhysicalSerialNum": hidden.serial,
+                    }
+                ],
+                "librenms_id": 1,
+            },
+        )
+        try:
+            view.post(request, pk=device.pk)
+        finally:
+            cache.delete(cache_key)
+
+        target.refresh_from_db()
+        hidden.refresh_from_db()
+        assert target.serial == "OLD-CONFLICT"
+        assert hidden.serial == "INCOMING-CONFLICT"
+        assert Module.objects.filter(serial="INCOMING-CONFLICT").count() == 1
+        assert any("cannot remove" in text for text in message_texts(request, "error"))
+
+    def test_module_preview_does_not_expose_a_hidden_serial_conflict(self):
+        """The preview must not render the location or id of a conflict outside view scope."""
+        from dcim.models import Device, Module
+        from django.core.cache import cache
+
+        from netbox_librenms_plugin.tests.conftest import make_device, make_module_bay, make_module_type
+        from netbox_librenms_plugin.views.sync.modules import ModuleMismatchPreviewView
+
+        device = make_device("scope-preview-target")
+        hidden_device = make_device("scope-preview-hidden")
+        module_type = make_module_type("MT-scope-preview")
+        target = Module.objects.create(
+            device=device,
+            module_bay=make_module_bay(device, "Visible Slot"),
+            module_type=module_type,
+            serial="OLD-PREVIEW",
+        )
+        hidden = Module.objects.create(
+            device=hidden_device,
+            module_bay=make_module_bay(hidden_device, "Hidden Slot"),
+            module_type=module_type,
+            serial="INCOMING-PREVIEW",
+        )
+        user = self._user(
+            "scope-preview-conflict",
+            [
+                (Device, "view", {"pk": device.pk}),
+                (Module, "view", {"pk": target.pk}),
+            ],
+        )
+        view = ModuleMismatchPreviewView()
+        view._librenms_api = MagicMock(server_key="default")
+        request = self._request(
+            user,
+            {"module_id": str(target.pk), "ent_index": "100"},
+            method="get",
+        )
+        view.setup(request)
+        cache_key = view.get_cache_key(device, "inventory", server_key="default")
+        cache.set(
+            cache_key,
+            {
+                "inventory": [
+                    {
+                        "entPhysicalIndex": 100,
+                        "entPhysicalModelName": module_type.model,
+                        "entPhysicalSerialNum": hidden.serial,
+                    }
+                ],
+                "librenms_id": 1,
+            },
+        )
+        try:
+            response = view.get(request, pk=device.pk)
+        finally:
+            cache.delete(cache_key)
+
+        html = response.content.decode()
+        assert hidden_device.name not in html
+        assert hidden.module_bay.name not in html
+        assert f'name="conflict_module_id" value="{hidden.pk}"' not in html
+        assert "cannot view" in html
 
     def test_site_location_push_refuses_a_site_outside_the_grant(self):
         """SyncSiteLocationView is gated by the plugin write permission alone and takes the site pk from the POST body."""

--- a/netbox_librenms_plugin/tests/test_vlan_sync_concurrency.py
+++ b/netbox_librenms_plugin/tests/test_vlan_sync_concurrency.py
@@ -1,0 +1,90 @@
+"""Concurrency tests for global VLAN synchronization."""
+
+from concurrent.futures import ThreadPoolExecutor
+from threading import Barrier, BrokenBarrierError
+
+import pytest
+from django.apps import apps
+from django.contrib.auth import get_user_model
+from django.contrib.messages.storage.fallback import FallbackStorage
+from django.core.cache import cache
+from django.db import close_old_connections, connection
+from django.test import RequestFactory
+
+from netbox_librenms_plugin.tests.conftest import make_device
+
+
+class _GlobalVLANLookupBarrier:
+    """Pause both workers after their first global VLAN lookup completes."""
+
+    def __init__(self, barrier):
+        self.barrier = barrier
+        self.lookup_seen = False
+
+    def __call__(self, execute, sql, params, many, context):
+        result = execute(sql, params, many, context)
+        if (
+            not self.lookup_seen
+            and sql.lstrip().upper().startswith("SELECT")
+            and 'FROM "ipam_vlan"' in sql
+            and '"ipam_vlan"."group_id" IS NULL' in sql
+            and '"ipam_vlan"."vid"' in sql
+        ):
+            self.lookup_seen = True
+            try:
+                self.barrier.wait(timeout=1)
+            except BrokenBarrierError:
+                # With serialization, the first worker times out while the second
+                # waits for its transaction lock. It can then create and commit.
+                pass
+        return result
+
+
+def _sync_global_vlan(device, user, vid, lookup_barrier):
+    from netbox_librenms_plugin.views.sync.vlans import SyncVLANsView
+
+    close_old_connections()
+    try:
+        request = RequestFactory().post(
+            "/sync/vlans/",
+            data={"action": "create_vlans", "select": [str(vid)], "server_key": "default"},
+        )
+        request.user = user
+        request.session = {}
+        setattr(request, "_messages", FallbackStorage(request))
+
+        view = SyncVLANsView()
+        view.request = request
+        cache_key = view.get_cache_key(device, "vlans", "default")
+        cache.set(cache_key, [{"vlan_vlan": vid, "vlan_name": "Concurrent global VLAN"}], timeout=60)
+
+        with connection.execute_wrapper(_GlobalVLANLookupBarrier(lookup_barrier)):
+            view.post(request, object_type="device", object_id=device.pk)
+    finally:
+        close_old_connections()
+
+
+@pytest.mark.django_db(
+    transaction=True,
+    # Explicit available apps make Django use cascade-aware transaction cleanup.
+    # This is required when another installed plugin has M2M tables outside the default flush list.
+    available_apps=[app.name for app in apps.get_app_configs()],
+)
+def test_concurrent_global_vlan_sync_creates_one_vlan():
+    """Two requests that sync the same missing global VID must create one row."""
+    from ipam.models import VLAN
+
+    user = get_user_model().objects.create_user(
+        username="global-vlan-concurrency-user",
+        password="test-password",
+        is_superuser=True,
+    )
+    devices = [make_device("global-vlan-device-a"), make_device("global-vlan-device-b")]
+    lookup_barrier = Barrier(2)
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        futures = [executor.submit(_sync_global_vlan, device, user, 321, lookup_barrier) for device in devices]
+        for future in futures:
+            future.result(timeout=10)
+
+    assert VLAN.objects.filter(vid=321, group__isnull=True).count() == 1

--- a/netbox_librenms_plugin/tests/test_vlan_sync_concurrency.py
+++ b/netbox_librenms_plugin/tests/test_vlan_sync_concurrency.py
@@ -6,12 +6,11 @@ from threading import Barrier, BrokenBarrierError
 import pytest
 from django.apps import apps
 from django.contrib.auth import get_user_model
-from django.contrib.messages.storage.fallback import FallbackStorage
 from django.core.cache import cache
 from django.db import close_old_connections, connection
-from django.test import RequestFactory
 
 from netbox_librenms_plugin.tests.conftest import make_device
+from netbox_librenms_plugin.tests.view_test_helpers import make_request
 
 
 class _GlobalVLANLookupBarrier:
@@ -40,28 +39,30 @@ class _GlobalVLANLookupBarrier:
         return result
 
 
-def _sync_global_vlan(device, user, vid, lookup_barrier):
+def _sync_global_vlan(device, user, vid, lookup_wrapper):
     from netbox_librenms_plugin.views.sync.vlans import SyncVLANsView
 
     close_old_connections()
     try:
-        request = RequestFactory().post(
-            "/sync/vlans/",
+        with connection.cursor() as cursor:
+            cursor.execute("SET lock_timeout = '5s'")
+            cursor.execute("SET statement_timeout = '5s'")
+
+        request = make_request(
             data={"action": "create_vlans", "select": [str(vid)], "server_key": "default"},
+            user=user,
+            path="/sync/vlans/",
         )
-        request.user = user
-        request.session = {}
-        setattr(request, "_messages", FallbackStorage(request))
 
         view = SyncVLANsView()
         view.request = request
         cache_key = view.get_cache_key(device, "vlans", "default")
         cache.set(cache_key, [{"vlan_vlan": vid, "vlan_name": "Concurrent global VLAN"}], timeout=60)
 
-        with connection.execute_wrapper(_GlobalVLANLookupBarrier(lookup_barrier)):
+        with connection.execute_wrapper(lookup_wrapper):
             view.post(request, object_type="device", object_id=device.pk)
     finally:
-        close_old_connections()
+        connection.close()
 
 
 @pytest.mark.django_db(
@@ -81,10 +82,15 @@ def test_concurrent_global_vlan_sync_creates_one_vlan():
     )
     devices = [make_device("global-vlan-device-a"), make_device("global-vlan-device-b")]
     lookup_barrier = Barrier(2)
+    lookup_wrappers = [_GlobalVLANLookupBarrier(lookup_barrier) for _device in devices]
 
     with ThreadPoolExecutor(max_workers=2) as executor:
-        futures = [executor.submit(_sync_global_vlan, device, user, 321, lookup_barrier) for device in devices]
+        futures = [
+            executor.submit(_sync_global_vlan, device, user, 321, lookup_wrapper)
+            for device, lookup_wrapper in zip(devices, lookup_wrappers, strict=True)
+        ]
         for future in futures:
             future.result(timeout=10)
 
+    assert all(wrapper.lookup_seen for wrapper in lookup_wrappers)
     assert VLAN.objects.filter(vid=321, group__isnull=True).count() == 1

--- a/netbox_librenms_plugin/tests/view_test_helpers.py
+++ b/netbox_librenms_plugin/tests/view_test_helpers.py
@@ -1,0 +1,22 @@
+"""Shared drivers for tests that call a view's ``get``/``post`` directly.
+
+Production always reaches a view through ``dispatch()``, which runs ``View.setup()`` and binds
+``self.request``. The object-scoped lookups read it, so a test that calls ``view.post(request, ...)``
+straight would hit an unset attribute. These drivers bind the request the same way.
+"""
+
+
+def bind_and_call(view, request, method, **kwargs):
+    """Call ``view.<method>(request, **kwargs)`` with the request bound as ``setup()`` binds it."""
+    view.setup(request)
+    return getattr(view, method)(request, **kwargs)
+
+
+def post(view, request, **kwargs):
+    """POST into *view* with the request bound (see :func:`bind_and_call`)."""
+    return bind_and_call(view, request, "post", **kwargs)
+
+
+def get(view, request, **kwargs):
+    """GET into *view* with the request bound (see :func:`bind_and_call`)."""
+    return bind_and_call(view, request, "get", **kwargs)

--- a/netbox_librenms_plugin/tests/view_test_helpers.py
+++ b/netbox_librenms_plugin/tests/view_test_helpers.py
@@ -3,7 +3,17 @@
 Production always reaches a view through ``dispatch()``, which runs ``View.setup()`` and binds
 ``self.request``. The object-scoped lookups read it, so a test that calls ``view.post(request, ...)``
 straight would hit an unset attribute. These drivers bind the request the same way.
+
+The builders below give a view a REAL request, a REAL user and REAL permission grants, so the
+permission gate, ``restrict()`` and the messages framework all run as they do in production. A
+view test that instead patches ``Device``/``Interface`` and stubs ``objects.get`` re-asserts its
+own assumptions: a ``MagicMock`` answers any attribute, so such a test stays green while the real
+query path is broken. Reserve mocks for the LibreNMS HTTP boundary and for errors a local DB
+cannot produce (a lock ``DatabaseError``, a ``save()`` that raises).
 """
+
+from netbox_librenms_plugin.constants import PERM_CHANGE_PLUGIN, PERM_VIEW_PLUGIN
+from netbox_librenms_plugin.tests.conftest import make_superuser
 
 
 def bind_and_call(view, request, method, **kwargs):
@@ -20,3 +30,169 @@ def post(view, request, **kwargs):
 def get(view, request, **kwargs):
     """GET into *view* with the request bound (see :func:`bind_and_call`)."""
     return bind_and_call(view, request, "get", **kwargs)
+
+
+# =============================================================================
+# Real users and real permission grants
+# =============================================================================
+#
+# NetBox enforces permissions only through ObjectPermissionBackend, which ignores Django's
+# ``user_permissions`` m2m. A grant therefore has to be a real ``ObjectPermission`` row, and the
+# user must be re-read afterwards to drop the per-instance permission cache.
+# ``make_superuser`` (re-exported from conftest) covers the unconstrained case.
+
+
+def grant(user, action, model, *, constraints=None, name=None):
+    """Grant *user* ``action`` on *model* through a real ObjectPermission.
+
+    Pass *constraints* to make the grant a CONSTRAINED one: the model-level ``has_perm`` the
+    gate asks (no instance) still passes, while ``restrict()`` narrows to the matching rows.
+    That is the only way to reproduce the authorization hole the object-scoped lookups close.
+
+    Returns:
+        The user re-read from the DB, so the permission cache reflects the new grant.
+    """
+    from core.models import ObjectType
+    from django.contrib.auth import get_user_model
+    from users.models import ObjectPermission
+
+    op = ObjectPermission.objects.create(
+        name=name or f"{user.username}-{action}-{model._meta.model_name}-{ObjectPermission.objects.count()}",
+        actions=[action],
+        constraints=constraints,
+    )
+    op.object_types.set([ObjectType.objects.get_for_model(model)])
+    op.users.set([user])
+    return get_user_model().objects.get(pk=user.pk)
+
+
+def make_user_with_perms(username, perm_specs, *, constraints=None, plugin_write=True):
+    """Create a real non-superuser granted exactly *perm_specs*.
+
+    Args:
+        username: Username for the new user.
+        perm_specs: Iterable of ``(action, model)`` pairs to grant.
+        constraints: Applied to every grant in *perm_specs*, making them constrained (see
+            :func:`grant`). The plugin grants below stay unconstrained.
+        plugin_write: Also grant the plugin's view+change permissions, which every write view
+            demands before it looks at the object permissions. Set False to exercise that gate.
+
+    Returns:
+        The user, re-read so its permission cache is current.
+    """
+    from django.contrib.auth import get_user_model
+    from netbox_librenms_plugin.models import LibreNMSSettings
+
+    user = get_user_model().objects.create_user(username=username, password="x")
+    if plugin_write:
+        for action in ("view", "change"):
+            user = grant(user, action, LibreNMSSettings, name=f"{username}-plugin-{action}")
+    for action, model in perm_specs:
+        user = grant(user, action, model, constraints=constraints)
+    return user
+
+
+def plugin_perms():
+    """The two plugin permission strings every write view checks."""
+    return (PERM_VIEW_PLUGIN, PERM_CHANGE_PLUGIN)
+
+
+# =============================================================================
+# Real requests
+# =============================================================================
+
+
+def make_request(method="post", data=None, *, user=None, path="/", **factory_kwargs):
+    """Build a real Django request with a real user and a working messages framework.
+
+    ``RequestFactory`` skips the session and message middleware, so both are attached here:
+    without them ``messages.error(request, ...)`` raises instead of recording, and a test would
+    have to patch the whole ``messages`` module (which then proves nothing about what the user
+    is actually told).
+
+    Args:
+        method: ``"post"``, ``"get"`` or any other RequestFactory method name.
+        data: Request body / query data.
+        user: The request user; defaults to a real superuser.
+        path: Request path.
+        **factory_kwargs: Passed through to the RequestFactory method (e.g. ``content_type``).
+
+    Returns:
+        The request, with ``request._messages`` readable via :func:`messages_on`.
+    """
+    from django.contrib.messages.storage.fallback import FallbackStorage
+    from django.contrib.sessions.backends.db import SessionStore
+    from django.test import RequestFactory
+
+    request = getattr(RequestFactory(), method)(path, data if data is not None else {}, **factory_kwargs)
+    request.user = user if user is not None else make_superuser()
+    request.session = SessionStore()
+    request._messages = FallbackStorage(request)
+    return request
+
+
+def _message_level(name):
+    """Map ``"error"``/``"warning"``/``"info"``/``"success"`` to the messages constant.
+
+    Levels, not tag strings: NetBox remaps ERROR's tag to ``"danger"``, so filtering on
+    ``level_tag == "error"`` silently matches nothing and every assertion built on it passes
+    vacuously.
+    """
+    from django.contrib import messages
+
+    try:
+        return getattr(messages, name.upper())
+    except AttributeError:
+        raise ValueError(f"unknown message level {name!r}") from None
+
+
+def messages_on(request):
+    """Return the messages recorded on *request* as ``[(level_name, text), ...]``."""
+    from django.contrib.messages import constants, get_messages
+
+    names = {level: name.lower() for name, level in constants.DEFAULT_LEVELS.items()}
+    return [(names.get(m.level, str(m.level)), str(m.message)) for m in get_messages(request)]
+
+
+def message_texts(request, level=None):
+    """Return the recorded message texts, optionally only those at *level* (e.g. ``"error"``)."""
+    from django.contrib.messages import get_messages
+
+    wanted = None if level is None else _message_level(level)
+    return [str(m.message) for m in get_messages(request) if wanted is None or m.level == wanted]
+
+
+# =============================================================================
+# Real views
+# =============================================================================
+
+
+def make_view(view_class, request=None, *, librenms_api=None, **attrs):
+    """Instantiate *view_class* for real and bind *request* the way ``dispatch()`` does.
+
+    Only the LibreNMS client is substitutable: it is the one true external boundary these views
+    touch. Everything else (permission gate, ``restrict()``, ORM, messages) stays real.
+
+    Args:
+        view_class: The view class under test.
+        request: Request to bind; defaults to a superuser POST.
+        librenms_api: Stub bound as ``_librenms_api``. Defaults to a MagicMock whose
+            ``server_key`` is ``"default"``. Pass ``False`` to leave the attribute unset so the
+            lazy real-client construction runs.
+        **attrs: Extra attributes set on the view after setup.
+
+    Returns:
+        The view instance, with ``self.request`` bound.
+    """
+    from unittest.mock import MagicMock
+
+    view = view_class()
+    if librenms_api is not False:
+        if librenms_api is None:
+            librenms_api = MagicMock()
+            librenms_api.server_key = "default"
+        view._librenms_api = librenms_api
+    view.setup(request if request is not None else make_request())
+    for name, value in attrs.items():
+        setattr(view, name, value)
+    return view

--- a/netbox_librenms_plugin/tests/view_test_helpers.py
+++ b/netbox_librenms_plugin/tests/view_test_helpers.py
@@ -18,7 +18,7 @@ from netbox_librenms_plugin.tests.conftest import make_superuser
 
 def bind_and_call(view, request, method, **kwargs):
     """Call ``view.<method>(request, **kwargs)`` with the request bound as ``setup()`` binds it."""
-    view.setup(request)
+    view.setup(request, **kwargs)
     return getattr(view, method)(request, **kwargs)
 
 
@@ -144,9 +144,16 @@ def _message_level(name):
     """
     from django.contrib import messages
 
+    levels = {
+        "debug": messages.DEBUG,
+        "info": messages.INFO,
+        "success": messages.SUCCESS,
+        "warning": messages.WARNING,
+        "error": messages.ERROR,
+    }
     try:
-        return getattr(messages, name.upper())
-    except AttributeError:
+        return levels[name.lower()]
+    except (AttributeError, KeyError):
         raise ValueError(f"unknown message level {name!r}") from None
 
 

--- a/netbox_librenms_plugin/tests/view_test_helpers.py
+++ b/netbox_librenms_plugin/tests/view_test_helpers.py
@@ -80,13 +80,17 @@ def make_user_with_perms(username, perm_specs, *, constraints=None, plugin_write
     Returns:
         The user, re-read so its permission cache is current.
     """
+    from django.apps import apps
     from django.contrib.auth import get_user_model
-    from netbox_librenms_plugin.models import LibreNMSSettings
 
     user = get_user_model().objects.create_user(username=username, password="x")
     if plugin_write:
+        # Resolve through the app registry, not the module attribute: a suite-wide autouse
+        # fixture patches ``netbox_librenms_plugin.models.LibreNMSSettings`` (spread by
+        # pytest_plugins), and importing it here would hand a MagicMock to get_for_model.
+        settings_model = apps.get_model("netbox_librenms_plugin", "LibreNMSSettings")
         for action in ("view", "change"):
-            user = grant(user, action, LibreNMSSettings, name=f"{username}-plugin-{action}")
+            user = grant(user, action, settings_model, name=f"{username}-plugin-{action}")
     for action, model in perm_specs:
         user = grant(user, action, model, constraints=constraints)
     return user

--- a/netbox_librenms_plugin/tests/view_test_helpers.py
+++ b/netbox_librenms_plugin/tests/view_test_helpers.py
@@ -173,6 +173,12 @@ def message_texts(request, level=None):
     return [str(m.message) for m in get_messages(request) if wanted is None or m.level == wanted]
 
 
+def missing_pk(model, offset=1000):
+    """Return a primary key that is above every current row for *model*."""
+    highest_pk = model.objects.order_by("-pk").values_list("pk", flat=True).first()
+    return (highest_pk or 0) + offset
+
+
 # =============================================================================
 # Real views
 # =============================================================================

--- a/netbox_librenms_plugin/utils.py
+++ b/netbox_librenms_plugin/utils.py
@@ -659,7 +659,10 @@ def get_table_paginate_count(request: HttpRequest, table_prefix: str) -> int:
     if f"{table_prefix}per_page" in request.GET:
         try:
             per_page = int(request.GET.get(f"{table_prefix}per_page"))
-            return min(per_page, config.MAX_PAGE_SIZE)
+            max_page_size = config.MAX_PAGE_SIZE
+            # MAX_PAGE_SIZE 0/None disables the NetBox ceiling; don't clamp to it (min() with 0
+            # would zero the page size, and with None it TypeErrors).
+            return min(per_page, max_page_size) if max_page_size else per_page
         except ValueError:
             pass
 

--- a/netbox_librenms_plugin/utils.py
+++ b/netbox_librenms_plugin/utils.py
@@ -1333,6 +1333,29 @@ def coerce_positive_int(value) -> int | None:
     return coerce_librenms_id(value)
 
 
+def cached_row_matches(cached_row, device_id) -> bool:
+    """
+    Decide whether a cached LibreNMS device row may be served for *device_id*.
+
+    A row whose OWN ``device_id`` contradicts the requested id (a mis-keyed or stale
+    cache entry — another device's row stored under this key) must not be served AS
+    this device. A row without a readable ``device_id`` stays trusted (a real LibreNMS
+    row always carries one), and ``None`` (no cached row) never matches. Shared by the
+    single-import and bulk-import cache reads so the acceptance rule can't drift.
+
+    Args:
+        cached_row: The cached payload for *device_id* (usually a dict, possibly None).
+        device_id: The LibreNMS device id the caller asked for.
+
+    Returns:
+        bool: True when the cached row may be used for *device_id*.
+    """
+    if cached_row is None:
+        return False
+    cached_row_id = cached_row.get("device_id") if isinstance(cached_row, dict) else None
+    return cached_row_id is None or coerce_librenms_id(cached_row_id) == coerce_librenms_id(device_id)
+
+
 def get_librenms_device_id(obj, server_key: str = "default", *, auto_save: bool = True):
     """
     Get the LibreNMS device/port ID for a specific server from the JSON custom field.

--- a/netbox_librenms_plugin/utils.py
+++ b/netbox_librenms_plugin/utils.py
@@ -1315,14 +1315,14 @@ def coerce_positive_int(value):
     """
     Coerce a value to a strictly-positive ``int``, or ``None`` when invalid.
 
-    Accepts only an ``int`` (excluding ``bool``, an ``int`` subclass, so ``int(True)``
-    can't silently become ``1``) or an integer-parseable ``str``, and keeps the result
-    only when ``> 0``. Non-integer types such as ``float`` are rejected outright rather
-    than coerced — ``int(1.9)`` would truncate to a valid-looking ``1`` and resolve a
-    malformed id to the wrong object — mirroring the stricter guard in
-    :func:`coerce_librenms_id`. Shared by the NetBox-pk coercion sites — bulk-import
-    collision detection and module-inventory port identity — so the positive-int rule
-    lives in one place.
+    A named alias for :func:`coerce_librenms_id` at the NetBox-pk coercion sites —
+    bulk-import collision detection and module-inventory port identity — so the call
+    reads as pk handling while the strictly-positive-int rule genuinely lives in ONE
+    place and can't drift. The two apply the identical rule: only an ``int`` (excluding
+    ``bool``, an ``int`` subclass, so ``int(True)`` can't silently become ``1``) or an
+    integer-parseable ``str``, kept only when ``> 0``; non-integer types such as ``float``
+    are rejected outright (``int(1.9)`` would truncate to a valid-looking ``1`` and resolve
+    a malformed id to the wrong object).
 
     Args:
         value: The raw value to coerce (a NetBox pk or similar identifier).
@@ -1330,17 +1330,7 @@ def coerce_positive_int(value):
     Returns:
         int | None: The positive integer, or None if it can't be coerced.
     """
-    if isinstance(value, bool):
-        return None
-    if isinstance(value, int):
-        return value if value > 0 else None
-    if isinstance(value, str):
-        try:
-            coerced = int(value)
-        except ValueError:
-            return None
-        return coerced if coerced > 0 else None
-    return None
+    return coerce_librenms_id(value)
 
 
 def get_librenms_device_id(obj, server_key: str = "default", *, auto_save: bool = True):

--- a/netbox_librenms_plugin/utils.py
+++ b/netbox_librenms_plugin/utils.py
@@ -2344,6 +2344,8 @@ def mark_librenms_migrated(donor, winner_pk: int, server_key: str = "default", a
     # ids so a malformed marker can never target the wrong device.
     if isinstance(winner_pk, bool) or not isinstance(winner_pk, int) or winner_pk <= 0:
         raise ValueError(f"winner_pk must be a positive integer, got {winner_pk!r}")
+    # Keep the writer's key normalization paired with get_migrated_to_marker()'s.
+    server_key = server_key or "default"
 
     cf_value = donor.custom_field_data.get("librenms_id")
     if cf_value is None:
@@ -2448,6 +2450,9 @@ def get_migrated_to_marker(device, server_key: str = "default") -> dict | None:
     """
     if device is None:
         return None
+    # Blank/None server_key means the default server everywhere else in this plugin; normalize
+    # here so every marker reader agrees, whatever key hygiene its call site has.
+    server_key = server_key or "default"
     cf_value = device.cf.get("librenms_id") if hasattr(device, "cf") else None
     if not isinstance(cf_value, dict):
         return None

--- a/netbox_librenms_plugin/utils.py
+++ b/netbox_librenms_plugin/utils.py
@@ -1315,11 +1315,14 @@ def coerce_positive_int(value):
     """
     Coerce a value to a strictly-positive ``int``, or ``None`` when invalid.
 
-    Rejects ``None`` and ``bool`` (``bool`` is an ``int`` subclass, so ``int(True)``
-    would silently become ``1``), then attempts ``int(value)`` and keeps the result
-    only when ``> 0``. Shared by the NetBox-pk coercion sites — bulk-import collision
-    detection and module-inventory port identity — so the positive-int rule lives in
-    one place.
+    Accepts only an ``int`` (excluding ``bool``, an ``int`` subclass, so ``int(True)``
+    can't silently become ``1``) or an integer-parseable ``str``, and keeps the result
+    only when ``> 0``. Non-integer types such as ``float`` are rejected outright rather
+    than coerced — ``int(1.9)`` would truncate to a valid-looking ``1`` and resolve a
+    malformed id to the wrong object — mirroring the stricter guard in
+    :func:`coerce_librenms_id`. Shared by the NetBox-pk coercion sites — bulk-import
+    collision detection and module-inventory port identity — so the positive-int rule
+    lives in one place.
 
     Args:
         value: The raw value to coerce (a NetBox pk or similar identifier).
@@ -1327,13 +1330,17 @@ def coerce_positive_int(value):
     Returns:
         int | None: The positive integer, or None if it can't be coerced.
     """
-    if value is None or isinstance(value, bool):
+    if isinstance(value, bool):
         return None
-    try:
-        int_value = int(value)
-    except (TypeError, ValueError):
-        return None
-    return int_value if int_value > 0 else None
+    if isinstance(value, int):
+        return value if value > 0 else None
+    if isinstance(value, str):
+        try:
+            coerced = int(value)
+        except ValueError:
+            return None
+        return coerced if coerced > 0 else None
+    return None
 
 
 def get_librenms_device_id(obj, server_key: str = "default", *, auto_save: bool = True):

--- a/netbox_librenms_plugin/utils.py
+++ b/netbox_librenms_plugin/utils.py
@@ -1340,13 +1340,10 @@ def cached_row_matches(cached_row, device_id) -> bool:
     """
     Decide whether a cached LibreNMS device row may be served for *device_id*.
 
-    A row whose OWN ``device_id`` contradicts the requested id (a mis-keyed or stale
-    cache entry — another device's row stored under this key) must not be served AS
-    this device. A row without a readable ``device_id`` stays trusted (a real LibreNMS
-    row always carries one), and ``None`` (no cached row) never matches. An un-coercible
-    requested id never matches either — it can't be identity-checked, and two invalid ids
-    must not compare equal as ``None == None``. Shared by the single-import and
-    bulk-import cache reads so the acceptance rule can't drift.
+    A non-dictionary row or a row whose own ``device_id`` contradicts the requested id
+    must not be served as this device. A dictionary without a readable ``device_id`` stays
+    trusted, and ``None`` never matches. An uncoercible requested id never matches either.
+    Shared by the single-import and bulk-import cache reads so the acceptance rule cannot drift.
 
     Args:
         cached_row: The cached payload for *device_id* (usually a dict, possibly None).
@@ -1355,12 +1352,12 @@ def cached_row_matches(cached_row, device_id) -> bool:
     Returns:
         bool: True when the cached row may be used for *device_id*.
     """
-    if cached_row is None:
+    if not isinstance(cached_row, dict):
         return False
     requested_id = coerce_librenms_id(device_id)
     if requested_id is None:
         return False
-    cached_row_id = cached_row.get("device_id") if isinstance(cached_row, dict) else None
+    cached_row_id = cached_row.get("device_id")
     return cached_row_id is None or coerce_librenms_id(cached_row_id) == requested_id
 
 

--- a/netbox_librenms_plugin/utils.py
+++ b/netbox_librenms_plugin/utils.py
@@ -1340,8 +1340,10 @@ def cached_row_matches(cached_row, device_id) -> bool:
     A row whose OWN ``device_id`` contradicts the requested id (a mis-keyed or stale
     cache entry — another device's row stored under this key) must not be served AS
     this device. A row without a readable ``device_id`` stays trusted (a real LibreNMS
-    row always carries one), and ``None`` (no cached row) never matches. Shared by the
-    single-import and bulk-import cache reads so the acceptance rule can't drift.
+    row always carries one), and ``None`` (no cached row) never matches. An un-coercible
+    requested id never matches either — it can't be identity-checked, and two invalid ids
+    must not compare equal as ``None == None``. Shared by the single-import and
+    bulk-import cache reads so the acceptance rule can't drift.
 
     Args:
         cached_row: The cached payload for *device_id* (usually a dict, possibly None).
@@ -1352,8 +1354,35 @@ def cached_row_matches(cached_row, device_id) -> bool:
     """
     if cached_row is None:
         return False
+    requested_id = coerce_librenms_id(device_id)
+    if requested_id is None:
+        return False
     cached_row_id = cached_row.get("device_id") if isinstance(cached_row, dict) else None
-    return cached_row_id is None or coerce_librenms_id(cached_row_id) == coerce_librenms_id(device_id)
+    return cached_row_id is None or coerce_librenms_id(cached_row_id) == requested_id
+
+
+def row_identity_matches(row, device_id) -> bool:
+    """
+    Decide whether a LibreNMS device payload verifiably describes *device_id*.
+
+    Stricter than :func:`cached_row_matches`: a real LibreNMS device read always returns
+    a dict carrying its own ``device_id``, so anything else — a non-dict payload, a
+    missing or contradicting id, an un-coercible requested id — fails closed. Shared by
+    the bulk-import collision pre-check and the single-row live-fetch fallback so a
+    payload that flunks this check is neither imported nor written into the shared cache.
+
+    Args:
+        row: The fetched (or cached) payload to identity-check.
+        device_id: The LibreNMS device id the caller asked for.
+
+    Returns:
+        bool: True when the payload's own device_id equals the requested id.
+    """
+    requested_id = coerce_librenms_id(device_id)
+    if requested_id is None:
+        return False
+    row_id = coerce_librenms_id(row.get("device_id")) if isinstance(row, dict) else None
+    return row_id == requested_id
 
 
 def get_librenms_device_id(obj, server_key: str = "default", *, auto_save: bool = True):

--- a/netbox_librenms_plugin/utils.py
+++ b/netbox_librenms_plugin/utils.py
@@ -1311,7 +1311,7 @@ def resolve_server_mapping_display_id(entry) -> tuple[int | None, bool]:
     return coerce_librenms_id(entry), False
 
 
-def coerce_positive_int(value):
+def coerce_positive_int(value) -> int | None:
     """
     Coerce a value to a strictly-positive ``int``, or ``None`` when invalid.
 

--- a/netbox_librenms_plugin/utils.py
+++ b/netbox_librenms_plugin/utils.py
@@ -1311,6 +1311,31 @@ def resolve_server_mapping_display_id(entry) -> tuple[int | None, bool]:
     return coerce_librenms_id(entry), False
 
 
+def coerce_positive_int(value):
+    """
+    Coerce a value to a strictly-positive ``int``, or ``None`` when invalid.
+
+    Rejects ``None`` and ``bool`` (``bool`` is an ``int`` subclass, so ``int(True)``
+    would silently become ``1``), then attempts ``int(value)`` and keeps the result
+    only when ``> 0``. Shared by the NetBox-pk coercion sites — bulk-import collision
+    detection and module-inventory port identity — so the positive-int rule lives in
+    one place.
+
+    Args:
+        value: The raw value to coerce (a NetBox pk or similar identifier).
+
+    Returns:
+        int | None: The positive integer, or None if it can't be coerced.
+    """
+    if value is None or isinstance(value, bool):
+        return None
+    try:
+        int_value = int(value)
+    except (TypeError, ValueError):
+        return None
+    return int_value if int_value > 0 else None
+
+
 def get_librenms_device_id(obj, server_key: str = "default", *, auto_save: bool = True):
     """
     Get the LibreNMS device/port ID for a specific server from the JSON custom field.

--- a/netbox_librenms_plugin/views/base/ip_addresses_view.py
+++ b/netbox_librenms_plugin/views/base/ip_addresses_view.py
@@ -499,7 +499,7 @@ class BaseIPAddressTableView(LibreNMSPermissionMixin, LibreNMSAPIMixin, CacheMix
 
         from netbox_librenms_plugin.utils import get_migrated_to_marker
 
-        if not isinstance(obj, Device) or not get_migrated_to_marker(obj, server_key):
+        if not isinstance(obj, Device) or not get_migrated_to_marker(obj, server_key or "default"):
             return []
         name_by_id = {iface.pk: iface.name for iface in obj.interfaces.all()}
         if not name_by_id:

--- a/netbox_librenms_plugin/views/base/modules_view.py
+++ b/netbox_librenms_plugin/views/base/modules_view.py
@@ -57,6 +57,11 @@ _SKIP_TRANSCEIVER_TYPES = {"Port Container", "Port", ""}
 _NON_HARDWARE_CLASSES = {"sensor", "backplane", "stack"}
 
 
+def _normalize_librenms_text(value) -> str:
+    """Coerce a LibreNMS text value to a trimmed string without changing placeholder semantics."""
+    return normalize_serial(value)
+
+
 def _clean_librenms_value(value) -> str:
     """
     Return a LibreNMS model/serial/type value trimmed, with placeholders blanked.
@@ -70,7 +75,7 @@ def _clean_librenms_value(value) -> str:
     Returns:
         The cleaned string, or "" for a missing/placeholder value.
     """
-    text = normalize_serial(value)
+    text = _normalize_librenms_text(value)
     return "" if text.lower() in _PLACEHOLDER_VALUES else text
 
 
@@ -316,7 +321,7 @@ class BaseModuleTableView(LibreNMSPermissionMixin, LibreNMSAPIMixin, CacheMixin,
         hints = [
             (item.get("entPhysicalName") or "").strip(),
             (item.get("entPhysicalDescr") or "").strip(),
-            (item.get("entPhysicalModelName") or "").strip(),
+            _normalize_librenms_text(item.get("entPhysicalModelName")),
         ]
         for hint in hints:
             if not hint:
@@ -771,7 +776,7 @@ class BaseModuleTableView(LibreNMSPermissionMixin, LibreNMSAPIMixin, CacheMixin,
             if action == "transparent":
                 continue
             # Skip items with generic model names (not real hardware), regardless of class.
-            model = (item.get("entPhysicalModelName") or "").strip().lower()
+            model = _normalize_librenms_text(item.get("entPhysicalModelName")).lower()
             if model in _GENERIC_CONTAINER_MODELS:
                 continue
             # Walk up ancestor chain; skip if any ancestor is an inventory-class item.
@@ -787,7 +792,7 @@ class BaseModuleTableView(LibreNMSPermissionMixin, LibreNMSAPIMixin, CacheMixin,
                     continue
                 anc_class = ancestor.get("entPhysicalClass")
                 if anc_class in INVENTORY_CLASSES:
-                    anc_model = (ancestor.get("entPhysicalModelName") or "").strip().lower()
+                    anc_model = _normalize_librenms_text(ancestor.get("entPhysicalModelName")).lower()
                     if anc_model in _GENERIC_CONTAINER_MODELS:
                         current_idx = ancestor.get("entPhysicalContainedIn", 0)
                         continue
@@ -1750,7 +1755,7 @@ class BaseModuleTableView(LibreNMSPermissionMixin, LibreNMSAPIMixin, CacheMixin,
                     device_serial=device_serial,
                 )
                 continue
-            model = (child.get("entPhysicalModelName") or "").strip().lower()
+            model = _normalize_librenms_text(child.get("entPhysicalModelName")).lower()
             if model and model not in _GENERIC_CONTAINER_MODELS:
                 results.append((depth, child))
                 # Continue looking for deeper components (e.g., SFPs inside converters)
@@ -2206,7 +2211,7 @@ class BaseModuleTableView(LibreNMSPermissionMixin, LibreNMSAPIMixin, CacheMixin,
         while current_idx and current_idx in index_map and current_idx not in visited:
             visited.add(current_idx)
             ancestor = index_map[current_idx]
-            model = (ancestor.get("entPhysicalModelName") or "").strip().lower()
+            model = _normalize_librenms_text(ancestor.get("entPhysicalModelName")).lower()
             if model and model not in _GENERIC_CONTAINER_MODELS:
                 # Found the parent with a real model; container_idx is the intermediate container
                 break
@@ -2352,7 +2357,7 @@ class BaseModuleTableView(LibreNMSPermissionMixin, LibreNMSAPIMixin, CacheMixin,
             resolve_module_type,
         )
 
-        model_name = (item.get("entPhysicalModelName", "") or "").strip()
+        model_name = _normalize_librenms_text(item.get("entPhysicalModelName"))
         serial = _clean_librenms_value(item.get("entPhysicalSerialNum"))
         phys_class = item.get("entPhysicalClass", "")
         name = item.get("entPhysicalName", "") or "-"
@@ -3044,7 +3049,7 @@ class BaseModuleTableView(LibreNMSPermissionMixin, LibreNMSAPIMixin, CacheMixin,
         Returns None when the model name is blank — no meaningful mapping can
         be created without at least a model name to key on.
         """
-        model = (item.get("entPhysicalModelName") or "").strip()
+        model = _normalize_librenms_text(item.get("entPhysicalModelName"))
         if not model:
             return None
 
@@ -3083,7 +3088,7 @@ class BaseModuleTableView(LibreNMSPermissionMixin, LibreNMSAPIMixin, CacheMixin,
         there's nothing meaningful to pre-fill and the row can't be made
         installable by adding a type either.
         """
-        model = (item.get("entPhysicalModelName") or "").strip()
+        model = _normalize_librenms_text(item.get("entPhysicalModelName"))
         if not model:
             return None
 
@@ -3112,7 +3117,7 @@ class BaseModuleTableView(LibreNMSPermissionMixin, LibreNMSAPIMixin, CacheMixin,
         guess.  The message names each conflicting ``manufacturer / model``
         pair so the user can resolve the data issue in NetBox itself.
         """
-        model = (item.get("entPhysicalModelName") or "").strip()
+        model = _normalize_librenms_text(item.get("entPhysicalModelName"))
         if not model:
             return "LibreNMS did not report a model name for this item; cannot match to a NetBox ModuleType."
         if ambiguity_candidates:
@@ -3180,7 +3185,7 @@ class BaseModuleTableView(LibreNMSPermissionMixin, LibreNMSAPIMixin, CacheMixin,
         item_serial = _clean_librenms_value(item.get("entPhysicalSerialNum"))
         if not item_serial:
             return None
-        item_model = (item.get("entPhysicalModelName") or "").strip().lower()
+        item_model = _clean_librenms_value(item.get("entPhysicalModelName")).lower()
         if not item_model or item_model in _PLACEHOLDER_VALUES:
             return None
 
@@ -3197,7 +3202,7 @@ class BaseModuleTableView(LibreNMSPermissionMixin, LibreNMSAPIMixin, CacheMixin,
                 return None
             if anc_class in INVENTORY_CLASSES and anc_class not in {"container", "powerSupply", "fan"}:
                 anc_serial = _clean_librenms_value(ancestor.get("entPhysicalSerialNum"))
-                anc_model = (ancestor.get("entPhysicalModelName") or "").strip().lower()
+                anc_model = _clean_librenms_value(ancestor.get("entPhysicalModelName")).lower()
                 if anc_serial and anc_serial == item_serial and anc_model and anc_model == item_model:
                     return ancestor
             current_idx = ancestor.get("entPhysicalContainedIn", 0)

--- a/netbox_librenms_plugin/views/base/modules_view.py
+++ b/netbox_librenms_plugin/views/base/modules_view.py
@@ -319,8 +319,8 @@ class BaseModuleTableView(LibreNMSPermissionMixin, LibreNMSAPIMixin, CacheMixin,
 
         # Name/model hint fallback: common "<position>/..." prefixes.
         hints = [
-            (item.get("entPhysicalName") or "").strip(),
-            (item.get("entPhysicalDescr") or "").strip(),
+            _normalize_librenms_text(item.get("entPhysicalName")),
+            _normalize_librenms_text(item.get("entPhysicalDescr")),
             _normalize_librenms_text(item.get("entPhysicalModelName")),
         ]
         for hint in hints:

--- a/netbox_librenms_plugin/views/imports/actions.py
+++ b/netbox_librenms_plugin/views/imports/actions.py
@@ -1040,6 +1040,30 @@ class BulkImportDevicesView(LibreNMSPermissionMixin, LibreNMSAPIMixin, View):
         device_ids_to_import = [d for d in parsed_ids if d not in vm_imports]
         vm_ids_to_import = list(vm_imports.keys())
 
+        # Authorize the model add/change perms BEFORE the background dispatch and the collision
+        # pre-check below (mirrors ImportDevicesJob, which authorizes before its scan).
+        # require_write_permission() above only checks the plugin-settings perm, while the job would
+        # raise PermissionDenied only once it ran — leaving the caller with a doomed job and an
+        # "Import job started" message. The pre-check likewise surfaces NetBox collision details
+        # (object names + pks) in its modal. Enforce the same perm sets the import paths do, for
+        # every import, before either path starts.
+        required_import_perms = set()
+        if device_ids_to_import:
+            # Any device row may be flagged import_as_vm during validation; VC updates need change.
+            required_import_perms.update({"dcim.add_device", "dcim.change_device", "virtualization.add_virtualmachine"})
+        if vm_imports:
+            required_import_perms.add("virtualization.add_virtualmachine")
+        missing_import_perms = [p for p in sorted(required_import_perms) if not request.user.has_perm(p)]
+        if missing_import_perms:
+            deny_msg = f"You do not have permission to import these rows (missing: {', '.join(missing_import_perms)})."
+            messages.error(request, deny_msg)
+            if is_htmx:
+                # 200 + HX-Redirect, like the other denial paths: HTMX skips the swap on non-2xx.
+                return HttpResponse(
+                    "", headers={"HX-Redirect": reverse("plugins:netbox_librenms_plugin:librenms_import")}
+                )
+            return redirect("plugins:netbox_librenms_plugin:librenms_import")
+
         # Seed the shared device cache from ALREADY-cached entries only, before the
         # background-vs-sync decision. Reading the Django cache directly (not
         # fetch_device_with_cache, which falls through to the LibreNMS HTTP API on a miss)
@@ -1132,33 +1156,10 @@ class BulkImportDevicesView(LibreNMSPermissionMixin, LibreNMSAPIMixin, View):
                         f"Background job requested but no workers available. Importing {total_import_count} devices synchronously...",
                     )
 
-        # Authorize the model add/change perms BEFORE the collision pre-check below (mirrors
-        # ImportDevicesJob, which authorizes before its scan). require_write_permission() above only
-        # checks the plugin-settings perm, but the pre-check surfaces NetBox collision details (object
-        # names + pks) in the returned modal, and the import paths' own require_permissions runs only
-        # later — so a user with change_librenmssettings but without dcim.add_device could otherwise
-        # see that modal. Enforce the same perm sets the import paths do, for every synchronous import.
-        required_import_perms = set()
-        if device_ids_to_import:
-            # Any device row may be flagged import_as_vm during validation; VC updates need change.
-            required_import_perms.update({"dcim.add_device", "dcim.change_device", "virtualization.add_virtualmachine"})
-        if vm_imports:
-            required_import_perms.add("virtualization.add_virtualmachine")
-        missing_import_perms = [p for p in sorted(required_import_perms) if not request.user.has_perm(p)]
-        if missing_import_perms:
-            deny_msg = f"You do not have permission to import these rows (missing: {', '.join(missing_import_perms)})."
-            messages.error(request, deny_msg)
-            if is_htmx:
-                # 200 + HX-Redirect, like the other denial paths: HTMX skips the swap on non-2xx.
-                return HttpResponse(
-                    "", headers={"HX-Redirect": reverse("plugins:netbox_librenms_plugin:librenms_import")}
-                )
-            return redirect("plugins:netbox_librenms_plugin:librenms_import")
-
         # Re-run the same-NetBox-device collision check the confirm modal performs. The confirm
         # preview is advisory only — a re-submitted stale confirm form or a scripted POST reaches
         # this view directly — so block a colliding batch here too. This runs on the SYNCHRONOUS
-        # path only: it sits AFTER the background-job dispatch above, so a batch that enqueued a job
+        # path only: it sits after the background-job dispatch above, so a batch that enqueued a job
         # doesn't pay this validation cost synchronously (ImportDevicesJob re-runs the same check).
         # A single selected device can never collide (collisions need two distinct LibreNMS ids on
         # one NetBox object), so skip the extra validation pass for the common single-row case.

--- a/netbox_librenms_plugin/views/imports/actions.py
+++ b/netbox_librenms_plugin/views/imports/actions.py
@@ -1695,7 +1695,9 @@ class DeviceConflictActionView(
                 # best-effort guard for different devices; a DB unique constraint
                 # would be needed for full protection.
                 try:
-                    existing_device = Device.objects.select_for_update().get(pk=existing_device.pk)
+                    existing_device = (
+                        self.restricted_queryset(Device, "change").select_for_update().get(pk=existing_device.pk)
+                    )
                 except Device.DoesNotExist:
                     return _htmx_error_response("Device no longer exists; it may have been deleted concurrently.")
                 try:
@@ -1804,7 +1806,9 @@ class DeviceConflictActionView(
             if incoming_serial and incoming_serial != "-":
                 with transaction.atomic():
                     try:
-                        locked_device = Device.objects.select_for_update().get(pk=existing_device.pk)
+                        locked_device = (
+                            self.restricted_queryset(Device, "change").select_for_update().get(pk=existing_device.pk)
+                        )
                     except Device.DoesNotExist:
                         return _htmx_error_response("Device no longer exists; it may have been deleted concurrently.")
                     # Re-check for serial ownership conflict under the locks, on the LOCKED row.
@@ -1883,7 +1887,11 @@ class DeviceConflictActionView(
                 )
             with transaction.atomic():
                 try:
-                    locked_device = existing_model.objects.select_for_update().get(pk=existing_device.pk)
+                    locked_device = (
+                        self.restricted_queryset(existing_model, "change")
+                        .select_for_update()
+                        .get(pk=existing_device.pk)
+                    )
                 except existing_model.DoesNotExist:
                     return _htmx_error_response("Object no longer exists; it may have been deleted concurrently.")
                 # Re-check under lock — another request may have already migrated it
@@ -2000,7 +2008,7 @@ class AddDeviceTypeMappingView(
             return _htmx_error_response("Invalid device type selection.")
 
         try:
-            device_type = DeviceType.objects.get(pk=device_type_id)
+            device_type = self.restricted_queryset(DeviceType).get(pk=device_type_id)
         except DeviceType.DoesNotExist:
             return _htmx_error_response("Selected device type not found.")
 
@@ -2259,6 +2267,10 @@ class CreatePlatformFromImportView(
         perms = [("add", Platform)]
         if target_model is not None:
             perms.append(("change", target_model))
+        # When a manufacturer is posted it is resolved by client-supplied id through a restricted
+        # queryset, so state that read in the gate.
+        if (request.POST.get("manufacturer") or "").strip():
+            perms.append(("view", Manufacturer))
         self.required_object_permissions = {"POST": perms}
 
         if error := self.require_object_permissions("POST"):
@@ -2276,7 +2288,7 @@ class CreatePlatformFromImportView(
         manufacturer = None
         if manufacturer_id:
             try:
-                manufacturer = Manufacturer.objects.get(pk=int(manufacturer_id))
+                manufacturer = self.restricted_queryset(Manufacturer).get(pk=int(manufacturer_id))
             except (Manufacturer.DoesNotExist, ValueError, TypeError):
                 # The user explicitly submitted a manufacturer; a stale/tampered id must be
                 # rejected, not silently dropped to None (which would persist a Platform with
@@ -2399,7 +2411,7 @@ class CreatePlatformFromImportView(
         if target_model is not None and target_pk is not None:
             try:
                 with transaction.atomic():
-                    target = target_model.objects.select_for_update().get(pk=target_pk)
+                    target = self.restricted_queryset(target_model, "change").select_for_update().get(pk=target_pk)
                     target.platform = platform
                     target.full_clean()
                     target.save()
@@ -2569,7 +2581,7 @@ class AddAsOOBView(
 
         with transaction.atomic():
             try:
-                sync_device = Device.objects.select_for_update().get(pk=sync_device.pk)
+                sync_device = self.restricted_queryset(Device, "change").select_for_update().get(pk=sync_device.pk)
             except Device.DoesNotExist:
                 return _htmx_error_response("Device no longer exists; it may have been deleted concurrently.")
 
@@ -2957,7 +2969,14 @@ class AddAsOOBView(
         if iface_id:
             try:
                 # Lock the reused row too (same orphan-on-concurrent-delete reasoning).
-                return Interface.objects.select_for_update().get(pk=int(iface_id), device=device), None
+                # Scoped like every other client-supplied id: the device filter proves where the
+                # interface sits, not that the caller's grant covers it.
+                return (
+                    Interface.objects.restrict(request.user, "view")
+                    .select_for_update()
+                    .get(pk=int(iface_id), device=device),
+                    None,
+                )
             except (Interface.DoesNotExist, ValueError):
                 return None, None
         return None, None
@@ -3645,7 +3664,7 @@ class AddPlatformMappingView(
             return _htmx_error_response("Invalid platform selection.")
 
         try:
-            platform = Platform.objects.get(pk=platform_id)
+            platform = self.restricted_queryset(Platform).get(pk=platform_id)
         except Platform.DoesNotExist:
             return _htmx_error_response("Selected platform not found.")
 

--- a/netbox_librenms_plugin/views/imports/actions.py
+++ b/netbox_librenms_plugin/views/imports/actions.py
@@ -1180,7 +1180,7 @@ class BulkImportDevicesView(LibreNMSPermissionMixin, LibreNMSAPIMixin, View):
                     return render(
                         request,
                         "netbox_librenms_plugin/htmx/bulk_import_collision.html",
-                        {"collisions": outcome.collisions},
+                        {"collisions": outcome.collisions, "oob": True},
                     )
                 messages.error(request, outcome.block_message)
                 return redirect("plugins:netbox_librenms_plugin:librenms_import")

--- a/netbox_librenms_plugin/views/imports/actions.py
+++ b/netbox_librenms_plugin/views/imports/actions.py
@@ -1049,8 +1049,7 @@ class BulkImportDevicesView(LibreNMSPermissionMixin, LibreNMSAPIMixin, View):
         # every import, before either path starts.
         required_import_perms = set()
         if device_ids_to_import:
-            # Any device row may be flagged import_as_vm during validation; VC updates need change.
-            required_import_perms.update({"dcim.add_device", "dcim.change_device", "virtualization.add_virtualmachine"})
+            required_import_perms.update({"dcim.add_device", "dcim.change_device"})
         if vm_imports:
             required_import_perms.add("virtualization.add_virtualmachine")
         missing_import_perms = [p for p in sorted(required_import_perms) if not request.user.has_perm(p)]

--- a/netbox_librenms_plugin/views/imports/actions.py
+++ b/netbox_librenms_plugin/views/imports/actions.py
@@ -25,6 +25,7 @@ from netbox_librenms_plugin.import_utils import (
     _determine_device_name,
     bulk_import_devices,
     bulk_import_vms,
+    classify_bulk_precheck,
     detect_bulk_collisions,
     detect_collisions_for_device_ids,
     fetch_device_with_cache,
@@ -1057,62 +1058,6 @@ class BulkImportDevicesView(LibreNMSPermissionMixin, LibreNMSAPIMixin, View):
             if cached_device
         }
 
-        # Re-run the same-NetBox-device collision check the confirm modal performs. The confirm
-        # preview is advisory only — a re-submitted stale confirm form, a scripted POST, or the
-        # "run as background job" path reaches this view directly. Block a colliding batch here
-        # (and again in ImportDevicesJob) so it can't be imported by bypassing the preview.
-        # A single selected device can never collide (collisions need two distinct LibreNMS ids
-        # on one NetBox device), so skip the extra validation pass for the common single-row case.
-        collisions, unresolved = (
-            detect_collisions_for_device_ids(
-                parsed_ids,
-                self.librenms_api,
-                libre_devices_cache=libre_devices_cache,
-                sync_options=sync_options,
-                # Each row validates in its actual import mode: a VM row checked in Device mode
-                # would run the serial/IP matching bulk_import_vms skips and could fabricate a
-                # collision that blocks a valid batch.
-                vm_device_ids=vm_imports,
-            )
-            if len(parsed_ids) >= 2
-            else ([], [])
-        )
-        if unresolved:
-            # Fail closed: these ids couldn't be fetched to collision-check, so block rather than
-            # import them unchecked (mirrors ImportDevicesJob). A transient get_device_info miss
-            # could otherwise let a colliding row through on retry.
-            ids = ", ".join(str(d) for d in unresolved)
-            # Object-neutral wording (row(s), not device(s)): parsed_ids includes VM rows via
-            # vm_device_ids=vm_imports, so a VM-only batch must not be mislabelled — matches
-            # the deliberately neutral copy in ImportDevicesJob.
-            msg = (
-                f"Bulk import blocked: could not fetch LibreNMS device info for {len(unresolved)} "
-                f"selected row(s) (id(s): {ids}) to verify collisions. Retry the import."
-            )
-            if is_htmx:
-                # 200, like the collision step: HTMX skips the swap on non-2xx.
-                return render(
-                    request,
-                    "netbox_librenms_plugin/htmx/bulk_import_collision.html",
-                    {"error_message": msg},
-                )
-            messages.error(request, msg)
-            return redirect("plugins:netbox_librenms_plugin:librenms_import")
-        if collisions:
-            if is_htmx:
-                # 200, like the confirm step: HTMX skips the swap on non-2xx.
-                return render(
-                    request,
-                    "netbox_librenms_plugin/htmx/bulk_import_collision.html",
-                    {"collisions": collisions},
-                )
-            messages.error(
-                request,
-                "Bulk import blocked: two or more selected LibreNMS devices resolve to the same "
-                "NetBox object. Resolve each colliding object individually, or deselect the duplicates.",
-            )
-            return redirect("plugins:netbox_librenms_plugin:librenms_import")
-
         # Check if we should use background job for import
         total_import_count = len(parsed_ids)
 
@@ -1186,6 +1131,48 @@ class BulkImportDevicesView(LibreNMSPermissionMixin, LibreNMSAPIMixin, View):
                         request,
                         f"Background job requested but no workers available. Importing {total_import_count} devices synchronously...",
                     )
+
+        # Re-run the same-NetBox-device collision check the confirm modal performs. The confirm
+        # preview is advisory only — a re-submitted stale confirm form or a scripted POST reaches
+        # this view directly — so block a colliding batch here too. This runs on the SYNCHRONOUS
+        # path only: it sits AFTER the background-job dispatch above, so a batch that enqueued a job
+        # doesn't pay this validation cost synchronously (ImportDevicesJob re-runs the same check).
+        # A single selected device can never collide (collisions need two distinct LibreNMS ids on
+        # one NetBox object), so skip the extra validation pass for the common single-row case.
+        precheck_skip_msg = None
+        if len(parsed_ids) >= 2:
+            collisions, unresolved = detect_collisions_for_device_ids(
+                parsed_ids,
+                self.librenms_api,
+                libre_devices_cache=libre_devices_cache,
+                sync_options=sync_options,
+                # Each row validates in its actual import mode: a VM row checked in Device mode
+                # would run the serial/IP matching bulk_import_vms skips and could fabricate a
+                # collision that blocks a valid batch.
+                vm_device_ids=vm_imports,
+            )
+            outcome = classify_bulk_precheck(collisions, unresolved, device_ids_to_import, vm_imports)
+            if outcome.blocked:
+                # Genuine collision (two rows → one NetBox object): block the whole batch, exactly
+                # as the confirm modal does. Same shared wording ImportDevicesJob logs.
+                if is_htmx:
+                    # 200, like the confirm step: HTMX skips the swap on non-2xx.
+                    return render(
+                        request,
+                        "netbox_librenms_plugin/htmx/bulk_import_collision.html",
+                        {"collisions": outcome.collisions},
+                    )
+                messages.error(request, outcome.block_message)
+                return redirect("plugins:netbox_librenms_plugin:librenms_import")
+            if outcome.skipped_ids:
+                # Skip ONLY the rows that couldn't be fetched/validated to collision-check them
+                # (import the rest) rather than blocking the whole batch — a transient fetch miss on
+                # one row no longer drops the entire import. Those rows are not imported (importing
+                # an un-collision-checked row could bypass this guard); the skip is surfaced below.
+                device_ids_to_import = outcome.importable_device_ids
+                vm_imports = outcome.importable_vm_imports
+                vm_ids_to_import = list(vm_imports.keys())
+                precheck_skip_msg = outcome.skip_message
 
         # Synchronous import execution (reuses libre_devices_cache built above).
         # Import devices and VMs separately
@@ -1274,6 +1261,12 @@ class BulkImportDevicesView(LibreNMSPermissionMixin, LibreNMSAPIMixin, View):
             if not is_htmx:
                 messages.warning(request, _msg)
             htmx_toasts.append(("text-bg-warning", "mdi-alert", "Warning", _msg))
+        # Rows the collision pre-check couldn't fetch/validate were skipped (not imported) rather
+        # than blocking the whole batch; surface that so the user knows which rows to retry.
+        if precheck_skip_msg:
+            if not is_htmx:
+                messages.warning(request, precheck_skip_msg)
+            htmx_toasts.append(("text-bg-warning", "mdi-alert", "Warning", precheck_skip_msg))
 
         if request.headers.get("HX-Request"):
             # Return updated rows for all imported devices using HTMX OOB swaps

--- a/netbox_librenms_plugin/views/imports/actions.py
+++ b/netbox_librenms_plugin/views/imports/actions.py
@@ -1132,6 +1132,29 @@ class BulkImportDevicesView(LibreNMSPermissionMixin, LibreNMSAPIMixin, View):
                         f"Background job requested but no workers available. Importing {total_import_count} devices synchronously...",
                     )
 
+        # Authorize the model add/change perms BEFORE the collision pre-check below (mirrors
+        # ImportDevicesJob, which authorizes before its scan). require_write_permission() above only
+        # checks the plugin-settings perm, but the pre-check surfaces NetBox collision details (object
+        # names + pks) in the returned modal, and the import paths' own require_permissions runs only
+        # later — so a user with change_librenmssettings but without dcim.add_device could otherwise
+        # see that modal. Enforce the same perm sets the import paths do, for every synchronous import.
+        required_import_perms = set()
+        if device_ids_to_import:
+            # Any device row may be flagged import_as_vm during validation; VC updates need change.
+            required_import_perms.update({"dcim.add_device", "dcim.change_device", "virtualization.add_virtualmachine"})
+        if vm_imports:
+            required_import_perms.add("virtualization.add_virtualmachine")
+        missing_import_perms = [p for p in sorted(required_import_perms) if not request.user.has_perm(p)]
+        if missing_import_perms:
+            deny_msg = f"You do not have permission to import these rows (missing: {', '.join(missing_import_perms)})."
+            messages.error(request, deny_msg)
+            if is_htmx:
+                # 200 + HX-Redirect, like the other denial paths: HTMX skips the swap on non-2xx.
+                return HttpResponse(
+                    "", headers={"HX-Redirect": reverse("plugins:netbox_librenms_plugin:librenms_import")}
+                )
+            return redirect("plugins:netbox_librenms_plugin:librenms_import")
+
         # Re-run the same-NetBox-device collision check the confirm modal performs. The confirm
         # preview is advisory only — a re-submitted stale confirm form or a scripted POST reaches
         # this view directly — so block a colliding batch here too. This runs on the SYNCHRONOUS
@@ -3576,6 +3599,15 @@ class MergeNetBoxDevicesView(
                     if isinstance(oob_assigned, Interface):
                         locked_iface = Interface.objects.select_for_update().filter(pk=oob_assigned.pk).first()
                         if locked_iface is not None and locked_iface.device_id == winner.pk:
+                            # Refresh the cached GenericForeignKey on locked_oob_ip to the freshly
+                            # locked interface: set_device_ip_fk() re-reads locked_oob_ip.assigned_object
+                            # for its ownership check, but the GFK cache still holds the pre-lock
+                            # snapshot (the FK id fields didn't change, so Django won't re-query). A
+                            # concurrent move ONTO the winner landing between the assigned_object read
+                            # above and this lock would otherwise pass the locked-row gate here and then
+                            # be spuriously rejected against the stale device_id — mirrors the
+                            # freshen-after-lock pattern in migrate._reconcile_donor_device_ip_fks.
+                            locked_oob_ip.assigned_object = locked_iface
                             # set_device_ip_fk() re-checks the address is on a winner interface
                             # (verified above under lock) and assigns without saving — the batched
                             # donor-then-winner save below preserves the release-before-claim

--- a/netbox_librenms_plugin/views/imports/actions.py
+++ b/netbox_librenms_plugin/views/imports/actions.py
@@ -1063,13 +1063,31 @@ class BulkImportDevicesView(LibreNMSPermissionMixin, LibreNMSAPIMixin, View):
         # (and again in ImportDevicesJob) so it can't be imported by bypassing the preview.
         # A single selected device can never collide (collisions need two distinct LibreNMS ids
         # on one NetBox device), so skip the extra validation pass for the common single-row case.
-        collisions = (
+        collisions, unresolved = (
             detect_collisions_for_device_ids(
                 parsed_ids, self.librenms_api, libre_devices_cache=libre_devices_cache, sync_options=sync_options
             )
             if len(parsed_ids) >= 2
-            else []
+            else ([], [])
         )
+        if unresolved:
+            # Fail closed: these ids couldn't be fetched to collision-check, so block rather than
+            # import them unchecked (mirrors ImportDevicesJob). A transient get_device_info miss
+            # could otherwise let a colliding row through on retry.
+            ids = ", ".join(str(d) for d in unresolved)
+            msg = (
+                f"Bulk import blocked: could not fetch LibreNMS device info for {len(unresolved)} "
+                f"selected device(s) (id(s): {ids}) to verify collisions. Retry the import."
+            )
+            if is_htmx:
+                # 200, like the collision step: HTMX skips the swap on non-2xx.
+                return render(
+                    request,
+                    "netbox_librenms_plugin/htmx/bulk_import_collision.html",
+                    {"error_message": msg},
+                )
+            messages.error(request, msg)
+            return redirect("plugins:netbox_librenms_plugin:librenms_import")
         if collisions:
             if is_htmx:
                 # 200, like the confirm step: HTMX skips the swap on non-2xx.

--- a/netbox_librenms_plugin/views/imports/actions.py
+++ b/netbox_librenms_plugin/views/imports/actions.py
@@ -1696,7 +1696,9 @@ class DeviceConflictActionView(
                 # would be needed for full protection.
                 try:
                     existing_device = (
-                        self.restricted_queryset(Device, "change").select_for_update().get(pk=existing_device.pk)
+                        self.restricted_queryset(Device, "change")
+                        .select_for_update(of=("self",))
+                        .get(pk=existing_device.pk)
                     )
                 except Device.DoesNotExist:
                     return _htmx_error_response("Device no longer exists; it may have been deleted concurrently.")
@@ -1807,7 +1809,9 @@ class DeviceConflictActionView(
                 with transaction.atomic():
                     try:
                         locked_device = (
-                            self.restricted_queryset(Device, "change").select_for_update().get(pk=existing_device.pk)
+                            self.restricted_queryset(Device, "change")
+                            .select_for_update(of=("self",))
+                            .get(pk=existing_device.pk)
                         )
                     except Device.DoesNotExist:
                         return _htmx_error_response("Device no longer exists; it may have been deleted concurrently.")
@@ -1889,7 +1893,7 @@ class DeviceConflictActionView(
                 try:
                     locked_device = (
                         self.restricted_queryset(existing_model, "change")
-                        .select_for_update()
+                        .select_for_update(of=("self",))
                         .get(pk=existing_device.pk)
                     )
                 except existing_model.DoesNotExist:
@@ -2007,11 +2011,6 @@ class AddDeviceTypeMappingView(
         except (ValueError, TypeError):
             return _htmx_error_response("Invalid device type selection.")
 
-        try:
-            device_type = self.restricted_queryset(DeviceType).get(pk=device_type_id)
-        except DeviceType.DoesNotExist:
-            return _htmx_error_response("Selected device type not found.")
-
         # Reject ambiguous state up front: multiple case-variant rows for the same hardware
         # string mean .first() would silently mutate an arbitrary one and leave the duplicate
         # unresolved. Fetch [:2] once and reuse it for both the ambiguity check and the
@@ -2027,11 +2026,16 @@ class AddDeviceTypeMappingView(
         # actually needed: "add" for a new mapping, "change" for an update.
         existing_mapping = upfront_rows[0] if upfront_rows else None
         if existing_mapping:
-            self.required_object_permissions = {"POST": [("change", DeviceTypeMapping)]}
+            self.required_object_permissions = {"POST": [("view", DeviceType), ("change", DeviceTypeMapping)]}
         else:
-            self.required_object_permissions = {"POST": [("add", DeviceTypeMapping)]}
+            self.required_object_permissions = {"POST": [("view", DeviceType), ("add", DeviceTypeMapping)]}
         if error := self.require_object_permissions("POST"):
             return error
+
+        try:
+            device_type = self.restricted_queryset(DeviceType).get(pk=device_type_id)
+        except DeviceType.DoesNotExist:
+            return _htmx_error_response("Selected device type not found.")
 
         try:
             with transaction.atomic():
@@ -2056,13 +2060,15 @@ class AddDeviceTypeMappingView(
                     # if the locked row already maps to the same device type this is a no-op
                     # and the caller needs only the add permission they already passed above.
                     if locked.netbox_device_type_id != device_type_id:
-                        self.required_object_permissions = {"POST": [("change", DeviceTypeMapping)]}
+                        self.required_object_permissions = {
+                            "POST": [("view", DeviceType), ("change", DeviceTypeMapping)]
+                        }
                         if error := self.require_object_permissions("POST"):
                             return error
                 if existing_mapping and not locked:
                     # The mapping was deleted between our upfront read and the lock.
                     # We are about to CREATE a new row, so require add permission.
-                    self.required_object_permissions = {"POST": [("add", DeviceTypeMapping)]}
+                    self.required_object_permissions = {"POST": [("view", DeviceType), ("add", DeviceTypeMapping)]}
                     if error := self.require_object_permissions("POST"):
                         return error
                 if locked:
@@ -2411,7 +2417,11 @@ class CreatePlatformFromImportView(
         if target_model is not None and target_pk is not None:
             try:
                 with transaction.atomic():
-                    target = self.restricted_queryset(target_model, "change").select_for_update().get(pk=target_pk)
+                    target = (
+                        self.restricted_queryset(target_model, "change")
+                        .select_for_update(of=("self",))
+                        .get(pk=target_pk)
+                    )
                     target.platform = platform
                     target.full_clean()
                     target.save()
@@ -2581,7 +2591,9 @@ class AddAsOOBView(
 
         with transaction.atomic():
             try:
-                sync_device = self.restricted_queryset(Device, "change").select_for_update().get(pk=sync_device.pk)
+                sync_device = (
+                    self.restricted_queryset(Device, "change").select_for_update(of=("self",)).get(pk=sync_device.pk)
+                )
             except Device.DoesNotExist:
                 return _htmx_error_response("Device no longer exists; it may have been deleted concurrently.")
 
@@ -2973,7 +2985,7 @@ class AddAsOOBView(
                 # interface sits, not that the caller's grant covers it.
                 return (
                     Interface.objects.restrict(request.user, "view")
-                    .select_for_update()
+                    .select_for_update(of=("self",))
                     .get(pk=int(iface_id), device=device),
                     None,
                 )
@@ -3663,11 +3675,6 @@ class AddPlatformMappingView(
         except (ValueError, TypeError):
             return _htmx_error_response("Invalid platform selection.")
 
-        try:
-            platform = self.restricted_queryset(Platform).get(pk=platform_id)
-        except Platform.DoesNotExist:
-            return _htmx_error_response("Selected platform not found.")
-
         # Fetch [:2] once and reuse it for both the ambiguity check and the existing-mapping
         # resolution rather than a separate count() + first() (two queries for the same filter).
         # Mirrors AddDeviceTypeMappingView and the locked read below.
@@ -3678,10 +3685,18 @@ class AddPlatformMappingView(
             )
         existing_mapping = upfront_rows[0] if upfront_rows else None
         self.required_object_permissions = {
-            "POST": [("change", PlatformMapping) if existing_mapping else ("add", PlatformMapping)]
+            "POST": [
+                ("view", Platform),
+                ("change", PlatformMapping) if existing_mapping else ("add", PlatformMapping),
+            ]
         }
         if error := self.require_object_permissions("POST"):
             return error
+
+        try:
+            platform = self.restricted_queryset(Platform).get(pk=platform_id)
+        except Platform.DoesNotExist:
+            return _htmx_error_response("Selected platform not found.")
 
         try:
             with transaction.atomic():
@@ -3702,13 +3717,13 @@ class AddPlatformMappingView(
                     # Concurrent request created the mapping after our upfront read.
                     # Only escalate to change permission if we would actually mutate.
                     if locked.netbox_platform_id != platform_id:
-                        self.required_object_permissions = {"POST": [("change", PlatformMapping)]}
+                        self.required_object_permissions = {"POST": [("view", Platform), ("change", PlatformMapping)]}
                         if error := self.require_object_permissions("POST"):
                             return error
                 if existing_mapping and not locked:
                     # Mapping was deleted between our upfront read and the lock.
                     # We are about to CREATE a new row, so require add permission.
-                    self.required_object_permissions = {"POST": [("add", PlatformMapping)]}
+                    self.required_object_permissions = {"POST": [("view", Platform), ("add", PlatformMapping)]}
                     if error := self.require_object_permissions("POST"):
                         return error
                 if locked:

--- a/netbox_librenms_plugin/views/imports/actions.py
+++ b/netbox_librenms_plugin/views/imports/actions.py
@@ -32,6 +32,7 @@ from netbox_librenms_plugin.import_utils import (
     get_import_device_cache_key,
     get_librenms_device_by_id,
     get_virtual_chassis_data,
+    required_import_permissions,
     update_vc_member_suggested_names,
     validate_device_for_import,
 )
@@ -1047,12 +1048,8 @@ class BulkImportDevicesView(LibreNMSPermissionMixin, LibreNMSAPIMixin, View):
         # "Import job started" message. The pre-check likewise surfaces NetBox collision details
         # (object names + pks) in its modal. Enforce the same perm sets the import paths do, for
         # every import, before either path starts.
-        required_import_perms = set()
-        if device_ids_to_import:
-            required_import_perms.update({"dcim.add_device", "dcim.change_device"})
-        if vm_imports:
-            required_import_perms.add("virtualization.add_virtualmachine")
-        missing_import_perms = [p for p in sorted(required_import_perms) if not request.user.has_perm(p)]
+        required_import_perms = required_import_permissions(device_ids_to_import, vm_imports)
+        missing_import_perms = [p for p in required_import_perms if not request.user.has_perm(p)]
         if missing_import_perms:
             deny_msg = f"You do not have permission to import these rows (missing: {', '.join(missing_import_perms)})."
             messages.error(request, deny_msg)

--- a/netbox_librenms_plugin/views/imports/actions.py
+++ b/netbox_librenms_plugin/views/imports/actions.py
@@ -26,6 +26,7 @@ from netbox_librenms_plugin.import_utils import (
     bulk_import_devices,
     bulk_import_vms,
     detect_bulk_collisions,
+    detect_collisions_for_device_ids,
     fetch_device_with_cache,
     get_import_device_cache_key,
     get_librenms_device_by_id,
@@ -39,6 +40,7 @@ from netbox_librenms_plugin.import_validation_helpers import (
     apply_role_to_validation,
     extract_device_selections,
     fetch_model_by_id,
+    merge_candidate_pks,
 )
 from netbox_librenms_plugin.tables.device_status import DeviceImportTable
 from netbox_librenms_plugin.utils import (
@@ -894,7 +896,7 @@ class BulkImportConfirmView(LibreNMSPermissionMixin, LibreNMSAPIMixin, View):
             return render(
                 request,
                 "netbox_librenms_plugin/htmx/bulk_import_collision.html",
-                {"collisions": collisions, "device_count": len(devices)},
+                {"collisions": collisions},
             )
 
         return render(
@@ -1054,6 +1056,34 @@ class BulkImportDevicesView(LibreNMSPermissionMixin, LibreNMSAPIMixin, View):
             for key, cached_device in cache.get_many(list(key_to_device_id)).items()
             if cached_device
         }
+
+        # Re-run the same-NetBox-device collision check the confirm modal performs. The confirm
+        # preview is advisory only — a re-submitted stale confirm form, a scripted POST, or the
+        # "run as background job" path reaches this view directly. Block a colliding batch here
+        # (and again in ImportDevicesJob) so it can't be imported by bypassing the preview.
+        # A single selected device can never collide (collisions need two distinct LibreNMS ids
+        # on one NetBox device), so skip the extra validation pass for the common single-row case.
+        collisions = (
+            detect_collisions_for_device_ids(
+                parsed_ids, self.librenms_api, libre_devices_cache=libre_devices_cache, sync_options=sync_options
+            )
+            if len(parsed_ids) >= 2
+            else []
+        )
+        if collisions:
+            if is_htmx:
+                # 200, like the confirm step: HTMX skips the swap on non-2xx.
+                return render(
+                    request,
+                    "netbox_librenms_plugin/htmx/bulk_import_collision.html",
+                    {"collisions": collisions},
+                )
+            messages.error(
+                request,
+                "Bulk import blocked: two or more selected LibreNMS devices resolve to the same "
+                "NetBox device. Resolve each colliding device individually, or deselect the duplicates.",
+            )
+            return redirect("plugins:netbox_librenms_plugin:librenms_import")
 
         # Check if we should use background job for import
         total_import_count = len(parsed_ids)
@@ -3386,12 +3416,7 @@ class MergeNetBoxDevicesView(
         if not libre_device:
             return _htmx_error_response("LibreNMS device not found")
 
-        merge_candidates = (validation or {}).get("merge_candidates") or {}
-        candidate_pks = {
-            (merge_candidates.get("host_named") or {}).get("pk"),
-            (merge_candidates.get("oob_named") or {}).get("pk"),
-        }
-        candidate_pks.discard(None)
+        candidate_pks = merge_candidate_pks(validation)
         # Derive the donor from the selected winner. The merge is always between this fixed pair
         # of candidates, so the donor is unambiguously the other candidate and no client-supplied
         # donor state is needed. This also enforces that the winner is one of the two candidates.

--- a/netbox_librenms_plugin/views/imports/actions.py
+++ b/netbox_librenms_plugin/views/imports/actions.py
@@ -1082,9 +1082,12 @@ class BulkImportDevicesView(LibreNMSPermissionMixin, LibreNMSAPIMixin, View):
             # import them unchecked (mirrors ImportDevicesJob). A transient get_device_info miss
             # could otherwise let a colliding row through on retry.
             ids = ", ".join(str(d) for d in unresolved)
+            # Object-neutral wording (row(s), not device(s)): parsed_ids includes VM rows via
+            # vm_device_ids=vm_imports, so a VM-only batch must not be mislabelled — matches
+            # the deliberately neutral copy in ImportDevicesJob.
             msg = (
                 f"Bulk import blocked: could not fetch LibreNMS device info for {len(unresolved)} "
-                f"selected device(s) (id(s): {ids}) to verify collisions. Retry the import."
+                f"selected row(s) (id(s): {ids}) to verify collisions. Retry the import."
             )
             if is_htmx:
                 # 200, like the collision step: HTMX skips the swap on non-2xx.
@@ -1106,7 +1109,7 @@ class BulkImportDevicesView(LibreNMSPermissionMixin, LibreNMSAPIMixin, View):
             messages.error(
                 request,
                 "Bulk import blocked: two or more selected LibreNMS devices resolve to the same "
-                "NetBox device. Resolve each colliding device individually, or deselect the duplicates.",
+                "NetBox object. Resolve each colliding object individually, or deselect the duplicates.",
             )
             return redirect("plugins:netbox_librenms_plugin:librenms_import")
 

--- a/netbox_librenms_plugin/views/imports/actions.py
+++ b/netbox_librenms_plugin/views/imports/actions.py
@@ -25,6 +25,7 @@ from netbox_librenms_plugin.import_utils import (
     _determine_device_name,
     bulk_import_devices,
     bulk_import_vms,
+    detect_bulk_collisions,
     fetch_device_with_cache,
     get_import_device_cache_key,
     get_librenms_device_by_id,
@@ -882,6 +883,19 @@ class BulkImportConfirmView(LibreNMSPermissionMixin, LibreNMSAPIMixin, View):
             "server_key": self.librenms_api.server_key,
             "vc_detection_enabled": vc_detection_enabled,
         }
+
+        collisions = detect_bulk_collisions(devices)
+        if collisions:
+            # Render at 200 (not 4xx): this is an interstitial modal swapped
+            # into #htmx-modal-content, exactly like the confirm step. A non-2xx
+            # status makes HTMX skip the swap and route the body through
+            # htmx:responseError -> showErrorToast(), which would dump the
+            # collision template as raw text in a toast.
+            return render(
+                request,
+                "netbox_librenms_plugin/htmx/bulk_import_collision.html",
+                {"collisions": collisions, "device_count": len(devices)},
+            )
 
         return render(
             request,

--- a/netbox_librenms_plugin/views/imports/actions.py
+++ b/netbox_librenms_plugin/views/imports/actions.py
@@ -1065,7 +1065,14 @@ class BulkImportDevicesView(LibreNMSPermissionMixin, LibreNMSAPIMixin, View):
         # on one NetBox device), so skip the extra validation pass for the common single-row case.
         collisions, unresolved = (
             detect_collisions_for_device_ids(
-                parsed_ids, self.librenms_api, libre_devices_cache=libre_devices_cache, sync_options=sync_options
+                parsed_ids,
+                self.librenms_api,
+                libre_devices_cache=libre_devices_cache,
+                sync_options=sync_options,
+                # Each row validates in its actual import mode: a VM row checked in Device mode
+                # would run the serial/IP matching bulk_import_vms skips and could fabricate a
+                # collision that blocks a valid batch.
+                vm_device_ids=vm_imports,
             )
             if len(parsed_ids) >= 2
             else ([], [])

--- a/netbox_librenms_plugin/views/mixins.py
+++ b/netbox_librenms_plugin/views/mixins.py
@@ -344,7 +344,7 @@ class NetBoxObjectPermissionMixin:
         """
         return model.objects.restrict(self.request.user, action)
 
-    def restrict_object_or_404(self, model, action="view", **kwargs):
+    def restrict_object_or_404(self, model, action="view", select_related=(), **kwargs):
         """
         Resolve one object through :meth:`restricted_queryset` (fail-closed lookup).
 
@@ -354,12 +354,17 @@ class NetBoxObjectPermissionMixin:
         Args:
             model: A NetBox model whose manager is a ``RestrictedQuerySet``.
             action: The permission action to scope by (default ``"view"``).
+            select_related: Relations to join in the same query, for a caller that reads them right
+                after (the plain ``Model.objects.select_related(...)`` form would skip the scoping).
             **kwargs: Lookup kwargs forwarded to ``get_object_or_404`` (e.g. ``pk=...``).
 
         Returns:
             The resolved object the user is permitted to access.
         """
-        return get_object_or_404(self.restricted_queryset(model, action), **kwargs)
+        queryset = self.restricted_queryset(model, action)
+        if select_related:
+            queryset = queryset.select_related(*select_related)
+        return get_object_or_404(queryset, **kwargs)
 
     def require_all_permissions(self, method="POST"):
         """

--- a/netbox_librenms_plugin/views/object_sync/devices.py
+++ b/netbox_librenms_plugin/views/object_sync/devices.py
@@ -5,7 +5,7 @@ from django.core.cache import cache
 from django.http import JsonResponse
 from django.urls import reverse
 from django.views import View
-from ipam.models import VLAN
+from ipam.models import VLAN, VLANGroup
 from utilities.views import ViewTab, register_model_view
 
 from netbox_librenms_plugin.constants import PERM_VIEW_PLUGIN
@@ -374,11 +374,9 @@ class SingleVlanGroupVerifyView(LibreNMSPermissionMixin, NetBoxObjectPermissionM
 
     # Read-only verify endpoint that surfaces a device's interface VLAN assignments —
     # require object-view permission on the underlying Device (mirrors the other verify views).
-    required_object_permissions = {"POST": [("view", Device)]}
+    required_object_permissions = {"POST": [("view", Device), ("view", VLANGroup)]}
 
     def post(self, request):
-        from ipam.models import VLANGroup
-
         data, err = parse_request_json(request)
         if err:
             return err
@@ -513,11 +511,9 @@ class VerifyVlanSyncGroupView(LibreNMSPermissionMixin, NetBoxObjectPermissionMix
     # Read-only verify endpoint that surfaces NetBox VLAN existence + names — require
     # object-view permission on VLAN (there is no device in scope here, unlike the other
     # verify views), so an unauthorized caller can't enumerate VLANs/groups.
-    required_object_permissions = {"POST": [("view", VLAN)]}
+    required_object_permissions = {"POST": [("view", VLAN), ("view", VLANGroup)]}
 
     def post(self, request):
-        from ipam.models import VLANGroup
-
         data, err = parse_request_json(request)
         if err:
             return err

--- a/netbox_librenms_plugin/views/object_sync/devices.py
+++ b/netbox_librenms_plugin/views/object_sync/devices.py
@@ -374,7 +374,7 @@ class SingleVlanGroupVerifyView(LibreNMSPermissionMixin, NetBoxObjectPermissionM
 
     # Read-only verify endpoint that surfaces a device's interface VLAN assignments —
     # require object-view permission on the underlying Device (mirrors the other verify views).
-    required_object_permissions = {"POST": [("view", Device), ("view", VLANGroup)]}
+    required_object_permissions = {"POST": [("view", Device), ("view", VLANGroup), ("view", VLAN)]}
 
     def post(self, request):
         data, err = parse_request_json(request)

--- a/netbox_librenms_plugin/views/object_sync/devices.py
+++ b/netbox_librenms_plugin/views/object_sync/devices.py
@@ -404,15 +404,16 @@ class SingleVlanGroupVerifyView(LibreNMSPermissionMixin, NetBoxObjectPermissionM
             return JsonResponse({"status": "error", "message": "Invalid VID"}, status=400)
 
         # Build lookup for the selected group
+        visible_vlans = self.restricted_queryset(VLAN)
         if vlan_group_id:
             vlan_group = self.restrict_object_or_404(VLANGroup, pk=vlan_group_id)
             # Get VLANs in selected group + global VLANs
-            group_vids = set(VLAN.objects.filter(group=vlan_group).values_list("vid", flat=True))
-            global_vids = set(VLAN.objects.filter(group__isnull=True).values_list("vid", flat=True))
+            group_vids = set(visible_vlans.filter(group=vlan_group).values_list("vid", flat=True))
+            global_vids = set(visible_vlans.filter(group__isnull=True).values_list("vid", flat=True))
             available_vids = group_vids | global_vids
         else:
             # No group selected - use global VLANs only
-            available_vids = set(VLAN.objects.filter(group__isnull=True).values_list("vid", flat=True))
+            available_vids = set(visible_vlans.filter(group__isnull=True).values_list("vid", flat=True))
 
         # Compute whether VID is missing from selected group
         is_missing = vid not in available_vids
@@ -533,12 +534,13 @@ class VerifyVlanSyncGroupView(LibreNMSPermissionMixin, NetBoxObjectPermissionMix
             return JsonResponse({"status": "error", "message": "Invalid VID"}, status=400)
 
         # Check if VLAN exists in the selected group (or globally)
+        visible_vlans = self.restricted_queryset(VLAN)
         if vlan_group_id:
             vlan_group = self.restrict_object_or_404(VLANGroup, pk=vlan_group_id)
-            netbox_vlan = VLAN.objects.filter(vid=vid, group=vlan_group).first()
+            netbox_vlan = visible_vlans.filter(vid=vid, group=vlan_group).first()
         else:
             # No group = global VLANs
-            netbox_vlan = VLAN.objects.filter(vid=vid, group__isnull=True).first()
+            netbox_vlan = visible_vlans.filter(vid=vid, group__isnull=True).first()
 
         exists_in_netbox = bool(netbox_vlan)
         name_matches = netbox_vlan.name == librenms_name if netbox_vlan else False

--- a/netbox_librenms_plugin/views/object_sync/devices.py
+++ b/netbox_librenms_plugin/views/object_sync/devices.py
@@ -3,7 +3,6 @@ import copy
 from dcim.models import Device
 from django.core.cache import cache
 from django.http import JsonResponse
-from django.shortcuts import get_object_or_404
 from django.urls import reverse
 from django.views import View
 from ipam.models import VLAN
@@ -408,7 +407,7 @@ class SingleVlanGroupVerifyView(LibreNMSPermissionMixin, NetBoxObjectPermissionM
 
         # Build lookup for the selected group
         if vlan_group_id:
-            vlan_group = get_object_or_404(VLANGroup, pk=vlan_group_id)
+            vlan_group = self.restrict_object_or_404(VLANGroup, pk=vlan_group_id)
             # Get VLANs in selected group + global VLANs
             group_vids = set(VLAN.objects.filter(group=vlan_group).values_list("vid", flat=True))
             global_vids = set(VLAN.objects.filter(group__isnull=True).values_list("vid", flat=True))
@@ -539,7 +538,7 @@ class VerifyVlanSyncGroupView(LibreNMSPermissionMixin, NetBoxObjectPermissionMix
 
         # Check if VLAN exists in the selected group (or globally)
         if vlan_group_id:
-            vlan_group = get_object_or_404(VLANGroup, pk=vlan_group_id)
+            vlan_group = self.restrict_object_or_404(VLANGroup, pk=vlan_group_id)
             netbox_vlan = VLAN.objects.filter(vid=vid, group=vlan_group).first()
         else:
             # No group = global VLANs

--- a/netbox_librenms_plugin/views/sync/cables.py
+++ b/netbox_librenms_plugin/views/sync/cables.py
@@ -168,41 +168,41 @@ class SyncCablesView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixin, Libre
 
         try:
             local_interface = self.restricted_queryset(Interface).get(pk=link_data["netbox_local_interface_id"])
+        except Interface.DoesNotExist:
+            return {"status": "invalid", "interface": display_name}
 
-            # Honour user's VC member selection: if the selected device_id differs from
-            # the cached interface's device, look up the same port name on that device.
-            selected_device_id = interface.get("device_id")
-            if selected_device_id and str(local_interface.device_id) != str(selected_device_id):
-                if not self._selected_device_is_in_page_context(selected_device_id):
-                    logger.debug(
-                        "Selected device %s is outside the cable-sync page context; rejecting cable creation",
-                        selected_device_id,
-                    )
-                    return {"status": "rejected_selection", "interface": display_name}
-                port_name = link_data.get("local_port") or local_interface.name
-                try:
-                    local_interface = self.restricted_queryset(Interface).get(
-                        device_id=selected_device_id, name=port_name
-                    )
-                except Interface.DoesNotExist:
-                    logger.debug(
-                        "Port %s not found on selected device %s; rejecting cable creation",
-                        port_name,
-                        selected_device_id,
-                    )
-                    return {"status": "invalid", "interface": display_name}
+        # Honour user's VC member selection: if the selected device_id differs from
+        # the cached interface's device, look up the same port name on that device.
+        selected_device_id = interface.get("device_id")
+        if selected_device_id and str(local_interface.device_id) != str(selected_device_id):
+            if not self._selected_device_is_in_page_context(selected_device_id):
+                logger.debug(
+                    "Selected device %s is outside the cable-sync page context; rejecting cable creation",
+                    selected_device_id,
+                )
+                return {"status": "rejected_selection", "interface": display_name}
+            port_name = link_data.get("local_port") or local_interface.name
+            try:
+                local_interface = self.restricted_queryset(Interface).get(device_id=selected_device_id, name=port_name)
+            except Interface.DoesNotExist:
+                logger.debug(
+                    "Port %s not found on selected device %s; rejecting cable creation",
+                    port_name,
+                    selected_device_id,
+                )
+                return {"status": "invalid", "interface": display_name}
 
+        try:
             remote_interface = self.restricted_queryset(Interface).get(pk=link_data["netbox_remote_interface_id"])
-
-            if self.check_existing_cable(local_interface, remote_interface):
-                return {"status": "duplicate", "interface": display_name}
-
-            if self.create_cable(local_interface, remote_interface, self.request):
-                return {"status": "valid", "interface": display_name}
-            return {"status": "invalid", "interface": display_name}  # pragma: no cover
-
         except Interface.DoesNotExist:
             return {"status": "missing_remote", "interface": display_name}
+
+        if self.check_existing_cable(local_interface, remote_interface):
+            return {"status": "duplicate", "interface": display_name}
+
+        if self.create_cable(local_interface, remote_interface, self.request):
+            return {"status": "valid", "interface": display_name}
+        return {"status": "invalid", "interface": display_name}  # pragma: no cover
 
     def process_interface_sync(self, selected_interfaces, cached_links):
         """

--- a/netbox_librenms_plugin/views/sync/cables.py
+++ b/netbox_librenms_plugin/views/sync/cables.py
@@ -172,11 +172,13 @@ class SyncCablesView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixin, Libre
             # Honour user's VC member selection: if the selected device_id differs from
             # the cached interface's device, look up the same port name on that device.
             selected_device_id = interface.get("device_id")
-            if (
-                selected_device_id
-                and str(local_interface.device_id) != str(selected_device_id)
-                and self._selected_device_is_in_page_context(selected_device_id)
-            ):
+            if selected_device_id and str(local_interface.device_id) != str(selected_device_id):
+                if not self._selected_device_is_in_page_context(selected_device_id):
+                    logger.debug(
+                        "Selected device %s is outside the cable-sync page context; rejecting cable creation",
+                        selected_device_id,
+                    )
+                    return {"status": "invalid", "interface": display_name}
                 port_name = link_data.get("local_port") or local_interface.name
                 try:
                     local_interface = self.restricted_queryset(Interface).get(

--- a/netbox_librenms_plugin/views/sync/cables.py
+++ b/netbox_librenms_plugin/views/sync/cables.py
@@ -31,6 +31,9 @@ class SyncCablesView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixin, Libre
             # queryset, so state that read here: a missing grant is then an explicit 403
             # rather than a puzzling 404 at the lookup.
             ("view", Device),
+            # Both cable terminations are resolved by client-supplied id below, through a
+            # restricted queryset for the same reason.
+            ("view", Interface),
             ("add", Cable),
             ("change", Cable),
         ],
@@ -150,7 +153,7 @@ class SyncCablesView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixin, Libre
             return {"status": "invalid", "interface": display_name}
 
         try:
-            local_interface = Interface.objects.get(pk=link_data["netbox_local_interface_id"])
+            local_interface = self.restricted_queryset(Interface).get(pk=link_data["netbox_local_interface_id"])
 
             # Honour user's VC member selection: if the selected device_id differs from
             # the cached interface's device, look up the same port name on that device.
@@ -158,7 +161,9 @@ class SyncCablesView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixin, Libre
             if selected_device_id and str(local_interface.device_id) != str(selected_device_id):
                 port_name = link_data.get("local_port") or local_interface.name
                 try:
-                    local_interface = Interface.objects.get(device_id=selected_device_id, name=port_name)
+                    local_interface = self.restricted_queryset(Interface).get(
+                        device_id=selected_device_id, name=port_name
+                    )
                 except Interface.DoesNotExist:
                     logger.debug(
                         "Port %s not found on device %s; falling back to cached interface",
@@ -166,7 +171,7 @@ class SyncCablesView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixin, Libre
                         selected_device_id,
                     )
 
-            remote_interface = Interface.objects.get(pk=link_data["netbox_remote_interface_id"])
+            remote_interface = self.restricted_queryset(Interface).get(pk=link_data["netbox_remote_interface_id"])
 
             if self.check_existing_cable(local_interface, remote_interface):
                 return {"status": "duplicate", "interface": display_name}

--- a/netbox_librenms_plugin/views/sync/cables.py
+++ b/netbox_librenms_plugin/views/sync/cables.py
@@ -184,10 +184,11 @@ class SyncCablesView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixin, Libre
                     )
                 except Interface.DoesNotExist:
                     logger.debug(
-                        "Port %s not found on device %s; falling back to cached interface",
+                        "Port %s not found on selected device %s; rejecting cable creation",
                         port_name,
                         selected_device_id,
                     )
+                    return {"status": "invalid", "interface": display_name}
 
             remote_interface = self.restricted_queryset(Interface).get(pk=link_data["netbox_remote_interface_id"])
 

--- a/netbox_librenms_plugin/views/sync/cables.py
+++ b/netbox_librenms_plugin/views/sync/cables.py
@@ -31,9 +31,9 @@ class SyncCablesView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixin, Libre
             # queryset, so state that read here: a missing grant is then an explicit 403
             # rather than a puzzling 404 at the lookup.
             ("view", Device),
-            # Both cable terminations are resolved by client-supplied id below, through a
-            # restricted queryset for the same reason.
-            ("view", Interface),
+            # Creating a cable changes the cable state of both terminations. Resolve the
+            # client-supplied ids through the same change scope NetBox's cable form uses.
+            ("change", Interface),
             ("add", Cable),
             ("change", Cable),
         ],
@@ -167,7 +167,9 @@ class SyncCablesView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixin, Libre
             return {"status": "invalid", "interface": display_name}
 
         try:
-            local_interface = self.restricted_queryset(Interface).get(pk=link_data["netbox_local_interface_id"])
+            local_interface = self.restricted_queryset(Interface, "change").get(
+                pk=link_data["netbox_local_interface_id"]
+            )
         except Interface.DoesNotExist:
             return {"status": "invalid", "interface": display_name}
 
@@ -183,7 +185,10 @@ class SyncCablesView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixin, Libre
                 return {"status": "rejected_selection", "interface": display_name}
             port_name = link_data.get("local_port") or local_interface.name
             try:
-                local_interface = self.restricted_queryset(Interface).get(device_id=selected_device_id, name=port_name)
+                local_interface = self.restricted_queryset(Interface, "change").get(
+                    device_id=selected_device_id,
+                    name=port_name,
+                )
             except Interface.DoesNotExist:
                 logger.debug(
                     "Port %s not found on selected device %s; rejecting cable creation",
@@ -193,7 +198,9 @@ class SyncCablesView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixin, Libre
                 return {"status": "invalid", "interface": display_name}
 
         try:
-            remote_interface = self.restricted_queryset(Interface).get(pk=link_data["netbox_remote_interface_id"])
+            remote_interface = self.restricted_queryset(Interface, "change").get(
+                pk=link_data["netbox_remote_interface_id"]
+            )
         except Interface.DoesNotExist:
             return {"status": "missing_remote", "interface": display_name}
 

--- a/netbox_librenms_plugin/views/sync/cables.py
+++ b/netbox_librenms_plugin/views/sync/cables.py
@@ -178,7 +178,7 @@ class SyncCablesView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixin, Libre
                         "Selected device %s is outside the cable-sync page context; rejecting cable creation",
                         selected_device_id,
                     )
-                    return {"status": "invalid", "interface": display_name}
+                    return {"status": "rejected_selection", "interface": display_name}
                 port_name = link_data.get("local_port") or local_interface.name
                 try:
                     local_interface = self.restricted_queryset(Interface).get(
@@ -211,7 +211,14 @@ class SyncCablesView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixin, Libre
         Each interface is processed in its own atomic block so individual
         failures roll back only that cable without affecting others.
         """
-        results = {"valid": [], "invalid": [], "duplicate": [], "missing_remote": [], "skipped": []}
+        results = {
+            "valid": [],
+            "invalid": [],
+            "duplicate": [],
+            "missing_remote": [],
+            "rejected_selection": [],
+            "skipped": [],
+        }
 
         for interface in selected_interfaces:
             try:
@@ -261,6 +268,12 @@ class SyncCablesView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixin, Libre
             messages.error(
                 request,
                 f"No LibreNMS link data found for interfaces: {', '.join(results['invalid'])}",
+            )
+        if results.get("rejected_selection"):
+            messages.error(
+                request,
+                "Selected device is not part of this cable-sync page for interfaces: "
+                f"{', '.join(results['rejected_selection'])}",
             )
         if results["duplicate"]:
             messages.warning(

--- a/netbox_librenms_plugin/views/sync/cables.py
+++ b/netbox_librenms_plugin/views/sync/cables.py
@@ -7,7 +7,7 @@ from django.contrib.contenttypes.models import ContentType
 from django.core.cache import cache
 from django.db import transaction
 from django.db.models import Q
-from django.shortcuts import get_object_or_404, redirect
+from django.shortcuts import redirect
 from django.urls import reverse
 from django.views import View
 
@@ -27,6 +27,10 @@ class SyncCablesView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixin, Libre
 
     required_object_permissions = {
         "POST": [
+            # The device whose cable tab is being synced is resolved through a restricted
+            # queryset, so state that read here: a missing grant is then an explicit 403
+            # rather than a puzzling 404 at the lookup.
+            ("view", Device),
             ("add", Cable),
             ("change", Cable),
         ],
@@ -200,7 +204,7 @@ class SyncCablesView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixin, Libre
         if error := self.require_all_permissions("POST"):
             return error
 
-        initial_device = get_object_or_404(Device, pk=pk)
+        initial_device = self.restrict_object_or_404(Device, pk=pk)
         server_key = request.POST.get("server_key") or self.librenms_api.server_key
         self._post_server_key = server_key
         self._initial_device = initial_device

--- a/netbox_librenms_plugin/views/sync/cables.py
+++ b/netbox_librenms_plugin/views/sync/cables.py
@@ -144,6 +144,20 @@ class SyncCablesView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixin, Libre
 
         return all(link_data.get(field) for field in required_fields)
 
+    def _selected_device_is_in_page_context(self, selected_device_id):
+        """Return whether a posted device is the page device or one of its VC members."""
+        initial_device = getattr(self, "_initial_device", None)
+        if initial_device is None:
+            return False
+        try:
+            selected_device_id = int(selected_device_id)
+        except (TypeError, ValueError):
+            return False
+        if selected_device_id == initial_device.pk:
+            return True
+        virtual_chassis = getattr(initial_device, "virtual_chassis", None)
+        return bool(virtual_chassis and virtual_chassis.members.filter(pk=selected_device_id).exists())
+
     def handle_cable_creation(self, link_data, interface):
         """Create a cable from link data and return the operation result."""
         display_name = link_data.get("local_port") or interface.get("local_port_id", "")
@@ -158,7 +172,11 @@ class SyncCablesView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixin, Libre
             # Honour user's VC member selection: if the selected device_id differs from
             # the cached interface's device, look up the same port name on that device.
             selected_device_id = interface.get("device_id")
-            if selected_device_id and str(local_interface.device_id) != str(selected_device_id):
+            if (
+                selected_device_id
+                and str(local_interface.device_id) != str(selected_device_id)
+                and self._selected_device_is_in_page_context(selected_device_id)
+            ):
                 port_name = link_data.get("local_port") or local_interface.name
                 try:
                     local_interface = self.restricted_queryset(Interface).get(

--- a/netbox_librenms_plugin/views/sync/device_fields.py
+++ b/netbox_librenms_plugin/views/sync/device_fields.py
@@ -691,7 +691,10 @@ class AssignVCSerialView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixin, L
                 continue
 
             try:
-                member = Device.objects.get(pk=member_id)
+                # Scoped like the page device: the member's serial is overwritten below and its pk
+                # comes from the POST, so the same-VC check alone would let a constrained grant
+                # write a serial onto a member it does not cover.
+                member = self.restricted_queryset(Device, "change").get(pk=member_id)
 
                 if not member.virtual_chassis or member.virtual_chassis.pk != device.virtual_chassis.pk:
                     errors.append(f"{member.name} is not part of the same virtual chassis")

--- a/netbox_librenms_plugin/views/sync/device_fields.py
+++ b/netbox_librenms_plugin/views/sync/device_fields.py
@@ -7,7 +7,7 @@ from django.db import IntegrityError, transaction
 from django.utils.text import slugify
 
 from django.http import HttpResponse
-from django.shortcuts import get_object_or_404, redirect
+from django.shortcuts import redirect
 from django.urls import reverse
 from django.utils.html import escape
 from django.views import View
@@ -65,7 +65,7 @@ class UpdateDeviceNameView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixin,
         if error := self.require_all_permissions("POST"):
             return error
 
-        device = get_object_or_404(Device, pk=pk)
+        device = self.restrict_object_or_404(Device, "change", pk=pk)
 
         # Rebind the API client to the POSTed server before resolving the per-server librenms_id,
         # so a multi-server user acting on a non-default tab isn't routed through the globally
@@ -160,7 +160,7 @@ class UpdateDeviceSerialView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixi
         if error := self.require_all_permissions("POST"):
             return error
 
-        device = get_object_or_404(Device, pk=pk)
+        device = self.restrict_object_or_404(Device, "change", pk=pk)
 
         # Rebind the API client to the POSTed server before resolving the per-server librenms_id,
         # so a multi-server user acting on a non-default tab isn't routed through the globally
@@ -224,7 +224,7 @@ class UpdateDeviceTypeView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixin,
         if error := self.require_all_permissions("POST"):
             return error
 
-        device = get_object_or_404(Device, pk=pk)
+        device = self.restrict_object_or_404(Device, "change", pk=pk)
 
         # Rebind the API client to the POSTed server before resolving the per-server librenms_id,
         # so a multi-server user acting on a non-default tab isn't routed through the globally
@@ -302,7 +302,7 @@ class UpdateDevicePlatformView(LibreNMSPermissionMixin, NetBoxObjectPermissionMi
         if error := self.require_all_permissions("POST"):
             return error
 
-        device = get_object_or_404(Device, pk=pk)
+        device = self.restrict_object_or_404(Device, "change", pk=pk)
 
         # Rebind the API client to the POSTed server before resolving the per-server librenms_id,
         # so a multi-server user acting on a non-default tab isn't routed through the globally
@@ -415,7 +415,7 @@ class CreateAndAssignPlatformView(LibreNMSPermissionMixin, NetBoxObjectPermissio
         if error := self.require_all_permissions("POST"):
             return error
 
-        device = get_object_or_404(Device, pk=pk)
+        device = self.restrict_object_or_404(Device, "change", pk=pk)
 
         # Rebind the API client to the POSTed server so the server_key fallback in _sync_redirect
         # below resolves to the active server instead of None (self._librenms_api would otherwise
@@ -672,7 +672,7 @@ class AssignVCSerialView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixin, L
         if error := self.require_all_permissions("POST"):
             return error
 
-        device = get_object_or_404(Device, pk=pk)
+        device = self.restrict_object_or_404(Device, "change", pk=pk)
 
         if not device.virtual_chassis:
             messages.error(request, "Device is not part of a virtual chassis")
@@ -745,7 +745,7 @@ class RemoveServerMappingView(LibreNMSPermissionMixin, NetBoxObjectPermissionMix
     def _get_object(self, object_type, pk):
         """Return the Device or VirtualMachine for the given pk."""
         model = VirtualMachine if object_type == "vm" else Device
-        return get_object_or_404(model, pk=pk), model
+        return self.restrict_object_or_404(model, "change", pk=pk), model
 
     def _sync_url_name(self, object_type):
         if object_type == "vm":
@@ -860,7 +860,7 @@ class ConvertLegacyLibreNMSIdView(LibreNMSPermissionMixin, NetBoxObjectPermissio
 
     def _get_model_and_object(self, object_type, pk):
         model = VirtualMachine if object_type == "vm" else Device
-        return model, get_object_or_404(model, pk=pk)
+        return model, self.restrict_object_or_404(model, "change", pk=pk)
 
     def _sync_url(self, object_type, pk):
         name = "vm_librenms_sync" if object_type == "vm" else "device_librenms_sync"

--- a/netbox_librenms_plugin/views/sync/device_fields.py
+++ b/netbox_librenms_plugin/views/sync/device_fields.py
@@ -428,7 +428,7 @@ class CreateAndAssignPlatformView(LibreNMSPermissionMixin, NetBoxObjectPermissio
         # primary source, so a bad key can't refuse the platform create (which needs no LibreNMS).
         self.rebind_api_for_server(request.POST.get("server_key"))
 
-        manufacturer_id = request.POST.get("manufacturer")
+        manufacturer_id = (request.POST.get("manufacturer") or "").strip()
 
         if not platform_name:
             messages.error(request, "Platform name is required")
@@ -439,7 +439,12 @@ class CreateAndAssignPlatformView(LibreNMSPermissionMixin, NetBoxObjectPermissio
             try:
                 manufacturer = self.restricted_queryset(Manufacturer).get(pk=manufacturer_id)
             except (Manufacturer.DoesNotExist, ValueError):
-                pass
+                messages.error(request, "Selected manufacturer is not available.")
+                return self._sync_redirect(
+                    request,
+                    pk,
+                    getattr(getattr(self, "_librenms_api", None), "server_key", None),
+                )
 
         with transaction.atomic():
             platform_created = False

--- a/netbox_librenms_plugin/views/sync/device_fields.py
+++ b/netbox_librenms_plugin/views/sync/device_fields.py
@@ -403,6 +403,10 @@ class CreateAndAssignPlatformView(LibreNMSPermissionMixin, NetBoxObjectPermissio
         required = [("change", Device)]
         if existing_platform is None:
             required.append(("add", Platform))
+        # The manufacturer is optional, but when one IS posted it is resolved by client-supplied
+        # id through a restricted queryset — so state that read in the gate.
+        if (request.POST.get("manufacturer") or "").strip():
+            required.append(("view", Manufacturer))
         # Deliberately do NOT gate the upfront POST on "add PlatformMapping": assigning the
         # platform is the primary action and must succeed for a user who can change the device
         # (and create the platform) even when they can't create OS mappings. The optional
@@ -433,7 +437,7 @@ class CreateAndAssignPlatformView(LibreNMSPermissionMixin, NetBoxObjectPermissio
         manufacturer = None
         if manufacturer_id:
             try:
-                manufacturer = Manufacturer.objects.get(pk=manufacturer_id)
+                manufacturer = self.restricted_queryset(Manufacturer).get(pk=manufacturer_id)
             except Manufacturer.DoesNotExist:
                 pass
 
@@ -495,7 +499,7 @@ class CreateAndAssignPlatformView(LibreNMSPermissionMixin, NetBoxObjectPermissio
                 platform = existing_platform
 
             try:
-                device = Device.objects.select_for_update().get(pk=pk)
+                device = self.restricted_queryset(Device, "change").select_for_update().get(pk=pk)
             except Device.DoesNotExist:
                 transaction.set_rollback(True)
                 messages.error(request, "Device no longer exists.")
@@ -814,7 +818,7 @@ class RemoveServerMappingView(LibreNMSPermissionMixin, NetBoxObjectPermissionMix
 
         with transaction.atomic():
             try:
-                obj_locked = model.objects.select_for_update().get(pk=pk)
+                obj_locked = self.restricted_queryset(model, "change").select_for_update().get(pk=pk)
             except model.DoesNotExist:
                 messages.error(request, f"{model.__name__} no longer exists.")
                 return redirect(sync_url, pk=pk)
@@ -954,7 +958,7 @@ class ConvertLegacyLibreNMSIdView(LibreNMSPermissionMixin, NetBoxObjectPermissio
 
         with transaction.atomic():
             try:
-                locked = model.objects.select_for_update().get(pk=pk)
+                locked = self.restricted_queryset(model, "change").select_for_update().get(pk=pk)
             except model.DoesNotExist:
                 messages.error(request, f"{model.__name__} no longer exists.")
                 return self._sync_url(object_type, pk)

--- a/netbox_librenms_plugin/views/sync/device_fields.py
+++ b/netbox_librenms_plugin/views/sync/device_fields.py
@@ -438,7 +438,7 @@ class CreateAndAssignPlatformView(LibreNMSPermissionMixin, NetBoxObjectPermissio
         if manufacturer_id:
             try:
                 manufacturer = self.restricted_queryset(Manufacturer).get(pk=manufacturer_id)
-            except Manufacturer.DoesNotExist:
+            except (Manufacturer.DoesNotExist, ValueError):
                 pass
 
         with transaction.atomic():
@@ -499,7 +499,7 @@ class CreateAndAssignPlatformView(LibreNMSPermissionMixin, NetBoxObjectPermissio
                 platform = existing_platform
 
             try:
-                device = self.restricted_queryset(Device, "change").select_for_update().get(pk=pk)
+                device = self.restricted_queryset(Device, "change").select_for_update(of=("self",)).get(pk=pk)
             except Device.DoesNotExist:
                 transaction.set_rollback(True)
                 messages.error(request, "Device no longer exists.")
@@ -818,7 +818,7 @@ class RemoveServerMappingView(LibreNMSPermissionMixin, NetBoxObjectPermissionMix
 
         with transaction.atomic():
             try:
-                obj_locked = self.restricted_queryset(model, "change").select_for_update().get(pk=pk)
+                obj_locked = self.restricted_queryset(model, "change").select_for_update(of=("self",)).get(pk=pk)
             except model.DoesNotExist:
                 messages.error(request, f"{model.__name__} no longer exists.")
                 return redirect(sync_url, pk=pk)
@@ -958,7 +958,7 @@ class ConvertLegacyLibreNMSIdView(LibreNMSPermissionMixin, NetBoxObjectPermissio
 
         with transaction.atomic():
             try:
-                locked = self.restricted_queryset(model, "change").select_for_update().get(pk=pk)
+                locked = self.restricted_queryset(model, "change").select_for_update(of=("self",)).get(pk=pk)
             except model.DoesNotExist:
                 messages.error(request, f"{model.__name__} no longer exists.")
                 return self._sync_url(object_type, pk)

--- a/netbox_librenms_plugin/views/sync/devices.py
+++ b/netbox_librenms_plugin/views/sync/devices.py
@@ -52,11 +52,8 @@ class AddDeviceToLibreNMSView(
 
     def post(self, request, object_id):
         """Add a device to LibreNMS using the submitted SNMP form."""
-        # Resolve the target object first so we can apply object-level perms
-        # against the correct model (Device vs VirtualMachine).
         object_type = request.POST.get("object_type")
-        self.object = self.get_object(object_id, object_type=object_type)
-        if self.object is None:
+        if object_type not in ("device", "virtualmachine"):
             # Match the convention used in views/sync/device_fields.py — return
             # 400 (Bad Request) with an escaped echo of the offending value
             # rather than raising 404, which would mislead clients into
@@ -66,14 +63,14 @@ class AddDeviceToLibreNMSView(
                 status=400,
             )
 
-        # Plugin write perm + NetBox change perm on the resolved model. The
-        # mapping is set per-request because object_type can be either
-        # device or virtualmachine; static class-level declaration cannot
-        # express that branch.
+        # Gate before the change-scoped lookup so a missing grant produces the
+        # named permission error instead of a bare 404.
         target_model = VirtualMachine if object_type == "virtualmachine" else Device
         self.required_object_permissions = {"POST": [("change", target_model)]}
         if error := self.require_all_permissions("POST"):
             return error
+
+        self.object = self.get_object(object_id, object_type=object_type)
 
         form_class = self.get_form_class()
 

--- a/netbox_librenms_plugin/views/sync/devices.py
+++ b/netbox_librenms_plugin/views/sync/devices.py
@@ -45,9 +45,9 @@ class AddDeviceToLibreNMSView(
         a client error, not a missing-resource error).
         """
         if object_type == "virtualmachine":
-            return get_object_or_404(VirtualMachine, pk=object_id)
+            return self.restrict_object_or_404(VirtualMachine, "change", pk=object_id)
         if object_type == "device":
-            return get_object_or_404(Device, pk=object_id)
+            return self.restrict_object_or_404(Device, "change", pk=object_id)
         return None
 
     def post(self, request, object_id):

--- a/netbox_librenms_plugin/views/sync/devices.py
+++ b/netbox_librenms_plugin/views/sync/devices.py
@@ -1,7 +1,7 @@
 from dcim.models import Device
 from django.contrib import messages
 from django.http import HttpResponse
-from django.shortcuts import get_object_or_404, redirect
+from django.shortcuts import redirect
 from django.utils.html import escape
 from django.views import View
 from virtualization.models import VirtualMachine
@@ -141,16 +141,21 @@ class AddDeviceToLibreNMSView(
         return redirect(self.object.get_absolute_url())
 
 
-class UpdateDeviceLocationView(LibreNMSPermissionMixin, LibreNMSAPIMixin, View):
+class UpdateDeviceLocationView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixin, LibreNMSAPIMixin, View):
     """Update the LibreNMS site/location based on the NetBox site."""
+
+    # The device is only read here (the write lands in LibreNMS), but it is read by raw URL pk —
+    # so gate on the object view permission and resolve through the restricted queryset, or a
+    # constrained grant could push any device's site to LibreNMS.
+    required_object_permissions = {"POST": [("view", Device)]}
 
     def post(self, request, pk):
         """Sync the device location to LibreNMS from the NetBox site."""
-        # Check write permission before updating location in LibreNMS
-        if error := self.require_write_permission():
+        # Check plugin write permission AND the object view permission before touching the device.
+        if error := self.require_all_permissions("POST"):
             return error
 
-        device = get_object_or_404(Device, pk=pk)
+        device = self.restrict_object_or_404(Device, pk=pk)
 
         # Rebind the API client to the POSTed server before resolving the per-server
         # librenms_id and writing the location, so a multi-server user acting on a

--- a/netbox_librenms_plugin/views/sync/interfaces.py
+++ b/netbox_librenms_plugin/views/sync/interfaces.py
@@ -449,10 +449,12 @@ class DeleteNetBoxInterfacesView(LibreNMSPermissionMixin, NetBoxObjectPermission
 
     def get_required_permissions_for_object_type(self, object_type):
         """Return the required permissions based on object type."""
+        # The owner is resolved through a restricted queryset, so its view permission is stated
+        # here too (mirroring SyncInterfacesView): a missing grant is a 403, not a bare 404.
         if object_type == "device":
-            return [("delete", Interface)]
+            return [("view", Device), ("delete", Interface)]
         elif object_type == "virtualmachine":
-            return [("delete", VMInterface)]
+            return [("view", VirtualMachine), ("delete", VMInterface)]
         else:
             raise Http404(f"Invalid object type: {object_type}")
 

--- a/netbox_librenms_plugin/views/sync/interfaces.py
+++ b/netbox_librenms_plugin/views/sync/interfaces.py
@@ -208,7 +208,7 @@ class SyncInterfacesView(
 
             if selected_device_id:
                 try:
-                    target_device = Device.objects.get(id=selected_device_id)
+                    target_device = self.restricted_queryset(Device).get(id=selected_device_id)
                     # Validate the target is the current device or a VC member
                     if hasattr(obj, "virtual_chassis") and obj.virtual_chassis:
                         valid_ids = set(obj.virtual_chassis.members.values_list("id", flat=True))

--- a/netbox_librenms_plugin/views/sync/interfaces.py
+++ b/netbox_librenms_plugin/views/sync/interfaces.py
@@ -491,7 +491,9 @@ class DeleteNetBoxInterfacesView(LibreNMSPermissionMixin, NetBoxObjectPermission
                     interface_name = None
                     try:
                         if object_type == "device":
-                            interface = Interface.objects.get(id=interface_id)
+                            # Scoped by "delete": the ownership checks below prove where the
+                            # interface sits, not that the grant covers it.
+                            interface = self.restricted_queryset(Interface, "delete").get(id=interface_id)
                             interface_name = interface.name
                             if hasattr(obj, "virtual_chassis") and obj.virtual_chassis:
                                 valid_device_ids = [member.id for member in obj.virtual_chassis.members.all()]
@@ -506,7 +508,7 @@ class DeleteNetBoxInterfacesView(LibreNMSPermissionMixin, NetBoxObjectPermission
                                 errors.append(f"Interface {interface.name} does not belong to this device")
                                 continue
                         else:
-                            interface = VMInterface.objects.get(id=interface_id)
+                            interface = self.restricted_queryset(VMInterface, "delete").get(id=interface_id)
                             interface_name = interface.name
                             if interface.virtual_machine_id != obj.id:
                                 errors.append(f"Interface {interface.name} does not belong to this virtual machine")

--- a/netbox_librenms_plugin/views/sync/interfaces.py
+++ b/netbox_librenms_plugin/views/sync/interfaces.py
@@ -6,7 +6,7 @@ from django.contrib import messages
 from django.core.cache import cache
 from django.db import transaction
 from django.http import Http404, JsonResponse
-from django.shortcuts import get_object_or_404, redirect
+from django.shortcuts import redirect
 from django.urls import reverse
 from django.views import View
 from virtualization.models import VirtualMachine, VMInterface
@@ -39,10 +39,12 @@ class SyncInterfacesView(
 
     def get_required_permissions_for_object_type(self, object_type):
         """Return the required permissions based on object type."""
+        # The owner is resolved through a restricted queryset (get_object), so its view
+        # permission is stated here: a missing grant is an explicit 403, not a 404.
         if object_type == "device":
-            return [("add", Interface), ("change", Interface)]
+            return [("view", Device), ("add", Interface), ("change", Interface)]
         elif object_type == "virtualmachine":
-            return [("add", VMInterface), ("change", VMInterface)]
+            return [("view", VirtualMachine), ("add", VMInterface), ("change", VMInterface)]
         else:
             raise Http404(f"Invalid object type: {object_type}")
 
@@ -123,11 +125,11 @@ class SyncInterfacesView(
         return redirect(redirect_url)
 
     def get_object(self, object_type, object_id):
-        """Return the Device or VirtualMachine for the given type and ID."""
+        """Return the Device or VirtualMachine for the given type and ID (object-scoped)."""
         if object_type == "device":
-            return get_object_or_404(Device, pk=object_id)
+            return self.restrict_object_or_404(Device, pk=object_id)
         if object_type == "virtualmachine":
-            return get_object_or_404(VirtualMachine, pk=object_id)
+            return self.restrict_object_or_404(VirtualMachine, pk=object_id)
         raise Http404("Invalid object type.")
 
     def get_selected_interfaces(self, request, interface_name_field):
@@ -466,9 +468,9 @@ class DeleteNetBoxInterfacesView(LibreNMSPermissionMixin, NetBoxObjectPermission
             return error
 
         if object_type == "device":
-            obj = get_object_or_404(Device, pk=object_id)
+            obj = self.restrict_object_or_404(Device, pk=object_id)
         elif object_type == "virtualmachine":
-            obj = get_object_or_404(VirtualMachine, pk=object_id)
+            obj = self.restrict_object_or_404(VirtualMachine, pk=object_id)
         else:
             return JsonResponse({"error": "Invalid object type"}, status=400)
 

--- a/netbox_librenms_plugin/views/sync/interfaces.py
+++ b/netbox_librenms_plugin/views/sync/interfaces.py
@@ -116,10 +116,7 @@ class SyncInterfacesView(
             skipped = ", ".join(self._skipped_conflicts)
             messages.warning(
                 request,
-                # Generic reason: the skip list covers both "port already mapped to a different
-                # interface" and ambiguous-port_id cases, so don't claim a single cause.
-                f"{len(self._skipped_conflicts)} interface(s) skipped — their LibreNMS port could not "
-                f"be safely matched to a NetBox interface (already mapped elsewhere, or ambiguous): {skipped}.",
+                f"{len(self._skipped_conflicts)} interface(s) skipped: {skipped}.",
             )
         messages.success(request, "Selected interfaces synced successfully.")
         return redirect(redirect_url)
@@ -213,15 +210,15 @@ class SyncInterfacesView(
                     if hasattr(obj, "virtual_chassis") and obj.virtual_chassis:
                         valid_ids = set(obj.virtual_chassis.members.values_list("id", flat=True))
                         if target_device.id not in valid_ids:
-                            self._record_skipped_conflict(interface_name)
+                            self._record_skipped_conflict(interface_name, "selected target unavailable")
                             return
                     elif target_device.id != obj.id:
-                        self._record_skipped_conflict(interface_name)
+                        self._record_skipped_conflict(interface_name, "selected target unavailable")
                         return
                 except (Device.DoesNotExist, ValueError, TypeError):
                     # The user explicitly selected a target. If it is stale or outside the
                     # caller's grant, do not silently sync the row onto the page device.
-                    self._record_skipped_conflict(interface_name)
+                    self._record_skipped_conflict(interface_name, "selected target unavailable")
                     return
             else:
                 target_device = obj
@@ -241,7 +238,7 @@ class SyncInterfacesView(
             )
             # Record for the user-facing summary in post(). Defensive getattr: sync_interface
             # may be exercised directly (without post() initialising the list).
-            self._record_skipped_conflict(interface_name)
+            self._record_skipped_conflict(interface_name, "port already mapped elsewhere or ambiguous")
             return
 
         netbox_type = None
@@ -260,11 +257,11 @@ class SyncInterfacesView(
         if "vlans" not in exclude_columns:
             self._sync_interface_vlans(interface, librenms_interface, interface_name)
 
-    def _record_skipped_conflict(self, interface_name):
+    def _record_skipped_conflict(self, interface_name, reason):
         """Record a row that cannot be synced to its requested target."""
         skipped = getattr(self, "_skipped_conflicts", None)
         if skipped is not None:
-            skipped.append(interface_name or "(unnamed)")
+            skipped.append(f"{interface_name or '(unnamed)'} ({reason})")
 
     def _resolve_device_interface(self, target_device, interface_name, port_id, server_key):
         """Resolve a device interface using port_id first, then safe name fallback."""

--- a/netbox_librenms_plugin/views/sync/interfaces.py
+++ b/netbox_librenms_plugin/views/sync/interfaces.py
@@ -213,11 +213,16 @@ class SyncInterfacesView(
                     if hasattr(obj, "virtual_chassis") and obj.virtual_chassis:
                         valid_ids = set(obj.virtual_chassis.members.values_list("id", flat=True))
                         if target_device.id not in valid_ids:
-                            target_device = obj
+                            self._record_skipped_conflict(interface_name)
+                            return
                     elif target_device.id != obj.id:
-                        target_device = obj
+                        self._record_skipped_conflict(interface_name)
+                        return
                 except (Device.DoesNotExist, ValueError, TypeError):
-                    target_device = obj
+                    # The user explicitly selected a target. If it is stale or outside the
+                    # caller's grant, do not silently sync the row onto the page device.
+                    self._record_skipped_conflict(interface_name)
+                    return
             else:
                 target_device = obj
 
@@ -236,9 +241,7 @@ class SyncInterfacesView(
             )
             # Record for the user-facing summary in post(). Defensive getattr: sync_interface
             # may be exercised directly (without post() initialising the list).
-            skipped = getattr(self, "_skipped_conflicts", None)
-            if skipped is not None:
-                skipped.append(interface_name or "(unnamed)")
+            self._record_skipped_conflict(interface_name)
             return
 
         netbox_type = None
@@ -256,6 +259,12 @@ class SyncInterfacesView(
         # Sync VLANs if not excluded
         if "vlans" not in exclude_columns:
             self._sync_interface_vlans(interface, librenms_interface, interface_name)
+
+    def _record_skipped_conflict(self, interface_name):
+        """Record a row that cannot be synced to its requested target."""
+        skipped = getattr(self, "_skipped_conflicts", None)
+        if skipped is not None:
+            skipped.append(interface_name or "(unnamed)")
 
     def _resolve_device_interface(self, target_device, interface_name, port_id, server_key):
         """Resolve a device interface using port_id first, then safe name fallback."""

--- a/netbox_librenms_plugin/views/sync/ip_addresses.py
+++ b/netbox_librenms_plugin/views/sync/ip_addresses.py
@@ -55,7 +55,7 @@ class SyncIPAddressesView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixin, 
             dict: The ``required_object_permissions`` mapping for this request.
         """
         owner_model = VirtualMachine if object_type == "virtualmachine" else Device
-        perms = [("view", owner_model), *self.required_object_permissions["POST"]]
+        perms = [("view", owner_model), *type(self).required_object_permissions["POST"]]
         # A per-row VRF is resolved by client-supplied id through a restricted queryset. Only
         # demand its view permission when one is actually posted, so the common no-VRF sync
         # is not gated on a permission it never uses.

--- a/netbox_librenms_plugin/views/sync/ip_addresses.py
+++ b/netbox_librenms_plugin/views/sync/ip_addresses.py
@@ -345,6 +345,7 @@ class SyncIPAddressesView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixin, 
             "failed": [],
             "primary_set": [],
             "primary_no_interface": [],
+            "primary_interface_not_eligible": [],
             "skipped_no_interface": [],
             "errors": {},
         }
@@ -430,7 +431,7 @@ class SyncIPAddressesView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixin, 
                                 and not interface.mgmt_only
                             )
                         ):
-                            results["primary_no_interface"].append(ip_address)
+                            results["primary_interface_not_eligible"].append(ip_address)
                         elif self._set_primary_ip(obj, ip_obj):
                             results["primary_set"].append(ip_address)
 
@@ -455,6 +456,13 @@ class SyncIPAddressesView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixin, 
                 "Primary IP not set for "
                 f"{', '.join(results['primary_no_interface'])} — no NetBox interface for this IP. "
                 "Sync interfaces first, then re-run.",
+            )
+        if results.get("primary_interface_not_eligible"):
+            messages.warning(
+                request,
+                "Primary IP not set for "
+                f"{', '.join(results['primary_interface_not_eligible'])} — the matched interface is not eligible "
+                "(it is outside this virtual chassis or is a management-only interface).",
             )
         if results.get("skipped_no_interface"):
             messages.warning(

--- a/netbox_librenms_plugin/views/sync/ip_addresses.py
+++ b/netbox_librenms_plugin/views/sync/ip_addresses.py
@@ -381,17 +381,30 @@ class SyncIPAddressesView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixin, 
                         ip_data, interfaces_by_librenms_id, interfaces_by_name, interfaces_by_pk
                     )
 
+                    # This row ends in obj.save() (primary_ip) when it matches the management
+                    # address, so it takes BOTH an ipam_ipaddress and a dcim_device row lock.
+                    is_primary_candidate = bool(mgmt_ip) and self._same_host(ip_data["ip_address"], mgmt_ip)
+
                     if interface is None:
                         # No matching NetBox interface — the row is stale, the interface isn't
                         # synced yet, or _match_interface refused an ambiguous port_id. Writing
                         # here would either drop an existing IP's binding (assigned_object=None)
                         # or create an unassigned/global address, both of which violate the
                         # interface-assigned model. Skip the row instead of corrupting state.
-                        if mgmt_ip and self._same_host(ip_data["ip_address"], mgmt_ip):
+                        if is_primary_candidate:
                             results["primary_no_interface"].append(ip_address)
                         else:
                             results["skipped_no_interface"].append(ip_address)
                         continue
+
+                    if is_primary_candidate:
+                        # Lock obj's row BEFORE the address write, so this path takes the same
+                        # Device -> IPAddress lock order as the migrate move views. The reverse
+                        # order closes a deadlock cycle with a concurrent donor move.
+                        if type(obj).objects.select_for_update().filter(pk=obj.pk).first() is not None:
+                            # Re-read the primary_ip ids from the locked row: a stale in-memory
+                            # value would make _set_primary_ip skip a set it must perform.
+                            obj.refresh_from_db()
 
                     ip_with_mask = ip_data["ip_with_mask"]
 
@@ -421,7 +434,7 @@ class SyncIPAddressesView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixin, 
                     # Primary-IP auto-match for the management IP. The no-interface case is
                     # handled above (the row was skipped before any write), so here the IP is
                     # guaranteed interface-assigned and can satisfy NetBox's primary constraint.
-                    if mgmt_ip and self._same_host(ip_data["ip_address"], mgmt_ip):
+                    if is_primary_candidate:
                         # _build_interface_maps indexes ALL VC member interfaces, so `interface`
                         # can belong to a sibling member. NetBox's Device.clean() accepts a
                         # primary IP on any same-VC member's non-mgmt-only interface

--- a/netbox_librenms_plugin/views/sync/ip_addresses.py
+++ b/netbox_librenms_plugin/views/sync/ip_addresses.py
@@ -59,7 +59,7 @@ class SyncIPAddressesView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixin, 
         # A per-row VRF is resolved by client-supplied id through a restricted queryset. Only
         # demand its view permission when one is actually posted, so the common no-VRF sync
         # is not gated on a permission it never uses.
-        if any(k.startswith("vrf_") for k in self.request.POST):
+        if any(key.startswith("vrf_") and value for key, value in self.request.POST.items()):
             perms.append(("view", VRF))
         return {"POST": perms}
 

--- a/netbox_librenms_plugin/views/sync/ip_addresses.py
+++ b/netbox_librenms_plugin/views/sync/ip_addresses.py
@@ -10,7 +10,7 @@ from django.shortcuts import redirect
 from django.urls import reverse
 from django.views import View
 from ipam.models import VRF, IPAddress
-from virtualization.models import VirtualMachine
+from virtualization.models import VirtualMachine, VMInterface
 
 from netbox_librenms_plugin.utils import (
     get_librenms_device_id,
@@ -43,10 +43,9 @@ class SyncIPAddressesView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixin, 
         """
         Return the POST permissions, narrowed to the owner model this request targets.
 
-        The owner is resolved through a restricted queryset (:meth:`get_object`), so its view
-        permission belongs in the gate: a missing grant is then an explicit 403 instead of a
-        puzzling 404 at the lookup. It cannot be declared statically because one view serves both
-        Devices and VirtualMachines.
+        The owner and target interfaces are resolved through restricted querysets, so their view
+        permissions belong in the gate. They cannot be declared statically because one view serves
+        both Devices and VirtualMachines.
 
         Args:
             object_type (str): ``"device"`` or ``"virtualmachine"`` from the URL.
@@ -54,8 +53,20 @@ class SyncIPAddressesView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixin, 
         Returns:
             dict: The ``required_object_permissions`` mapping for this request.
         """
-        owner_model = VirtualMachine if object_type == "virtualmachine" else Device
-        perms = [("view", owner_model), *type(self).required_object_permissions["POST"]]
+        if object_type == "device":
+            owner_model = Device
+            interface_model = Interface
+        elif object_type == "virtualmachine":
+            owner_model = VirtualMachine
+            interface_model = VMInterface
+        else:
+            raise Http404("Invalid object type.")
+
+        perms = [
+            ("view", owner_model),
+            ("view", interface_model),
+            *type(self).required_object_permissions["POST"],
+        ]
         # A per-row VRF is resolved by client-supplied id through a restricted queryset. Only
         # demand its view permission when one is actually posted, so the common no-VRF sync
         # is not gated on a permission it never uses.
@@ -197,15 +208,13 @@ class SyncIPAddressesView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixin, 
         Used to re-resolve the target interface at sync time instead of trusting the cached
         ``interface_url`` (see ``_match_interface``).
 
-        For a Device in a Virtual Chassis, all member interfaces are indexed (not just the viewed
-        member's), mirroring ``_resolve_interface_by_port_id`` in ``views/sync/interfaces``: LibreNMS
-        treats a VC as one logical device, so a VC member IP can legitimately resolve to an interface
-        on another member by stable port id. For the name fallback the viewed object's own interface
-        wins — that's exactly what the rendered IP table binds to (the render indexes only
-        ``obj.interfaces``; see ``ip_addresses_view._prefetch_netbox_data``), so the sync must agree
-        rather than skip what the user sees linked. A name shared only by sibling members (none on the
-        viewed object) stays ambiguous (None) so the address can't silently rebind to an arbitrary
-        member; duplicate port ids are always ambiguous.
+        For a Device in a Virtual Chassis, authorized member interfaces are indexed (not just the
+        viewed member's), mirroring ``_resolve_interface_by_port_id`` in ``views/sync/interfaces``:
+        LibreNMS treats a VC as one logical device, so a VC member IP can legitimately resolve to an
+        interface on another member by stable port id. For the name fallback the viewed object's own
+        interface wins. A name shared only by sibling members (none on the viewed object) stays
+        ambiguous (None) so the address can't silently rebind to an arbitrary member; duplicate port
+        ids are always ambiguous.
 
         Args:
             obj (Device | VirtualMachine): The synced object whose current interfaces to index.
@@ -220,10 +229,10 @@ class SyncIPAddressesView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixin, 
             # Route member expansion through the shared helper (returns [obj] when not in a VC)
             # so this can't drift from the VC member set used by the interface-sync path.
             member_devices = get_virtual_chassis_members(obj)
-            interfaces = list(Interface.objects.filter(device__in=member_devices))
+            interfaces = list(self.restricted_queryset(Interface).filter(device__in=member_devices))
             obj_device_id = obj.pk
         else:
-            interfaces = list(obj.interfaces.all())
+            interfaces = list(self.restricted_queryset(VMInterface).filter(virtual_machine=obj))
             obj_device_id = None
         by_librenms_id = {}
         by_name = {}

--- a/netbox_librenms_plugin/views/sync/ip_addresses.py
+++ b/netbox_librenms_plugin/views/sync/ip_addresses.py
@@ -68,16 +68,16 @@ class SyncIPAddressesView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixin, 
         return [x for x in request.POST.getlist("select") if x]
 
     def get_vrf_selection(self, request, ip_address):
-        """Return the VRF selected for a given IP address, or None."""
+        """Return the selected VRF, or None only when the row requests no VRF."""
         vrf_id = request.POST.get(f"vrf_{ip_address}")
 
-        if vrf_id:
-            try:
-                return self.restricted_queryset(VRF).get(pk=vrf_id)
-            except (VRF.DoesNotExist, TypeError, ValueError):
-                pass
+        if not vrf_id:
+            return None
 
-        return None
+        try:
+            return self.restricted_queryset(VRF).get(pk=vrf_id)
+        except (VRF.DoesNotExist, TypeError, ValueError):
+            raise ValueError("Selected VRF is no longer available or you do not have permission to view it.") from None
 
     def get_cached_ip_data(self, request, obj):
         """Return cached LibreNMS IP address data for the given object."""

--- a/netbox_librenms_plugin/views/sync/ip_addresses.py
+++ b/netbox_librenms_plugin/views/sync/ip_addresses.py
@@ -401,10 +401,11 @@ class SyncIPAddressesView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixin, 
                         # Lock obj's row BEFORE the address write, so this path takes the same
                         # Device -> IPAddress lock order as the migrate move views. The reverse
                         # order closes a deadlock cycle with a concurrent donor move.
-                        if type(obj).objects.select_for_update().filter(pk=obj.pk).first() is not None:
-                            # Re-read the primary_ip ids from the locked row: a stale in-memory
-                            # value would make _set_primary_ip skip a set it must perform.
-                            obj.refresh_from_db()
+                        if type(obj).objects.select_for_update().filter(pk=obj.pk).first() is None:
+                            raise type(obj).DoesNotExist(f"{type(obj).__name__} {obj.pk} no longer exists")
+                        # Re-read the primary_ip ids from the locked row. A stale in-memory value
+                        # would make _set_primary_ip skip a set it must perform.
+                        obj.refresh_from_db()
 
                     ip_with_mask = ip_data["ip_with_mask"]
 

--- a/netbox_librenms_plugin/views/sync/ip_addresses.py
+++ b/netbox_librenms_plugin/views/sync/ip_addresses.py
@@ -55,7 +55,13 @@ class SyncIPAddressesView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixin, 
             dict: The ``required_object_permissions`` mapping for this request.
         """
         owner_model = VirtualMachine if object_type == "virtualmachine" else Device
-        return {"POST": [("view", owner_model), *self.required_object_permissions["POST"]]}
+        perms = [("view", owner_model), *self.required_object_permissions["POST"]]
+        # A per-row VRF is resolved by client-supplied id through a restricted queryset. Only
+        # demand its view permission when one is actually posted, so the common no-VRF sync
+        # is not gated on a permission it never uses.
+        if any(k.startswith("vrf_") for k in self.request.POST):
+            perms.append(("view", VRF))
+        return {"POST": perms}
 
     def get_selected_ips(self, request):
         """Return selected IP addresses from POST data."""
@@ -67,7 +73,7 @@ class SyncIPAddressesView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixin, 
 
         if vrf_id:
             try:
-                return VRF.objects.get(pk=vrf_id)
+                return self.restricted_queryset(VRF).get(pk=vrf_id)
             except VRF.DoesNotExist:
                 pass
 

--- a/netbox_librenms_plugin/views/sync/ip_addresses.py
+++ b/netbox_librenms_plugin/views/sync/ip_addresses.py
@@ -6,7 +6,7 @@ from django.contrib import messages
 from django.core.cache import cache
 from django.db import transaction
 from django.http import Http404
-from django.shortcuts import get_object_or_404, redirect
+from django.shortcuts import redirect
 from django.urls import reverse
 from django.views import View
 from ipam.models import VRF, IPAddress
@@ -39,6 +39,24 @@ class SyncIPAddressesView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixin, 
         ],
     }
 
+    def _required_permissions(self, object_type):
+        """
+        Return the POST permissions, narrowed to the owner model this request targets.
+
+        The owner is resolved through a restricted queryset (:meth:`get_object`), so its view
+        permission belongs in the gate: a missing grant is then an explicit 403 instead of a
+        puzzling 404 at the lookup. It cannot be declared statically because one view serves both
+        Devices and VirtualMachines.
+
+        Args:
+            object_type (str): ``"device"`` or ``"virtualmachine"`` from the URL.
+
+        Returns:
+            dict: The ``required_object_permissions`` mapping for this request.
+        """
+        owner_model = VirtualMachine if object_type == "virtualmachine" else Device
+        return {"POST": [("view", owner_model), *self.required_object_permissions["POST"]]}
+
     def get_selected_ips(self, request):
         """Return selected IP addresses from POST data."""
         return [x for x in request.POST.getlist("select") if x]
@@ -64,11 +82,11 @@ class SyncIPAddressesView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixin, 
         return cached_data.get("ip_addresses", [])
 
     def get_object(self, object_type, pk):
-        """Return the Device or VirtualMachine instance for the given type and pk."""
+        """Return the Device or VirtualMachine instance for the given type and pk (object-scoped)."""
         if object_type == "device":
-            return get_object_or_404(Device, pk=pk)
+            return self.restrict_object_or_404(Device, pk=pk)
         if object_type == "virtualmachine":
-            return get_object_or_404(VirtualMachine, pk=pk)
+            return self.restrict_object_or_404(VirtualMachine, pk=pk)
         raise Http404("Invalid object type.")
 
     def get_ip_tab_url(self, obj):
@@ -101,7 +119,8 @@ class SyncIPAddressesView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixin, 
 
     def post(self, request, object_type, pk):
         """Sync selected IP addresses from LibreNMS into NetBox."""
-        # Check both plugin write and NetBox object permissions
+        # Check both plugin write and NetBox object permissions (owner read included).
+        self.required_object_permissions = self._required_permissions(object_type)
         if error := self.require_all_permissions("POST"):
             return error
 

--- a/netbox_librenms_plugin/views/sync/ip_addresses.py
+++ b/netbox_librenms_plugin/views/sync/ip_addresses.py
@@ -74,7 +74,7 @@ class SyncIPAddressesView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixin, 
         if vrf_id:
             try:
                 return self.restricted_queryset(VRF).get(pk=vrf_id)
-            except VRF.DoesNotExist:
+            except (VRF.DoesNotExist, TypeError, ValueError):
                 pass
 
         return None

--- a/netbox_librenms_plugin/views/sync/locations.py
+++ b/netbox_librenms_plugin/views/sync/locations.py
@@ -8,10 +8,14 @@ from django_tables2 import SingleTableView
 
 from netbox_librenms_plugin.filtersets import SiteLocationFilterSet
 from netbox_librenms_plugin.tables.locations import SiteLocationSyncTable
-from netbox_librenms_plugin.views.mixins import LibreNMSAPIMixin, LibreNMSPermissionMixin
+from netbox_librenms_plugin.views.mixins import (
+    LibreNMSAPIMixin,
+    LibreNMSPermissionMixin,
+    NetBoxObjectPermissionMixin,
+)
 
 
-class SyncSiteLocationView(LibreNMSPermissionMixin, LibreNMSAPIMixin, SingleTableView):
+class SyncSiteLocationView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixin, LibreNMSAPIMixin, SingleTableView):
     """Synchronize NetBox Sites with LibreNMS locations."""
 
     table_class = SiteLocationSyncTable
@@ -106,10 +110,10 @@ class SyncSiteLocationView(LibreNMSPermissionMixin, LibreNMSAPIMixin, SingleTabl
         return redirect("plugins:netbox_librenms_plugin:site_location_sync")
 
     def get_site_by_pk(self, pk):
-        """Return the Site for the given pk, or None if not found."""
+        """Return the Site for the given pk, or None if not found or outside the user's grant."""
         try:
-            return Site.objects.get(pk=pk)
-        except ObjectDoesNotExist:
+            return self.restricted_queryset(Site).get(pk=pk)
+        except (ObjectDoesNotExist, ValueError):
             return None
 
     def create_librenms_location(self, request, site):

--- a/netbox_librenms_plugin/views/sync/locations.py
+++ b/netbox_librenms_plugin/views/sync/locations.py
@@ -24,6 +24,16 @@ class SyncSiteLocationView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixin,
 
     COORDINATE_TOLERANCE = 0.0001
     SyncData = namedtuple("SyncData", ["netbox_site", "librenms_location", "is_synced"])
+    required_object_permissions = {
+        "GET": [("view", Site)],
+        "POST": [("view", Site)],
+    }
+
+    def get(self, request, *args, **kwargs):
+        """Render only after checking the declared Site read permission."""
+        if error := self.require_all_permissions("GET"):
+            return error
+        return super().get(request, *args, **kwargs)
 
     def get_table(self, *args, **kwargs):
         """Return the configured sync table."""
@@ -40,7 +50,7 @@ class SyncSiteLocationView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixin,
 
     def get_queryset(self):
         """Return sync data pairing NetBox sites with LibreNMS locations."""
-        netbox_sites = Site.objects.all()
+        netbox_sites = self.restricted_queryset(Site)
         success, librenms_locations = self.get_librenms_locations()
         if not success or not isinstance(librenms_locations, list):
             return []
@@ -86,8 +96,8 @@ class SyncSiteLocationView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixin,
 
     def post(self, request):
         """Handle create or update of a LibreNMS location from a NetBox site."""
-        # Check write permission before modifying LibreNMS locations
-        if error := self.require_write_permission():
+        # Check plugin write and Site view permissions before modifying LibreNMS locations.
+        if error := self.require_all_permissions("POST"):
             return error
 
         action = request.POST.get("action")

--- a/netbox_librenms_plugin/views/sync/locations.py
+++ b/netbox_librenms_plugin/views/sync/locations.py
@@ -31,7 +31,7 @@ class SyncSiteLocationView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixin,
 
     def get(self, request, *args, **kwargs):
         """Render only after checking the declared Site read permission."""
-        if error := self.require_all_permissions("GET"):
+        if error := self.require_object_permissions("GET"):
             return error
         return super().get(request, *args, **kwargs)
 

--- a/netbox_librenms_plugin/views/sync/migrate.py
+++ b/netbox_librenms_plugin/views/sync/migrate.py
@@ -429,7 +429,13 @@ class _BaseMoveToWinnerView(LibreNMSAPIMixin, LibreNMSPermissionMixin, NetBoxObj
                 error_response)`` when a device was deleted or the marker changed concurrently.
         """
         ordered = sorted({donor.pk, winner.pk})
-        locked = {d.pk: d for d in Device.objects.select_for_update().filter(pk__in=ordered).order_by("pk")}
+        locked = {
+            d.pk: d
+            for d in self.restricted_queryset(Device, "change")
+            .select_for_update()
+            .filter(pk__in=ordered)
+            .order_by("pk")
+        }
         donor = locked.get(donor.pk)
         winner = locked.get(winner.pk)
         if donor is None or winner is None:
@@ -548,7 +554,12 @@ class MoveInterfaceToWinnerView(_BaseMoveToWinnerView):
             # Lock the donor interface row and re-read it under the lock. A
             # concurrent rename would otherwise let a stale name slip past the
             # collision check below while the row is still moved by pk.
-            interface = Interface.objects.select_for_update().filter(pk=interface.pk, device=donor).first()
+            interface = (
+                self.restricted_queryset(Interface, "change")
+                .select_for_update()
+                .filter(pk=interface.pk, device=donor)
+                .first()
+            )
             if interface is None:
                 return self._fail(
                     request,
@@ -769,7 +780,7 @@ class MoveIPAddressToWinnerView(_BaseMoveToWinnerView):
             donor, winner, err = self._lock_donor_winner_and_reverify(request, donor, winner, server_key)
             if err is not None:
                 return err
-            ip = IPAddress.objects.select_for_update().filter(pk=ip.pk).first()
+            ip = self.restricted_queryset(IPAddress, "change").select_for_update().filter(pk=ip.pk).first()
             if ip is None:
                 return self._fail(request, "IP address no longer exists.", status=410)
             assigned = ip.assigned_object

--- a/netbox_librenms_plugin/views/sync/migrate.py
+++ b/netbox_librenms_plugin/views/sync/migrate.py
@@ -432,7 +432,7 @@ class _BaseMoveToWinnerView(LibreNMSAPIMixin, LibreNMSPermissionMixin, NetBoxObj
         locked = {
             d.pk: d
             for d in self.restricted_queryset(Device, "change")
-            .select_for_update()
+            .select_for_update(of=("self",))
             .filter(pk__in=ordered)
             .order_by("pk")
         }
@@ -556,7 +556,7 @@ class MoveInterfaceToWinnerView(_BaseMoveToWinnerView):
             # collision check below while the row is still moved by pk.
             interface = (
                 self.restricted_queryset(Interface, "change")
-                .select_for_update()
+                .select_for_update(of=("self",))
                 .filter(pk=interface.pk, device=donor)
                 .first()
             )
@@ -780,7 +780,7 @@ class MoveIPAddressToWinnerView(_BaseMoveToWinnerView):
             donor, winner, err = self._lock_donor_winner_and_reverify(request, donor, winner, server_key)
             if err is not None:
                 return err
-            ip = self.restricted_queryset(IPAddress, "change").select_for_update().filter(pk=ip.pk).first()
+            ip = self.restricted_queryset(IPAddress, "change").select_for_update(of=("self",)).filter(pk=ip.pk).first()
             if ip is None:
                 return self._fail(request, "IP address no longer exists.", status=410)
             assigned = ip.assigned_object

--- a/netbox_librenms_plugin/views/sync/migrate.py
+++ b/netbox_librenms_plugin/views/sync/migrate.py
@@ -913,6 +913,12 @@ class TransferDeviceIPView(_BaseMoveToWinnerView):
             if isinstance(assigned, Interface):
                 # Lock the owning interface row (this transfer is device-scoped).
                 assigned = Interface.objects.select_for_update().filter(pk=assigned.pk).first()
+                if assigned is not None:
+                    # Freshen the cached GFK to the locked row: set_device_ip_fk() re-reads
+                    # donor_ip.assigned_object for its ownership check, and the pre-lock snapshot
+                    # would spuriously 409 a move that landed on the winner just before the lock —
+                    # same freshen-after-lock as _reconcile_donor_device_ip_fks.
+                    donor_ip.assigned_object = assigned
             else:
                 assigned = None
             if getattr(assigned, "device_id", None) != winner.pk:

--- a/netbox_librenms_plugin/views/sync/modules.py
+++ b/netbox_librenms_plugin/views/sync/modules.py
@@ -9,7 +9,7 @@ from django.core.cache import cache
 from django.core.exceptions import ValidationError
 from django.db import IntegrityError, models, transaction
 from django.http import HttpResponse
-from django.shortcuts import get_object_or_404, redirect, render
+from django.shortcuts import redirect, render
 from django.urls import reverse
 from django.views import View
 
@@ -569,7 +569,7 @@ class InstallModuleView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixin, Li
         if error := self.require_all_permissions("POST"):
             return error
 
-        page_device = get_object_or_404(Device, pk=pk)
+        page_device = self.restrict_object_or_404(Device, pk=pk)
         target_device, invalid_selected_device = _resolve_target_device_with_validation(
             page_device, request.POST.get("selected_device_id")
         )
@@ -594,8 +594,10 @@ class InstallModuleView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixin, Li
             messages.error(request, "Missing or invalid module bay/module type ID.")
             return _modules_redirect_response(request, sync_url, server_key)
 
-        get_object_or_404(ModuleBay, pk=module_bay_id, device=target_device)  # verify bay belongs to selected device
-        module_type = get_object_or_404(ModuleType, pk=module_type_id)
+        self.restrict_object_or_404(
+            ModuleBay, pk=module_bay_id, device=target_device
+        )  # verify bay belongs to selected device
+        module_type = self.restrict_object_or_404(ModuleType, pk=module_type_id)
 
         try:
             with transaction.atomic():
@@ -682,7 +684,7 @@ class InstallBranchView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixin, Li
         if error := self.require_all_permissions("POST"):
             return error
 
-        page_device = get_object_or_404(Device, pk=pk)
+        page_device = self.restrict_object_or_404(Device, pk=pk)
         target_device, invalid_selected_device = _resolve_target_device_with_validation(
             page_device, request.POST.get("selected_device_id")
         )
@@ -1239,7 +1241,7 @@ class InstallSelectedView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixin, 
         if error := self.require_all_permissions("POST"):
             return error
 
-        page_device = get_object_or_404(Device, pk=pk)
+        page_device = self.restrict_object_or_404(Device, pk=pk)
         server_key = self.resolve_posted_server_key(request.POST)
         sync_url = reverse("plugins:netbox_librenms_plugin:device_librenms_sync", kwargs={"pk": pk})
 
@@ -1370,7 +1372,7 @@ class UpdateModuleSerialView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixi
         if error := self.require_all_permissions("POST"):
             return error
 
-        page_device = get_object_or_404(Device, pk=pk)
+        page_device = self.restrict_object_or_404(Device, pk=pk)
         target_device, invalid_selected_device = _resolve_target_device_with_validation(
             page_device, request.POST.get("selected_device_id")
         )
@@ -1423,7 +1425,7 @@ class UpdateModuleInterfaceView(
         if error := self.require_all_permissions("POST"):
             return error
 
-        page_device = get_object_or_404(Device, pk=pk)
+        page_device = self.restrict_object_or_404(Device, pk=pk)
         target_device, invalid_selected_device = _resolve_target_device_with_validation(
             page_device, request.POST.get("selected_device_id")
         )
@@ -1444,7 +1446,7 @@ class UpdateModuleInterfaceView(
             messages.error(request, "Missing or invalid module ID.")
             return _modules_redirect_response(request, sync_url, server_key)
 
-        module = get_object_or_404(Module, pk=module_id, device=target_device)
+        module = self.restrict_object_or_404(Module, "change", pk=module_id, device=target_device)
 
         bind_result = None
         # A primary interface is bindable only with both a cache-resolved item AND a server
@@ -1554,7 +1556,7 @@ class ModuleMismatchPreviewView(
         if error := self.require_object_permissions("GET"):
             return error
 
-        page_device = get_object_or_404(Device, pk=pk)
+        page_device = self.restrict_object_or_404(Device, pk=pk)
         target_device, invalid_selected_device = _resolve_target_device_with_validation(
             page_device, request.GET.get("selected_device_id")
         )
@@ -1568,8 +1570,9 @@ class ModuleMismatchPreviewView(
         except (TypeError, ValueError):
             return HttpResponse("Missing or invalid module_id/ent_index.", status=400)
 
-        installed_module = get_object_or_404(
-            Module.objects.select_related("module_type", "module_bay", "device"),
+        installed_module = self.restrict_object_or_404(
+            Module,
+            select_related=("module_type", "module_bay", "device"),
             pk=module_id,
             device=target_device,
         )
@@ -1667,7 +1670,7 @@ class VCNormalizationReportView(LibreNMSPermissionMixin, NetBoxObjectPermissionM
         if error := self.require_object_permissions("GET"):
             return error
 
-        page_device = get_object_or_404(Device, pk=pk)
+        page_device = self.restrict_object_or_404(Device, pk=pk)
         target_device, invalid_selected_device = _resolve_target_device_with_validation(
             page_device, request.GET.get("selected_device_id")
         )
@@ -1679,8 +1682,9 @@ class VCNormalizationReportView(LibreNMSPermissionMixin, NetBoxObjectPermissionM
         except (TypeError, ValueError):
             return HttpResponse("Missing or invalid module_id.", status=400)
 
-        module = get_object_or_404(
-            Module.objects.select_related("module_type", "module_type__manufacturer", "module_bay", "device"),
+        module = self.restrict_object_or_404(
+            Module,
+            select_related=("module_type", "module_type__manufacturer", "module_bay", "device"),
             pk=module_id,
             device=target_device,
         )
@@ -1726,7 +1730,7 @@ class ReplaceModuleView(LibreNMSPermissionMixin, LibreNMSAPIMixin, NetBoxObjectP
         if error := self.require_all_permissions("POST"):
             return error
 
-        page_device = get_object_or_404(Device, pk=pk)
+        page_device = self.restrict_object_or_404(Device, pk=pk)
         target_device, invalid_selected_device = _resolve_target_device_with_validation(
             page_device, request.POST.get("selected_device_id")
         )
@@ -1742,8 +1746,10 @@ class ReplaceModuleView(LibreNMSPermissionMixin, LibreNMSAPIMixin, NetBoxObjectP
             messages.error(request, "Missing or invalid module_id/ent_index.")
             return _modules_redirect_response(request, sync_url, server_key)
 
-        installed_module = get_object_or_404(
-            Module.objects.select_related("module_type", "module_bay"),
+        installed_module = self.restrict_object_or_404(
+            Module,
+            "change",
+            select_related=("module_type", "module_bay"),
             pk=module_id,
             device=target_device,
         )
@@ -1923,7 +1929,7 @@ class MoveModuleView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixin, View)
         if error := self.require_all_permissions("POST"):
             return error
 
-        page_device = get_object_or_404(Device, pk=pk)
+        page_device = self.restrict_object_or_404(Device, pk=pk)
         target_device, invalid_selected_device = _resolve_target_device_with_validation(
             page_device, request.POST.get("selected_device_id")
         )
@@ -1945,7 +1951,7 @@ class MoveModuleView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixin, View)
         except (TypeError, ValueError):
             module_id = None
 
-        get_object_or_404(ModuleBay, pk=target_bay_id, device=target_device)
+        self.restrict_object_or_404(ModuleBay, pk=target_bay_id, device=target_device)
 
         try:
             occupant_removed_msg = None
@@ -2012,9 +2018,9 @@ class AddBayTemplateView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixin, V
         from dcim.models import DeviceType, ModuleType
 
         if target_kind == "device_type":
-            return get_object_or_404(DeviceType, pk=target_pk)
+            return self.restrict_object_or_404(DeviceType, pk=target_pk)
         if target_kind == "module_type":
-            return get_object_or_404(ModuleType, pk=target_pk)
+            return self.restrict_object_or_404(ModuleType, pk=target_pk)
         return None
 
     @staticmethod
@@ -2210,7 +2216,7 @@ class AddBayTemplateView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixin, V
         if error := self.require_all_permissions("GET"):
             return error
 
-        device = get_object_or_404(Device, pk=pk)
+        device = self.restrict_object_or_404(Device, pk=pk)
 
         target_kind = request.GET.get("target_kind", "")
         if target_kind not in self.TARGET_KINDS:
@@ -2272,7 +2278,7 @@ class AddBayTemplateView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixin, V
         if error := self.require_all_permissions("POST"):
             return error
 
-        device = get_object_or_404(Device, pk=pk)
+        device = self.restrict_object_or_404(Device, pk=pk)
         sync_url = reverse("plugins:netbox_librenms_plugin:device_librenms_sync", kwargs={"pk": pk})
 
         target_kind = request.POST.get("target_kind", "")

--- a/netbox_librenms_plugin/views/sync/modules.py
+++ b/netbox_librenms_plugin/views/sync/modules.py
@@ -564,7 +564,15 @@ class InstallModuleView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixin, Li
         from dcim.models import Device, Interface, Module, ModuleBay, ModuleType
 
         self.required_object_permissions = {
-            "POST": [("add", Module), ("add", Interface), ("change", Interface), ("delete", Interface)]
+            "POST": [
+                ("view", Device),
+                ("view", ModuleBay),
+                ("view", ModuleType),
+                ("add", Module),
+                ("add", Interface),
+                ("change", Interface),
+                ("delete", Interface),
+            ]
         }
         if error := self.require_all_permissions("POST"):
             return error
@@ -602,7 +610,7 @@ class InstallModuleView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixin, Li
         try:
             with transaction.atomic():
                 # Re-fetch bay under lock to prevent TOCTOU race with concurrent installs.
-                locked_bay = self.restricted_queryset(ModuleBay).select_for_update().get(pk=module_bay_id)
+                locked_bay = self.restricted_queryset(ModuleBay).select_for_update(of=("self",)).get(pk=module_bay_id)
                 if hasattr(locked_bay, "installed_module") and locked_bay.installed_module:
                     messages.warning(request, f"Module bay '{locked_bay.name}' already has a module installed.")
                     return _modules_redirect_response(request, sync_url, server_key)
@@ -675,6 +683,7 @@ class InstallBranchView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixin, Li
 
         self.required_object_permissions = {
             "POST": [
+                ("view", Device),
                 ("add", Module),
                 ("add", Interface),
                 ("change", Interface),
@@ -1232,6 +1241,7 @@ class InstallSelectedView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixin, 
 
         self.required_object_permissions = {
             "POST": [
+                ("view", Device),
                 ("add", Module),
                 ("add", Interface),
                 ("change", Interface),
@@ -1368,7 +1378,7 @@ class UpdateModuleSerialView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixi
     def post(self, request, pk):
         from dcim.models import Device, Module
 
-        self.required_object_permissions = {"POST": [("change", Module)]}
+        self.required_object_permissions = {"POST": [("view", Device), ("change", Module)]}
         if error := self.require_all_permissions("POST"):
             return error
 
@@ -1393,7 +1403,7 @@ class UpdateModuleSerialView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixi
             with transaction.atomic():
                 module = (
                     self.restricted_queryset(Module, "change")
-                    .select_for_update()
+                    .select_for_update(of=("self",))
                     .select_related("module_type", "module_bay")
                     .filter(pk=module_id, device=target_device)
                     .first()
@@ -1422,7 +1432,7 @@ class UpdateModuleInterfaceView(
     def post(self, request, pk):
         from dcim.models import Device, Interface, Module
 
-        self.required_object_permissions = {"POST": [("change", Interface)]}
+        self.required_object_permissions = {"POST": [("view", Device), ("view", Module), ("change", Interface)]}
         if error := self.require_all_permissions("POST"):
             return error
 
@@ -1447,7 +1457,7 @@ class UpdateModuleInterfaceView(
             messages.error(request, "Missing or invalid module ID.")
             return _modules_redirect_response(request, sync_url, server_key)
 
-        module = self.restrict_object_or_404(Module, "change", pk=module_id, device=target_device)
+        module = self.restrict_object_or_404(Module, "view", pk=module_id, device=target_device)
 
         bind_result = None
         # A primary interface is bindable only with both a cache-resolved item AND a server
@@ -1720,6 +1730,7 @@ class ReplaceModuleView(LibreNMSPermissionMixin, LibreNMSAPIMixin, NetBoxObjectP
 
         self.required_object_permissions = {
             "POST": [
+                ("view", Device),
                 ("add", Module),
                 ("change", Module),
                 ("delete", Module),
@@ -1794,7 +1805,7 @@ class ReplaceModuleView(LibreNMSPermissionMixin, LibreNMSAPIMixin, NetBoxObjectP
                 # Re-fetch with row lock to prevent concurrent modifications
                 installed_module = (
                     self.restricted_queryset(Module, "change")
-                    .select_for_update()
+                    .select_for_update(of=("self",))
                     .filter(pk=module_id, device=target_device)
                     .select_related("module_type", "module_bay")
                     .first()
@@ -1927,7 +1938,14 @@ class MoveModuleView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixin, View)
     def post(self, request, pk):
         from dcim.models import Device, Module, ModuleBay
 
-        self.required_object_permissions = {"POST": [("change", Module), ("delete", Module)]}
+        self.required_object_permissions = {
+            "POST": [
+                ("view", Device),
+                ("view", ModuleBay),
+                ("change", Module),
+                ("delete", Module),
+            ]
+        }
         if error := self.require_all_permissions("POST"):
             return error
 
@@ -1960,7 +1978,9 @@ class MoveModuleView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixin, View)
             with transaction.atomic():
                 # Lock target bay to prevent concurrent modifications
                 target_bay = (
-                    self.restricted_queryset(ModuleBay).select_for_update().get(pk=target_bay_id, device=target_device)
+                    self.restricted_queryset(ModuleBay)
+                    .select_for_update(of=("self",))
+                    .get(pk=target_bay_id, device=target_device)
                 )
 
                 # Re-fetch with row lock to prevent concurrent modifications. Scoped like the
@@ -1969,7 +1989,7 @@ class MoveModuleView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixin, View)
                 # user's grant does not cover.
                 conflict_module = (
                     self.restricted_queryset(Module, "change")
-                    .select_for_update()
+                    .select_for_update(of=("self",))
                     .filter(pk=conflict_module_id)
                     .select_related("module_type", "module_bay", "device")
                     .first()
@@ -1984,7 +2004,7 @@ class MoveModuleView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixin, View)
                 if module_id:
                     occupant = (
                         self.restricted_queryset(Module, "delete")
-                        .select_for_update()
+                        .select_for_update(of=("self",))
                         .filter(pk=module_id, device=target_device, module_bay=target_bay)
                         .first()
                     )
@@ -2216,22 +2236,31 @@ class AddBayTemplateView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixin, V
         return qs.exists()
 
     def get(self, request, pk):
-        from dcim.models import Device, ModuleBay, ModuleBayTemplate
+        from dcim.models import Device, DeviceType, ModuleBay, ModuleBayTemplate, ModuleType
+
+        target_kind = request.GET.get("target_kind", "")
+        if target_kind not in self.TARGET_KINDS:
+            return HttpResponse("Invalid target_kind.", status=400)
+        target_model = DeviceType if target_kind == "device_type" else ModuleType
 
         # Read-only modal render — only require plugin view permission and
         # NetBox add-permission on ModuleBayTemplate so users without it never
         # see a form they cannot submit. POST also instantiates live ModuleBay
         # rows via _instantiate_template_on_existing(), so require add_modulebay
         # here too to keep the GET/POST permission contract aligned.
-        self.required_object_permissions = {"GET": [("add", ModuleBayTemplate), ("add", ModuleBay)]}
+        self.required_object_permissions = {
+            "GET": [
+                ("view", Device),
+                ("view", target_model),
+                ("add", ModuleBayTemplate),
+                ("add", ModuleBay),
+            ]
+        }
         if error := self.require_all_permissions("GET"):
             return error
 
         device = self.restrict_object_or_404(Device, pk=pk)
 
-        target_kind = request.GET.get("target_kind", "")
-        if target_kind not in self.TARGET_KINDS:
-            return HttpResponse("Invalid target_kind.", status=400)
         try:
             target_pk = int(request.GET.get("target_pk", ""))
         except (TypeError, ValueError):
@@ -2278,24 +2307,34 @@ class AddBayTemplateView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixin, V
         return render(request, "netbox_librenms_plugin/htmx/add_bay_template_modal.html", context)
 
     def post(self, request, pk):
-        from dcim.models import Device, ModuleBay, ModuleBayTemplate
+        from dcim.models import Device, DeviceType, ModuleBay, ModuleBayTemplate, ModuleType
 
         from netbox_librenms_plugin.models import ModuleBayMapping
+
+        target_kind = request.POST.get("target_kind", "")
+        if target_kind not in self.TARGET_KINDS:
+            messages.error(request, "Invalid target_kind for bay template.")
+            sync_url = reverse("plugins:netbox_librenms_plugin:device_librenms_sync", kwargs={"pk": pk})
+            return _modules_redirect_response(request, sync_url)
+        target_model = DeviceType if target_kind == "device_type" else ModuleType
 
         # POST creates the template AND instantiates live ModuleBay rows on
         # existing devices/modules via _instantiate_template_on_existing(), so
         # gate on add_modulebay in addition to add_modulebaytemplate.
-        self.required_object_permissions = {"POST": [("add", ModuleBayTemplate), ("add", ModuleBay)]}
+        self.required_object_permissions = {
+            "POST": [
+                ("view", Device),
+                ("view", target_model),
+                ("add", ModuleBayTemplate),
+                ("add", ModuleBay),
+            ]
+        }
         if error := self.require_all_permissions("POST"):
             return error
 
         device = self.restrict_object_or_404(Device, pk=pk)
         sync_url = reverse("plugins:netbox_librenms_plugin:device_librenms_sync", kwargs={"pk": pk})
 
-        target_kind = request.POST.get("target_kind", "")
-        if target_kind not in self.TARGET_KINDS:
-            messages.error(request, "Invalid target_kind for bay template.")
-            return _modules_redirect_response(request, sync_url)
         try:
             target_pk = int(request.POST.get("target_pk", ""))
         except (TypeError, ValueError):

--- a/netbox_librenms_plugin/views/sync/modules.py
+++ b/netbox_librenms_plugin/views/sync/modules.py
@@ -602,7 +602,7 @@ class InstallModuleView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixin, Li
         try:
             with transaction.atomic():
                 # Re-fetch bay under lock to prevent TOCTOU race with concurrent installs.
-                locked_bay = ModuleBay.objects.select_for_update().get(pk=module_bay_id)
+                locked_bay = self.restricted_queryset(ModuleBay).select_for_update().get(pk=module_bay_id)
                 if hasattr(locked_bay, "installed_module") and locked_bay.installed_module:
                     messages.warning(request, f"Module bay '{locked_bay.name}' already has a module installed.")
                     return _modules_redirect_response(request, sync_url, server_key)
@@ -1392,7 +1392,8 @@ class UpdateModuleSerialView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixi
         try:
             with transaction.atomic():
                 module = (
-                    Module.objects.select_for_update()
+                    self.restricted_queryset(Module, "change")
+                    .select_for_update()
                     .select_related("module_type", "module_bay")
                     .filter(pk=module_id, device=target_device)
                     .first()
@@ -1792,7 +1793,8 @@ class ReplaceModuleView(LibreNMSPermissionMixin, LibreNMSAPIMixin, NetBoxObjectP
             with transaction.atomic():
                 # Re-fetch with row lock to prevent concurrent modifications
                 installed_module = (
-                    Module.objects.select_for_update()
+                    self.restricted_queryset(Module, "change")
+                    .select_for_update()
                     .filter(pk=module_id, device=target_device)
                     .select_related("module_type", "module_bay")
                     .first()
@@ -1957,7 +1959,9 @@ class MoveModuleView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixin, View)
             occupant_removed_msg = None
             with transaction.atomic():
                 # Lock target bay to prevent concurrent modifications
-                target_bay = ModuleBay.objects.select_for_update().get(pk=target_bay_id, device=target_device)
+                target_bay = (
+                    self.restricted_queryset(ModuleBay).select_for_update().get(pk=target_bay_id, device=target_device)
+                )
 
                 # Re-fetch with row lock to prevent concurrent modifications. Scoped like the
                 # primary lookup: this module's device and bay are reassigned below, and its pk

--- a/netbox_librenms_plugin/views/sync/modules.py
+++ b/netbox_librenms_plugin/views/sync/modules.py
@@ -15,6 +15,7 @@ from django.views import View
 
 from netbox_librenms_plugin.utils import (
     AmbiguousLibreNMSIdError,
+    coerce_positive_int as _coerce_positive_int,
     find_by_librenms_id,
     get_librenms_device_id,
     get_librenms_sync_device,
@@ -169,17 +170,6 @@ class _SerialConflictUnavailable(Exception):
 def _get_sync_device_for_inventory(device, server_key):
     """Return the VC sync device used for module inventory cache keys."""
     return get_librenms_sync_device(device, server_key=server_key) or device
-
-
-def _coerce_positive_int(value):
-    """Return ``value`` as a positive int, or ``None`` when invalid."""
-    if value is None or isinstance(value, bool):
-        return None
-    try:
-        int_value = int(value)
-    except (TypeError, ValueError):
-        return None
-    return int_value if int_value > 0 else None
 
 
 def _get_item_port_identity(item):

--- a/netbox_librenms_plugin/views/sync/modules.py
+++ b/netbox_librenms_plugin/views/sync/modules.py
@@ -1828,7 +1828,8 @@ class ReplaceModuleView(LibreNMSPermissionMixin, LibreNMSAPIMixin, NetBoxObjectP
                 conflict_module = None
                 if serial:
                     conflict_qs = (
-                        Module.objects.select_for_update()
+                        self.restricted_queryset(Module, "delete")
+                        .select_for_update(of=("self",))
                         .filter(serial=serial)
                         .exclude(pk=installed_module.pk)
                         .select_related("module_type", "module_bay", "device")

--- a/netbox_librenms_plugin/views/sync/modules.py
+++ b/netbox_librenms_plugin/views/sync/modules.py
@@ -158,6 +158,14 @@ class _SerialConflictAmbiguous(Exception):
         self.serial = serial
 
 
+class _SerialConflictUnavailable(Exception):
+    """Abort replacement when a serial conflict is outside the caller's delete scope."""
+
+    def __init__(self, serial):
+        super().__init__(serial)
+        self.serial = serial
+
+
 def _get_sync_device_for_inventory(device, server_key):
     """Return the VC sync device used for module inventory cache keys."""
     return get_librenms_sync_device(device, server_key=server_key) or device
@@ -1631,15 +1639,18 @@ class ModuleMismatchPreviewView(
         # Check whether the LibreNMS serial already exists at a different location
         serial_conflict = None
         serial_conflict_ambiguous = False
+        serial_conflict_hidden = False
         if librenms_serial:
-            conflict_qs = (
-                Module.objects.filter(serial=librenms_serial)
-                .exclude(pk=installed_module.pk)
-                .select_related("module_type", "module_bay", "device")
-            )
+            conflict_qs = Module.objects.filter(serial=librenms_serial).exclude(pk=installed_module.pk)
             conflict_count = conflict_qs.count()
             if conflict_count == 1:
-                serial_conflict = conflict_qs.first()
+                serial_conflict = (
+                    self.restricted_queryset(Module)
+                    .filter(pk__in=conflict_qs)
+                    .select_related("module_type", "module_bay", "device")
+                    .first()
+                )
+                serial_conflict_hidden = serial_conflict is None
             elif conflict_count > 1:
                 serial_conflict_ambiguous = True
 
@@ -1659,6 +1670,7 @@ class ModuleMismatchPreviewView(
                 "serial_mismatch": serial_mismatch,
                 "serial_conflict": serial_conflict,
                 "serial_conflict_ambiguous": serial_conflict_ambiguous,
+                "serial_conflict_hidden": serial_conflict_hidden,
                 "ent_index": ent_index_int,
                 "server_key": server_key or "",
                 "selected_device_id": target_device.pk,
@@ -1764,6 +1776,7 @@ class ReplaceModuleView(LibreNMSPermissionMixin, LibreNMSAPIMixin, NetBoxObjectP
             select_related=("module_type", "module_bay"),
             pk=module_id,
             device=target_device,
+            pk__in=self.restricted_queryset(Module, "delete").values("pk"),
         )
 
         sync_device = _get_sync_device_for_inventory(target_device, server_key)
@@ -1806,7 +1819,11 @@ class ReplaceModuleView(LibreNMSPermissionMixin, LibreNMSAPIMixin, NetBoxObjectP
                 installed_module = (
                     self.restricted_queryset(Module, "change")
                     .select_for_update(of=("self",))
-                    .filter(pk=module_id, device=target_device)
+                    .filter(
+                        pk=module_id,
+                        device=target_device,
+                        pk__in=self.restricted_queryset(Module, "delete").values("pk"),
+                    )
                     .select_related("module_type", "module_bay")
                     .first()
                 )
@@ -1835,11 +1852,14 @@ class ReplaceModuleView(LibreNMSPermissionMixin, LibreNMSAPIMixin, NetBoxObjectP
                         .select_related("module_type", "module_bay", "device")
                     )
                     locked_conflicts = list(conflict_qs)
-                    if len(locked_conflicts) > 1:
+                    conflict_count = Module.objects.filter(serial=serial).exclude(pk=installed_module.pk).count()
+                    if conflict_count > 1:
                         # Roll back and surface a clear error — we don't want to
                         # guess which of N conflicts to remove.
                         raise _SerialConflictAmbiguous(serial)
-                    if len(locked_conflicts) == 1:
+                    if conflict_count != len(locked_conflicts):
+                        raise _SerialConflictUnavailable(serial)
+                    if conflict_count == 1:
                         conflict_module = locked_conflicts[0]
 
                 # Remove the serial-conflicting module from its current location.
@@ -1912,6 +1932,12 @@ class ReplaceModuleView(LibreNMSPermissionMixin, LibreNMSAPIMixin, NetBoxObjectP
                 request,
                 f"Serial '{exc.serial}' is assigned to multiple modules; cannot determine which to remove. "
                 "Please resolve the conflict manually.",
+            )
+        except _SerialConflictUnavailable as exc:
+            messages.error(
+                request,
+                f"Serial '{exc.serial}' is assigned to a module you cannot remove. "
+                "Ask an administrator to resolve the conflict.",
             )
         except (ValidationError, IntegrityError) as e:
             error_msg = str(e)

--- a/netbox_librenms_plugin/views/sync/modules.py
+++ b/netbox_librenms_plugin/views/sync/modules.py
@@ -1974,10 +1974,13 @@ class MoveModuleView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixin, View)
                     messages.error(request, "Module no longer exists.")
                     return _modules_redirect_response(request, sync_url)
 
-                # Remove whatever is currently in the target bay (if provided and different)
+                # Remove whatever is currently in the target bay (if provided and different).
+                # Scoped by "delete": the device and bay filters prove where the row sits, not that
+                # the grant covers it, and the gate asked has_perm without an instance.
                 if module_id:
                     occupant = (
-                        Module.objects.select_for_update()
+                        self.restricted_queryset(Module, "delete")
+                        .select_for_update()
                         .filter(pk=module_id, device=target_device, module_bay=target_bay)
                         .first()
                     )

--- a/netbox_librenms_plugin/views/sync/modules.py
+++ b/netbox_librenms_plugin/views/sync/modules.py
@@ -618,7 +618,12 @@ class InstallModuleView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixin, Li
         try:
             with transaction.atomic():
                 # Re-fetch bay under lock to prevent TOCTOU race with concurrent installs.
-                locked_bay = self.restricted_queryset(ModuleBay).select_for_update(of=("self",)).get(pk=module_bay_id)
+                locked_bay = (
+                    self.restricted_queryset(ModuleBay).select_for_update(of=("self",)).filter(pk=module_bay_id).first()
+                )
+                if not locked_bay:
+                    messages.error(request, "Module bay no longer exists.")
+                    return _modules_redirect_response(request, sync_url, server_key)
                 if hasattr(locked_bay, "installed_module") and locked_bay.installed_module:
                     messages.warning(request, f"Module bay '{locked_bay.name}' already has a module installed.")
                     return _modules_redirect_response(request, sync_url, server_key)
@@ -2007,8 +2012,12 @@ class MoveModuleView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixin, View)
                 target_bay = (
                     self.restricted_queryset(ModuleBay)
                     .select_for_update(of=("self",))
-                    .get(pk=target_bay_id, device=target_device)
+                    .filter(pk=target_bay_id, device=target_device)
+                    .first()
                 )
+                if not target_bay:
+                    messages.error(request, "Module bay no longer exists.")
+                    return _modules_redirect_response(request, sync_url)
 
                 # Re-fetch with row lock to prevent concurrent modifications. Scoped like the
                 # primary lookup: this module's device and bay are reassigned below, and its pk

--- a/netbox_librenms_plugin/views/sync/modules.py
+++ b/netbox_librenms_plugin/views/sync/modules.py
@@ -1959,9 +1959,13 @@ class MoveModuleView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixin, View)
                 # Lock target bay to prevent concurrent modifications
                 target_bay = ModuleBay.objects.select_for_update().get(pk=target_bay_id, device=target_device)
 
-                # Re-fetch with row lock to prevent concurrent modifications
+                # Re-fetch with row lock to prevent concurrent modifications. Scoped like the
+                # primary lookup: this module's device and bay are reassigned below, and its pk
+                # comes straight from the POST, so an unscoped read would move a module the
+                # user's grant does not cover.
                 conflict_module = (
-                    Module.objects.select_for_update()
+                    self.restricted_queryset(Module, "change")
+                    .select_for_update()
                     .filter(pk=conflict_module_id)
                     .select_related("module_type", "module_bay", "device")
                     .first()

--- a/netbox_librenms_plugin/views/sync/modules.py
+++ b/netbox_librenms_plugin/views/sync/modules.py
@@ -619,7 +619,10 @@ class InstallModuleView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixin, Li
             with transaction.atomic():
                 # Re-fetch bay under lock to prevent TOCTOU race with concurrent installs.
                 locked_bay = (
-                    self.restricted_queryset(ModuleBay).select_for_update(of=("self",)).filter(pk=module_bay_id).first()
+                    self.restricted_queryset(ModuleBay)
+                    .select_for_update(of=("self",))
+                    .filter(pk=module_bay_id, device=target_device)
+                    .first()
                 )
                 if not locked_bay:
                     messages.error(request, "Module bay no longer exists.")

--- a/netbox_librenms_plugin/views/sync/vlans.py
+++ b/netbox_librenms_plugin/views/sync/vlans.py
@@ -104,6 +104,7 @@ class SyncVLANsView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixin, LibreN
         skipped_count = 0
         group_missing_count = 0
         permission_skipped_count = 0
+        ambiguous_count = 0
         changeable_vlans = self.restricted_queryset(VLAN, "change")
 
         with transaction.atomic():
@@ -144,6 +145,13 @@ class SyncVLANsView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixin, LibreN
                 try:
                     vlan = changeable_vlans.get(**lookup)
                     created = False
+                except VLAN.MultipleObjectsReturned:
+                    messages.error(
+                        request,
+                        f"VLAN {vid}: several VLANs match this VID and scope; skipped to avoid renaming the wrong one.",
+                    )
+                    ambiguous_count += 1
+                    continue
                 except VLAN.DoesNotExist:
                     # A matching row can exist outside the caller's constrained change grant.
                     # Do not let an unrestricted get_or_create return that row for mutation.
@@ -169,6 +177,14 @@ class SyncVLANsView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixin, LibreN
                         try:
                             vlan = changeable_vlans.get(**lookup)
                             created = False
+                        except VLAN.MultipleObjectsReturned:
+                            messages.error(
+                                request,
+                                f"VLAN {vid}: several VLANs match this VID and scope; skipped to avoid "
+                                "renaming the wrong one.",
+                            )
+                            ambiguous_count += 1
+                            continue
                         except VLAN.DoesNotExist:
                             messages.error(
                                 request,
@@ -203,14 +219,18 @@ class SyncVLANsView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixin, LibreN
                 parts.append(f"{group_missing_count} skipped (VLAN group missing)")
             if permission_skipped_count > 0:
                 parts.append(f"{permission_skipped_count} skipped (change permission missing)")
+            if ambiguous_count > 0:
+                parts.append(f"{ambiguous_count} skipped (VLAN match ambiguous)")
             messages.success(request, f"VLANs synced: {', '.join(parts)}.")
-        elif group_missing_count > 0 or permission_skipped_count > 0:
+        elif group_missing_count > 0 or permission_skipped_count > 0 or ambiguous_count > 0:
             # Nothing actually synced. Do not claim success for rows rejected by a scope check.
             reasons = []
             if group_missing_count > 0:
                 reasons.append(f"{group_missing_count} skipped (VLAN group missing)")
             if permission_skipped_count > 0:
                 reasons.append(f"{permission_skipped_count} skipped (change permission missing)")
+            if ambiguous_count > 0:
+                reasons.append(f"{ambiguous_count} skipped (VLAN match ambiguous)")
             messages.warning(request, f"No VLANs synced: {', '.join(reasons)}.")
         else:
             messages.warning(request, "No VLANs were created or updated.")

--- a/netbox_librenms_plugin/views/sync/vlans.py
+++ b/netbox_librenms_plugin/views/sync/vlans.py
@@ -1,10 +1,11 @@
+import hashlib
 from urllib.parse import quote_plus
 
 from dcim.models import Device
 from django.contrib import messages
 from django.core.cache import cache
 from django.core.exceptions import ValidationError
-from django.db import IntegrityError, transaction
+from django.db import IntegrityError, connection, transaction
 from django.http import Http404
 from django.shortcuts import redirect
 from django.urls import reverse
@@ -17,6 +18,24 @@ from netbox_librenms_plugin.views.mixins import (
     LibreNMSPermissionMixin,
     NetBoxObjectPermissionMixin,
 )
+
+
+def _acquire_global_vlan_locks(vids):
+    """Lock global VLAN VIDs in stable order for the current transaction."""
+    if not connection.in_atomic_block:
+        raise RuntimeError("_acquire_global_vlan_locks() requires an open transaction")
+
+    with connection.cursor() as cursor:
+        for vid in sorted(set(vids)):
+            lock_key = int.from_bytes(
+                hashlib.blake2b(
+                    f"netbox-librenms-plugin:global-vlan:{vid}".encode(),
+                    digest_size=8,
+                ).digest(),
+                byteorder="big",
+                signed=True,
+            )
+            cursor.execute("SELECT pg_advisory_xact_lock(%s)", [lock_key])
 
 
 class SyncVLANsView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixin, LibreNMSAPIMixin, CacheMixin, View):
@@ -111,6 +130,20 @@ class SyncVLANsView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixin, LibreN
         changeable_vlans = self.restricted_queryset(VLAN, "change")
 
         with transaction.atomic():
+            # A global VLAN has no parent row to lock, and PostgreSQL treats NULL
+            # group values as distinct in the VLAN uniqueness constraint. Lock all
+            # selected global VIDs before lookup so concurrent batches cannot both
+            # observe a missing row. Stable ordering prevents cross-batch deadlocks.
+            global_vids = []
+            for vid_str in selected_vlans:
+                try:
+                    vid = int(vid_str)
+                except ValueError:
+                    continue
+                if vid_str in librenms_vlans and not request.POST.get(f"vlan_group_{vid}", ""):
+                    global_vids.append(vid)
+            _acquire_global_vlan_locks(global_vids)
+
             for vid_str in selected_vlans:
                 try:
                     vid = int(vid_str)

--- a/netbox_librenms_plugin/views/sync/vlans.py
+++ b/netbox_librenms_plugin/views/sync/vlans.py
@@ -5,7 +5,7 @@ from django.contrib import messages
 from django.core.cache import cache
 from django.db import transaction
 from django.http import Http404
-from django.shortcuts import get_object_or_404, redirect
+from django.shortcuts import redirect
 from django.urls import reverse
 from django.views import View
 from ipam.models import VLAN, VLANGroup
@@ -25,6 +25,9 @@ class SyncVLANsView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixin, LibreN
 
     required_object_permissions = {
         "POST": [
+            # The owner device is resolved through a restricted queryset (see get_object), so
+            # state that read here: a missing grant is an explicit 403, not a 404 at the lookup.
+            ("view", Device),
             ("add", VLAN),
             ("change", VLAN),
         ],
@@ -58,7 +61,7 @@ class SyncVLANsView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixin, LibreN
     def get_object(self, object_type: str, object_id: int):
         """Get the target object (Device or VM)."""
         if object_type == "device":
-            return get_object_or_404(Device, pk=object_id)
+            return self.restrict_object_or_404(Device, pk=object_id)
         raise Http404("Invalid object type.")
 
     def _redirect(self, object_type: str, object_id: int):

--- a/netbox_librenms_plugin/views/sync/vlans.py
+++ b/netbox_librenms_plugin/views/sync/vlans.py
@@ -28,6 +28,7 @@ class SyncVLANsView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixin, LibreN
             # The owner device is resolved through a restricted queryset (see get_object), so
             # state that read here: a missing grant is an explicit 403, not a 404 at the lookup.
             ("view", Device),
+            ("view", VLANGroup),
             ("add", VLAN),
             ("change", VLAN),
         ],

--- a/netbox_librenms_plugin/views/sync/vlans.py
+++ b/netbox_librenms_plugin/views/sync/vlans.py
@@ -3,6 +3,7 @@ from urllib.parse import quote_plus
 from dcim.models import Device
 from django.contrib import messages
 from django.core.cache import cache
+from django.core.exceptions import ValidationError
 from django.db import IntegrityError, transaction
 from django.http import Http404
 from django.shortcuts import redirect
@@ -106,6 +107,7 @@ class SyncVLANsView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixin, LibreN
         permission_skipped_count = 0
         ambiguous_count = 0
         concurrent_change_count = 0
+        invalid_name_count = 0
         changeable_vlans = self.restricted_queryset(VLAN, "change")
 
         with transaction.atomic():
@@ -141,6 +143,12 @@ class SyncVLANsView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixin, LibreN
                         continue
 
                 librenms_name = vlan_data.get("vlan_name", f"VLAN {vid}")
+                try:
+                    VLAN._meta.get_field("name").clean(librenms_name, None)
+                except ValidationError:
+                    messages.error(request, f"VLAN {vid}: the LibreNMS name is invalid; skipped.")
+                    invalid_name_count += 1
+                    continue
 
                 lookup = {"vid": vid, "group": row_vlan_group}
                 try:
@@ -227,6 +235,8 @@ class SyncVLANsView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixin, LibreN
             skip_reasons.append(f"{ambiguous_count} skipped (VLAN match ambiguous)")
         if concurrent_change_count > 0:
             skip_reasons.append(f"{concurrent_change_count} skipped (concurrent VLAN change)")
+        if invalid_name_count > 0:
+            skip_reasons.append(f"{invalid_name_count} skipped (invalid VLAN name)")
 
         if parts:
             messages.success(request, f"VLANs synced: {', '.join(parts + skip_reasons)}.")

--- a/netbox_librenms_plugin/views/sync/vlans.py
+++ b/netbox_librenms_plugin/views/sync/vlans.py
@@ -119,7 +119,7 @@ class SyncVLANsView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixin, LibreN
                 row_vlan_group = None
                 if group_id_str:
                     try:
-                        row_vlan_group = VLANGroup.objects.get(pk=int(group_id_str))
+                        row_vlan_group = self.restricted_queryset(VLANGroup).get(pk=int(group_id_str))
                     except (ValueError, VLANGroup.DoesNotExist):
                         # A group was explicitly requested but doesn't exist (stale page or
                         # tampered id). Fail closed: do NOT fall back to a global VLAN, which

--- a/netbox_librenms_plugin/views/sync/vlans.py
+++ b/netbox_librenms_plugin/views/sync/vlans.py
@@ -218,33 +218,21 @@ class SyncVLANsView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixin, LibreN
         if skipped_count > 0:
             parts.append(f"{skipped_count} unchanged")
 
+        skip_reasons = []
+        if group_missing_count > 0:
+            skip_reasons.append(f"{group_missing_count} skipped (VLAN group missing)")
+        if permission_skipped_count > 0:
+            skip_reasons.append(f"{permission_skipped_count} skipped (change permission missing)")
+        if ambiguous_count > 0:
+            skip_reasons.append(f"{ambiguous_count} skipped (VLAN match ambiguous)")
+        if concurrent_change_count > 0:
+            skip_reasons.append(f"{concurrent_change_count} skipped (concurrent VLAN change)")
+
         if parts:
-            if group_missing_count > 0:
-                parts.append(f"{group_missing_count} skipped (VLAN group missing)")
-            if permission_skipped_count > 0:
-                parts.append(f"{permission_skipped_count} skipped (change permission missing)")
-            if ambiguous_count > 0:
-                parts.append(f"{ambiguous_count} skipped (VLAN match ambiguous)")
-            if concurrent_change_count > 0:
-                parts.append(f"{concurrent_change_count} skipped (concurrent VLAN change)")
-            messages.success(request, f"VLANs synced: {', '.join(parts)}.")
-        elif (
-            group_missing_count > 0
-            or permission_skipped_count > 0
-            or ambiguous_count > 0
-            or concurrent_change_count > 0
-        ):
+            messages.success(request, f"VLANs synced: {', '.join(parts + skip_reasons)}.")
+        elif skip_reasons:
             # Nothing actually synced. Do not claim success for rows rejected by a scope check.
-            reasons = []
-            if group_missing_count > 0:
-                reasons.append(f"{group_missing_count} skipped (VLAN group missing)")
-            if permission_skipped_count > 0:
-                reasons.append(f"{permission_skipped_count} skipped (change permission missing)")
-            if ambiguous_count > 0:
-                reasons.append(f"{ambiguous_count} skipped (VLAN match ambiguous)")
-            if concurrent_change_count > 0:
-                reasons.append(f"{concurrent_change_count} skipped (concurrent VLAN change)")
-            messages.warning(request, f"No VLANs synced: {', '.join(reasons)}.")
+            messages.warning(request, f"No VLANs synced: {', '.join(skip_reasons)}.")
         else:
             messages.warning(request, "No VLANs were created or updated.")
 

--- a/netbox_librenms_plugin/views/sync/vlans.py
+++ b/netbox_librenms_plugin/views/sync/vlans.py
@@ -3,7 +3,7 @@ from urllib.parse import quote_plus
 from dcim.models import Device
 from django.contrib import messages
 from django.core.cache import cache
-from django.db import transaction
+from django.db import IntegrityError, transaction
 from django.http import Http404
 from django.shortcuts import redirect
 from django.urls import reverse
@@ -103,6 +103,8 @@ class SyncVLANsView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixin, LibreN
         updated_count = 0
         skipped_count = 0
         group_missing_count = 0
+        permission_skipped_count = 0
+        changeable_vlans = self.restricted_queryset(VLAN, "change")
 
         with transaction.atomic():
             for vid_str in selected_vlans:
@@ -138,42 +140,51 @@ class SyncVLANsView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixin, LibreN
 
                 librenms_name = vlan_data.get("vlan_name", f"VLAN {vid}")
 
-                if row_vlan_group:
-                    # Grouped VLAN: match by VID (unique constraint within group)
-                    vlan, created = VLAN.objects.get_or_create(
-                        vid=vid,
-                        group=row_vlan_group,
-                        defaults={
-                            "name": librenms_name,
-                            "status": "active",
-                        },
-                    )
-                    if created:
-                        created_count += 1
-                    elif vlan.name != librenms_name:
-                        vlan.name = librenms_name
-                        vlan.save()
-                        updated_count += 1
-                    else:
-                        skipped_count += 1
+                lookup = {"vid": vid, "group": row_vlan_group}
+                try:
+                    vlan = changeable_vlans.get(**lookup)
+                    created = False
+                except VLAN.DoesNotExist:
+                    # A matching row can exist outside the caller's constrained change grant.
+                    # Do not let an unrestricted get_or_create return that row for mutation.
+                    if VLAN.objects.filter(**lookup).exists():
+                        messages.error(
+                            request,
+                            f"VLAN {vid}: an existing VLAN in this scope is outside your change permission; skipped.",
+                        )
+                        permission_skipped_count += 1
+                        continue
+                    try:
+                        # A concurrent creator can win after the existence check. Keep the
+                        # IntegrityError inside a savepoint so the outer batch can continue.
+                        with transaction.atomic():
+                            vlan = VLAN.objects.create(
+                                **lookup,
+                                name=librenms_name,
+                                status="active",
+                            )
+                        created = True
+                    except IntegrityError:
+                        # Reuse the winner only when it is inside the caller's change scope.
+                        try:
+                            vlan = changeable_vlans.get(**lookup)
+                            created = False
+                        except VLAN.DoesNotExist:
+                            messages.error(
+                                request,
+                                f"VLAN {vid}: an existing VLAN in this scope is outside your change permission; skipped.",
+                            )
+                            permission_skipped_count += 1
+                            continue
+
+                if created:
+                    created_count += 1
+                elif vlan.name != librenms_name:
+                    vlan.name = librenms_name
+                    vlan.save(update_fields=["name"])
+                    updated_count += 1
                 else:
-                    # Global VLAN: match by VID only (unique constraint with group=NULL)
-                    vlan, created = VLAN.objects.get_or_create(
-                        vid=vid,
-                        group=None,
-                        defaults={
-                            "name": librenms_name,
-                            "status": "active",
-                        },
-                    )
-                    if created:
-                        created_count += 1
-                    elif vlan.name != librenms_name:
-                        vlan.name = librenms_name
-                        vlan.save()
-                        updated_count += 1
-                    else:
-                        skipped_count += 1
+                    skipped_count += 1
 
         # Build summary message. created/updated/unchanged are all successful sync outcomes (an
         # "unchanged" VID exists and already matches — nothing to do). Group-missing skips are NOT:
@@ -190,10 +201,17 @@ class SyncVLANsView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixin, LibreN
         if parts:
             if group_missing_count > 0:
                 parts.append(f"{group_missing_count} skipped (VLAN group missing)")
+            if permission_skipped_count > 0:
+                parts.append(f"{permission_skipped_count} skipped (change permission missing)")
             messages.success(request, f"VLANs synced: {', '.join(parts)}.")
-        elif group_missing_count > 0:
-            # Nothing actually synced — only group-missing failures. Don't claim success.
-            messages.warning(request, f"No VLANs synced: {group_missing_count} skipped (VLAN group missing).")
+        elif group_missing_count > 0 or permission_skipped_count > 0:
+            # Nothing actually synced. Do not claim success for rows rejected by a scope check.
+            reasons = []
+            if group_missing_count > 0:
+                reasons.append(f"{group_missing_count} skipped (VLAN group missing)")
+            if permission_skipped_count > 0:
+                reasons.append(f"{permission_skipped_count} skipped (change permission missing)")
+            messages.warning(request, f"No VLANs synced: {', '.join(reasons)}.")
         else:
             messages.warning(request, "No VLANs were created or updated.")
 

--- a/netbox_librenms_plugin/views/sync/vlans.py
+++ b/netbox_librenms_plugin/views/sync/vlans.py
@@ -105,6 +105,7 @@ class SyncVLANsView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixin, LibreN
         group_missing_count = 0
         permission_skipped_count = 0
         ambiguous_count = 0
+        concurrent_change_count = 0
         changeable_vlans = self.restricted_queryset(VLAN, "change")
 
         with transaction.atomic():
@@ -143,7 +144,9 @@ class SyncVLANsView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixin, LibreN
 
                 lookup = {"vid": vid, "group": row_vlan_group}
                 try:
-                    vlan = changeable_vlans.get(**lookup)
+                    # Resolve the catalog match before applying the user's change scope. A
+                    # constrained grant must not make duplicate rows look like one safe match.
+                    vlan = VLAN.objects.get(**lookup)
                     created = False
                 except VLAN.MultipleObjectsReturned:
                     messages.error(
@@ -153,17 +156,8 @@ class SyncVLANsView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixin, LibreN
                     ambiguous_count += 1
                     continue
                 except VLAN.DoesNotExist:
-                    # A matching row can exist outside the caller's constrained change grant.
-                    # Do not let an unrestricted get_or_create return that row for mutation.
-                    if VLAN.objects.filter(**lookup).exists():
-                        messages.error(
-                            request,
-                            f"VLAN {vid}: an existing VLAN in this scope is outside your change permission; skipped.",
-                        )
-                        permission_skipped_count += 1
-                        continue
                     try:
-                        # A concurrent creator can win after the existence check. Keep the
+                        # A concurrent creator can win after the initial lookup. Keep the
                         # IntegrityError inside a savepoint so the outer batch can continue.
                         with transaction.atomic():
                             vlan = VLAN.objects.create(
@@ -173,9 +167,8 @@ class SyncVLANsView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixin, LibreN
                             )
                         created = True
                     except IntegrityError:
-                        # Reuse the winner only when it is inside the caller's change scope.
                         try:
-                            vlan = changeable_vlans.get(**lookup)
+                            vlan = VLAN.objects.get(**lookup)
                             created = False
                         except VLAN.MultipleObjectsReturned:
                             messages.error(
@@ -188,10 +181,21 @@ class SyncVLANsView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixin, LibreN
                         except VLAN.DoesNotExist:
                             messages.error(
                                 request,
-                                f"VLAN {vid}: an existing VLAN in this scope is outside your change permission; skipped.",
+                                f"VLAN {vid}: the VLAN could not be resolved after a concurrent change; skipped.",
                             )
-                            permission_skipped_count += 1
+                            concurrent_change_count += 1
                             continue
+
+                if not created:
+                    try:
+                        vlan = changeable_vlans.get(pk=vlan.pk)
+                    except VLAN.DoesNotExist:
+                        messages.error(
+                            request,
+                            f"VLAN {vid}: an existing VLAN in this scope is outside your change permission; skipped.",
+                        )
+                        permission_skipped_count += 1
+                        continue
 
                 if created:
                     created_count += 1
@@ -221,8 +225,15 @@ class SyncVLANsView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixin, LibreN
                 parts.append(f"{permission_skipped_count} skipped (change permission missing)")
             if ambiguous_count > 0:
                 parts.append(f"{ambiguous_count} skipped (VLAN match ambiguous)")
+            if concurrent_change_count > 0:
+                parts.append(f"{concurrent_change_count} skipped (concurrent VLAN change)")
             messages.success(request, f"VLANs synced: {', '.join(parts)}.")
-        elif group_missing_count > 0 or permission_skipped_count > 0 or ambiguous_count > 0:
+        elif (
+            group_missing_count > 0
+            or permission_skipped_count > 0
+            or ambiguous_count > 0
+            or concurrent_change_count > 0
+        ):
             # Nothing actually synced. Do not claim success for rows rejected by a scope check.
             reasons = []
             if group_missing_count > 0:
@@ -231,6 +242,8 @@ class SyncVLANsView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixin, LibreN
                 reasons.append(f"{permission_skipped_count} skipped (change permission missing)")
             if ambiguous_count > 0:
                 reasons.append(f"{ambiguous_count} skipped (VLAN match ambiguous)")
+            if concurrent_change_count > 0:
+                reasons.append(f"{concurrent_change_count} skipped (concurrent VLAN change)")
             messages.warning(request, f"No VLANs synced: {', '.join(reasons)}.")
         else:
             messages.warning(request, "No VLANs were created or updated.")


### PR DESCRIPTION
## Summary
**Stacked on #330   — review only the delta over.**

Bulk-import collision detection. At refresh time each import row is re-checked against existing NetBox devices by serial, primary IP and `oob_ip` before it can be imported, so a device that already exists under a different name can't be re-imported as new.

## Motivation / Problem
Feature / bug. Close a gap where a row whose `librenms_id`/name link disappeared could flip to importable and duplicate an existing device.

## Scope of Change
- Sync/Import logic
- Web UI / templates
- Tests

## How Was This Tested?
- Unit tests: yes — refresh re-match by serial / primary IP / oob_ip blocks import; real Device/Interface/IP rows.

## Risk Assessment
Makes the refresh re-check stricter (fail-closed); cannot cause new imports.

## Backwards Compatibility
- No breaking changes