### PR TITLE
feat: sidebar navigation consolidation

### DIFF
--- a/docs/usage_tips/interface_mappings.md
+++ b/docs/usage_tips/interface_mappings.md
@@ -24,8 +24,8 @@ Example:
 
 ![Interface Mappings Page](../img/interface_mappings/interfacemappings_menu.png){ width="250" }
 
-* From the main menu, navigate to the Plugins section
-* Under Netbox Librenms Plugin, select "Mappings" — Interface Mappings is the first tab
+* From the main menu, navigate to the LibreNMS section
+* Select "Mappings" — Interface Mappings is the first tab
 
 #### Creating a New Mapping:
 

--- a/docs/usage_tips/interface_mappings.md
+++ b/docs/usage_tips/interface_mappings.md
@@ -25,13 +25,13 @@ Example:
 ![Interface Mappings Page](../img/interface_mappings/interfacemappings_menu.png){ width="250" }
 
 * From the main menu, navigate to the Plugins section
-* Under Netbox Librenms Plugin, Select "Interface Mappings"
+* Under Netbox Librenms Plugin, select "Mappings" — Interface Mappings is the first tab
 
 #### Creating a New Mapping:
 
 ![Add Mapping button on the Interface Mappings page](../img/interface_mappings/addmapping.png){ width="50" }
 
-* Click the green `+` or `Add` button either from the menu or on the Interface Mappings page
+* Click the green `+` or `Add` button on the Interface Mappings page
 * Enter LibreNMS interface type. _You can copy this from plugin's device interface sync page_
 * Enter Librenms interface speed as Kbps
 * Select the Netbox interface type from the dropdown

--- a/docs/usage_tips/mapping_rules.md
+++ b/docs/usage_tips/mapping_rules.md
@@ -2,7 +2,7 @@
 
 Mapping rules are the configuration layer that connects LibreNMS identifiers to NetBox objects. Without them the plugin relies on exact-string matching; with them you can cover vendor naming variations, OS string aliases, model-number differences, and bay naming schemes across your entire fleet.
 
-The type mappings live under **Plugins > LibreNMS > Mappings** and the rule engines under **Plugins > LibreNMS > Rules & Patterns** — each is a single menu entry, and the individual lists are reached through the tabs at the top of the page. All of them support individual creation, editing, deletion, and bulk YAML import/export.
+The type mappings live under **LibreNMS > Mappings** and the rule engines under **LibreNMS > Rules & Patterns** — each is a single menu entry, and the individual lists are reached through the tabs at the top of the page. All of them support individual creation, editing, deletion, and bulk YAML import/export.
 
 ---
 

--- a/docs/usage_tips/mapping_rules.md
+++ b/docs/usage_tips/mapping_rules.md
@@ -2,7 +2,7 @@
 
 Mapping rules are the configuration layer that connects LibreNMS identifiers to NetBox objects. Without them the plugin relies on exact-string matching; with them you can cover vendor naming variations, OS string aliases, model-number differences, and bay naming schemes across your entire fleet.
 
-All mapping types live under **Plugins > LibreNMS > Mappings** in the NetBox menu and support individual creation, editing, deletion, and bulk YAML import/export.
+The type mappings live under **Plugins > LibreNMS > Mappings** and the rule engines under **Plugins > LibreNMS > Rules & Patterns** — each is a single menu entry, and the individual lists are reached through the tabs at the top of the page. All of them support individual creation, editing, deletion, and bulk YAML import/export.
 
 ---
 

--- a/netbox_librenms_plugin/navigation.py
+++ b/netbox_librenms_plugin/navigation.py
@@ -1,6 +1,6 @@
-from netbox.plugins import PluginMenu, PluginMenuButton, PluginMenuItem
+from netbox.plugins import PluginMenu, PluginMenuItem
 
-from netbox_librenms_plugin.constants import PERM_CHANGE_PLUGIN, PERM_VIEW_PLUGIN
+from netbox_librenms_plugin.constants import PERM_VIEW_PLUGIN
 
 menu = PluginMenu(
     label="LibreNMS",
@@ -36,160 +36,28 @@ menu = PluginMenu(
                 ),
             ),
         ),
