### PR TITLE
fix: raise NetBox minimum version to 4.4.0 and test the floor in CI

### DIFF
--- a/.github/workflows/lint-format.yaml
+++ b/.github/workflows/lint-format.yaml
@@ -19,6 +19,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Set up Python
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -16,10 +16,33 @@ permissions:
 jobs:
   test-netbox:
     runs-on: ubuntu-latest
+    name: NetBox ${{ matrix.netbox-ref }} / Python ${{ matrix.python-version }}
+    # main is unreleased; report but don't gate.
+    continue-on-error: ${{ matrix.experimental }}
 
     strategy:
+      # one red version shouldn't cancel the others.
+      fail-fast: false
       matrix:
-        python-version: ["3.12", "3.13", "3.14"]
+        include:
+          # Floor: min_version = 4.4.0 (gating regression guard).
+          - netbox-ref: "v4.4.0"
+            python-version: "3.12"
+            experimental: false
+          # Current stable (gating).
+          - netbox-ref: "v4.6.5"
+            python-version: "3.12"
+            experimental: false
+          - netbox-ref: "v4.6.5"
+            python-version: "3.13"
+            experimental: false
+          # Unreleased NetBox — non-gating.
+          - netbox-ref: "main"
+            python-version: "3.13"
+            experimental: true
+          - netbox-ref: "main"
+            python-version: "3.14"
+            experimental: true
 
     services:
       redis:
@@ -45,6 +68,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           path: netbox-librenms-plugin
+          persist-credentials: false
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
@@ -56,7 +80,8 @@ jobs:
         with:
           repository: "netbox-community/netbox"
           path: netbox
-          ref: main
+          ref: ${{ matrix.netbox-ref }}
+          persist-credentials: false
 
       - name: Install NetBox LibreNMS Plugin
         working-directory: netbox-librenms-plugin
@@ -85,7 +110,8 @@ jobs:
 
       - name: Upload coverage report
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        if: matrix.python-version == '3.12'
+        # Upload from exactly one job so the artifact name doesn't collide.
+        if: matrix.netbox-ref == 'v4.6.5' && matrix.python-version == '3.12'
         with:
           name: coverage-report
           path: netbox-librenms-plugin/coverage_html/

--- a/README.md
+++ b/README.md
@@ -115,8 +115,10 @@ Alternatively, share your ideas for the plugin over in [discussions](https://git
 
 | NetBox Version | Plugin Version |
 |----------------|----------------|
-|     4.1        | 0.2.x - 0.3.5  |
-|     4.2 - 4.5       | 0.3.6+          |
+| 4.1            | 0.2.x - 0.3.5  |
+| 4.2 - 4.3.x    | 0.3.6 - 0.3.9  |
+| 4.4.0+         | 0.4.7+         |
+
 ## Installing
 
 

--- a/netbox_librenms_plugin/__init__.py
+++ b/netbox_librenms_plugin/__init__.py
@@ -12,7 +12,7 @@ class LibreNMSSyncConfig(PluginConfig):
     author = __author__
     version = __version__
     base_url = "librenms_plugin"
-    min_version = "4.2.0"
+    min_version = "4.4.0"
     required_settings = []  # Custom validation in ready() method
     default_settings = {
         "enable_caching": True,

--- a/netbox_librenms_plugin/migrations/0010_inventory_and_mapping_models.py
+++ b/netbox_librenms_plugin/migrations/0010_inventory_and_mapping_models.py
@@ -96,13 +96,8 @@ def _delete_default_inventory_ignore_rules(apps, schema_editor):
 
 class Migration(migrations.Migration):
     dependencies = [
-        # Pinned to the NetBox 4.2 floor declared by ``min_version`` in
-        # ``netbox_librenms_plugin/__init__.py``. Only ``Manufacturer``,
-        # ``DeviceType``, ``ModuleType``, and ``Platform`` are referenced from
-        # dcim, and only ``Tag``/``TaggedItem`` from extras (via taggit) — all
-        # of which exist in 4.2.x. ``makemigrations`` will try to bump these to
-        # the dev environment's NetBox tip; revert it unless we actually start
-        # depending on a newer field.
+        # makemigrations will try to bump these to the dev NetBox tip; revert unless we
+        # actually depend on a newer field.
         ("dcim", "0200_populate_mac_addresses"),
         ("extras", "0122_charfield_null_choices"),
         ("netbox_librenms_plugin", "0009_convert_librenms_id_to_json"),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,8 +52,12 @@ addopts = "-v --tb=short"
 
 [tool.ruff]
 line-length = 120
+# Python only (skip Ruff Markdown formatting).
+extend-exclude = ["*.md"]
 
 [tool.ruff.lint]
+# Explicit defaults; stable across Ruff versions.
+select = ["E4", "E7", "E9", "F"]
 # Follow NetBox conventions - ignore certain rules
 ignore = [
     "E501",  # Line too long (strongly encouraged but not enforced)


### PR DESCRIPTION
## Summary
Raise the plugin's minimum NetBox version to **4.4.0** and test the floor, current stable, and `main` in CI.

Would address #321 #322

## Why
The 0.4.x series needs NetBox 4.4.0: the LibreNMS import page uses the `action_buttons` template tag added in 4.4.0, and migration 0010 needs `netbox.models.deletion` (4.3.3). `min_version` was 4.2.0 and CI only tested NetBox `main`, so the mismatch shipped. Verified by CI — 4.4.0 passes the suite, 4.3.3 fails.

## Changes
- `min_version` 4.2.0 → 4.4.0
- CI matrix: gating floor (`v4.4.0`) + current stable (`v4.6.5`, py 3.12/3.13) + `main` (non-gating); was `main` only
- Ruff: explicit `select` + Markdown excluded, so a Ruff release that changes defaults can't break CI on unrelated code
- `persist-credentials: false` on all checkouts