+        # One sidebar entry per group: the individual object lists cross-link through the
+        # switcher tabs rendered on each list page (inc/_mapping_tabs.html and
+        # inc/_rules_patterns_tabs.html), and every list page carries its own native
+        # add/import controls — so per-model menu items (and their buttons) would only
+        # duplicate what the pages already offer while crowding the sidebar.
         (
             "Mappings",
             (
                 PluginMenuItem(
                     link="plugins:netbox_librenms_plugin:interfacetypemapping_list",
-                    link_text="Interface Mappings",
+                    link_text="Mappings",
                     permissions=[PERM_VIEW_PLUGIN],
-                    buttons=(
-                        PluginMenuButton(
-                            link="plugins:netbox_librenms_plugin:interfacetypemapping_add",
-                            title="Add",
-                            icon_class="mdi mdi-plus-thick",
-                            permissions=[PERM_CHANGE_PLUGIN],
-                        ),
-                        PluginMenuButton(
-                            link="plugins:netbox_librenms_plugin:interfacetypemapping_bulk_import",
-                            title="Import",
-                            icon_class="mdi mdi-upload",
-                            permissions=[PERM_CHANGE_PLUGIN],
-                        ),
-                    ),
                 ),
-                PluginMenuItem(
-                    link="plugins:netbox_librenms_plugin:devicetypemapping_list",
-                    link_text="Device Type Mappings",
-                    permissions=[PERM_VIEW_PLUGIN],
-                    buttons=(
-                        PluginMenuButton(
-                            link="plugins:netbox_librenms_plugin:devicetypemapping_add",
-                            title="Add",
-                            icon_class="mdi mdi-plus-thick",
-                            permissions=[PERM_CHANGE_PLUGIN],
-                        ),
-                        PluginMenuButton(
-                            link="plugins:netbox_librenms_plugin:devicetypemapping_bulk_import",
-                            title="Import",
-                            icon_class="mdi mdi-upload",
-                            permissions=[PERM_CHANGE_PLUGIN],
-                        ),
-                    ),
-                ),
-                PluginMenuItem(
-                    link="plugins:netbox_librenms_plugin:moduletypemapping_list",
-                    link_text="Module Type Mappings",
-                    permissions=[PERM_VIEW_PLUGIN],
-                    buttons=(
-                        PluginMenuButton(
-                            link="plugins:netbox_librenms_plugin:moduletypemapping_add",
-                            title="Add",
-                            icon_class="mdi mdi-plus-thick",
-                            permissions=[PERM_CHANGE_PLUGIN],
-                        ),
-                        PluginMenuButton(
-                            link="plugins:netbox_librenms_plugin:moduletypemapping_bulk_import",
-                            title="Import",
-                            icon_class="mdi mdi-upload",
-                            permissions=[PERM_CHANGE_PLUGIN],
-                        ),
-                    ),
-                ),
-                PluginMenuItem(
-                    link="plugins:netbox_librenms_plugin:modulebaymapping_list",
-                    link_text="Module Bay Mappings",
-                    permissions=[PERM_VIEW_PLUGIN],
-                    buttons=(
-                        PluginMenuButton(
-                            link="plugins:netbox_librenms_plugin:modulebaymapping_add",
-                            title="Add",
-                            icon_class="mdi mdi-plus-thick",
-                            permissions=[PERM_CHANGE_PLUGIN],
-                        ),
-                        PluginMenuButton(
-                            link="plugins:netbox_librenms_plugin:modulebaymapping_bulk_import",
-                            title="Import",
-                            icon_class="mdi mdi-upload",
-                            permissions=[PERM_CHANGE_PLUGIN],
-                        ),
-                    ),
-                ),
-                PluginMenuItem(
-                    link="plugins:netbox_librenms_plugin:platformmapping_list",
-                    link_text="Platform Mappings",
-                    permissions=[PERM_VIEW_PLUGIN],
-                    buttons=(
-                        PluginMenuButton(
-                            link="plugins:netbox_librenms_plugin:platformmapping_add",
-                            title="Add",
-                            icon_class="mdi mdi-plus-thick",
-                            permissions=[PERM_CHANGE_PLUGIN],
-                        ),
-                        PluginMenuButton(
-                            link="plugins:netbox_librenms_plugin:platformmapping_bulk_import",
-                            title="Import",
-                            icon_class="mdi mdi-upload",
-                            permissions=[PERM_CHANGE_PLUGIN],
-                        ),
-                    ),
-                ),
+            ),
+        ),
+        (
+            "Rules & Patterns",
+            (
                 PluginMenuItem(
                     link="plugins:netbox_librenms_plugin:inventoryignorerule_list",
-                    link_text="Inventory Ignore Rules",
+                    link_text="Rules & Patterns",
                     permissions=[PERM_VIEW_PLUGIN],
-                    buttons=(
-                        PluginMenuButton(
-                            link="plugins:netbox_librenms_plugin:inventoryignorerule_add",
-                            title="Add",
-                            icon_class="mdi mdi-plus-thick",
-                            permissions=[PERM_CHANGE_PLUGIN],
-                        ),
-                        PluginMenuButton(
-                            link="plugins:netbox_librenms_plugin:inventoryignorerule_bulk_import",
-                            title="Import",
-                            icon_class="mdi mdi-upload",
-                            permissions=[PERM_CHANGE_PLUGIN],
-                        ),
-                    ),
-                ),
-                PluginMenuItem(
-                    link="plugins:netbox_librenms_plugin:normalizationrule_list",
-                    link_text="Normalization Rules",
-                    permissions=[PERM_VIEW_PLUGIN],
-                    buttons=(
-                        PluginMenuButton(
-                            link="plugins:netbox_librenms_plugin:normalizationrule_add",
-                            title="Add",
-                            icon_class="mdi mdi-plus-thick",
-                            permissions=[PERM_CHANGE_PLUGIN],
-                        ),
-                        PluginMenuButton(
-                            link="plugins:netbox_librenms_plugin:normalizationrule_bulk_import",
-                            title="Import",
-                            icon_class="mdi mdi-upload",
-                            permissions=[PERM_CHANGE_PLUGIN],
-                        ),
-                    ),
-                ),
-                PluginMenuItem(
-                    link="plugins:netbox_librenms_plugin:carrierautoinstallrule_list",
-                    link_text="Carrier Auto-Install Rules",
-                    permissions=[PERM_VIEW_PLUGIN],
-                    buttons=(
-                        PluginMenuButton(
-                            link="plugins:netbox_librenms_plugin:carrierautoinstallrule_add",
-                            title="Add",
-                            icon_class="mdi mdi-plus-thick",
-                            permissions=[PERM_CHANGE_PLUGIN],
-                        ),
-                        PluginMenuButton(
-                            link="plugins:netbox_librenms_plugin:carrierautoinstallrule_bulk_import",
-                            title="Import",
-                            icon_class="mdi mdi-upload",
-                            permissions=[PERM_CHANGE_PLUGIN],
-                        ),
-                    ),
                 ),
             ),
         ),

--- a/netbox_librenms_plugin/templates/netbox_librenms_plugin/carrierautoinstallrule_list.html
+++ b/netbox_librenms_plugin/templates/netbox_librenms_plugin/carrierautoinstallrule_list.html
@@ -1,5 +1,10 @@
 {% extends 'generic/object_list.html' %}
 
+{% block tabs %}
+    {% include 'netbox_librenms_plugin/inc/_rules_patterns_tabs.html' with rules_tab_active="carrierautoinstallrule" %}
+    {{ block.super }}
+{% endblock %}
+
 {% block content %}
     <div class="alert alert-info">
         <h4>Carrier Auto-Install Rules</h4>

--- a/netbox_librenms_plugin/templates/netbox_librenms_plugin/devicetypemapping_list.html
+++ b/netbox_librenms_plugin/templates/netbox_librenms_plugin/devicetypemapping_list.html
@@ -1,5 +1,10 @@
 {% extends 'generic/object_list.html' %}
 
+{% block tabs %}
+    {% include 'netbox_librenms_plugin/inc/_mapping_tabs.html' with mapping_tab_active="devicetypemapping" %}
+    {{ block.super }}
+{% endblock %}
+
 {% block content %}
     <div class="alert alert-info">
         <h4>Device Type Mapping</h4>

--- a/netbox_librenms_plugin/templates/netbox_librenms_plugin/inc/_mapping_tabs.html
+++ b/netbox_librenms_plugin/templates/netbox_librenms_plugin/inc/_mapping_tabs.html
@@ -3,23 +3,25 @@ Switcher across the five type-mapping object lists. The sidebar has ONE "Mapping
 entry, so the lists cross-link here, rendered above the native Results/Filters tabs.
 Plain page links (no data-bs-toggle): every tab is the full generic list view of its
 model, keeping filters / bulk ops / import / export intact. `mapping_tab_active` is
-the current page's URL-name prefix. Keep each <a> on one line: tests match the
-rendered `class="nav-link active" href="..."` pair verbatim.
+the current page's URL-name prefix; the active pill also carries aria-current="page"
+(Bootstrap's nav-pills guidance) so screen readers announce the current page. Keep each
+<a> on one line: tests match the rendered
+`class="nav-link active" href="..." aria-current="page"` run verbatim.
 {% endcomment %}
 <ul class="nav nav-pills mb-3">
     <li class="nav-item">
-        <a class="nav-link{% if mapping_tab_active == "interfacetypemapping" %} active{% endif %}" href="{% url 'plugins:netbox_librenms_plugin:interfacetypemapping_list' %}">Interface Mappings</a>
+        <a class="nav-link{% if mapping_tab_active == "interfacetypemapping" %} active{% endif %}" href="{% url 'plugins:netbox_librenms_plugin:interfacetypemapping_list' %}"{% if mapping_tab_active == "interfacetypemapping" %} aria-current="page"{% endif %}>Interface Mappings</a>
     </li>
     <li class="nav-item">
-        <a class="nav-link{% if mapping_tab_active == "devicetypemapping" %} active{% endif %}" href="{% url 'plugins:netbox_librenms_plugin:devicetypemapping_list' %}">Device Type Mappings</a>
+        <a class="nav-link{% if mapping_tab_active == "devicetypemapping" %} active{% endif %}" href="{% url 'plugins:netbox_librenms_plugin:devicetypemapping_list' %}"{% if mapping_tab_active == "devicetypemapping" %} aria-current="page"{% endif %}>Device Type Mappings</a>
     </li>
     <li class="nav-item">
-        <a class="nav-link{% if mapping_tab_active == "moduletypemapping" %} active{% endif %}" href="{% url 'plugins:netbox_librenms_plugin:moduletypemapping_list' %}">Module Type Mappings</a>
+        <a class="nav-link{% if mapping_tab_active == "moduletypemapping" %} active{% endif %}" href="{% url 'plugins:netbox_librenms_plugin:moduletypemapping_list' %}"{% if mapping_tab_active == "moduletypemapping" %} aria-current="page"{% endif %}>Module Type Mappings</a>
     </li>
     <li class="nav-item">
-        <a class="nav-link{% if mapping_tab_active == "modulebaymapping" %} active{% endif %}" href="{% url 'plugins:netbox_librenms_plugin:modulebaymapping_list' %}">Module Bay Mappings</a>
+        <a class="nav-link{% if mapping_tab_active == "modulebaymapping" %} active{% endif %}" href="{% url 'plugins:netbox_librenms_plugin:modulebaymapping_list' %}"{% if mapping_tab_active == "modulebaymapping" %} aria-current="page"{% endif %}>Module Bay Mappings</a>
     </li>
     <li class="nav-item">
-        <a class="nav-link{% if mapping_tab_active == "platformmapping" %} active{% endif %}" href="{% url 'plugins:netbox_librenms_plugin:platformmapping_list' %}">Platform Mappings</a>
+        <a class="nav-link{% if mapping_tab_active == "platformmapping" %} active{% endif %}" href="{% url 'plugins:netbox_librenms_plugin:platformmapping_list' %}"{% if mapping_tab_active == "platformmapping" %} aria-current="page"{% endif %}>Platform Mappings</a>
     </li>
 </ul>

--- a/netbox_librenms_plugin/templates/netbox_librenms_plugin/inc/_mapping_tabs.html
+++ b/netbox_librenms_plugin/templates/netbox_librenms_plugin/inc/_mapping_tabs.html
@@ -4,9 +4,9 @@ entry, so the lists cross-link here, rendered above the native Results/Filters t
 Plain page links (no data-bs-toggle): every tab is the full generic list view of its
 model, keeping filters / bulk ops / import / export intact. `mapping_tab_active` is
 the current page's URL-name prefix; the active pill also carries aria-current="page"
-(Bootstrap's nav-pills guidance) so screen readers announce the current page. Keep each
-<a> on one line: tests match the rendered
-`class="nav-link active" href="..." aria-current="page"` run verbatim.
+(Bootstrap's nav-pills guidance) so screen readers announce the current page. Navigation
+tests assert the active link's class, href, and aria-current attributes independently;
+attribute order is not part of that contract.
 {% endcomment %}
 <ul class="nav nav-pills mb-3">
     <li class="nav-item">

--- a/netbox_librenms_plugin/templates/netbox_librenms_plugin/inc/_mapping_tabs.html
+++ b/netbox_librenms_plugin/templates/netbox_librenms_plugin/inc/_mapping_tabs.html
@@ -1,0 +1,25 @@
+{% comment %}
+Switcher across the five type-mapping object lists. The sidebar has ONE "Mappings"
+entry, so the lists cross-link here, rendered above the native Results/Filters tabs.
+Plain page links (no data-bs-toggle): every tab is the full generic list view of its
+model, keeping filters / bulk ops / import / export intact. `mapping_tab_active` is
+the current page's URL-name prefix. Keep each <a> on one line: tests match the
+rendered `class="nav-link active" href="..."` pair verbatim.
+{% endcomment %}
+<ul class="nav nav-pills mb-3">
+    <li class="nav-item">
+        <a class="nav-link{% if mapping_tab_active == "interfacetypemapping" %} active{% endif %}" href="{% url 'plugins:netbox_librenms_plugin:interfacetypemapping_list' %}">Interface Mappings</a>
+    </li>
+    <li class="nav-item">
+        <a class="nav-link{% if mapping_tab_active == "devicetypemapping" %} active{% endif %}" href="{% url 'plugins:netbox_librenms_plugin:devicetypemapping_list' %}">Device Type Mappings</a>
+    </li>
+    <li class="nav-item">
+        <a class="nav-link{% if mapping_tab_active == "moduletypemapping" %} active{% endif %}" href="{% url 'plugins:netbox_librenms_plugin:moduletypemapping_list' %}">Module Type Mappings</a>
+    </li>
+    <li class="nav-item">
+        <a class="nav-link{% if mapping_tab_active == "modulebaymapping" %} active{% endif %}" href="{% url 'plugins:netbox_librenms_plugin:modulebaymapping_list' %}">Module Bay Mappings</a>
+    </li>
+    <li class="nav-item">
+        <a class="nav-link{% if mapping_tab_active == "platformmapping" %} active{% endif %}" href="{% url 'plugins:netbox_librenms_plugin:platformmapping_list' %}">Platform Mappings</a>
+    </li>
+</ul>

--- a/netbox_librenms_plugin/templates/netbox_librenms_plugin/inc/_rules_patterns_tabs.html
+++ b/netbox_librenms_plugin/templates/netbox_librenms_plugin/inc/_rules_patterns_tabs.html
@@ -1,0 +1,19 @@
+{% comment %}
+Switcher across the sync rule/pattern object lists (the sidebar has ONE
+"Rules & Patterns" entry). Same contract as _mapping_tabs.html: plain page links
+above the native Results/Filters tabs, one <a> per line for the tests' verbatim
+`class="nav-link active" href="..."` match. A branch that introduces a new rule or
+pattern model adds its tab here (and to RULE_LIST_ROUTES in the navigation tests)
+in the same commit that adds the model.
+{% endcomment %}
+<ul class="nav nav-pills mb-3">
+    <li class="nav-item">
+        <a class="nav-link{% if rules_tab_active == "inventoryignorerule" %} active{% endif %}" href="{% url 'plugins:netbox_librenms_plugin:inventoryignorerule_list' %}">Inventory Ignore Rules</a>
+    </li>
+    <li class="nav-item">
+        <a class="nav-link{% if rules_tab_active == "normalizationrule" %} active{% endif %}" href="{% url 'plugins:netbox_librenms_plugin:normalizationrule_list' %}">Normalization Rules</a>
+    </li>
+    <li class="nav-item">
+        <a class="nav-link{% if rules_tab_active == "carrierautoinstallrule" %} active{% endif %}" href="{% url 'plugins:netbox_librenms_plugin:carrierautoinstallrule_list' %}">Carrier Auto-Install Rules</a>
+    </li>
+</ul>

--- a/netbox_librenms_plugin/templates/netbox_librenms_plugin/inc/_rules_patterns_tabs.html
+++ b/netbox_librenms_plugin/templates/netbox_librenms_plugin/inc/_rules_patterns_tabs.html
@@ -1,11 +1,11 @@
 {% comment %}
 Switcher across the sync rule/pattern object lists (the sidebar has ONE
 "Rules & Patterns" entry). Same contract as _mapping_tabs.html: plain page links
-above the native Results/Filters tabs (active pill also aria-current="page"), one <a>
-per line for the tests' verbatim
-`class="nav-link active" href="..." aria-current="page"` match. A branch that introduces a new rule or
-pattern model adds its tab here (and to RULE_LIST_ROUTES in the navigation tests)
-in the same commit that adds the model.
+above the native Results/Filters tabs, with the active pill also carrying
+aria-current="page". Navigation tests assert its class, href, and aria-current
+attributes independently. A branch that introduces a new rule or pattern model adds
+its tab here (and to RULE_LIST_ROUTES in the navigation tests) in the same commit that
+adds the model.
 {% endcomment %}
 <ul class="nav nav-pills mb-3">
     <li class="nav-item">

--- a/netbox_librenms_plugin/templates/netbox_librenms_plugin/inc/_rules_patterns_tabs.html
+++ b/netbox_librenms_plugin/templates/netbox_librenms_plugin/inc/_rules_patterns_tabs.html
@@ -1,19 +1,20 @@
 {% comment %}
 Switcher across the sync rule/pattern object lists (the sidebar has ONE
 "Rules & Patterns" entry). Same contract as _mapping_tabs.html: plain page links
-above the native Results/Filters tabs, one <a> per line for the tests' verbatim
-`class="nav-link active" href="..."` match. A branch that introduces a new rule or
+above the native Results/Filters tabs (active pill also aria-current="page"), one <a>
+per line for the tests' verbatim
+`class="nav-link active" href="..." aria-current="page"` match. A branch that introduces a new rule or
 pattern model adds its tab here (and to RULE_LIST_ROUTES in the navigation tests)
 in the same commit that adds the model.
 {% endcomment %}
 <ul class="nav nav-pills mb-3">
     <li class="nav-item">
-        <a class="nav-link{% if rules_tab_active == "inventoryignorerule" %} active{% endif %}" href="{% url 'plugins:netbox_librenms_plugin:inventoryignorerule_list' %}">Inventory Ignore Rules</a>
+        <a class="nav-link{% if rules_tab_active == "inventoryignorerule" %} active{% endif %}" href="{% url 'plugins:netbox_librenms_plugin:inventoryignorerule_list' %}"{% if rules_tab_active == "inventoryignorerule" %} aria-current="page"{% endif %}>Inventory Ignore Rules</a>
     </li>
     <li class="nav-item">
-        <a class="nav-link{% if rules_tab_active == "normalizationrule" %} active{% endif %}" href="{% url 'plugins:netbox_librenms_plugin:normalizationrule_list' %}">Normalization Rules</a>
+        <a class="nav-link{% if rules_tab_active == "normalizationrule" %} active{% endif %}" href="{% url 'plugins:netbox_librenms_plugin:normalizationrule_list' %}"{% if rules_tab_active == "normalizationrule" %} aria-current="page"{% endif %}>Normalization Rules</a>
     </li>
     <li class="nav-item">
-        <a class="nav-link{% if rules_tab_active == "carrierautoinstallrule" %} active{% endif %}" href="{% url 'plugins:netbox_librenms_plugin:carrierautoinstallrule_list' %}">Carrier Auto-Install Rules</a>
+        <a class="nav-link{% if rules_tab_active == "carrierautoinstallrule" %} active{% endif %}" href="{% url 'plugins:netbox_librenms_plugin:carrierautoinstallrule_list' %}"{% if rules_tab_active == "carrierautoinstallrule" %} aria-current="page"{% endif %}>Carrier Auto-Install Rules</a>
     </li>
 </ul>

--- a/netbox_librenms_plugin/templates/netbox_librenms_plugin/interfacetypemapping_list.html
+++ b/netbox_librenms_plugin/templates/netbox_librenms_plugin/interfacetypemapping_list.html
@@ -1,5 +1,10 @@
 {% extends 'generic/object_list.html' %}
 
+{% block tabs %}
+    {% include 'netbox_librenms_plugin/inc/_mapping_tabs.html' with mapping_tab_active="interfacetypemapping" %}
+    {{ block.super }}
+{% endblock %}
+
 {% block content %}
     <div class="alert alert-info">
         <h4>Interface Type Mapping</h4>

--- a/netbox_librenms_plugin/templates/netbox_librenms_plugin/inventoryignorerule_list.html
+++ b/netbox_librenms_plugin/templates/netbox_librenms_plugin/inventoryignorerule_list.html
@@ -1,5 +1,10 @@
 {% extends 'generic/object_list.html' %}
 
+{% block tabs %}
+    {% include 'netbox_librenms_plugin/inc/_rules_patterns_tabs.html' with rules_tab_active="inventoryignorerule" %}
+    {{ block.super }}
+{% endblock %}
+
 {% block content %}
     <div class="alert alert-info">
         <h4>Inventory Ignore Rules</h4>

--- a/netbox_librenms_plugin/templates/netbox_librenms_plugin/modulebaymapping_list.html
+++ b/netbox_librenms_plugin/templates/netbox_librenms_plugin/modulebaymapping_list.html
@@ -1,5 +1,10 @@
 {% extends 'generic/object_list.html' %}
 
+{% block tabs %}
+    {% include 'netbox_librenms_plugin/inc/_mapping_tabs.html' with mapping_tab_active="modulebaymapping" %}
+    {{ block.super }}
+{% endblock %}
+
 {% block content %}
     <div class="alert alert-info">
         <h4>Module Bay Mapping</h4>

--- a/netbox_librenms_plugin/templates/netbox_librenms_plugin/moduletypemapping_list.html
+++ b/netbox_librenms_plugin/templates/netbox_librenms_plugin/moduletypemapping_list.html
@@ -1,5 +1,10 @@
 {% extends 'generic/object_list.html' %}
 
+{% block tabs %}
+    {% include 'netbox_librenms_plugin/inc/_mapping_tabs.html' with mapping_tab_active="moduletypemapping" %}
+    {{ block.super }}
+{% endblock %}
+
 {% block content %}
     <div class="alert alert-info">
         <h4>Module Type Mapping</h4>

--- a/netbox_librenms_plugin/templates/netbox_librenms_plugin/normalizationrule_list.html
+++ b/netbox_librenms_plugin/templates/netbox_librenms_plugin/normalizationrule_list.html
@@ -1,5 +1,10 @@
 {% extends 'generic/object_list.html' %}
 
+{% block tabs %}
+    {% include 'netbox_librenms_plugin/inc/_rules_patterns_tabs.html' with rules_tab_active="normalizationrule" %}
+    {{ block.super }}
+{% endblock %}
+
 {% block content %}
     <div class="alert alert-info">
         <h4>Normalization Rules</h4>

--- a/netbox_librenms_plugin/templates/netbox_librenms_plugin/platformmapping_list.html
+++ b/netbox_librenms_plugin/templates/netbox_librenms_plugin/platformmapping_list.html
@@ -1,5 +1,10 @@
 {% extends 'generic/object_list.html' %}
 
+{% block tabs %}
+    {% include 'netbox_librenms_plugin/inc/_mapping_tabs.html' with mapping_tab_active="platformmapping" %}
+    {{ block.super }}
+{% endblock %}
+
 {% block content %}
     <div class="alert alert-info">
         <h4>Platform Mappings</h4>

--- a/netbox_librenms_plugin/tests/test_coverage_sync_views2.py
+++ b/netbox_librenms_plugin/tests/test_coverage_sync_views2.py
@@ -1961,47 +1961,6 @@ class TestSyncIPAddressesViewInterfaceResolution:
         assert "no longer exists" in results["errors"]["10.0.0.1"]
         assert not IPAddress.objects.filter(address="10.0.0.1/24").exists()
 
-    def test_primary_ip_row_locks_the_device_before_writing_the_address(self):
-        """The primary-IP row writes the address and then the device (primary_ip4), while the migrate move views lock Device then IPAddress — so this path must take the device row lock FIRST or the two orders close a deadlock cycle."""
-        from django.db import connection
-        from django.test.utils import CaptureQueriesContext
-
-        from netbox_librenms_plugin.utils import set_librenms_device_id
-
-        dev = make_device("ipres-lockorder")
-        iface = make_interface(dev, "eth0")
-        set_librenms_device_id(iface, 5, "default")
-        iface.save()
-
-        view = self._view()
-        view._post_server_key = "default"
-        view.get_management_ip = MagicMock(return_value="10.0.0.1")
-
-        ip_data = {
-            "ip_address": "10.0.0.1",
-            "ip_with_mask": "10.0.0.1/24",
-            "interface_url": None,
-            "port_id": 5,
-            "interface_name": "eth0",
-        }
-        request = _make_request(post_data={"select": ["10.0.0.1"]})
-        with (
-            patch(
-                "netbox_librenms_plugin.views.sync.ip_addresses.resolve_set_primary_ip",
-                return_value=True,
-            ),
-            CaptureQueriesContext(connection) as ctx,
-        ):
-            results = view.process_ip_sync(request, ["10.0.0.1"], [ip_data], dev, "device")
-
-        assert results["primary_set"] == ["10.0.0.1"]
-        sqls = [q["sql"] for q in ctx.captured_queries]
-        device_locks = [i for i, sql in enumerate(sqls) if 'FROM "dcim_device"' in sql and "FOR UPDATE" in sql]
-        address_writes = [i for i, sql in enumerate(sqls) if 'INSERT INTO "ipam_ipaddress"' in sql]
-        assert device_locks, "the primary-IP row must lock the device row (SELECT ... FOR UPDATE)"
-        assert address_writes, "the address must be written"
-        assert min(device_locks) < min(address_writes), "the device lock must precede the address write"
-
     def test_build_interface_maps_vc_shared_name_prefers_viewed_member(self):
         """A name shared across VC members resolves to the VIEWED member's own interface (matching the rendered table), not ambiguous."""
         _vc, members = self._make_vc("ipres-vcdup", [1, 2])

--- a/netbox_librenms_plugin/tests/test_coverage_sync_views2.py
+++ b/netbox_librenms_plugin/tests/test_coverage_sync_views2.py
@@ -1961,6 +1961,47 @@ class TestSyncIPAddressesViewInterfaceResolution:
         assert "no longer exists" in results["errors"]["10.0.0.1"]
         assert not IPAddress.objects.filter(address="10.0.0.1/24").exists()
 
+    def test_primary_ip_row_locks_the_device_before_writing_the_address(self):
+        """The primary-IP row writes the address and then the device (primary_ip4), while the migrate move views lock Device then IPAddress — so this path must take the device row lock FIRST or the two orders close a deadlock cycle."""
+        from django.db import connection
+        from django.test.utils import CaptureQueriesContext
+
+        from netbox_librenms_plugin.utils import set_librenms_device_id
+
+        dev = make_device("ipres-lockorder")
+        iface = make_interface(dev, "eth0")
+        set_librenms_device_id(iface, 5, "default")
+        iface.save()
+
+        view = self._view()
+        view._post_server_key = "default"
+        view.get_management_ip = MagicMock(return_value="10.0.0.1")
+
+        ip_data = {
+            "ip_address": "10.0.0.1",
+            "ip_with_mask": "10.0.0.1/24",
+            "interface_url": None,
+            "port_id": 5,
+            "interface_name": "eth0",
+        }
+        request = _make_request(post_data={"select": ["10.0.0.1"]})
+        with (
+            patch(
+                "netbox_librenms_plugin.views.sync.ip_addresses.resolve_set_primary_ip",
+                return_value=True,
+            ),
+            CaptureQueriesContext(connection) as ctx,
+        ):
+            results = view.process_ip_sync(request, ["10.0.0.1"], [ip_data], dev, "device")
+
+        assert results["primary_set"] == ["10.0.0.1"]
+        sqls = [q["sql"] for q in ctx.captured_queries]
+        device_locks = [i for i, sql in enumerate(sqls) if 'FROM "dcim_device"' in sql and "FOR UPDATE" in sql]
+        address_writes = [i for i, sql in enumerate(sqls) if 'INSERT INTO "ipam_ipaddress"' in sql]
+        assert device_locks, "the primary-IP row must lock the device row (SELECT ... FOR UPDATE)"
+        assert address_writes, "the address must be written"
+        assert min(device_locks) < min(address_writes), "the device lock must precede the address write"
+
     def test_build_interface_maps_vc_shared_name_prefers_viewed_member(self):
         """A name shared across VC members resolves to the VIEWED member's own interface (matching the rendered table), not ambiguous."""
         _vc, members = self._make_vc("ipres-vcdup", [1, 2])

--- a/netbox_librenms_plugin/tests/test_import_utils.py
+++ b/netbox_librenms_plugin/tests/test_import_utils.py
@@ -4543,9 +4543,9 @@ class TestBulkImportCancellation:
             mock_api.server_key = "default"
             # Echo the requested id like the real API — the import loop's identity check
             # (row_identity_matches) rejects a payload describing another device.
-            mock_api.get_device_info.side_effect = lambda did, **_kwargs: (
+            mock_api.get_device_info.side_effect = lambda device_id, **_kwargs: (
                 True,
-                {"device_id": did, "hostname": "sw"},
+                {"device_id": device_id, "hostname": "sw"},
             )
             mock_api_cls.return_value = mock_api
             mock_import.return_value = {"success": True, "device": MagicMock(), "is_vm": False}

--- a/netbox_librenms_plugin/tests/test_rules_patterns_navigation.py
+++ b/netbox_librenms_plugin/tests/test_rules_patterns_navigation.py
@@ -6,6 +6,8 @@ each list keeps the full generic feature set (filters, bulk ops, import/export,
 changelog) while the sidebar stays small.
 """
 
+import re
+
 import pytest
 from django.urls import reverse
 
@@ -61,6 +63,15 @@ class TestListPageSwitchers:
         assert response.status_code == 200
         return url, response.content.decode()
 
+    def _assert_active_pill(self, html, url):
+        """The current page's pill carries BOTH the visual active class and the aria-current="page" announcement (Bootstrap nav-pills a11y guidance) — and only it does: a second aria-current would misannounce a sibling as current. Attributes are asserted independently so a harmless attribute reorder/insertion in the switcher include doesn't fail the contract."""
+        pills = re.findall(r'<a\b[^>]*aria-current="page"[^>]*>', html)
+        assert len(pills) == 1, f"expected exactly one aria-current pill, got {len(pills)}"
+        assert html.count('aria-current="page"') == 1  # nothing outside the pill announces current
+        pill = pills[0]
+        assert re.search(r'class="[^"]*\bactive\b[^"]*"', pill), f"current pill lacks the active class: {pill}"
+        assert f'href="{url}"' in pill, f"current pill does not point at the page itself: {pill}"
+
     @pytest.mark.parametrize("route", MAPPING_LIST_ROUTES)
     def test_mapping_pages_cross_link_all_mapping_lists(self, route, client):
         url, html = self._rendered(client, route)
@@ -68,11 +79,7 @@ class TestListPageSwitchers:
             assert reverse(f"plugins:netbox_librenms_plugin:{other}") in html, (
                 f"{route} page is missing the switcher link to {other}"
             )
-        # The current page's pill carries BOTH the visual active class and the
-        # aria-current="page" announcement (Bootstrap nav-pills a11y guidance) — and
-        # only it does: a second aria-current would misannounce a sibling as current.
-        assert f'class="nav-link active" href="{url}" aria-current="page"' in html
-        assert html.count('aria-current="page"') == 1
+        self._assert_active_pill(html, url)
 
     @pytest.mark.parametrize("route", RULE_LIST_ROUTES)
     def test_rule_pages_cross_link_all_rule_lists(self, route, client):
@@ -82,5 +89,4 @@ class TestListPageSwitchers:
                 f"{route} page is missing the switcher link to {other}"
             )
         # Same contract as the mapping switcher: exactly one active pill, announced.
-        assert f'class="nav-link active" href="{url}" aria-current="page"' in html
-        assert html.count('aria-current="page"') == 1
+        self._assert_active_pill(html, url)

--- a/netbox_librenms_plugin/tests/test_rules_patterns_navigation.py
+++ b/netbox_librenms_plugin/tests/test_rules_patterns_navigation.py
@@ -7,6 +7,7 @@ changelog) while the sidebar stays small.
 """
 
 import re
+from pathlib import Path
 
 import pytest
 from django.urls import reverse
@@ -48,6 +49,15 @@ class TestConsolidatedMenu:
         assert groups.get("Rules & Patterns") == [
             f"plugins:netbox_librenms_plugin:{RULE_LIST_ROUTES[0]}",
         ]
+
+
+def test_mapping_rules_docs_use_top_level_librenms_menu_path():
+    """The mapping guide follows NetBox's top-level PluginMenu label."""
+    docs = (Path(__file__).resolve().parents[2] / "docs/usage_tips/mapping_rules.md").read_text(encoding="utf-8")
+
+    assert "Plugins > LibreNMS" not in docs
+    assert "**LibreNMS > Mappings**" in docs
+    assert "**LibreNMS > Rules & Patterns**" in docs
 
 
 @pytest.mark.django_db

--- a/netbox_librenms_plugin/tests/test_rules_patterns_navigation.py
+++ b/netbox_librenms_plugin/tests/test_rules_patterns_navigation.py
@@ -68,7 +68,11 @@ class TestListPageSwitchers:
             assert reverse(f"plugins:netbox_librenms_plugin:{other}") in html, (
                 f"{route} page is missing the switcher link to {other}"
             )
-        assert f'class="nav-link active" href="{url}"' in html
+        # The current page's pill carries BOTH the visual active class and the
+        # aria-current="page" announcement (Bootstrap nav-pills a11y guidance) — and
+        # only it does: a second aria-current would misannounce a sibling as current.
+        assert f'class="nav-link active" href="{url}" aria-current="page"' in html
+        assert html.count('aria-current="page"') == 1
 
     @pytest.mark.parametrize("route", RULE_LIST_ROUTES)
     def test_rule_pages_cross_link_all_rule_lists(self, route, client):
@@ -77,4 +81,6 @@ class TestListPageSwitchers:
             assert reverse(f"plugins:netbox_librenms_plugin:{other}") in html, (
                 f"{route} page is missing the switcher link to {other}"
             )
-        assert f'class="nav-link active" href="{url}"' in html
+        # Same contract as the mapping switcher: exactly one active pill, announced.
+        assert f'class="nav-link active" href="{url}" aria-current="page"' in html
+        assert html.count('aria-current="page"') == 1

--- a/netbox_librenms_plugin/tests/test_rules_patterns_navigation.py
+++ b/netbox_librenms_plugin/tests/test_rules_patterns_navigation.py
@@ -1,0 +1,80 @@
+"""The consolidated sidebar navigation: Mappings and Rules & Patterns.
+
+Nine per-model menu items collapse into two sidebar entries. The object lists
+cross-link through a switcher rendered above the native Results/Filters tabs, so
+each list keeps the full generic feature set (filters, bulk ops, import/export,
+changelog) while the sidebar stays small.
+"""
+
+import pytest
+from django.urls import reverse
+
+# Tab orders mirror the old menu order; each group's single nav entry lands on the
+# first tab. Branches that add a new rule/pattern model extend these lists (and the
+# switcher include) in the same commit that adds the model.
+MAPPING_LIST_ROUTES = [
+    "interfacetypemapping_list",
+    "devicetypemapping_list",
+    "moduletypemapping_list",
+    "modulebaymapping_list",
+    "platformmapping_list",
+]
+RULE_LIST_ROUTES = [
+    "inventoryignorerule_list",
+    "normalizationrule_list",
+    "carrierautoinstallrule_list",
+]
+
+
+def _menu_groups():
+    from netbox_librenms_plugin.navigation import menu
+
+    return {group.label: [item.link for item in group.items] for group in menu.groups}
+
+
+class TestConsolidatedMenu:
+    """One sidebar entry per group; no per-model items remain."""
+
+    def test_mappings_group_is_a_single_entry(self):
+        groups = _menu_groups()
+        assert groups["Mappings"] == [
+            f"plugins:netbox_librenms_plugin:{MAPPING_LIST_ROUTES[0]}",
+        ]
+
+    def test_rules_and_patterns_group_is_a_single_entry(self):
+        groups = _menu_groups()
+        assert groups.get("Rules & Patterns") == [
+            f"plugins:netbox_librenms_plugin:{RULE_LIST_ROUTES[0]}",
+        ]
+
+
+@pytest.mark.django_db
+class TestListPageSwitchers:
+    """Each list page renders its group's switcher, current page marked active."""
+
+    def _rendered(self, client, route):
+        from netbox_librenms_plugin.tests.conftest import make_superuser
+
+        client.force_login(make_superuser())
+        url = reverse(f"plugins:netbox_librenms_plugin:{route}")
+        response = client.get(url)
+        assert response.status_code == 200
+        return url, response.content.decode()
+
+    @pytest.mark.parametrize("route", MAPPING_LIST_ROUTES)
+    def test_mapping_pages_cross_link_all_mapping_lists(self, route, client):
+        url, html = self._rendered(client, route)
+        for other in MAPPING_LIST_ROUTES:
+            assert reverse(f"plugins:netbox_librenms_plugin:{other}") in html, (
+                f"{route} page is missing the switcher link to {other}"
+            )
+        assert f'class="nav-link active" href="{url}"' in html
+
+    @pytest.mark.parametrize("route", RULE_LIST_ROUTES)
+    def test_rule_pages_cross_link_all_rule_lists(self, route, client):
+        url, html = self._rendered(client, route)
+        for other in RULE_LIST_ROUTES:
+            assert reverse(f"plugins:netbox_librenms_plugin:{other}") in html, (
+                f"{route} page is missing the switcher link to {other}"
+            )
+        assert f'class="nav-link active" href="{url}"' in html


### PR DESCRIPTION
## Summary

Collapse the plugin sidebar's nine per-model Mappings items (five type mappings + four rule/pattern engines) into **two** single entries — **Mappings** and **Rules & Patterns**. The individual object lists now cross-link through a switcher-pills row rendered above the native Results/Filters tabs, so each tab is the model's real `ObjectListView` page (not an embedded pane) and keeps the full generic feature set (filters, bulk ops, YAML import/export, changelog). The active pill is announced to screen readers with `aria-current="page"`.

> **This description covers only the delta over `feat/bulk-import` (#318 )** — the three tip commits below. The GitHub diff shows the parent-branch commits too until they merge; review this PR against `feat/bulk-import`.

- `feat(nav)`: collapse the mapping/rule menus into the two tabbed entries; move the per-model menu buttons off the sidebar (each list page already carries its own Add/Import controls).
- `fix(nav)`: announce the active switcher pill with `aria-current="page"` (Bootstrap nav-pills a11y) on both switchers.
- `test(nav)`: assert the active pill by attributes (class + href + exactly-one `aria-current="page"`), decoupled from exact attribute order.

## Motivation / Problem

- Feature + Refactor / cleanup.

Nine sidebar items crowded the plugin menu. Grouping them into two entries with an in-page switcher keeps every list fully functional while decluttering the nav. Convention going forward (enforced by the navigation tests): a branch that introduces a new rule/pattern model adds its switcher tab in the same commit that adds the model — `feat/parent-child-interfaces` (Port Stack LAG Patterns) and `feat/serial-ports` (Serial Sensor Types) already follow it up-stack.

## Scope of Change

- Web UI / templates
- Tests
- Docs only (menu-path references)

## How Was This Tested?

- Unit tests: **yes** — menu-structure tests (two entries, no per-model items) plus **rendered-switcher e2e** tests (real client → view → template) in `test_rules_patterns_navigation.py`, asserting each tab renders the real list page and that exactly one `aria-current="page"` pill is announced per page. Red → green on the a11y change.
- Manual testing: **yes** — verified live against the dev server: the sidebar shows the two entries, the switcher pills render above Results/Filters, and each pill lands on its real list page with filters/bulk-ops/import-export/changelog intact.

### Manual Test Steps

1. Open the plugin sidebar → confirm only **Mappings** and **Rules & Patterns** appear (not the previous nine items).
2. Open a Mappings list → confirm the switcher-pills row above the Results/Filters tabs; the current list's pill carries `aria-current="page"`.
3. Click through the pills → each opens the real `ObjectListView` (filters, bulk operations, import/export, changelog all present).

## Risk Assessment

- **Affects existing users?** Navigation layout only — the Mappings group changes from nine sidebar items to two, with an added in-page switcher. No behavioural change to sync/import.
- **Could cause unintended imports / updates?** No — no sync/import, ORM, LibreNMS API, config, or migration code is touched.

## Backwards Compatibility

- No breaking changes — model URLs and views are unchanged; only the sidebar grouping and a cross-link row are added.

## Other Notes

 The only delta this PR adds over that base is the navigation consolidation described above (`navigation.py`, the `_mapping_tabs.html` / `_rules_patterns_tabs.html` switcher includes, the tab row added to the eight list templates, `test_rules_patterns_navigation.py`, and the two docs menu-path updates).

