### PR TITLE
fix: hardening pass — NetBox 4.4 IP sync, serial normalization, object-scoped lookups

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -265,7 +265,18 @@ systemctl restart netbox
 
 ## Uninstall
 
-See [the instructions for uninstalling plugins](https://netboxlabs.com/docs/netbox/en/stable/plugins/removal/).
+To cleanly uninstall the plugin and reverse its migrations, **while the plugin is still installed and enabled**, do the following:
+
+```
+source /opt/netbox/venv/bin/activate
+python manage.py migrate netbox_librenms_plugin zero
+```
+
+This is the supported way to undo everything the plugin's migrations created: its own tables and migration records, plus any objects it adds to NetBox's own tables (for example indexes on `dcim_device`). Those cross-app changes are **not** covered by NetBox's generic removal steps — which only look for tables named `netbox_librenms_plugin_*` — so reversing the migrations first ensures nothing is left behind.
+
+Then continue with the [general removal instructions](https://netboxlabs.com/docs/netbox/en/stable/plugins/removal/) (disable the plugin, remove its configuration, uninstall the package, and restart NetBox).
+
+> If you already removed the plugin without reversing its migrations, reinstall the matching version, run the `migrate … zero` command above, and then uninstall again.
 
 ## Credits
 

--- a/docs/usage_tips/interface_mappings.md
+++ b/docs/usage_tips/interface_mappings.md
@@ -29,7 +29,7 @@ Example:
 
 #### Creating a New Mapping:
 
-![](../img/interface_mappings/addmapping.png){ width="50" }
+![Add Mapping button on the Interface Mappings page](../img/interface_mappings/addmapping.png){ width="50" }
 
 * Click the green `+` or `Add` button either from the menu or on the Interface Mappings page
 * Enter LibreNMS interface type. _You can copy this from plugin's device interface sync page_
@@ -110,7 +110,7 @@ The plugin supports NetBox's standard bulk import feature for interface mappings
 
 #### Editing Existing Mappings:
 
-![](../img/interface_mappings/editmapping.png){ width="50" }
+![Edit button on an interface mapping row](../img/interface_mappings/editmapping.png){ width="50" }
 
 * On the Mappings page, Locate the desired mapping in the list
 * Click the `edit` (pencil icon) button
@@ -119,7 +119,7 @@ The plugin supports NetBox's standard bulk import feature for interface mappings
 
 #### Deleting Mappings:
 
-![](../img/interface_mappings/deletemapping.png){ width="150" }
+![Delete confirmation for an interface mapping](../img/interface_mappings/deletemapping.png){ width="150" }
 
 * Find the mapping you wish to remove
 * Select the `Delete` button from the drop down

--- a/netbox_librenms_plugin/import_utils/bulk_import.py
+++ b/netbox_librenms_plugin/import_utils/bulk_import.py
@@ -18,6 +18,7 @@ from ..utils import (
     coerce_librenms_id,
     find_by_librenms_id,
     get_librenms_oob,
+    filter_by_trimmed_serial,
     normalize_serial,
     preload_normalization_rules,
 )
@@ -792,7 +793,7 @@ def _refresh_existing_device(validation: dict, libre_device: dict = None, server
             ambiguous_fallback = False
             serial = normalize_serial(libre_device.get("serial"))
             if serial and serial != "-":
-                serial_matches = list(_Device.objects.filter(serial=serial)[:2])
+                serial_matches = list(filter_by_trimmed_serial(_Device.objects.all(), serial)[:2])
                 if len(serial_matches) > 1:
                     ambiguous_fallback = True
                 elif serial_matches:

--- a/netbox_librenms_plugin/import_utils/bulk_import.py
+++ b/netbox_librenms_plugin/import_utils/bulk_import.py
@@ -886,6 +886,19 @@ def _refresh_existing_device(validation: dict, libre_device: dict = None, server
             validation["issues"].append(message)
     except Exception as e:
         logger.error(f"Failed to check for newly imported device: {e}")
+        # Fail closed: this recheck exists to catch duplicates that appeared after the cache
+        # was built, so a transient failure (e.g. a DB error mid-lookup) must not leave a
+        # previously-cached "importable" row importable — that would let a duplicate import
+        # slip through exactly when the duplicate check couldn't run. Matches the fail-closed
+        # behaviour of every other failure branch in this function.
+        validation["can_import"] = False
+        validation["is_ready"] = False
+        message = "Duplicate re-check failed (transient lookup error); import blocked. Refresh to retry."
+        # Append to issues (not just a warning) — a later recalculate_validation_status()
+        # recomputes can_import from the issues list, so anything weaker would be silently
+        # re-enabled. Dedup so repeated refreshes don't stack the same message.
+        if message not in validation.setdefault("issues", []):
+            validation["issues"].append(message)
 
 
 def _empty_return(return_cache_status: bool):

--- a/netbox_librenms_plugin/import_utils/bulk_import.py
+++ b/netbox_librenms_plugin/import_utils/bulk_import.py
@@ -6,7 +6,12 @@ from typing import List
 
 from django.core.cache import cache
 
-from ..import_validation_helpers import apply_role_to_validation, recalculate_validation_status, remove_validation_issue
+from ..import_validation_helpers import (
+    apply_cluster_to_validation,
+    apply_role_to_validation,
+    recalculate_validation_status,
+    remove_validation_issue,
+)
 from ..librenms_api import LibreNMSAPI
 from ..utils import (
     AmbiguousLibreNMSIdError,
@@ -852,6 +857,16 @@ def _refresh_existing_device(validation: dict, libre_device: dict = None, server
                     "found": False,
                     "role": None,
                     "available_roles": validation.get("device_role", {}).get("available_roles", []),
+                }
+            elif hasattr(new_device, "cluster") and new_device.cluster:
+                # VM match: mirror the device-role display above — show the matched
+                # VM's actual cluster rather than leaving the cached selection stale.
+                apply_cluster_to_validation(validation, new_device.cluster)
+            else:
+                validation["cluster"] = {
+                    "found": False,
+                    "cluster": None,
+                    "available_clusters": validation.get("cluster", {}).get("available_clusters", []),
                 }
             recalculate_validation_status(validation, is_vm=actual_is_vm)
             # Re-assert non-importable: recalculate sets can_import from issues list,

--- a/netbox_librenms_plugin/import_utils/bulk_import.py
+++ b/netbox_librenms_plugin/import_utils/bulk_import.py
@@ -18,7 +18,6 @@ from ..utils import (
     coerce_librenms_id,
     find_by_librenms_id,
     get_librenms_oob,
-    filter_by_trimmed_serial,
     normalize_serial,
     preload_normalization_rules,
 )
@@ -793,7 +792,7 @@ def _refresh_existing_device(validation: dict, libre_device: dict = None, server
             ambiguous_fallback = False
             serial = normalize_serial(libre_device.get("serial"))
             if serial and serial != "-":
-                serial_matches = list(filter_by_trimmed_serial(_Device.objects.all(), serial)[:2])
+                serial_matches = list(_Device.objects.filter(serial=serial)[:2])
                 if len(serial_matches) > 1:
                     ambiguous_fallback = True
                 elif serial_matches:

--- a/netbox_librenms_plugin/import_utils/bulk_import.py
+++ b/netbox_librenms_plugin/import_utils/bulk_import.py
@@ -789,7 +789,7 @@ def _refresh_existing_device(validation: dict, libre_device: dict = None, server
             # binding to whichever row sorts first would render the wrong device as the existing
             # match, so flag the row ambiguous and block instead of picking arbitrarily.
             ambiguous_fallback = False
-            serial = (libre_device.get("serial") or "").strip()
+            serial = str(libre_device.get("serial") or "").strip()
             if serial and serial != "-":
                 serial_matches = list(_Device.objects.filter(serial=serial)[:2])
                 if len(serial_matches) > 1:

--- a/netbox_librenms_plugin/import_utils/bulk_import.py
+++ b/netbox_librenms_plugin/import_utils/bulk_import.py
@@ -18,6 +18,7 @@ from ..utils import (
     coerce_librenms_id,
     find_by_librenms_id,
     get_librenms_oob,
+    normalize_serial,
     preload_normalization_rules,
 )
 from .cache import get_cache_metadata_key, get_import_device_cache_key, get_validated_device_cache_key
@@ -262,7 +263,7 @@ def bulk_import_devices_shared(
                     member_serials = sorted(
                         serial
                         for m in vc_data.get("members", [])
-                        if (serial := str(m.get("serial") or "").strip()) and serial != "-"
+                        if (serial := normalize_serial(m.get("serial"))) and serial != "-"
                     )
                     if member_serials:
                         vc_domain = f"librenms-stack-{','.join(member_serials)}"
@@ -789,7 +790,7 @@ def _refresh_existing_device(validation: dict, libre_device: dict = None, server
             # binding to whichever row sorts first would render the wrong device as the existing
             # match, so flag the row ambiguous and block instead of picking arbitrarily.
             ambiguous_fallback = False
-            serial = str(libre_device.get("serial") or "").strip()
+            serial = normalize_serial(libre_device.get("serial"))
             if serial and serial != "-":
                 serial_matches = list(_Device.objects.filter(serial=serial)[:2])
                 if len(serial_matches) > 1:

--- a/netbox_librenms_plugin/import_utils/device_operations.py
+++ b/netbox_librenms_plugin/import_utils/device_operations.py
@@ -914,7 +914,7 @@ def validate_device_for_import(
             # the Stage-2 merge-candidate detection below both run the identical UNIQUE [:2] query
             # for the matched type, so share the result instead of issuing it twice per device.
             _match_type = result.get("existing_match_type")
-            _serial_now = (libre_device.get("serial") or "").strip()
+            _serial_now = str(libre_device.get("serial") or "").strip()
             _dup_eligible = (
                 not import_as_vm and result.get("existing_device") is not None and _match_type in ("hostname", "serial")
             )
@@ -984,7 +984,7 @@ def validate_device_for_import(
             # physical box (host + OOB) imported as separate entries. Surface
             # this as a merge action instead of silently picking one.
             try:
-                _serial_for_pair = (libre_device.get("serial") or "").strip()
+                _serial_for_pair = str(libre_device.get("serial") or "").strip()
                 if (
                     _serial_for_pair
                     and _serial_for_pair != "-"

--- a/netbox_librenms_plugin/import_utils/device_operations.py
+++ b/netbox_librenms_plugin/import_utils/device_operations.py
@@ -21,6 +21,7 @@ from ..utils import (
     get_librenms_oob,
     is_legacy_librenms_id,
     match_librenms_hardware_to_device_type,
+    filter_by_trimmed_serial,
     normalize_serial,
     set_librenms_device_id,
 )
@@ -757,7 +758,9 @@ def validate_device_for_import(
                         result["serial_confirmed"] = True
                     elif existing_device.serial and existing_device.serial != incoming_serial:
                         serial_conflict = (
-                            Device.objects.filter(serial=incoming_serial).exclude(pk=existing_device.pk).first()
+                            filter_by_trimmed_serial(Device.objects.all(), incoming_serial)
+                            .exclude(pk=existing_device.pk)
+                            .first()
                         )
                         if serial_conflict:
                             result["serial_action"] = "conflict"
@@ -825,7 +828,9 @@ def validate_device_for_import(
                 incoming_serial = normalize_serial(libre_device.get("serial"))
                 if incoming_serial and incoming_serial != "-" and existing_device.serial != incoming_serial:
                     serial_conflict = (
-                        Device.objects.filter(serial=incoming_serial).exclude(pk=existing_device.pk).first()
+                        filter_by_trimmed_serial(Device.objects.all(), incoming_serial)
+                        .exclude(pk=existing_device.pk)
+                        .first()
                     )
                     if serial_conflict:
                         result["serial_action"] = "conflict"
@@ -862,7 +867,7 @@ def validate_device_for_import(
                     # and the downstream serial/OOB/merge flow would derive its guidance from a
                     # random device. Require a unique match before binding, mirroring the
                     # merge-peer [:2] guard (issue #101).
-                    serial_matches = list(Device.objects.filter(serial=serial)[:2])
+                    serial_matches = list(filter_by_trimmed_serial(Device.objects.all(), serial)[:2])
                     if len(serial_matches) > 1:
                         # Device.serial is not unique in NetBox, so several rows already share it.
                         # Binding to an arbitrary one is wrong, and importing anyway would mint YET
@@ -1027,7 +1032,9 @@ def validate_device_for_import(
                     # otherwise skip the suggestion and warn.
                     if _hostname_match and not _serial_match:
                         _serial_peers = list(
-                            Device.objects.filter(serial=_serial_for_pair).exclude(pk=_hostname_match.pk)[:2]
+                            filter_by_trimmed_serial(Device.objects.all(), _serial_for_pair).exclude(
+                                pk=_hostname_match.pk
+                            )[:2]
                         )
                         if len(_serial_peers) == 1:
                             _serial_match = _serial_peers[0]

--- a/netbox_librenms_plugin/import_utils/device_operations.py
+++ b/netbox_librenms_plugin/import_utils/device_operations.py
@@ -727,7 +727,7 @@ def validate_device_for_import(
 
                 # Check if name matches resolved name (VC-aware: compare against VC member name)
                 if hostname and existing_device.virtual_chassis and existing_device.vc_position:
-                    incoming_serial = (libre_device.get("serial") or "").strip()
+                    incoming_serial = str(libre_device.get("serial") or "").strip()
                     if incoming_serial == "-":
                         incoming_serial = ""
                     vc_expected_name = _generate_vc_member_name(
@@ -750,7 +750,7 @@ def validate_device_for_import(
                 # OOB sub-key (existing_match_type == "librenms_oob"): the incoming payload is the
                 # OOB controller's, so comparing it against the host record's serial would surface
                 # bogus replacement/conflict warnings on a row that is already correctly linked.
-                incoming_serial = (libre_device.get("serial") or "").strip()
+                incoming_serial = str(libre_device.get("serial") or "").strip()
                 if result["existing_match_type"] != "librenms_oob" and incoming_serial and incoming_serial != "-":
                     if existing_device.serial and existing_device.serial == incoming_serial:
                         result["serial_confirmed"] = True
@@ -821,7 +821,7 @@ def validate_device_for_import(
                 result["existing_librenms_link"] = _describe_existing_librenms_link(existing_device, server_key)
 
                 # Check for serial conflict on hostname-matched device
-                incoming_serial = (libre_device.get("serial") or "").strip()
+                incoming_serial = str(libre_device.get("serial") or "").strip()
                 if incoming_serial and incoming_serial != "-" and existing_device.serial != incoming_serial:
                     serial_conflict = (
                         Device.objects.filter(serial=incoming_serial).exclude(pk=existing_device.pk).first()
@@ -855,7 +855,7 @@ def validate_device_for_import(
                 # device that stored the trimmed value and mint a duplicate. The serial is stripped
                 # consistently across the drift checks above and the persisted value (import_single_device),
                 # so a match, a comparison, and the stored serial can't disagree on whitespace.
-                serial = (libre_device.get("serial") or "").strip()
+                serial = str(libre_device.get("serial") or "").strip()
                 if serial and serial != "-" and not import_as_vm:
                     # Serial is not unique in NetBox, so .first() would bind an arbitrary row
                     # and the downstream serial/OOB/merge flow would derive its guidance from a
@@ -1615,7 +1615,7 @@ def import_single_device(
             # Persist the serial TRIMMED (LibreNMS/SNMP serials often carry surrounding whitespace):
             # storing it padded would make the next import's trimmed ``filter(serial=...)`` miss this
             # device and mint a duplicate. Keeps the stored value consistent with the match lookups.
-            serial = (libre_device.get("serial") or "").strip()
+            serial = str(libre_device.get("serial") or "").strip()
             if serial and serial != "-":
                 device_data["serial"] = serial
 

--- a/netbox_librenms_plugin/import_utils/device_operations.py
+++ b/netbox_librenms_plugin/import_utils/device_operations.py
@@ -850,7 +850,10 @@ def validate_device_for_import(
 
             # Check by serial number (strong physical match - hardware identity)
             if not result["existing_device"]:
-                serial = libre_device.get("serial") or ""
+                # Strip the incoming serial before matching: SNMP-sourced serials often carry
+                # trailing/leading whitespace, so a raw ``filter(serial=...)`` would miss an existing
+                # device that stored the trimmed value and mint a duplicate. Mirrors ``_serial_now``.
+                serial = (libre_device.get("serial") or "").strip()
                 if serial and serial != "-" and not import_as_vm:
                     # Serial is not unique in NetBox, so .first() would bind an arbitrary row
                     # and the downstream serial/OOB/merge flow would derive its guidance from a

--- a/netbox_librenms_plugin/import_utils/device_operations.py
+++ b/netbox_librenms_plugin/import_utils/device_operations.py
@@ -735,7 +735,8 @@ def validate_device_for_import(
                     vc_expected_name = _generate_vc_member_name(
                         hostname,
                         existing_device.vc_position,
-                        serial=incoming_serial or existing_device.serial or "",
+                        # Trim the stored fallback too, or a padded serial mints a bogus name.
+                        serial=incoming_serial or normalize_serial(existing_device.serial),
                     )
                     if existing_device.name == vc_expected_name:
                         result["name_matches"] = True
@@ -753,10 +754,12 @@ def validate_device_for_import(
                 # OOB controller's, so comparing it against the host record's serial would surface
                 # bogus replacement/conflict warnings on a row that is already correctly linked.
                 incoming_serial = normalize_serial(libre_device.get("serial"))
+                # Normalize the stored side too: a legacy padded serial equals the incoming one.
+                stored_serial = normalize_serial(existing_device.serial)
                 if result["existing_match_type"] != "librenms_oob" and incoming_serial and incoming_serial != "-":
-                    if existing_device.serial and existing_device.serial == incoming_serial:
+                    if stored_serial and stored_serial == incoming_serial:
                         result["serial_confirmed"] = True
-                    elif existing_device.serial and existing_device.serial != incoming_serial:
+                    elif stored_serial and stored_serial != incoming_serial:
                         serial_conflict = (
                             filter_by_trimmed_serial(Device.objects.all(), incoming_serial)
                             .exclude(pk=existing_device.pk)
@@ -824,9 +827,11 @@ def validate_device_for_import(
                 # is already linked to LibreNMS isn't mislabelled as "not linked".
                 result["existing_librenms_link"] = _describe_existing_librenms_link(existing_device, server_key)
 
-                # Check for serial conflict on hostname-matched device
+                # Check for serial conflict on hostname-matched device. Both sides are
+                # normalized so a legacy padded stored serial isn't read as drift.
                 incoming_serial = normalize_serial(libre_device.get("serial"))
-                if incoming_serial and incoming_serial != "-" and existing_device.serial != incoming_serial:
+                stored_serial = normalize_serial(existing_device.serial)
+                if incoming_serial and incoming_serial != "-" and stored_serial != incoming_serial:
                     serial_conflict = (
                         filter_by_trimmed_serial(Device.objects.all(), incoming_serial)
                         .exclude(pk=existing_device.pk)

--- a/netbox_librenms_plugin/import_utils/device_operations.py
+++ b/netbox_librenms_plugin/import_utils/device_operations.py
@@ -21,7 +21,6 @@ from ..utils import (
     get_librenms_oob,
     is_legacy_librenms_id,
     match_librenms_hardware_to_device_type,
-    filter_by_trimmed_serial,
     normalize_serial,
     set_librenms_device_id,
 )
@@ -761,9 +760,7 @@ def validate_device_for_import(
                         result["serial_confirmed"] = True
                     elif stored_serial and stored_serial != incoming_serial:
                         serial_conflict = (
-                            filter_by_trimmed_serial(Device.objects.all(), incoming_serial)
-                            .exclude(pk=existing_device.pk)
-                            .first()
+                            Device.objects.filter(serial=incoming_serial).exclude(pk=existing_device.pk).first()
                         )
                         if serial_conflict:
                             result["serial_action"] = "conflict"
@@ -833,9 +830,7 @@ def validate_device_for_import(
                 stored_serial = normalize_serial(existing_device.serial)
                 if incoming_serial and incoming_serial != "-" and stored_serial != incoming_serial:
                     serial_conflict = (
-                        filter_by_trimmed_serial(Device.objects.all(), incoming_serial)
-                        .exclude(pk=existing_device.pk)
-                        .first()
+                        Device.objects.filter(serial=incoming_serial).exclude(pk=existing_device.pk).first()
                     )
                     if serial_conflict:
                         result["serial_action"] = "conflict"
@@ -861,18 +856,16 @@ def validate_device_for_import(
 
             # Check by serial number (strong physical match - hardware identity)
             if not result["existing_device"]:
-                # Strip the incoming serial before matching: SNMP-sourced serials often carry
-                # trailing/leading whitespace, so a raw ``filter(serial=...)`` would miss an existing
-                # device that stored the trimmed value and mint a duplicate. The serial is stripped
-                # consistently across the drift checks above and the persisted value (import_single_device),
-                # so a match, a comparison, and the stored serial can't disagree on whitespace.
+                # Normalize the incoming serial before the exact indexed lookup. Migration 0012
+                # canonicalizes legacy Device rows, and every plugin write path stores this same
+                # normalized form, so matching and persistence share one representation.
                 serial = normalize_serial(libre_device.get("serial"))
                 if serial and serial != "-" and not import_as_vm:
                     # Serial is not unique in NetBox, so .first() would bind an arbitrary row
                     # and the downstream serial/OOB/merge flow would derive its guidance from a
                     # random device. Require a unique match before binding, mirroring the
                     # merge-peer [:2] guard (issue #101).
-                    serial_matches = list(filter_by_trimmed_serial(Device.objects.all(), serial)[:2])
+                    serial_matches = list(Device.objects.filter(serial=serial)[:2])
                     if len(serial_matches) > 1:
                         # Device.serial is not unique in NetBox, so several rows already share it.
                         # Binding to an arbitrary one is wrong, and importing anyway would mint YET
@@ -1037,9 +1030,7 @@ def validate_device_for_import(
                     # otherwise skip the suggestion and warn.
                     if _hostname_match and not _serial_match:
                         _serial_peers = list(
-                            filter_by_trimmed_serial(Device.objects.all(), _serial_for_pair).exclude(
-                                pk=_hostname_match.pk
-                            )[:2]
+                            Device.objects.filter(serial=_serial_for_pair).exclude(pk=_hostname_match.pk)[:2]
                         )
                         if len(_serial_peers) == 1:
                             _serial_match = _serial_peers[0]
@@ -1625,9 +1616,7 @@ def import_single_device(
             if rack:
                 device_data["rack"] = rack
 
-            # Persist the serial TRIMMED (LibreNMS/SNMP serials often carry surrounding whitespace):
-            # storing it padded would make the next import's trimmed ``filter(serial=...)`` miss this
-            # device and mint a duplicate. Keeps the stored value consistent with the match lookups.
+            # Persist the canonical serial used by the exact indexed match lookups.
             serial = normalize_serial(libre_device.get("serial"))
             if serial and serial != "-":
                 device_data["serial"] = serial

--- a/netbox_librenms_plugin/import_utils/device_operations.py
+++ b/netbox_librenms_plugin/import_utils/device_operations.py
@@ -21,6 +21,7 @@ from ..utils import (
     get_librenms_oob,
     is_legacy_librenms_id,
     match_librenms_hardware_to_device_type,
+    normalize_serial,
     set_librenms_device_id,
 )
 from ..constants import normalize_oob_type
@@ -727,7 +728,7 @@ def validate_device_for_import(
 
                 # Check if name matches resolved name (VC-aware: compare against VC member name)
                 if hostname and existing_device.virtual_chassis and existing_device.vc_position:
-                    incoming_serial = str(libre_device.get("serial") or "").strip()
+                    incoming_serial = normalize_serial(libre_device.get("serial"))
                     if incoming_serial == "-":
                         incoming_serial = ""
                     vc_expected_name = _generate_vc_member_name(
@@ -750,7 +751,7 @@ def validate_device_for_import(
                 # OOB sub-key (existing_match_type == "librenms_oob"): the incoming payload is the
                 # OOB controller's, so comparing it against the host record's serial would surface
                 # bogus replacement/conflict warnings on a row that is already correctly linked.
-                incoming_serial = str(libre_device.get("serial") or "").strip()
+                incoming_serial = normalize_serial(libre_device.get("serial"))
                 if result["existing_match_type"] != "librenms_oob" and incoming_serial and incoming_serial != "-":
                     if existing_device.serial and existing_device.serial == incoming_serial:
                         result["serial_confirmed"] = True
@@ -821,7 +822,7 @@ def validate_device_for_import(
                 result["existing_librenms_link"] = _describe_existing_librenms_link(existing_device, server_key)
 
                 # Check for serial conflict on hostname-matched device
-                incoming_serial = str(libre_device.get("serial") or "").strip()
+                incoming_serial = normalize_serial(libre_device.get("serial"))
                 if incoming_serial and incoming_serial != "-" and existing_device.serial != incoming_serial:
                     serial_conflict = (
                         Device.objects.filter(serial=incoming_serial).exclude(pk=existing_device.pk).first()
@@ -855,7 +856,7 @@ def validate_device_for_import(
                 # device that stored the trimmed value and mint a duplicate. The serial is stripped
                 # consistently across the drift checks above and the persisted value (import_single_device),
                 # so a match, a comparison, and the stored serial can't disagree on whitespace.
-                serial = str(libre_device.get("serial") or "").strip()
+                serial = normalize_serial(libre_device.get("serial"))
                 if serial and serial != "-" and not import_as_vm:
                     # Serial is not unique in NetBox, so .first() would bind an arbitrary row
                     # and the downstream serial/OOB/merge flow would derive its guidance from a
@@ -914,7 +915,7 @@ def validate_device_for_import(
             # the Stage-2 merge-candidate detection below both run the identical UNIQUE [:2] query
             # for the matched type, so share the result instead of issuing it twice per device.
             _match_type = result.get("existing_match_type")
-            _serial_now = str(libre_device.get("serial") or "").strip()
+            _serial_now = normalize_serial(libre_device.get("serial"))
             _dup_eligible = (
                 not import_as_vm and result.get("existing_device") is not None and _match_type in ("hostname", "serial")
             )
@@ -984,7 +985,7 @@ def validate_device_for_import(
             # physical box (host + OOB) imported as separate entries. Surface
             # this as a merge action instead of silently picking one.
             try:
-                _serial_for_pair = str(libre_device.get("serial") or "").strip()
+                _serial_for_pair = normalize_serial(libre_device.get("serial"))
                 if (
                     _serial_for_pair
                     and _serial_for_pair != "-"
@@ -1615,7 +1616,7 @@ def import_single_device(
             # Persist the serial TRIMMED (LibreNMS/SNMP serials often carry surrounding whitespace):
             # storing it padded would make the next import's trimmed ``filter(serial=...)`` miss this
             # device and mint a duplicate. Keeps the stored value consistent with the match lookups.
-            serial = str(libre_device.get("serial") or "").strip()
+            serial = normalize_serial(libre_device.get("serial"))
             if serial and serial != "-":
                 device_data["serial"] = serial
 

--- a/netbox_librenms_plugin/import_utils/device_operations.py
+++ b/netbox_librenms_plugin/import_utils/device_operations.py
@@ -727,7 +727,7 @@ def validate_device_for_import(
 
                 # Check if name matches resolved name (VC-aware: compare against VC member name)
                 if hostname and existing_device.virtual_chassis and existing_device.vc_position:
-                    incoming_serial = libre_device.get("serial") or ""
+                    incoming_serial = (libre_device.get("serial") or "").strip()
                     if incoming_serial == "-":
                         incoming_serial = ""
                     vc_expected_name = _generate_vc_member_name(
@@ -750,7 +750,7 @@ def validate_device_for_import(
                 # OOB sub-key (existing_match_type == "librenms_oob"): the incoming payload is the
                 # OOB controller's, so comparing it against the host record's serial would surface
                 # bogus replacement/conflict warnings on a row that is already correctly linked.
-                incoming_serial = libre_device.get("serial") or ""
+                incoming_serial = (libre_device.get("serial") or "").strip()
                 if result["existing_match_type"] != "librenms_oob" and incoming_serial and incoming_serial != "-":
                     if existing_device.serial and existing_device.serial == incoming_serial:
                         result["serial_confirmed"] = True
@@ -821,7 +821,7 @@ def validate_device_for_import(
                 result["existing_librenms_link"] = _describe_existing_librenms_link(existing_device, server_key)
 
                 # Check for serial conflict on hostname-matched device
-                incoming_serial = libre_device.get("serial") or ""
+                incoming_serial = (libre_device.get("serial") or "").strip()
                 if incoming_serial and incoming_serial != "-" and existing_device.serial != incoming_serial:
                     serial_conflict = (
                         Device.objects.filter(serial=incoming_serial).exclude(pk=existing_device.pk).first()
@@ -852,7 +852,9 @@ def validate_device_for_import(
             if not result["existing_device"]:
                 # Strip the incoming serial before matching: SNMP-sourced serials often carry
                 # trailing/leading whitespace, so a raw ``filter(serial=...)`` would miss an existing
-                # device that stored the trimmed value and mint a duplicate. Mirrors ``_serial_now``.
+                # device that stored the trimmed value and mint a duplicate. The serial is stripped
+                # consistently across the drift checks above and the persisted value (import_single_device),
+                # so a match, a comparison, and the stored serial can't disagree on whitespace.
                 serial = (libre_device.get("serial") or "").strip()
                 if serial and serial != "-" and not import_as_vm:
                     # Serial is not unique in NetBox, so .first() would bind an arbitrary row
@@ -1610,7 +1612,10 @@ def import_single_device(
             if rack:
                 device_data["rack"] = rack
 
-            serial = libre_device.get("serial", "")
+            # Persist the serial TRIMMED (LibreNMS/SNMP serials often carry surrounding whitespace):
+            # storing it padded would make the next import's trimmed ``filter(serial=...)`` miss this
+            # device and mint a duplicate. Keeps the stored value consistent with the match lookups.
+            serial = (libre_device.get("serial") or "").strip()
             if serial and serial != "-":
                 device_data["serial"] = serial
 

--- a/netbox_librenms_plugin/import_utils/virtual_chassis.py
+++ b/netbox_librenms_plugin/import_utils/virtual_chassis.py
@@ -405,8 +405,8 @@ def _safe_pos(value) -> int | None:
 
 
 def _norm_serial(s) -> str:
-    """Normalize serial: strip whitespace; treat '-' as absent."""
-    s = str(s or "").strip()
+    """Normalize serial via normalize_serial (only None means missing); additionally treat '-' as absent."""
+    s = normalize_serial(s)
     return "" if s == "-" else s
 
 

--- a/netbox_librenms_plugin/import_utils/virtual_chassis.py
+++ b/netbox_librenms_plugin/import_utils/virtual_chassis.py
@@ -8,6 +8,7 @@ from django.core.cache import cache
 from django.db import transaction
 
 from ..librenms_api import LibreNMSAPI
+from ..utils import normalize_serial
 
 logger = logging.getLogger(__name__)
 
@@ -523,7 +524,7 @@ def create_virtual_chassis_with_members(
                 # Normalize serial and position up front so all skip-checks and
                 # downstream logic use consistent values (strips whitespace and
                 # treats the sentinel "-" as "no serial").
-                serial = str(member.get("serial") or "").strip()
+                serial = normalize_serial(member.get("serial"))
                 if serial == "-":
                     serial = ""
                 member_pos = _safe_pos(member.get("position"))

--- a/netbox_librenms_plugin/import_utils/virtual_chassis.py
+++ b/netbox_librenms_plugin/import_utils/virtual_chassis.py
@@ -8,7 +8,7 @@ from django.core.cache import cache
 from django.db import transaction
 
 from ..librenms_api import LibreNMSAPI
-from ..utils import filter_by_trimmed_serial, normalize_serial
+from ..utils import normalize_serial
 
 logger = logging.getLogger(__name__)
 
@@ -549,7 +549,7 @@ def create_virtual_chassis_with_members(
                 )
 
                 # Check for duplicate serial
-                if serial and filter_by_trimmed_serial(Device.objects.all(), serial).exists():
+                if serial and Device.objects.filter(serial=serial).exists():
                     logger.warning(f"Device with serial '{serial}' already exists, skipping VC member creation")
                     continue
 

--- a/netbox_librenms_plugin/import_utils/virtual_chassis.py
+++ b/netbox_librenms_plugin/import_utils/virtual_chassis.py
@@ -8,7 +8,7 @@ from django.core.cache import cache
 from django.db import transaction
 
 from ..librenms_api import LibreNMSAPI
-from ..utils import normalize_serial
+from ..utils import filter_by_trimmed_serial, normalize_serial
 
 logger = logging.getLogger(__name__)
 
@@ -551,7 +551,7 @@ def create_virtual_chassis_with_members(
                 )
 
                 # Check for duplicate serial
-                if serial and Device.objects.filter(serial=serial).exists():
+                if serial and filter_by_trimmed_serial(Device.objects.all(), serial).exists():
                     logger.warning(f"Device with serial '{serial}' already exists, skipping VC member creation")
                     continue
 

--- a/netbox_librenms_plugin/import_utils/virtual_chassis.py
+++ b/netbox_librenms_plugin/import_utils/virtual_chassis.py
@@ -524,9 +524,7 @@ def create_virtual_chassis_with_members(
                 # Normalize serial and position up front so all skip-checks and
                 # downstream logic use consistent values (strips whitespace and
                 # treats the sentinel "-" as "no serial").
-                serial = normalize_serial(member.get("serial"))
-                if serial == "-":
-                    serial = ""
+                serial = _norm_serial(member.get("serial"))
                 member_pos = _safe_pos(member.get("position"))
 
                 # Skip the master member — identified by is_master flag, serial match,

--- a/netbox_librenms_plugin/librenms_api.py
+++ b/netbox_librenms_plugin/librenms_api.py
@@ -799,6 +799,15 @@ class LibreNMSAPI:
                 message = data.get("message") if isinstance(data, dict) else None
                 return False, message or "Unexpected response format: 'addresses' must be a list"
             return True, addresses
+        except requests.exceptions.HTTPError as e:
+            # LibreNMS returns HTTP 404 from /devices/{id}/ip for a device that simply has no IP
+            # addresses (same as /links for a device with no LLDP neighbours). That is a successful
+            # empty result, not a fetch failure — surfacing it as one shows a red "Failed to fetch
+            # IP addresses" error and an empty table instead of just the empty table. Mirror
+            # get_device_links; any other HTTP status is a genuine failure.
+            if e.response is not None and e.response.status_code == 404:
+                return True, []
+            return False, str(e)
         except (requests.exceptions.RequestException, ValueError) as e:
             return False, str(e)
 

--- a/netbox_librenms_plugin/migrations/0012_normalize_device_serials.py
+++ b/netbox_librenms_plugin/migrations/0012_normalize_device_serials.py
@@ -4,6 +4,7 @@ from django.db import migrations
 
 _BATCH_SIZE = 1000
 _SERIAL_INDEX = "nblp_dcim_device_serial_idx"
+_SERIAL_TABLE = "dcim_device"
 
 
 def normalize_device_serials(apps, schema_editor):
@@ -27,6 +28,78 @@ def normalize_device_serials(apps, schema_editor):
         Device.objects.using(db_alias).bulk_update(pending, ["serial"], batch_size=_BATCH_SIZE)
 
 
+def ensure_device_serial_index(apps, schema_editor):
+    """Create the serial index, reusing a valid copy or repairing an interrupted build."""
+    del apps
+    connection = schema_editor.connection
+
+    # IF NOT EXISTS also accepts an invalid index left by a failed concurrent build.
+    # Inspect the catalog so retries can repair that state without trusting a wrong definition.
+    with connection.cursor() as cursor:
+        cursor.execute(
+            """
+            SELECT
+                index_state.indisvalid,
+                index_state.indisready,
+                index_state.indrelid = to_regclass(%s),
+                index_state.indisunique,
+                index_state.indisprimary,
+                index_state.indpred IS NULL,
+                index_state.indnatts = index_state.indnkeyatts,
+                access_method.amname,
+                ARRAY(
+                    SELECT attribute.attname
+                    FROM unnest(index_state.indkey) WITH ORDINALITY AS key(attnum, position)
+                    JOIN pg_attribute AS attribute
+                      ON attribute.attrelid = index_state.indrelid
+                     AND attribute.attnum = key.attnum
+                    WHERE key.position <= index_state.indnkeyatts
+                    ORDER BY key.position
+                )
+            FROM pg_index AS index_state
+            JOIN pg_class AS index_class
+              ON index_class.oid = index_state.indexrelid
+            JOIN pg_namespace AS index_namespace
+              ON index_namespace.oid = index_class.relnamespace
+            JOIN pg_am AS access_method
+              ON access_method.oid = index_class.relam
+            WHERE index_class.relname = %s
+              AND index_namespace.nspname = current_schema()
+            """,
+            [_SERIAL_TABLE, _SERIAL_INDEX],
+        )
+        existing = cursor.fetchone()
+
+    if existing is not None:
+        valid, ready, on_device, unique, primary, unfiltered, no_includes, method, columns = existing
+        expected_shape = (
+            on_device
+            and not unique
+            and not primary
+            and unfiltered
+            and no_includes
+            and method == "btree"
+            and columns == ["serial"]
+        )
+        if not expected_shape:
+            raise RuntimeError(f"Existing index {_SERIAL_INDEX!r} has an incompatible definition")
+        if valid and ready:
+            return
+
+        schema_editor.execute(f"DROP INDEX CONCURRENTLY IF EXISTS {schema_editor.quote_name(_SERIAL_INDEX)}")
+
+    schema_editor.execute(
+        f"CREATE INDEX CONCURRENTLY {schema_editor.quote_name(_SERIAL_INDEX)} "
+        f"ON {schema_editor.quote_name(_SERIAL_TABLE)} ({schema_editor.quote_name('serial')})"
+    )
+
+
+def drop_device_serial_index(apps, schema_editor):
+    """Drop the plugin-owned serial index when reversing the migration."""
+    del apps
+    schema_editor.execute(f"DROP INDEX CONCURRENTLY IF EXISTS {schema_editor.quote_name(_SERIAL_INDEX)}")
+
+
 class Migration(migrations.Migration):
     # CREATE INDEX CONCURRENTLY cannot run inside a transaction. Keep the data rewrite
     # atomic via RunPython.atomic while leaving the index operation outside it.
@@ -45,8 +118,9 @@ class Migration(migrations.Migration):
         ),
         # Device is owned by NetBox's dcim app, so the plugin cannot declare this index
         # through its model state. NetBox does not otherwise index Device.serial.
-        migrations.RunSQL(
-            sql=(f"CREATE INDEX CONCURRENTLY {_SERIAL_INDEX} ON dcim_device (serial)"),
-            reverse_sql=f"DROP INDEX CONCURRENTLY IF EXISTS {_SERIAL_INDEX}",
+        migrations.RunPython(
+            ensure_device_serial_index,
+            drop_device_serial_index,
+            atomic=False,
         ),
     ]

--- a/netbox_librenms_plugin/migrations/0012_normalize_device_serials.py
+++ b/netbox_librenms_plugin/migrations/0012_normalize_device_serials.py
@@ -1,0 +1,52 @@
+"""Canonicalize existing Device serials and index exact serial lookups."""
+
+from django.db import migrations
+
+_BATCH_SIZE = 1000
+_SERIAL_INDEX = "nblp_dcim_device_serial_idx"
+
+
+def normalize_device_serials(apps, schema_editor):
+    """Strip surrounding whitespace from every existing NetBox Device serial."""
+    Device = apps.get_model("dcim", "Device")
+    db_alias = schema_editor.connection.alias
+    pending = []
+
+    for device in Device.objects.using(db_alias).only("pk", "serial").iterator(chunk_size=_BATCH_SIZE):
+        raw_serial = device.serial
+        normalized = raw_serial.strip() if raw_serial is not None else ""
+        if normalized == raw_serial:
+            continue
+        device.serial = normalized
+        pending.append(device)
+        if len(pending) == _BATCH_SIZE:
+            Device.objects.using(db_alias).bulk_update(pending, ["serial"], batch_size=_BATCH_SIZE)
+            pending.clear()
+
+    if pending:
+        Device.objects.using(db_alias).bulk_update(pending, ["serial"], batch_size=_BATCH_SIZE)
+
+
+class Migration(migrations.Migration):
+    # CREATE INDEX CONCURRENTLY cannot run inside a transaction. Keep the data rewrite
+    # atomic via RunPython.atomic while leaving the index operation outside it.
+    atomic = False
+
+    dependencies = [
+        ("dcim", "0001_squashed"),
+        ("netbox_librenms_plugin", "0011_renormalize_device_type_mappings"),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            normalize_device_serials,
+            migrations.RunPython.noop,
+            atomic=True,
+        ),
+        # Device is owned by NetBox's dcim app, so the plugin cannot declare this index
+        # through its model state. NetBox does not otherwise index Device.serial.
+        migrations.RunSQL(
+            sql=(f"CREATE INDEX CONCURRENTLY {_SERIAL_INDEX} ON dcim_device (serial)"),
+            reverse_sql=f"DROP INDEX CONCURRENTLY IF EXISTS {_SERIAL_INDEX}",
+        ),
+    ]

--- a/netbox_librenms_plugin/tests/conftest.py
+++ b/netbox_librenms_plugin/tests/conftest.py
@@ -198,6 +198,18 @@ def delete_keeping_pk(obj):
     type(obj).objects.filter(pk=obj.pk).delete()
 
 
+def collapse_queryset_chain(mock_model):
+    """Fold ``.all()``/``.annotate()`` back onto a mocked manager.
+
+    ``filter_by_trimmed_serial()`` wraps a plain ``.filter()`` in ``.all().annotate()``,
+    which on a MagicMock forks a fresh auto-mock instead of reaching the test's ``filter``
+    pins — so a no-conflict test sees a truthy row. Real querysets clone and return, so
+    folding both calls back onto the manager keeps every existing pin on the trimmed path.
+    """
+    mock_model.objects.all.return_value = mock_model.objects
+    mock_model.objects.annotate.return_value = mock_model.objects
+
+
 def make_superuser(username="review-su"):
     """Return an ACTUAL active superuser for permission-sensitive view tests.
 

--- a/netbox_librenms_plugin/tests/conftest.py
+++ b/netbox_librenms_plugin/tests/conftest.py
@@ -198,18 +198,6 @@ def delete_keeping_pk(obj):
     type(obj).objects.filter(pk=obj.pk).delete()
 
 
-def collapse_queryset_chain(mock_model):
-    """Fold ``.all()``/``.annotate()`` back onto a mocked manager.
-
-    ``filter_by_trimmed_serial()`` wraps a plain ``.filter()`` in ``.all().annotate()``,
-    which on a MagicMock forks a fresh auto-mock instead of reaching the test's ``filter``
-    pins — so a no-conflict test sees a truthy row. Real querysets clone and return, so
-    folding both calls back onto the manager keeps every existing pin on the trimmed path.
-    """
-    mock_model.objects.all.return_value = mock_model.objects
-    mock_model.objects.annotate.return_value = mock_model.objects
-
-
 def make_superuser(username="review-su"):
     """Return an ACTUAL active superuser for permission-sensitive view tests.
 

--- a/netbox_librenms_plugin/tests/test_cable_verify.py
+++ b/netbox_librenms_plugin/tests/test_cable_verify.py
@@ -643,3 +643,50 @@ class TestSingleCableVerifyServerKeyRouting:
         # No cross-server bleed: the 'production' lookup misses → the default Missing-Ports row.
         assert row["local_port"] == ""
         assert row["cable_status"] == "Missing Ports"
+
+
+@pytest.mark.django_db
+class TestEnrichRemotePortEmptyPort:
+    """A resolvable remote device with no advertised remote port must not crash the Cables tab."""
+
+    def _make_device(self, name):
+        from dcim.models import Device, DeviceRole, DeviceType, Manufacturer, Site
+
+        site, _ = Site.objects.get_or_create(name="erp-site", slug="erp-site")
+        mfr, _ = Manufacturer.objects.get_or_create(name="erp-mfr", slug="erp-mfr")
+        dtype, _ = DeviceType.objects.get_or_create(manufacturer=mfr, model="erp-dt", slug="erp-dt")
+        role, _ = DeviceRole.objects.get_or_create(name="erp-role", slug="erp-role")
+        return Device.objects.create(name=name, site=site, device_type=dtype, role=role)
+
+    def _make_view(self):
+        from netbox_librenms_plugin.views.base.cables_view import SingleCableVerifyView
+
+        view = object.__new__(SingleCableVerifyView)
+        view._librenms_api = MagicMock()
+        view._librenms_api.server_key = "default"
+        view.request = MagicMock()
+        return view
+
+    def test_enrich_links_data_survives_remote_device_without_port(self):
+        """LLDP neighbor advertising a resolvable device but no remote port: enrich_links_data must not crash (regression: enrich_remote_port returned None → link.get() AttributeError)."""
+        obj = self._make_device("erp-local-sw")
+        remote = self._make_device("erp-remote-sw")
+        view = self._make_view()
+
+        # remote_device resolves by name; remote_port empty (no port advertised)
+        links = [{"remote_device": "erp-remote-sw", "remote_port": "", "remote_port_id": None}]
+
+        result = view.enrich_links_data(links, obj, server_key="default")  # must NOT raise AttributeError
+
+        assert result[0]["netbox_remote_device_id"] == remote.pk
+        assert result[0]["device_id"] == obj.id
+
+    def test_enrich_remote_port_returns_link_when_remote_port_empty(self):
+        """enrich_remote_port returns the link (never None) when remote_port is empty, so callers that reassign link don't NoneType-crash."""
+        remote = self._make_device("erp-remote-sw2")
+        view = self._make_view()
+
+        link = {"remote_port": ""}
+        result = view.enrich_remote_port(link, remote, server_key="default")
+
+        assert result is link

--- a/netbox_librenms_plugin/tests/test_coverage_actions.py
+++ b/netbox_librenms_plugin/tests/test_coverage_actions.py
@@ -6915,6 +6915,15 @@ class TestSerialActionsNormalizeAndLock:
         assert b"<script>" not in resp.content
         assert b"&lt;script&gt;" in resp.content
 
+    def test_conflict_detected_against_legacy_padded_stored_serial(self):
+        """A conflict row imported before serial normalization may store a padded serial; the trimmed conflict lookup must still find it."""
+        make_device("ser-act-legacy-owner", serial=" SN-LEG-9 ")
+        target = make_device("ser-act-legacy-loser")
+        resp = self._post_action("update_serial", target, "SN-LEG-9")
+        assert b"Serial conflict" in resp.content
+        target.refresh_from_db()
+        assert target.serial == ""
+
 
 @pytest.mark.django_db
 class TestConflictActionsObjectScope:

--- a/netbox_librenms_plugin/tests/test_coverage_actions.py
+++ b/netbox_librenms_plugin/tests/test_coverage_actions.py
@@ -1270,6 +1270,7 @@ class TestDeviceConflictActionView:
 
         view = object.__new__(DeviceConflictActionView)
         view._librenms_api = _make_api()
+        view.request = MagicMock()
         view.require_write_permission = MagicMock(return_value=None)
         view.require_object_permissions = MagicMock(return_value=None)
         return view
@@ -1691,7 +1692,7 @@ class TestDeviceConflictActionViewVMGuard:
                 MockAPI.get_available_servers.return_value = {"secondary": "Secondary"}
                 with patch("dcim.models.Device") as MockDevice:
                     mock_device_obj = MagicMock()
-                    MockDevice.objects.get.return_value = mock_device_obj
+                    MockDevice.objects.restrict.return_value.get.return_value = mock_device_obj
                     MockDevice.DoesNotExist = Exception
                     with patch("netbox_librenms_plugin.views.imports.actions.cache"):
                         with patch.object(
@@ -2176,7 +2177,7 @@ class TestDeviceConflictActionMissingExisting:
                     pass
 
                 MockDevice.DoesNotExist = _DeviceDoesNotExist
-                MockDevice.objects.get.side_effect = _DeviceDoesNotExist("Not found")
+                MockDevice.objects.restrict.return_value.get.side_effect = _DeviceDoesNotExist("Not found")
                 response = view.post(request, device_id=1)
 
         assert response.status_code == 200
@@ -2221,7 +2222,7 @@ class TestDeviceConflictActionMorePaths:
 
         with patch.object(view, "require_all_permissions", return_value=None):
             with patch("dcim.models.Device") as MockDevice:
-                MockDevice.objects.get.return_value = mock_existing
+                MockDevice.objects.restrict.return_value.get.return_value = mock_existing
                 MockDevice.DoesNotExist = Exception
                 with patch.object(view, "require_object_permissions", return_value=None):
                     with patch.object(
@@ -2253,7 +2254,7 @@ class TestDeviceConflictActionMorePaths:
 
         with patch.object(view, "require_all_permissions", return_value=None):
             with patch("dcim.models.Device") as MockDevice:
-                MockDevice.objects.get.return_value = mock_existing
+                MockDevice.objects.restrict.return_value.get.return_value = mock_existing
                 MockDevice.DoesNotExist = Exception
                 with patch.object(view, "require_object_permissions", return_value=None):
                     with patch.object(
@@ -2289,7 +2290,7 @@ class TestDeviceConflictActionMorePaths:
 
         with patch.object(view, "require_all_permissions", return_value=None):
             with patch("dcim.models.Device") as MockDevice:
-                MockDevice.objects.get.return_value = mock_existing
+                MockDevice.objects.restrict.return_value.get.return_value = mock_existing
                 MockDevice.DoesNotExist = Exception
                 with patch.object(view, "require_object_permissions", return_value=None):
                     with patch.object(
@@ -2322,7 +2323,7 @@ class TestDeviceConflictActionMorePaths:
 
         with patch.object(view, "require_all_permissions", return_value=None):
             with patch("dcim.models.Device") as MockDevice:
-                MockDevice.objects.get.return_value = mock_existing
+                MockDevice.objects.restrict.return_value.get.return_value = mock_existing
                 MockDevice.DoesNotExist = Exception
                 with patch.object(view, "require_object_permissions", return_value=None):
                     with patch.object(
@@ -2351,7 +2352,7 @@ class TestDeviceConflictActionMorePaths:
 
         with patch.object(view, "require_all_permissions", return_value=None):
             with patch("dcim.models.Device") as MockDevice:
-                MockDevice.objects.get.return_value = mock_existing
+                MockDevice.objects.restrict.return_value.get.return_value = mock_existing
                 MockDevice.DoesNotExist = Exception
                 with patch.object(view, "require_object_permissions", return_value=perm_error):
                     response = view.post(request, device_id=1)
@@ -2380,7 +2381,7 @@ class TestDeviceConflictActionMorePaths:
 
         with patch.object(view, "require_all_permissions", return_value=None):
             with patch("dcim.models.Device") as MockDevice:
-                MockDevice.objects.get.return_value = mock_existing
+                MockDevice.objects.restrict.return_value.get.return_value = mock_existing
                 MockDevice.DoesNotExist = Exception
                 with patch.object(view, "require_object_permissions", return_value=None):
                     with patch.object(
@@ -2415,7 +2416,7 @@ class TestDeviceConflictActionMorePaths:
 
         with patch.object(view, "require_all_permissions", return_value=None):
             with patch("dcim.models.Device") as MockDevice:
-                MockDevice.objects.get.return_value = mock_existing
+                MockDevice.objects.restrict.return_value.get.return_value = mock_existing
                 MockDevice.DoesNotExist = Exception
                 with patch.object(view, "require_object_permissions", return_value=None):
                     with patch.object(
@@ -2450,7 +2451,7 @@ class TestDeviceConflictActionMorePaths:
 
         with patch.object(view, "require_all_permissions", return_value=None):
             with patch("dcim.models.Device") as MockDevice:
-                MockDevice.objects.get.return_value = mock_existing
+                MockDevice.objects.restrict.return_value.get.return_value = mock_existing
                 MockDevice.DoesNotExist = Exception
                 with patch.object(view, "require_object_permissions", return_value=None):
                     with patch.object(
@@ -2483,7 +2484,7 @@ class TestDeviceConflictActionMorePaths:
 
         with patch.object(view, "require_all_permissions", return_value=None):
             with patch("dcim.models.Device") as MockDevice:
-                MockDevice.objects.get.return_value = mock_existing
+                MockDevice.objects.restrict.return_value.get.return_value = mock_existing
                 MockDevice.DoesNotExist = Exception
                 with patch.object(view, "require_object_permissions", return_value=None):
                     with patch.object(
@@ -2520,7 +2521,7 @@ class TestDeviceConflictActionMorePaths:
 
         with patch.object(view, "require_all_permissions", return_value=None):
             with patch("dcim.models.Device") as MockDevice:
-                MockDevice.objects.get.return_value = mock_existing
+                MockDevice.objects.restrict.return_value.get.return_value = mock_existing
                 MockDevice.DoesNotExist = Exception
                 with patch.object(view, "require_object_permissions", return_value=None):
                     with patch.object(
@@ -2553,7 +2554,7 @@ class TestDeviceConflictActionMorePaths:
 
         with patch.object(view, "require_all_permissions", return_value=None):
             with patch("dcim.models.Device") as MockDevice:
-                MockDevice.objects.get.return_value = mock_existing
+                MockDevice.objects.restrict.return_value.get.return_value = mock_existing
                 MockDevice.DoesNotExist = Exception
                 with patch.object(view, "require_object_permissions", return_value=None):
                     with patch.object(
@@ -2685,7 +2686,7 @@ class TestDeviceConflictActionBoolAndInvalidId:
 
         with patch.object(view, "require_all_permissions", return_value=None):
             with patch("dcim.models.Device") as MockDevice:
-                MockDevice.objects.get.return_value = mock_existing
+                MockDevice.objects.restrict.return_value.get.return_value = mock_existing
                 MockDevice.DoesNotExist = Exception
                 with patch.object(view, "require_object_permissions", return_value=None):
                     with patch.object(
@@ -2717,7 +2718,7 @@ class TestDeviceConflictActionBoolAndInvalidId:
 
         with patch.object(view, "require_all_permissions", return_value=None):
             with patch("dcim.models.Device") as MockDevice:
-                MockDevice.objects.get.return_value = mock_existing
+                MockDevice.objects.restrict.return_value.get.return_value = mock_existing
                 MockDevice.DoesNotExist = Exception
                 with patch.object(view, "require_object_permissions", return_value=None):
                     with patch.object(
@@ -2766,7 +2767,7 @@ class TestDeviceConflictLinkIdConflict:
 
         with patch.object(view, "require_all_permissions", return_value=None):
             with patch("dcim.models.Device") as MockDevice:
-                MockDevice.objects.get.return_value = mock_existing
+                MockDevice.objects.restrict.return_value.get.return_value = mock_existing
                 MockDevice.objects.select_for_update.return_value.get.return_value = mock_existing
                 MockDevice.DoesNotExist = Exception
                 with patch.object(view, "require_object_permissions", return_value=None):
@@ -2982,7 +2983,7 @@ class TestDeviceConflictSelectForUpdateDoesNotExist:
 
         with patch.object(view, "require_all_permissions", return_value=None):
             with patch("dcim.models.Device") as MockDevice:
-                MockDevice.objects.get.return_value = mock_existing
+                MockDevice.objects.restrict.return_value.get.return_value = mock_existing
                 # select_for_update().get() raises DoesNotExist
                 MockDevice.objects.select_for_update.return_value.get.side_effect = DoesNotExistExc("gone")
                 MockDevice.DoesNotExist = DoesNotExistExc
@@ -3047,7 +3048,7 @@ class TestMigrateLibreNMSIdMorePaths:
 
         with patch.object(view, "require_all_permissions", return_value=None):
             with patch("dcim.models.Device") as MockDevice:
-                MockDevice.objects.get.return_value = mock_existing
+                MockDevice.objects.restrict.return_value.get.return_value = mock_existing
                 MockDevice.DoesNotExist = Exception
                 with patch.object(view, "require_object_permissions", return_value=None):
                     with patch.object(
@@ -3087,7 +3088,7 @@ class TestMigrateLibreNMSIdMorePaths:
 
         with patch.object(view, "require_all_permissions", return_value=None):
             with patch("dcim.models.Device") as MockDevice:
-                MockDevice.objects.get.return_value = mock_existing
+                MockDevice.objects.restrict.return_value.get.return_value = mock_existing
                 MockDevice.DoesNotExist = DoesNotExistExc
                 with patch.object(view, "require_object_permissions", return_value=None):
                     with patch.object(
@@ -3100,7 +3101,7 @@ class TestMigrateLibreNMSIdMorePaths:
                                 # This inner patch shadows the outer one for the in-function
                                 # `from dcim.models import Device`, so it must serve BOTH the
                                 # pre-lock existing_device lookup and the locked re-read.
-                                MockDevice2.objects.get.return_value = mock_existing
+                                MockDevice2.objects.restrict.return_value.get.return_value = mock_existing
                                 MockDevice2.objects.select_for_update.return_value.get.return_value = locked_device
                                 MockDevice2.DoesNotExist = DoesNotExistExc
                                 with patch("netbox_librenms_plugin.utils.find_by_librenms_id", return_value=None):
@@ -3177,7 +3178,7 @@ class TestDeviceConflictMoreActions:
         stack.enter_context(patch.object(view, "require_all_permissions", return_value=None))
 
         MockDevice = MagicMock()
-        MockDevice.objects.get.return_value = mock_existing
+        MockDevice.objects.restrict.return_value.get.return_value = mock_existing
         MockDevice.objects.select_for_update.return_value.get.return_value = mock_existing
         MockDevice.objects.filter.return_value.exclude.return_value.first.return_value = None
         MockDevice.DoesNotExist = DoesNotExistExc
@@ -3385,7 +3386,7 @@ class TestMoreSaveErrorPaths:
 
         DoesNotExistExc = type("DoesNotExist", (Exception,), {})
         MockDevice = MagicMock()
-        MockDevice.objects.get.return_value = mock_existing
+        MockDevice.objects.restrict.return_value.get.return_value = mock_existing
         MockDevice.objects.select_for_update.return_value.get.return_value = mock_existing
         MockDevice.objects.filter.return_value.exclude.return_value.first.return_value = None
         MockDevice.DoesNotExist = DoesNotExistExc
@@ -3615,7 +3616,7 @@ class TestUpdateAndSerialSaveErrors:
 
         DoesNotExistExc = type("DoesNotExist", (Exception,), {})
         MockDevice = MagicMock()
-        MockDevice.objects.get.return_value = mock_existing
+        MockDevice.objects.restrict.return_value.get.return_value = mock_existing
         MockDevice.objects.select_for_update.return_value.get.return_value = mock_existing
         MockDevice.objects.filter.return_value.exclude.return_value.first.return_value = None
         MockDevice.DoesNotExist = DoesNotExistExc
@@ -3693,7 +3694,7 @@ class TestSyncSerialMorePaths:
 
         DoesNotExistExc = type("DoesNotExist", (Exception,), {})
         MockDevice = MagicMock()
-        MockDevice.objects.get.return_value = mock_existing
+        MockDevice.objects.restrict.return_value.get.return_value = mock_existing
         MockDevice.DoesNotExist = DoesNotExistExc
         mock_tx = MagicMock()
         mock_tx.atomic.return_value.__enter__ = MagicMock(return_value=None)
@@ -3896,7 +3897,7 @@ class TestMigrateLibreNMSIdTransactionPaths:
         locked_device.name = "router01"
 
         MockDevice = MagicMock()
-        MockDevice.objects.get.return_value = mock_existing
+        MockDevice.objects.restrict.return_value.get.return_value = mock_existing
         MockDevice.objects.select_for_update.return_value.get.return_value = locked_device
         MockDevice.DoesNotExist = DoesNotExistExc
 
@@ -5497,6 +5498,7 @@ class TestAddAsOOBViewPost:
         view = object.__new__(AddAsOOBView)
         view.kwargs = {}
         view._librenms_api = _make_api()
+        view.request = MagicMock()
 
         # Default: write permission granted
         view.require_write_permission = MagicMock(return_value=None)
@@ -5543,7 +5545,7 @@ class TestAddAsOOBViewPost:
         assert b"Existing device not found" in response.content
         assert response["HX-Reswap"] == "none"
         # The malformed id is rejected before any DB lookup.
-        mock_device.objects.get.assert_not_called()
+        mock_device.objects.restrict.return_value.get.assert_not_called()
 
     def test_device_does_not_exist_returns_htmx_error(self):
         """POST with an existing_device_id that isn't in the DB returns HTMX error — driven by a real ORM miss on an absent pk, not a stubbed manager raising DoesNotExist."""
@@ -5786,7 +5788,7 @@ class TestAddAsOOBViewPost:
             patch("netbox_librenms_plugin.utils.find_by_librenms_id", return_value=None) as mock_find,
         ):
             mock_device.DoesNotExist = Exception
-            mock_device.objects.get.return_value = existing_device
+            mock_device.objects.restrict.return_value.get.return_value = existing_device
             mock_device.objects.select_for_update.return_value.get.return_value = locked_device
             response = view.post(request, device_id=17)
 
@@ -6901,3 +6903,157 @@ class TestSerialActionsNormalizeAndLock:
         sqls = [q["sql"] for q in ctx.captured_queries]
         assert any("pg_advisory_xact_lock" in s for s in sqls)
         assert [s for s in sqls if "FOR UPDATE" in s and '."serial" = ' in s.split("WHERE", 1)[-1]] == []
+
+
+@pytest.mark.django_db
+class TestConflictActionsObjectScope:
+    """The conflict/OOB mutation endpoints must resolve the POSTed existing_device_id object-scoped.
+
+    require_object_permissions only asks ``user.has_perm("dcim.change_device")`` with no instance, so a
+    pk-constrained grant clears the gate. Without a restricted lookup the endpoint would then mutate any
+    device by raw pk.
+    """
+
+    @staticmethod
+    def _scoped_writer(in_scope_device, username):
+        """A real non-superuser with plugin write access and a pk-constrained change_device grant."""
+        from core.models import ObjectType
+        from dcim.models import Device
+        from django.apps import apps
+        from django.contrib.auth import get_user_model
+        from users.models import ObjectPermission
+
+        # Resolve via the app registry: the autouse config fixtures patch the models module during
+        # the full suite, so a plain import could hand get_for_model() a mock class.
+        LibreNMSSettings = apps.get_model("netbox_librenms_plugin", "LibreNMSSettings")
+
+        user = get_user_model().objects.create_user(username=username, password="x")
+        write = ObjectPermission.objects.create(name=f"{username}-plugin-write", actions=["change"])
+        write.object_types.set([ObjectType.objects.get_for_model(LibreNMSSettings)])
+        write.users.set([user])
+
+        scoped = ObjectPermission.objects.create(
+            name=f"{username}-scoped-change-device", actions=["change"], constraints={"pk": in_scope_device.pk}
+        )
+        scoped.object_types.set([ObjectType.objects.get_for_model(Device)])
+        scoped.users.set([user])
+
+        return get_user_model().objects.get(pk=user.pk)  # clear the per-request perm cache
+
+    def _post_conflict(self, user, target, action="link"):
+        """Drive the real DeviceConflictActionView.post against *target* with only the LibreNMS seams patched."""
+        from django.http import HttpResponse
+
+        from netbox_librenms_plugin.views.imports.actions import DeviceConflictActionView
+
+        view = DeviceConflictActionView()
+        view._librenms_api = _make_api()
+        libre_device = {"device_id": 4242, "hostname": target.name, "sysName": target.name, "serial": "-"}
+        validation = {"existing_device": target, "device_type_mismatch": False}
+        request = RequestFactory().post(
+            "/conflict-action/",
+            {"action": action, "existing_device_id": str(target.pk), "server_key": "default"},
+        )
+        request.user = user
+        view.request = request
+        with (
+            patch.object(
+                DeviceConflictActionView,
+                "get_validated_device_with_selections",
+                return_value=(libre_device, validation, {}),
+            ),
+            patch.object(DeviceConflictActionView, "render_device_row", return_value=HttpResponse(b"row-ok")),
+            patch.object(DeviceConflictActionView, "rebind_api_for_server", return_value=view._librenms_api),
+            patch(
+                "netbox_librenms_plugin.views.imports.actions._get_hostname_for_action",
+                return_value=target.name,
+            ),
+        ):
+            return view.post(request, device_id=4242)
+
+    def _post_add_as_oob(self, user, target):
+        """Drive the real AddAsOOBView.post against *target* with only the LibreNMS seams patched."""
+        from django.http import HttpResponse
+
+        from netbox_librenms_plugin.views.imports.actions import AddAsOOBView
+
+        view = AddAsOOBView()
+        view.kwargs = {}
+        view._librenms_api = _make_api()
+        libre_device = {"device_id": 4343, "hostname": f"{target.name}-oob", "sysName": f"{target.name}-oob"}
+        validation = {"oob_candidate": {"device": target, "type": "idrac", "ip": None}}
+        request = RequestFactory().post("/add-as-oob/", {"existing_device_id": str(target.pk), "server_key": "default"})
+        request.user = user
+        view.request = request
+        with (
+            patch.object(
+                AddAsOOBView,
+                "get_validated_device_with_selections",
+                return_value=(libre_device, validation, {}),
+            ),
+            patch.object(AddAsOOBView, "render_device_row", return_value=HttpResponse(b"row-ok")),
+            patch.object(AddAsOOBView, "rebind_api_for_server", return_value=view._librenms_api),
+        ):
+            return view.post(request, device_id=4343)
+
+    def test_conflict_action_cannot_link_an_out_of_scope_device(self):
+        """A pk-constrained change_device grant clears the model-level gate but must not link a device outside its scope."""
+        from dcim.models import Device
+
+        in_scope = make_device("scope-conflict-in")
+        out_of_scope = make_device("scope-conflict-out")
+        user = self._scoped_writer(in_scope, "scoped-conflict-writer")
+
+        response = self._post_conflict(user, out_of_scope)
+
+        assert b"Existing device not found" in response.content
+        assert "librenms_id" not in Device.objects.get(pk=out_of_scope.pk).custom_field_data
+
+    def test_conflict_action_still_links_the_in_scope_device(self):
+        """The device the grant DOES cover resolves through the restricted lookup (no over-block)."""
+        from dcim.models import Device
+
+        in_scope = make_device("scope-conflict-in-2")
+        user = self._scoped_writer(in_scope, "scoped-conflict-writer-2")
+
+        response = self._post_conflict(user, in_scope)
+
+        assert b"Existing device not found" not in response.content
+        assert Device.objects.get(pk=in_scope.pk).custom_field_data["librenms_id"]["default"] == 4242
+
+    def test_add_as_oob_cannot_attach_to_an_out_of_scope_device(self):
+        """AddAsOOB must object-scope its target too: a constrained grant cannot attach an OOB link elsewhere."""
+        from dcim.models import Device
+
+        in_scope = make_device("scope-oob-in")
+        out_of_scope = make_device("scope-oob-out")
+        user = self._scoped_writer(in_scope, "scoped-oob-writer")
+
+        response = self._post_add_as_oob(user, out_of_scope)
+
+        assert b"Existing device not found" in response.content
+        assert "librenms_id" not in Device.objects.get(pk=out_of_scope.pk).custom_field_data
+
+    def test_add_as_oob_still_attaches_to_the_in_scope_device(self):
+        """The in-scope device still resolves and receives the OOB link."""
+        from dcim.models import Device
+
+        in_scope = make_device("scope-oob-in-2")
+        user = self._scoped_writer(in_scope, "scoped-oob-writer-2")
+
+        response = self._post_add_as_oob(user, in_scope)
+
+        assert b"Existing device not found" not in response.content
+        stored = Device.objects.get(pk=in_scope.pk).custom_field_data["librenms_id"]["default"]
+        assert stored["oob"]["id"] == 4343
+
+    def test_superuser_is_unaffected_by_the_restricted_lookup(self):
+        """A superuser keeps the unrestricted queryset, so every device still resolves."""
+        from dcim.models import Device
+
+        target = make_device("scope-conflict-su")
+
+        response = self._post_conflict(make_superuser(), target)
+
+        assert b"Existing device not found" not in response.content
+        assert Device.objects.get(pk=target.pk).custom_field_data["librenms_id"]["default"] == 4242

--- a/netbox_librenms_plugin/tests/test_coverage_actions.py
+++ b/netbox_librenms_plugin/tests/test_coverage_actions.py
@@ -6920,6 +6920,17 @@ class TestSerialActionsNormalizeAndLock:
         conflict_row_locks = [s for s in sqls if "FOR UPDATE" in s and '."serial" = ' in s.split("WHERE", 1)[-1]]
         assert conflict_row_locks == [], f"conflict lookup still takes a row lock: {conflict_row_locks}"
 
+    def test_serial_lock_refuses_to_run_in_autocommit(self):
+        """pg_advisory_xact_lock is transaction-scoped, so taking it outside a transaction locks nothing and must fail loudly."""
+        from django.db import connection
+
+        from netbox_librenms_plugin.views.imports.actions import _acquire_serial_assignment_lock
+
+        # django_db wraps the test in a transaction, so autocommit has to be simulated on the
+        # connection flag itself — the guard reads exactly that flag.
+        with patch.object(connection, "in_atomic_block", False), pytest.raises(RuntimeError):
+            _acquire_serial_assignment_lock("SN-NO-TX")
+
     def test_update_action_serializes_on_the_serial_advisory_lock(self):
         """The update action's serial write takes the same advisory lock (same deadlock shape as sync_serial)."""
         from django.db import connection

--- a/netbox_librenms_plugin/tests/test_coverage_actions.py
+++ b/netbox_librenms_plugin/tests/test_coverage_actions.py
@@ -967,6 +967,20 @@ class TestBuildSyncInfo:
         result = build_sync_info(libre_device, existing)
         assert result["serial_synced"] is False
 
+    def test_padded_incoming_serial_counts_as_synced(self):
+        """A whitespace-padded LibreNMS serial equal to the stored trimmed value must not report drift."""
+        build_sync_info = self._get_method()
+        libre_device = {"serial": " SN001 ", "os": "ios", "hardware": "-"}
+        existing = MagicMock()
+        existing.serial = "SN001"
+        existing.platform = None
+        existing.device_type = None
+
+        with patch("netbox_librenms_plugin.utils.find_matching_platform", return_value={"found": False}):
+            result = build_sync_info(libre_device, existing)
+
+        assert result["serial_synced"] is True
+
     def test_platform_synced_when_matching(self):
         build_sync_info = self._get_method()
         libre_device = {"serial": "-", "os": "ios", "hardware": "-"}
@@ -3120,6 +3134,12 @@ class TestMigrateLibreNMSIdMorePaths:
 class TestDeviceConflictMoreActions:
     """Tests for many more action paths in DeviceConflictActionView."""
 
+    @pytest.fixture(autouse=True)
+    def _no_advisory_lock(self):
+        """The serial guard's pg_advisory_xact_lock needs a real connection these mock tests don't have."""
+        with patch("netbox_librenms_plugin.views.imports.actions._acquire_serial_assignment_lock"):
+            yield
+
     def _make_view(self):
         from netbox_librenms_plugin.views.imports.actions import DeviceConflictActionView
 
@@ -3159,7 +3179,7 @@ class TestDeviceConflictMoreActions:
         MockDevice = MagicMock()
         MockDevice.objects.get.return_value = mock_existing
         MockDevice.objects.select_for_update.return_value.get.return_value = mock_existing
-        MockDevice.objects.select_for_update.return_value.filter.return_value.exclude.return_value.first.return_value = None
+        MockDevice.objects.filter.return_value.exclude.return_value.first.return_value = None
         MockDevice.DoesNotExist = DoesNotExistExc
 
         stack.enter_context(patch("dcim.models.Device", MockDevice))
@@ -3211,7 +3231,7 @@ class TestDeviceConflictMoreActions:
 
         stack, MockDevice = self._common_patches(view, mock_existing, libre_device, validation)
         with stack:
-            MockDevice.objects.select_for_update.return_value.filter.return_value.exclude.return_value.first.return_value = conflict_device
+            MockDevice.objects.filter.return_value.exclude.return_value.first.return_value = conflict_device
             with patch("netbox_librenms_plugin.views.imports.actions._save_device", return_value=None):
                 response = view.post(request, device_id=42)
 
@@ -3328,6 +3348,12 @@ class TestDeviceConflictMoreActions:
 class TestMoreSaveErrorPaths:
     """Tests for save error paths in actions (lines 1108, 1116, 1119, 1146, 1149, 1168, 1182-1183, 1196-1210, 1222, 1238)."""
 
+    @pytest.fixture(autouse=True)
+    def _no_advisory_lock(self):
+        """The serial guard's pg_advisory_xact_lock needs a real connection these mock tests don't have."""
+        with patch("netbox_librenms_plugin.views.imports.actions._acquire_serial_assignment_lock"):
+            yield
+
     def _make_view(self):
         from netbox_librenms_plugin.views.imports.actions import DeviceConflictActionView
 
@@ -3361,7 +3387,7 @@ class TestMoreSaveErrorPaths:
         MockDevice = MagicMock()
         MockDevice.objects.get.return_value = mock_existing
         MockDevice.objects.select_for_update.return_value.get.return_value = mock_existing
-        MockDevice.objects.select_for_update.return_value.filter.return_value.exclude.return_value.first.return_value = None
+        MockDevice.objects.filter.return_value.exclude.return_value.first.return_value = None
         MockDevice.DoesNotExist = DoesNotExistExc
 
         mock_tx = MagicMock()
@@ -3405,7 +3431,7 @@ class TestMoreSaveErrorPaths:
 
         stack, MockDevice = self._setup_common(view, mock_existing, libre_device, validation, save_return=None)
         with stack:
-            MockDevice.objects.select_for_update.return_value.filter.return_value.exclude.return_value.first.return_value = conflict
+            MockDevice.objects.filter.return_value.exclude.return_value.first.return_value = conflict
             response = view.post(request, device_id=42)
 
         assert response.status_code == 200
@@ -3560,6 +3586,12 @@ class TestSyncSerialAction:
 class TestUpdateAndSerialSaveErrors:
     """Tests for update/update_serial _save_device error paths (lines 1119, 1149)."""
 
+    @pytest.fixture(autouse=True)
+    def _no_advisory_lock(self):
+        """The serial guard's pg_advisory_xact_lock needs a real connection these mock tests don't have."""
+        with patch("netbox_librenms_plugin.views.imports.actions._acquire_serial_assignment_lock"):
+            yield
+
     def _make_view(self):
         from netbox_librenms_plugin.views.imports.actions import DeviceConflictActionView
 
@@ -3585,7 +3617,7 @@ class TestUpdateAndSerialSaveErrors:
         MockDevice = MagicMock()
         MockDevice.objects.get.return_value = mock_existing
         MockDevice.objects.select_for_update.return_value.get.return_value = mock_existing
-        MockDevice.objects.select_for_update.return_value.filter.return_value.exclude.return_value.first.return_value = None
+        MockDevice.objects.filter.return_value.exclude.return_value.first.return_value = None
         MockDevice.DoesNotExist = DoesNotExistExc
         mock_tx = MagicMock()
         mock_tx.atomic.return_value.__enter__ = MagicMock(return_value=None)
@@ -3641,6 +3673,12 @@ class TestUpdateAndSerialSaveErrors:
 
 class TestSyncSerialMorePaths:
     """Tests for sync_serial action edge cases (lines 1182-1200, 1207)."""
+
+    @pytest.fixture(autouse=True)
+    def _no_advisory_lock(self):
+        """The serial guard's pg_advisory_xact_lock needs a real connection these mock tests don't have."""
+        with patch("netbox_librenms_plugin.views.imports.actions._acquire_serial_assignment_lock"):
+            yield
 
     def _make_view(self):
         from netbox_librenms_plugin.views.imports.actions import DeviceConflictActionView
@@ -3715,7 +3753,7 @@ class TestSyncSerialMorePaths:
         with stack:
             MockDevice.objects.select_for_update.return_value.get.return_value = locked_device
             # The conflict lookup runs under select_for_update() too (row lock on the conflicting device).
-            MockDevice.objects.select_for_update.return_value.filter.return_value.exclude.return_value.first.return_value = conflict_device
+            MockDevice.objects.filter.return_value.exclude.return_value.first.return_value = conflict_device
             response = view.post(request, device_id=42)
 
         assert response.status_code == 200
@@ -3744,23 +3782,23 @@ class TestSyncSerialMorePaths:
         with stack:
             MockDevice.objects.select_for_update.return_value.get.return_value = locked_device
             # The conflict lookup runs under select_for_update() too (row lock on the conflicting device).
-            MockDevice.objects.select_for_update.return_value.filter.return_value.exclude.return_value.first.return_value = None
+            MockDevice.objects.filter.return_value.exclude.return_value.first.return_value = None
             with patch("netbox_librenms_plugin.views.imports.actions._save_device", return_value=err):
                 response = view.post(request, device_id=42)
 
         assert response.status_code == 400
 
 
-class TestSyncSerialConflictRowLock:
-    """Real-DB check that the sync_serial conflict lookup locks the conflicting row.
+class TestSyncSerialConflictGuard:
+    """Real-DB check of the sync_serial conflict guard under an actual conflict.
 
-    The link/update/update_serial actions all select_for_update() the conflicting-serial
-    row; sync_serial's guard must do the same so a concurrent action re-pointing that
-    row's serial serializes against this check instead of racing it.
+    Writers of the same serial serialize on a transaction-scoped advisory lock keyed by
+    the serial value; the conflict lookup itself must NOT take a second row lock — with
+    own-device rows already held, two swap-direction requests would deadlock (A→B / B→A).
     """
 
     @pytest.mark.django_db
-    def test_sync_serial_conflict_lookup_runs_under_row_lock(self):
+    def test_sync_serial_conflict_guard_uses_advisory_lock_not_row_lock(self):
         from dcim.models import Device, DeviceRole, DeviceType, Manufacturer, Site
         from django.contrib.auth import get_user_model
         from django.db import connection
@@ -3812,9 +3850,12 @@ class TestSyncSerialConflictRowLock:
             if "dcim_device" in q["sql"] and "SN-LOCK-CONF" in q["sql"] and q["sql"].lstrip().startswith("SELECT")
         ]
         assert conflict_lookups, "conflicting-serial lookup was not captured"
-        assert all("FOR UPDATE" in sql for sql in conflict_lookups), (
-            "sync_serial conflict lookup must lock the conflicting row "
-            f"(unlocked queries: {[s for s in conflict_lookups if 'FOR UPDATE' not in s]})"
+        assert all("FOR UPDATE" not in sql for sql in conflict_lookups), (
+            "sync_serial conflict lookup must not row-lock the conflicting row "
+            f"(locked queries: {[s for s in conflict_lookups if 'FOR UPDATE' in s]})"
+        )
+        assert any("pg_advisory_xact_lock" in q["sql"] for q in ctx.captured_queries), (
+            "advisory lock on the serial value was not taken"
         )
         # The pre-check must not have been broken by the lock: the conflicting row still owns the serial.
         conflict.refresh_from_db()
@@ -6774,3 +6815,89 @@ class TestRebindOrHtmxErrorHelper:
         ):
             assert _rebind_or_htmx_error(view, request) is None
         assert view._librenms_api.server_key == "prod"
+
+
+@pytest.mark.django_db
+class TestSerialActionsNormalizeAndLock:
+    """Serial-writing actions must persist/compare the TRIMMED serial and guard conflicts without a second row lock."""
+
+    def _post_action(self, action, target, serial, monkey=()):
+        """Drive DeviceConflictActionView.post for *action* against real device *target* with only the API/cache seams patched."""
+        from django.http import HttpResponse
+
+        from netbox_librenms_plugin.views.imports.actions import DeviceConflictActionView
+
+        view = DeviceConflictActionView()
+        view._librenms_api = _make_api()
+        libre_device = {
+            "device_id": 10,
+            "hostname": target.name,
+            "sysName": target.name,
+            "serial": serial,
+        }
+        validation = {"can_import": False, "existing_device": target}
+        request = RequestFactory().post(
+            "/conflict-action/",
+            {"action": action, "existing_device_id": str(target.pk), "server_key": "default"},
+        )
+        request.user = make_superuser()
+        view.request = request
+        with (
+            patch.object(
+                DeviceConflictActionView,
+                "get_validated_device_with_selections",
+                return_value=(libre_device, validation, {}),
+            ),
+            patch.object(DeviceConflictActionView, "render_device_row", return_value=HttpResponse(b"row-ok")),
+            patch.object(DeviceConflictActionView, "rebind_api_for_server", return_value=view._librenms_api),
+        ):
+            return view.post(request, device_id=10)
+
+    def test_update_serial_persists_trimmed_serial(self):
+        """A padded LibreNMS serial is stored TRIMMED so the next import's trimmed filter(serial=...) still matches."""
+        target = make_device("ser-act-upd")
+        self._post_action("update_serial", target, " SN-42 ")
+        target.refresh_from_db()
+        assert target.serial == "SN-42"
+
+    def test_sync_serial_persists_trimmed_serial(self):
+        """sync_serial stores the trimmed serial, consistent with validate/import normalization."""
+        target = make_device("ser-act-sync")
+        self._post_action("sync_serial", target, " SN-43 ")
+        target.refresh_from_db()
+        assert target.serial == "SN-43"
+
+    def test_update_serial_detects_conflict_against_trimmed_stored_serial(self):
+        """A padded incoming serial must still hit the conflict guard when another device stored the trimmed value."""
+        make_device("ser-act-owner", serial="SN-7")
+        target = make_device("ser-act-loser")
+        resp = self._post_action("update_serial", target, " SN-7 ")
+        assert b"Serial conflict" in resp.content
+        target.refresh_from_db()
+        assert target.serial == ""  # nothing persisted
+
+    def test_sync_serial_uses_advisory_lock_not_conflict_row_lock(self):
+        """The conflict guard serializes on an advisory lock keyed by the serial value; a second row lock would deadlock two swap-direction requests (A then B vs B then A)."""
+        from django.db import connection
+        from django.test.utils import CaptureQueriesContext
+
+        target = make_device("ser-act-lock")
+        with CaptureQueriesContext(connection) as ctx:
+            self._post_action("sync_serial", target, "SN-77")
+        sqls = [q["sql"] for q in ctx.captured_queries]
+        assert any("pg_advisory_xact_lock" in s for s in sqls), "advisory lock on the serial value not taken"
+        # The own-row lock (WHERE "id" = ...) is expected; a conflict-row lock filters on serial.
+        conflict_row_locks = [s for s in sqls if "FOR UPDATE" in s and '."serial" = ' in s.split("WHERE", 1)[-1]]
+        assert conflict_row_locks == [], f"conflict lookup still takes a row lock: {conflict_row_locks}"
+
+    def test_update_action_serializes_on_the_serial_advisory_lock(self):
+        """The update action's serial write takes the same advisory lock (same deadlock shape as sync_serial)."""
+        from django.db import connection
+        from django.test.utils import CaptureQueriesContext
+
+        target = make_device("ser-act-upd-lock")
+        with CaptureQueriesContext(connection) as ctx:
+            self._post_action("update", target, "SN-88")
+        sqls = [q["sql"] for q in ctx.captured_queries]
+        assert any("pg_advisory_xact_lock" in s for s in sqls)
+        assert [s for s in sqls if "FOR UPDATE" in s and '."serial" = ' in s.split("WHERE", 1)[-1]] == []

--- a/netbox_librenms_plugin/tests/test_coverage_actions.py
+++ b/netbox_librenms_plugin/tests/test_coverage_actions.py
@@ -988,6 +988,18 @@ class TestBuildSyncInfo:
 
         assert result["serial_synced"] is True
 
+    @pytest.mark.django_db
+    def test_padded_stored_serial_counts_as_synced(self):
+        """A real device whose STORED serial is legacy-padded must not report serial drift in the details modal."""
+        build_sync_info = self._get_method()
+        existing = make_device("sync-info-padded-serial", serial=" SN-STORED-1 ")
+        libre_device = {"serial": "SN-STORED-1", "os": "-", "hardware": "-"}
+
+        result = build_sync_info(libre_device, existing)
+
+        assert result["serial_synced"] is True, "padded stored serial reported as drift"
+        assert result["all_synced"] is True
+
     def test_platform_synced_when_matching(self):
         build_sync_info = self._get_method()
         libre_device = {"serial": "-", "os": "ios", "hardware": "-"}

--- a/netbox_librenms_plugin/tests/test_coverage_actions.py
+++ b/netbox_librenms_plugin/tests/test_coverage_actions.py
@@ -5,7 +5,14 @@ from unittest.mock import MagicMock, patch
 import pytest
 from django.test import RequestFactory
 
-from netbox_librenms_plugin.tests.conftest import make_device, make_interface, make_ip, make_superuser, make_vm
+from netbox_librenms_plugin.tests.conftest import (
+    collapse_queryset_chain,
+    make_device,
+    make_interface,
+    make_ip,
+    make_superuser,
+    make_vm,
+)
 
 
 def _make_request(post=None, get=None, headers=None, user_is_superuser=False):
@@ -2987,6 +2994,7 @@ class TestDeviceConflictSelectForUpdateDoesNotExist:
                 # select_for_update().get() raises DoesNotExist
                 MockDevice.objects.select_for_update.return_value.get.side_effect = DoesNotExistExc("gone")
                 MockDevice.DoesNotExist = DoesNotExistExc
+                collapse_queryset_chain(MockDevice)
                 with patch.object(view, "require_object_permissions", return_value=None):
                     with patch.object(
                         view, "get_validated_device_with_selections", return_value=(libre_device, validation, {})
@@ -3090,6 +3098,7 @@ class TestMigrateLibreNMSIdMorePaths:
             with patch("dcim.models.Device") as MockDevice:
                 MockDevice.objects.restrict.return_value.get.return_value = mock_existing
                 MockDevice.DoesNotExist = DoesNotExistExc
+                collapse_queryset_chain(MockDevice)
                 with patch.object(view, "require_object_permissions", return_value=None):
                     with patch.object(
                         view, "get_validated_device_with_selections", return_value=(libre_device, validation, {})
@@ -3182,6 +3191,7 @@ class TestDeviceConflictMoreActions:
         MockDevice.objects.select_for_update.return_value.get.return_value = mock_existing
         MockDevice.objects.filter.return_value.exclude.return_value.first.return_value = None
         MockDevice.DoesNotExist = DoesNotExistExc
+        collapse_queryset_chain(MockDevice)
 
         stack.enter_context(patch("dcim.models.Device", MockDevice))
         stack.enter_context(patch.object(view, "require_object_permissions", return_value=None))
@@ -3390,6 +3400,7 @@ class TestMoreSaveErrorPaths:
         MockDevice.objects.select_for_update.return_value.get.return_value = mock_existing
         MockDevice.objects.filter.return_value.exclude.return_value.first.return_value = None
         MockDevice.DoesNotExist = DoesNotExistExc
+        collapse_queryset_chain(MockDevice)
 
         mock_tx = MagicMock()
         mock_tx.atomic.return_value.__enter__ = MagicMock(return_value=None)
@@ -3620,6 +3631,7 @@ class TestUpdateAndSerialSaveErrors:
         MockDevice.objects.select_for_update.return_value.get.return_value = mock_existing
         MockDevice.objects.filter.return_value.exclude.return_value.first.return_value = None
         MockDevice.DoesNotExist = DoesNotExistExc
+        collapse_queryset_chain(MockDevice)
         mock_tx = MagicMock()
         mock_tx.atomic.return_value.__enter__ = MagicMock(return_value=None)
         mock_tx.atomic.return_value.__exit__ = MagicMock(return_value=False)
@@ -3696,6 +3708,7 @@ class TestSyncSerialMorePaths:
         MockDevice = MagicMock()
         MockDevice.objects.restrict.return_value.get.return_value = mock_existing
         MockDevice.DoesNotExist = DoesNotExistExc
+        collapse_queryset_chain(MockDevice)
         mock_tx = MagicMock()
         mock_tx.atomic.return_value.__enter__ = MagicMock(return_value=None)
         mock_tx.atomic.return_value.__exit__ = MagicMock(return_value=False)
@@ -3902,6 +3915,7 @@ class TestMigrateLibreNMSIdTransactionPaths:
         MockDevice.objects.restrict.return_value.get.return_value = mock_existing
         MockDevice.objects.select_for_update.return_value.get.return_value = locked_device
         MockDevice.DoesNotExist = DoesNotExistExc
+        collapse_queryset_chain(MockDevice)
 
         mock_tx = MagicMock()
         mock_tx.atomic.return_value.__enter__ = MagicMock(return_value=None)

--- a/netbox_librenms_plugin/tests/test_coverage_actions.py
+++ b/netbox_librenms_plugin/tests/test_coverage_actions.py
@@ -6,7 +6,6 @@ import pytest
 from django.test import RequestFactory
 
 from netbox_librenms_plugin.tests.conftest import (
-    collapse_queryset_chain,
     make_device,
     make_interface,
     make_ip,
@@ -3006,7 +3005,6 @@ class TestDeviceConflictSelectForUpdateDoesNotExist:
                 # select_for_update().get() raises DoesNotExist
                 MockDevice.objects.select_for_update.return_value.get.side_effect = DoesNotExistExc("gone")
                 MockDevice.DoesNotExist = DoesNotExistExc
-                collapse_queryset_chain(MockDevice)
                 with patch.object(view, "require_object_permissions", return_value=None):
                     with patch.object(
                         view, "get_validated_device_with_selections", return_value=(libre_device, validation, {})
@@ -3110,7 +3108,6 @@ class TestMigrateLibreNMSIdMorePaths:
             with patch("dcim.models.Device") as MockDevice:
                 MockDevice.objects.restrict.return_value.get.return_value = mock_existing
                 MockDevice.DoesNotExist = DoesNotExistExc
-                collapse_queryset_chain(MockDevice)
                 with patch.object(view, "require_object_permissions", return_value=None):
                     with patch.object(
                         view, "get_validated_device_with_selections", return_value=(libre_device, validation, {})
@@ -3203,7 +3200,6 @@ class TestDeviceConflictMoreActions:
         MockDevice.objects.select_for_update.return_value.get.return_value = mock_existing
         MockDevice.objects.filter.return_value.exclude.return_value.first.return_value = None
         MockDevice.DoesNotExist = DoesNotExistExc
-        collapse_queryset_chain(MockDevice)
 
         stack.enter_context(patch("dcim.models.Device", MockDevice))
         stack.enter_context(patch.object(view, "require_object_permissions", return_value=None))
@@ -3412,7 +3408,6 @@ class TestMoreSaveErrorPaths:
         MockDevice.objects.select_for_update.return_value.get.return_value = mock_existing
         MockDevice.objects.filter.return_value.exclude.return_value.first.return_value = None
         MockDevice.DoesNotExist = DoesNotExistExc
-        collapse_queryset_chain(MockDevice)
 
         mock_tx = MagicMock()
         mock_tx.atomic.return_value.__enter__ = MagicMock(return_value=None)
@@ -3643,7 +3638,6 @@ class TestUpdateAndSerialSaveErrors:
         MockDevice.objects.select_for_update.return_value.get.return_value = mock_existing
         MockDevice.objects.filter.return_value.exclude.return_value.first.return_value = None
         MockDevice.DoesNotExist = DoesNotExistExc
-        collapse_queryset_chain(MockDevice)
         mock_tx = MagicMock()
         mock_tx.atomic.return_value.__enter__ = MagicMock(return_value=None)
         mock_tx.atomic.return_value.__exit__ = MagicMock(return_value=False)
@@ -3720,7 +3714,6 @@ class TestSyncSerialMorePaths:
         MockDevice = MagicMock()
         MockDevice.objects.restrict.return_value.get.return_value = mock_existing
         MockDevice.DoesNotExist = DoesNotExistExc
-        collapse_queryset_chain(MockDevice)
         mock_tx = MagicMock()
         mock_tx.atomic.return_value.__enter__ = MagicMock(return_value=None)
         mock_tx.atomic.return_value.__exit__ = MagicMock(return_value=False)
@@ -3875,9 +3868,10 @@ class TestSyncSerialConflictGuard:
         conflict_lookups = [
             q["sql"]
             for q in ctx.captured_queries
-            if "dcim_device" in q["sql"] and "SN-LOCK-CONF" in q["sql"] and q["sql"].lstrip().startswith("SELECT")
+            if "dcim_device" in q["sql"] and '."serial" = ' in q["sql"] and q["sql"].lstrip().startswith("SELECT")
         ]
         assert conflict_lookups, "conflicting-serial lookup was not captured"
+        assert all("TRIM(" not in sql for sql in conflict_lookups)
         assert all("FOR UPDATE" not in sql for sql in conflict_lookups), (
             "sync_serial conflict lookup must not row-lock the conflicting row "
             f"(locked queries: {[s for s in conflict_lookups if 'FOR UPDATE' in s]})"
@@ -3927,7 +3921,6 @@ class TestMigrateLibreNMSIdTransactionPaths:
         MockDevice.objects.restrict.return_value.get.return_value = mock_existing
         MockDevice.objects.select_for_update.return_value.get.return_value = locked_device
         MockDevice.DoesNotExist = DoesNotExistExc
-        collapse_queryset_chain(MockDevice)
 
         mock_tx = MagicMock()
         mock_tx.atomic.return_value.__enter__ = MagicMock(return_value=None)
@@ -6851,7 +6844,7 @@ class TestRebindOrHtmxErrorHelper:
 class TestSerialActionsNormalizeAndLock:
     """Serial-writing actions must persist/compare the TRIMMED serial and guard conflicts without a second row lock."""
 
-    def _post_action(self, action, target, serial, monkey=()):
+    def _post_action(self, action, target, serial):
         """Drive DeviceConflictActionView.post for *action* against real device *target* with only the API/cache seams patched."""
         from django.http import HttpResponse
 
@@ -6883,8 +6876,21 @@ class TestSerialActionsNormalizeAndLock:
         ):
             return view.post(request, device_id=10)
 
+    @staticmethod
+    def _serial_row_locks(sqls):
+        """Return FOR UPDATE queries whose WHERE clause filters by serial."""
+        serial_row_locks = []
+        for sql in sqls:
+            if "FOR UPDATE" not in sql:
+                continue
+            _, separator, where_clause = sql.partition(" WHERE ")
+            assert separator, f"FOR UPDATE query has no WHERE clause: {sql}"
+            if '."serial" = ' in where_clause:
+                serial_row_locks.append(sql)
+        return serial_row_locks
+
     def test_update_serial_persists_trimmed_serial(self):
-        """A padded LibreNMS serial is stored TRIMMED so the next import's trimmed filter(serial=...) still matches."""
+        """A padded LibreNMS serial is stored trimmed so the next exact lookup still matches."""
         target = make_device("ser-act-upd")
         self._post_action("update_serial", target, " SN-42 ")
         target.refresh_from_db()
@@ -6917,7 +6923,7 @@ class TestSerialActionsNormalizeAndLock:
         sqls = [q["sql"] for q in ctx.captured_queries]
         assert any("pg_advisory_xact_lock" in s for s in sqls), "advisory lock on the serial value not taken"
         # The own-row lock (WHERE "id" = ...) is expected; a conflict-row lock filters on serial.
-        conflict_row_locks = [s for s in sqls if "FOR UPDATE" in s and '."serial" = ' in s.split("WHERE", 1)[-1]]
+        conflict_row_locks = self._serial_row_locks(sqls)
         assert conflict_row_locks == [], f"conflict lookup still takes a row lock: {conflict_row_locks}"
 
     def test_serial_lock_refuses_to_run_in_autocommit(self):
@@ -6941,7 +6947,7 @@ class TestSerialActionsNormalizeAndLock:
             self._post_action("update", target, "SN-88")
         sqls = [q["sql"] for q in ctx.captured_queries]
         assert any("pg_advisory_xact_lock" in s for s in sqls)
-        assert [s for s in sqls if "FOR UPDATE" in s and '."serial" = ' in s.split("WHERE", 1)[-1]] == []
+        assert self._serial_row_locks(sqls) == []
 
     def test_conflict_toast_escapes_the_conflicting_device_name(self):
         """_htmx_error_response substitutes the message via format_html('{}', ...), so a marked-up conflicting device name renders escaped — adding escape() at the call site would double-escape."""
@@ -6953,8 +6959,18 @@ class TestSerialActionsNormalizeAndLock:
         assert b"&lt;script&gt;" in resp.content
 
     def test_conflict_detected_against_legacy_padded_stored_serial(self):
-        """A conflict row imported before serial normalization may store a padded serial; the trimmed conflict lookup must still find it."""
-        make_device("ser-act-legacy-owner", serial=" SN-LEG-9 ")
+        """The migration canonicalizes a legacy owner before the exact conflict lookup runs."""
+        import importlib
+        from types import SimpleNamespace
+
+        from django.apps import apps
+        from django.db import connection
+
+        owner = make_device("ser-act-legacy-owner", serial=" SN-LEG-9 ")
+        migration = importlib.import_module("netbox_librenms_plugin.migrations.0012_normalize_device_serials")
+        migration.normalize_device_serials(apps, SimpleNamespace(connection=connection))
+        owner.refresh_from_db()
+        assert owner.serial == "SN-LEG-9"
         target = make_device("ser-act-legacy-loser")
         resp = self._post_action("update_serial", target, "SN-LEG-9")
         assert b"Serial conflict" in resp.content

--- a/netbox_librenms_plugin/tests/test_coverage_actions.py
+++ b/netbox_librenms_plugin/tests/test_coverage_actions.py
@@ -7091,3 +7091,56 @@ class TestConflictActionsObjectScope:
 
         assert b"Existing device not found" not in response.content
         assert Device.objects.get(pk=target.pk).custom_field_data["librenms_id"]["default"] == 4242
+
+    @staticmethod
+    def _vc_pair(name, *, sync_cf):
+        """A real 2-member VirtualChassis whose m1 holds ``sync_cf`` (so it is the sync device)."""
+        from dcim.models import VirtualChassis
+
+        vc = VirtualChassis.objects.create(name=name)
+        m1 = make_device(f"{name}-m1", librenms_cf=sync_cf)
+        m1.virtual_chassis = vc
+        m1.vc_position = 1
+        m1.save()
+        m2 = make_device(f"{name}-m2")
+        m2.virtual_chassis = vc
+        m2.vc_position = 2
+        m2.save()
+        return m1, m2
+
+    def test_add_as_oob_cannot_write_an_out_of_scope_vc_sync_device(self):
+        """The OOB link lands on the VC sync sibling, so a grant covering only the selected member must not attach it."""
+        from dcim.models import Device
+
+        sync, selected = self._vc_pair("scope-oob-vc", sync_cf={"default": {"id": 30}})
+        user = self._scoped_writer(selected, "scoped-oob-vc-writer")  # excludes the sync sibling
+
+        response = self._post_add_as_oob(user, selected)
+
+        assert b"Existing device not found" in response.content
+        sync_entry = Device.objects.get(pk=sync.pk).custom_field_data["librenms_id"]["default"]
+        assert sync_entry == {"id": 30}  # no OOB half written onto the unauthorized sibling
+        assert "librenms_id" not in Device.objects.get(pk=selected.pk).custom_field_data
+
+    def test_add_as_oob_writes_the_vc_sync_device_when_it_is_in_scope(self):
+        """Widening the grant to the sync sibling lets the same attach through (no over-block)."""
+        from core.models import ObjectType
+        from dcim.models import Device
+        from django.contrib.auth import get_user_model
+        from users.models import ObjectPermission
+
+        sync, selected = self._vc_pair("scope-oob-vc-ok", sync_cf={"default": {"id": 30}})
+        user = self._scoped_writer(selected, "scoped-oob-vc-writer-ok")
+        extra = ObjectPermission.objects.create(
+            name="scoped-oob-vc-sync", actions=["change"], constraints={"pk": sync.pk}
+        )
+        extra.object_types.set([ObjectType.objects.get_for_model(Device)])
+        extra.users.set([user])
+        user = get_user_model().objects.get(pk=user.pk)  # clear the per-request perm cache
+
+        response = self._post_add_as_oob(user, selected)
+
+        assert b"Existing device not found" not in response.content
+        sync_entry = Device.objects.get(pk=sync.pk).custom_field_data["librenms_id"]["default"]
+        assert sync_entry["id"] == 30
+        assert sync_entry["oob"]["id"] == 4343

--- a/netbox_librenms_plugin/tests/test_coverage_actions.py
+++ b/netbox_librenms_plugin/tests/test_coverage_actions.py
@@ -3714,7 +3714,8 @@ class TestSyncSerialMorePaths:
         )
         with stack:
             MockDevice.objects.select_for_update.return_value.get.return_value = locked_device
-            MockDevice.objects.filter.return_value.exclude.return_value.first.return_value = conflict_device
+            # The conflict lookup runs under select_for_update() too (row lock on the conflicting device).
+            MockDevice.objects.select_for_update.return_value.filter.return_value.exclude.return_value.first.return_value = conflict_device
             response = view.post(request, device_id=42)
 
         assert response.status_code == 200
@@ -3742,11 +3743,82 @@ class TestSyncSerialMorePaths:
         )
         with stack:
             MockDevice.objects.select_for_update.return_value.get.return_value = locked_device
-            MockDevice.objects.filter.return_value.exclude.return_value.first.return_value = None
+            # The conflict lookup runs under select_for_update() too (row lock on the conflicting device).
+            MockDevice.objects.select_for_update.return_value.filter.return_value.exclude.return_value.first.return_value = None
             with patch("netbox_librenms_plugin.views.imports.actions._save_device", return_value=err):
                 response = view.post(request, device_id=42)
 
         assert response.status_code == 400
+
+
+class TestSyncSerialConflictRowLock:
+    """Real-DB check that the sync_serial conflict lookup locks the conflicting row.
+
+    The link/update/update_serial actions all select_for_update() the conflicting-serial
+    row; sync_serial's guard must do the same so a concurrent action re-pointing that
+    row's serial serializes against this check instead of racing it.
+    """
+
+    @pytest.mark.django_db
+    def test_sync_serial_conflict_lookup_runs_under_row_lock(self):
+        from dcim.models import Device, DeviceRole, DeviceType, Manufacturer, Site
+        from django.contrib.auth import get_user_model
+        from django.db import connection
+        from django.test import RequestFactory
+        from django.test.utils import CaptureQueriesContext
+
+        from netbox_librenms_plugin.views.imports.actions import DeviceConflictActionView
+
+        site = Site.objects.create(name="site-serial-lock", slug="site-serial-lock")
+        manufacturer = Manufacturer.objects.create(name="mf-serial-lock", slug="mf-serial-lock")
+        device_type = DeviceType.objects.create(
+            manufacturer=manufacturer, model="dt-serial-lock", slug="dt-serial-lock"
+        )
+        role = DeviceRole.objects.create(name="role-serial-lock", slug="role-serial-lock")
+        target = Device.objects.create(
+            name="serial-lock-target", site=site, device_type=device_type, role=role, serial=""
+        )
+        conflict = Device.objects.create(
+            name="serial-lock-conflict", site=site, device_type=device_type, role=role, serial="SN-LOCK-CONF"
+        )
+
+        user = get_user_model().objects.create_user(username="serial-lock-admin", is_superuser=True)
+        request = RequestFactory().post("/", data={"action": "sync_serial", "existing_device_id": str(target.pk)})
+        request.user = user
+
+        view = DeviceConflictActionView()
+        view.request = request
+        libre_device = {"device_id": 42, "hostname": "serial-lock-target", "serial": "SN-LOCK-CONF"}
+        validation = {"existing_device": target, "device_type_mismatch": False}
+
+        with (
+            patch.object(
+                DeviceConflictActionView,
+                "get_validated_device_with_selections",
+                return_value=(libre_device, validation, {}),
+            ),
+            CaptureQueriesContext(connection) as ctx,
+        ):
+            response = view.post(request, device_id=42)
+
+        assert response.status_code == 200
+        assert b"Serial conflict" in response.content
+        target.refresh_from_db()
+        assert target.serial == ""
+
+        conflict_lookups = [
+            q["sql"]
+            for q in ctx.captured_queries
+            if "dcim_device" in q["sql"] and "SN-LOCK-CONF" in q["sql"] and q["sql"].lstrip().startswith("SELECT")
+        ]
+        assert conflict_lookups, "conflicting-serial lookup was not captured"
+        assert all("FOR UPDATE" in sql for sql in conflict_lookups), (
+            "sync_serial conflict lookup must lock the conflicting row "
+            f"(unlocked queries: {[s for s in conflict_lookups if 'FOR UPDATE' not in s]})"
+        )
+        # The pre-check must not have been broken by the lock: the conflicting row still owns the serial.
+        conflict.refresh_from_db()
+        assert conflict.serial == "SN-LOCK-CONF"
 
 
 class TestMigrateLibreNMSIdTransactionPaths:

--- a/netbox_librenms_plugin/tests/test_coverage_actions.py
+++ b/netbox_librenms_plugin/tests/test_coverage_actions.py
@@ -3753,7 +3753,8 @@ class TestSyncSerialMorePaths:
         )
         with stack:
             MockDevice.objects.select_for_update.return_value.get.return_value = locked_device
-            # The conflict lookup runs under select_for_update() too (row lock on the conflicting device).
+            # The conflict lookup is deliberately UNLOCKED (advisory lock on the serial value instead);
+            # a second row lock would deadlock two swap-direction requests (A→B / B→A).
             MockDevice.objects.filter.return_value.exclude.return_value.first.return_value = conflict_device
             response = view.post(request, device_id=42)
 
@@ -3782,7 +3783,8 @@ class TestSyncSerialMorePaths:
         )
         with stack:
             MockDevice.objects.select_for_update.return_value.get.return_value = locked_device
-            # The conflict lookup runs under select_for_update() too (row lock on the conflicting device).
+            # The conflict lookup is deliberately UNLOCKED (advisory lock on the serial value instead);
+            # a second row lock would deadlock two swap-direction requests (A→B / B→A).
             MockDevice.objects.filter.return_value.exclude.return_value.first.return_value = None
             with patch("netbox_librenms_plugin.views.imports.actions._save_device", return_value=err):
                 response = view.post(request, device_id=42)
@@ -6903,6 +6905,15 @@ class TestSerialActionsNormalizeAndLock:
         sqls = [q["sql"] for q in ctx.captured_queries]
         assert any("pg_advisory_xact_lock" in s for s in sqls)
         assert [s for s in sqls if "FOR UPDATE" in s and '."serial" = ' in s.split("WHERE", 1)[-1]] == []
+
+    def test_conflict_toast_escapes_the_conflicting_device_name(self):
+        """_htmx_error_response substitutes the message via format_html('{}', ...), so a marked-up conflicting device name renders escaped — adding escape() at the call site would double-escape."""
+        make_device("<script>alert(1)</script>-owner", serial="SN-XSS")
+        target = make_device("ser-act-xss-target")
+        resp = self._post_action("update_serial", target, "SN-XSS")
+        assert b"Serial conflict" in resp.content
+        assert b"<script>" not in resp.content
+        assert b"&lt;script&gt;" in resp.content
 
 
 @pytest.mark.django_db

--- a/netbox_librenms_plugin/tests/test_coverage_base_views2.py
+++ b/netbox_librenms_plugin/tests/test_coverage_base_views2.py
@@ -788,12 +788,15 @@ class TestEnrichRemotePort:
 
         assert result["netbox_remote_interface_id"] == iface.pk
 
-    def test_no_remote_port_key_returns_none(self):
-        """When link has no 'remote_port', method falls through and returns None."""
+    def test_no_remote_port_key_returns_link_unchanged(self):
+        """When link has no 'remote_port', enrichment is skipped but the link is returned (never None) so reassigning callers don't NoneType-crash."""
         view = self._make_view()
         device = make_device("erp-nokey")
-        result = view.enrich_remote_port({}, device)
-        assert result is None
+        link = {}  # No remote_port key
+
+        result = view.enrich_remote_port(link, device)
+        assert result is link
+        assert "remote_port_url" not in result
 
     def test_interface_not_found_does_not_set_url(self):
         """When no remote interface matches by id or name, url/id keys are not set."""

--- a/netbox_librenms_plugin/tests/test_coverage_bulk_import.py
+++ b/netbox_librenms_plugin/tests/test_coverage_bulk_import.py
@@ -1377,14 +1377,21 @@ class TestRefreshExistingDevice:
         args = mock_logger.error.call_args.args
         assert any("99" in str(arg) for arg in args)
 
-    def test_exception_during_new_device_lookup_logs_error(self):
-        """An exception in the newly-imported-device check is caught and logged (forced)."""
+    def test_exception_during_new_device_lookup_logs_error_and_fails_closed(self):
+        """An exception in the newly-imported-device re-check is logged and blocks the import (forced)."""
         from unittest.mock import patch
 
         from netbox_librenms_plugin.import_utils.bulk_import import _refresh_existing_device
 
         libre_device = {"device_id": 44, "hostname": "sw03", "sysName": "sw03"}
-        validation = {"existing_device": None, "import_as_vm": False, "resolved_name": None}
+        # Cache-time state said "importable" — the failed recheck must revoke that.
+        validation = {
+            "existing_device": None,
+            "import_as_vm": False,
+            "resolved_name": None,
+            "can_import": True,
+            "is_ready": True,
+        }
 
         with (
             patch(
@@ -1396,6 +1403,10 @@ class TestRefreshExistingDevice:
             _refresh_existing_device(validation, libre_device=libre_device, server_key="default")
 
         mock_logger.error.assert_called()
+        assert validation["can_import"] is False
+        assert validation["is_ready"] is False
+        # Surfaced to the user as a blocking issue, not silently greyed out.
+        assert any("re-check failed" in issue for issue in validation.get("issues", []))
 
 
 # ===========================================================================

--- a/netbox_librenms_plugin/tests/test_coverage_bulk_import.py
+++ b/netbox_librenms_plugin/tests/test_coverage_bulk_import.py
@@ -2712,3 +2712,63 @@ class TestRefreshLibreNMSLinkage:
         """Serial/hostname/primary_ip matches are left alone."""
         v = self._call(match_type="serial", scanned_id=42, host_id=None, oob_id=None)
         assert v["existing_match_type"] == "serial"
+
+
+# ===========================================================================
+# TestRefreshExistingDeviceVMMatch — real-DB display state for VM matches
+# ===========================================================================
+
+
+@pytest.mark.django_db
+class TestRefreshExistingDeviceVMMatch:
+    """Real-DB checks that a late-found VM match populates cluster display state."""
+
+    @staticmethod
+    def _cross_model_validation():
+        """Cached device row with no match at cache time, shaped like validate_device_for_import output."""
+        return {
+            "existing_device": None,
+            "import_as_vm": False,
+            "issues": [],
+            "site": {"found": True},
+            "device_type": {"found": True},
+            "device_role": {"found": False, "role": None, "available_roles": []},
+            "cluster": {"found": False, "cluster": None, "available_clusters": []},
+        }
+
+    def test_vm_match_shows_the_matched_vms_cluster(self):
+        """A cross-model VM match reflects the VM's actual cluster, mirroring the device-role display."""
+        from virtualization.models import Cluster, ClusterType, VirtualMachine
+
+        from netbox_librenms_plugin.import_utils.bulk_import import _refresh_existing_device
+
+        ctype = ClusterType.objects.create(name="ct-refresh", slug="ct-refresh")
+        cluster = Cluster.objects.create(name="cl-refresh", type=ctype)
+        VirtualMachine.objects.create(name="vm-clustered", cluster=cluster)
+
+        validation = self._cross_model_validation()
+        _refresh_existing_device(validation, {"hostname": "vm-clustered"}, server_key="default")
+
+        assert validation["import_as_vm"] is True
+        assert validation["cluster"]["found"] is True
+        assert validation["cluster"]["cluster"] == cluster
+        # Existing-match gating must stay force-blocked either way.
+        assert validation["can_import"] is False
+        assert validation["is_ready"] is False
+
+    def test_vm_match_without_cluster_resets_stale_cluster_display(self):
+        """A matched VM with no cluster clears a stale cached cluster selection."""
+        from virtualization.models import VirtualMachine
+
+        from netbox_librenms_plugin.import_utils.bulk_import import _refresh_existing_device
+
+        VirtualMachine.objects.create(name="vm-clusterless")
+
+        validation = self._cross_model_validation()
+        validation["cluster"] = {"found": True, "cluster": object(), "available_clusters": ["keep-me"]}
+
+        _refresh_existing_device(validation, {"hostname": "vm-clusterless"}, server_key="default")
+
+        assert validation["cluster"]["found"] is False
+        assert validation["cluster"]["cluster"] is None
+        assert validation["cluster"]["available_clusters"] == ["keep-me"]

--- a/netbox_librenms_plugin/tests/test_coverage_device_fields.py
+++ b/netbox_librenms_plugin/tests/test_coverage_device_fields.py
@@ -326,6 +326,40 @@ class TestUpdateDeviceSerialView:
         assert "set to" in mock_msg.success.call_args[0][1]
         assert Device.objects.get(pk=dev.pk).serial == "SN001"
 
+    def test_padded_serial_is_normalized_before_persisting(self):
+        """LibreNMS whitespace is stripped at this write boundary before Device.save()."""
+        from dcim.models import Device
+
+        view = self._view()
+        view._librenms_api.get_librenms_id.return_value = 5
+        view._librenms_api.get_device_info.return_value = (True, {"serial": "\t SN-SYNC-1 \n"})
+        dev = make_device("serial-padded-boundary", serial="")
+
+        with (
+            patch("netbox_librenms_plugin.views.sync.device_fields.messages"),
+            patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
+        ):
+            view.post(_make_request(), pk=dev.pk)
+
+        assert Device.objects.get(pk=dev.pk).serial == "SN-SYNC-1"
+
+    def test_numeric_zero_serial_is_not_dropped_as_missing(self):
+        """Only None is absent: an all-digit JSON serial parsed as numeric zero persists as "0"."""
+        from dcim.models import Device
+
+        view = self._view()
+        view._librenms_api.get_librenms_id.return_value = 5
+        view._librenms_api.get_device_info.return_value = (True, {"serial": 0})
+        dev = make_device("serial-zero-boundary", serial="")
+
+        with (
+            patch("netbox_librenms_plugin.views.sync.device_fields.messages"),
+            patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
+        ):
+            view.post(_make_request(), pk=dev.pk)
+
+        assert Device.objects.get(pk=dev.pk).serial == "0"
+
     def test_save_validation_error_restores_serial(self):
         from django.core.exceptions import ValidationError
 
@@ -1381,6 +1415,31 @@ class TestAssignVCSerialView:
             view.post(req, pk=host.pk)
         mock_msg.success.assert_called_once()
         assert Device.objects.get(pk=member.pk).serial == "SN100"  # real save committed
+
+    @pytest.mark.django_db
+    def test_member_serial_is_normalized_before_persisting(self):
+        """Whitespace from the posted LibreNMS VC inventory is stripped before Device.save()."""
+        from dcim.models import Device, VirtualChassis
+
+        view = self._view()
+        vc = VirtualChassis.objects.create(name="vc-serial-padded")
+        host = make_device("vc-padded-host")
+        host.virtual_chassis = vc
+        host.vc_position = 1
+        host.save()
+        member = make_device("vc-padded-member", serial="OLD")
+        member.virtual_chassis = vc
+        member.vc_position = 2
+        member.save()
+
+        req = _make_request({"serial_1": "\t SN-VC-1 \n", "member_id_1": str(member.pk)})
+        with (
+            patch("netbox_librenms_plugin.views.sync.device_fields.messages"),
+            patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
+        ):
+            view.post(req, pk=host.pk)
+
+        assert Device.objects.get(pk=member.pk).serial == "SN-VC-1"
 
     def test_permission_denied(self):
         view = self._view()

--- a/netbox_librenms_plugin/tests/test_coverage_device_fields.py
+++ b/netbox_librenms_plugin/tests/test_coverage_device_fields.py
@@ -2164,6 +2164,38 @@ class TestConvertLegacyLibreNMSIdViewPost:
         # The serial gate must read live info (use_cache=False), not a stale sync-tab cache snapshot.
         assert view._librenms_api.get_device_info.call_args.kwargs.get("use_cache") is False
 
+    def test_numeric_librenms_serial_passes_the_serial_gate(self):
+        """An all-digit LibreNMS serial can arrive as an int; the gate must coerce it before stripping, not raise."""
+        view = self._view()
+        mock_obj = MagicMock()
+        mock_obj.custom_field_data = {"librenms_id": "42"}
+        mock_obj.serial = "987654"
+        view._librenms_api.get_device_info.return_value = (True, {"serial": 987654})
+
+        DoesNotExist = type("DoesNotExist", (Exception,), {})
+        mock_locked = MagicMock()
+        mock_locked.custom_field_data = {"librenms_id": "42"}
+        mock_locked.serial = "987654"
+        mock_dev_cls = MagicMock()
+        mock_dev_cls.DoesNotExist = DoesNotExist
+        mock_dev_cls.objects.select_for_update.return_value.get.return_value = mock_locked
+
+        with (
+            patch("netbox_librenms_plugin.views.sync.device_fields.get_object_or_404", return_value=mock_obj),
+            patch("netbox_librenms_plugin.views.sync.device_fields.Device", mock_dev_cls),
+            patch("netbox_librenms_plugin.views.sync.device_fields.find_by_librenms_id", return_value=None),
+            patch(
+                "netbox_librenms_plugin.views.sync.device_fields.migrate_legacy_librenms_id", return_value=True
+            ) as mock_migrate,
+            patch("netbox_librenms_plugin.views.sync.device_fields.transaction"),
+            patch("netbox_librenms_plugin.views.sync.device_fields.messages") as mock_msg,
+            patch("netbox_librenms_plugin.views.sync.device_fields.redirect"),
+        ):
+            view.post(_make_request({"object_type": "device"}), pk=1)
+
+        mock_migrate.assert_called_once()
+        assert not any("Serial number mismatch" in str(c) for c in mock_msg.error.call_args_list)
+
     def test_permission_denied(self):
         view = self._view()
         err = MagicMock()

--- a/netbox_librenms_plugin/tests/test_coverage_device_operations.py
+++ b/netbox_librenms_plugin/tests/test_coverage_device_operations.py
@@ -1399,6 +1399,28 @@ class TestValidateDeviceForImportEdgeCases:
         assert validation.get("existing_match_type") == "primary_ip"
         assert validation.get("existing_device") is not None and validation["existing_device"].pk == dev_a.pk
 
+    def test_refresh_serial_fallback_accepts_a_numeric_serial(self):
+        """The refresh serial fallback must coerce an int serial before stripping it, or the whole refresh raises AttributeError instead of rebinding the row."""
+        from netbox_librenms_plugin.import_utils.bulk_import import _refresh_existing_device
+        from netbox_librenms_plugin.tests.conftest import make_device
+
+        dev = make_device("refresh-numeric-serial", serial="555777")
+        libre_device = {
+            "device_id": 92,
+            "hostname": "refresh-numeric-row",  # matches no device name → falls to the serial fallback
+            "sysName": "refresh-numeric-row",
+            "hardware": "-",
+            "serial": 555777,  # int, not str
+            "os": "-",
+            "location": "-",
+        }
+        validation = {"existing_device": None, "issues": [], "warnings": []}
+
+        _refresh_existing_device(validation, libre_device=libre_device, server_key="default")
+
+        assert validation.get("existing_match_type") == "serial"
+        assert validation.get("existing_device") is not None and validation["existing_device"].pk == dev.pk
+
     def test_no_hostname_adds_issue(self):
         """Empty hostname/sysName → _determine_device_name falls back to 'device-{id}'."""
         libre_device = {
@@ -1951,6 +1973,9 @@ class TestValidateSerialMatchStripsWhitespace:
 
         assert result["existing_device"] is not None, "numeric serial was not matched (crash swallowed by validator)"
         assert result["existing_device"].pk == device.pk
+        # The later duplicate/merge stages read the serial again; an uncast read raises AttributeError
+        # there and validate_device_for_import swallows it into a generic "Validation error" issue.
+        assert not any("Validation error" in i for i in result.get("issues", [])), result.get("issues")
 
 
 @pytest.mark.django_db
@@ -2474,6 +2499,29 @@ class TestOOBDetection:
         assert result["merge_candidates"]["oob_named"]["librenms_link"]["host_id"] == 99
         assert result["can_import"] is False
 
+    def test_merge_candidates_detected_for_a_numeric_serial(self):
+        """An all-digit serial arriving as an int must still pair the hostname- and serial-matched devices; the pairing stage reads the serial again and would otherwise raise into the silent merge-detection catch."""
+        from netbox_librenms_plugin.tests.conftest import make_device
+
+        host = make_device("eve-ng-num", serial="123456", librenms_cf={"default": {"id": 42}})
+        oob = make_device("idrac-num", serial="123456", librenms_cf={"default": {"id": 99}})
+        libre_device = {
+            "device_id": 7,
+            "hostname": "eve-ng-num",
+            "sysName": "eve-ng-num",
+            "hardware": "Dell PowerEdge R770",
+            "serial": 123456,  # int, not str
+            "os": "linux",
+            "ip": "10.0.0.11",
+            "version": "",
+            "location": "",
+        }
+        result = self._validate(libre_device)
+
+        assert result["merge_candidates"] is not None
+        assert result["merge_candidates"]["host_named"]["pk"] == host.pk
+        assert result["merge_candidates"]["oob_named"]["pk"] == oob.pk
+
     def test_merge_candidates_skipped_when_neither_device_has_librenms_link(self):
         """Two devices share serial but neither has a LibreNMS link → conservative skip."""
         from netbox_librenms_plugin.tests.conftest import make_device
@@ -2770,7 +2818,7 @@ class TestDetectSerialMatchRole:
         )
 
         existing_link = _describe_existing_librenms_link(existing_device, server_key)
-        serial = (libre_device.get("serial") or "").strip()
+        serial = str(libre_device.get("serial") or "").strip()
         return _detect_serial_match_role(existing_device, existing_link, hostname, serial, libre_device, server_key)
 
     def test_oob_candidate_default_when_incoming_is_oob_and_name_differs(self):

--- a/netbox_librenms_plugin/tests/test_coverage_device_operations.py
+++ b/netbox_librenms_plugin/tests/test_coverage_device_operations.py
@@ -1980,6 +1980,27 @@ class TestValidateSerialMatchStripsWhitespace:
         # there and validate_device_for_import swallows it into a generic "Validation error" issue.
         assert not any("Validation error" in i for i in result.get("issues", [])), result.get("issues")
 
+    def test_zero_serial_still_matches_existing_device(self):
+        """A serial of JSON number 0 is real (only None means missing) and must still match a device stored as "0"."""
+        from netbox_librenms_plugin.import_utils.device_operations import validate_device_for_import
+
+        device = self._make_device("zero-serial-host", serial="0")
+        libre_device = {
+            "device_id": 8815,
+            "hostname": "zero-import-row",
+            "sysName": "zero-import-row",
+            "serial": 0,  # falsey but real — `str(x or "")` would silently drop it
+            "hardware": "-",
+            "os": "-",
+            "location": "-",
+        }
+
+        result = validate_device_for_import(libre_device, api=None, server_key="default", include_vc_detection=False)
+
+        assert result["existing_device"] is not None, "zero serial was dropped as falsey instead of matched"
+        assert result["existing_device"].pk == device.pk
+        assert not any("Validation error" in i for i in result.get("issues", [])), result.get("issues")
+
 
 @pytest.mark.django_db
 class TestImportPersistsTrimmedSerial:

--- a/netbox_librenms_plugin/tests/test_coverage_device_operations.py
+++ b/netbox_librenms_plugin/tests/test_coverage_device_operations.py
@@ -1878,6 +1878,41 @@ class TestValidateForcesDeviceModeRealDB:
 
 
 @pytest.mark.django_db
+class TestValidateSerialMatchStripsWhitespace:
+    """A whitespace-padded incoming serial (common from SNMP) must still match an existing device by serial, so import doesn't mint a duplicate (real DB)."""
+
+    def _make_device(self, name, serial):
+        from dcim.models import Device, DeviceRole, DeviceType, Manufacturer, Site
+
+        mfr, _ = Manufacturer.objects.get_or_create(name="ACME-serialws", slug="acme-serialws")
+        dt, _ = DeviceType.objects.get_or_create(manufacturer=mfr, model="DT-serialws", slug="dt-serialws")
+        role, _ = DeviceRole.objects.get_or_create(name="Role-serialws", slug="role-serialws")
+        site, _ = Site.objects.get_or_create(name="Site-serialws", slug="site-serialws")
+        return Device.objects.create(name=name, device_type=dt, role=role, site=site, status="active", serial=serial)
+
+    def test_whitespace_padded_incoming_serial_matches_existing(self):
+        """An incoming serial with surrounding whitespace resolves to the existing device, not a new duplicate."""
+        from netbox_librenms_plugin.import_utils.device_operations import validate_device_for_import
+
+        device = self._make_device("serial-ws-existing", serial="SN-WS-4242")
+        libre_device = {
+            "device_id": 7777,
+            # Hostname matches no device, so the identity search falls through to the serial match.
+            "hostname": "serial-ws-importrow",
+            "sysName": "serial-ws-importrow",
+            "serial": " SN-WS-4242 ",  # SNMP-style whitespace padding around the real serial
+            "hardware": "-",
+            "os": "-",
+            "location": "-",
+        }
+
+        result = validate_device_for_import(libre_device, api=None, server_key="default", include_vc_detection=False)
+
+        assert result["existing_device"] is not None, "whitespace-padded serial was not matched (duplicate risk)"
+        assert result["existing_device"].pk == device.pk
+
+
+@pytest.mark.django_db
 class TestImportFallbackReadsLive:
     """Import fallbacks read LibreNMS live (use_cache=False) rather than the 60s get_device_info snapshot."""
 

--- a/netbox_librenms_plugin/tests/test_coverage_device_operations.py
+++ b/netbox_librenms_plugin/tests/test_coverage_device_operations.py
@@ -1387,7 +1387,10 @@ class TestValidateDeviceForImportEdgeCases:
         assert validation.get("existing_match_type") == "ambiguous_hostname_or_serial"
         assert any("serial or management IP" in i for i in validation.get("issues", []))
 
-        # Resolve the duplicate: dev_b no longer carries the shared host address.
+        # Resolve the duplicate: dev_b no longer carries the shared host address. Refresh first so
+        # `address` is an IPNetwork, not the str it was constructed with — NetBox 4.4's pre_delete
+        # `clear_primary_ip` reads `instance.family`, which dereferences `.version` unguarded there.
+        ip_b.refresh_from_db()
         ip_b.delete()
 
         _refresh_existing_device(validation, libre_device=libre_device, server_key="default")

--- a/netbox_librenms_plugin/tests/test_coverage_device_operations.py
+++ b/netbox_librenms_plugin/tests/test_coverage_device_operations.py
@@ -2001,6 +2001,26 @@ class TestValidateSerialMatchStripsWhitespace:
         assert result["existing_device"].pk == device.pk
         assert not any("Validation error" in i for i in result.get("issues", [])), result.get("issues")
 
+    def test_legacy_padded_stored_serial_still_matches(self):
+        """A device row imported before serial normalization may store a padded serial; the trimmed identity match must still bind it instead of minting a duplicate."""
+        from netbox_librenms_plugin.import_utils.device_operations import validate_device_for_import
+
+        device = self._make_device("legacy-padded-host", serial=" SN-LEG-7 ")
+        libre_device = {
+            "device_id": 8816,
+            "hostname": "legacy-import-row",
+            "sysName": "legacy-import-row",
+            "serial": "SN-LEG-7",
+            "hardware": "-",
+            "os": "-",
+            "location": "-",
+        }
+
+        result = validate_device_for_import(libre_device, api=None, server_key="default", include_vc_detection=False)
+
+        assert result["existing_device"] is not None, "legacy padded stored serial was not matched"
+        assert result["existing_device"].pk == device.pk
+
 
 @pytest.mark.django_db
 class TestImportPersistsTrimmedSerial:

--- a/netbox_librenms_plugin/tests/test_coverage_device_operations.py
+++ b/netbox_librenms_plugin/tests/test_coverage_device_operations.py
@@ -3188,9 +3188,10 @@ class TestValidateDedupsSerialDuplicateQuery:
 
         # The duplicate-detection serial lookup (serial[:2], no .exclude) must run exactly once,
         # not once per stage. The .first() match query is LIMIT 1; the cross-side query has NOT.
+        # filter_by_trimmed_serial() compares TRIM(serial), so match the trimmed predicate.
         serial_dup_queries = [
             q["sql"]
             for q in ctx.captured_queries
-            if 'serial" =' in q["sql"].lower() and "limit 2" in q["sql"].lower() and "not" not in q["sql"].lower()
+            if 'serial") =' in q["sql"].lower() and "limit 2" in q["sql"].lower() and "not" not in q["sql"].lower()
         ]
         assert len(serial_dup_queries) == 1

--- a/netbox_librenms_plugin/tests/test_coverage_device_operations.py
+++ b/netbox_librenms_plugin/tests/test_coverage_device_operations.py
@@ -1911,6 +1911,84 @@ class TestValidateSerialMatchStripsWhitespace:
         assert result["existing_device"] is not None, "whitespace-padded serial was not matched (duplicate risk)"
         assert result["existing_device"].pk == device.pk
 
+    def test_whitespace_only_serial_difference_is_not_a_drift_conflict(self):
+        """A hostname-matched device whose stored serial equals the incoming serial modulo whitespace must not be reported as a serial difference/conflict (the drift check compares the trimmed value)."""
+        from netbox_librenms_plugin.import_utils.device_operations import validate_device_for_import
+
+        device = self._make_device("serial-drift-host", serial="SN-DRIFT-7")
+        libre_device = {
+            "device_id": 8812,
+            "hostname": "serial-drift-host",  # hostname-matches the existing device
+            "sysName": "serial-drift-host",
+            "serial": " SN-DRIFT-7 ",  # same serial, only SNMP whitespace differs
+            "hardware": "-",
+            "os": "-",
+            "location": "-",
+        }
+
+        result = validate_device_for_import(libre_device, api=None, server_key="default", include_vc_detection=False)
+
+        assert result["existing_device"].pk == device.pk
+        assert result.get("serial_action") is None, "whitespace-only serial diff wrongly flagged as drift"
+        assert not any("differs" in w for w in result.get("warnings", [])), result.get("warnings")
+
+
+@pytest.mark.django_db
+class TestImportPersistsTrimmedSerial:
+    """import_single_device must persist a whitespace-trimmed serial, so the next import's trimmed filter(serial=...) matches it instead of minting a duplicate (real DB, real Device.save())."""
+
+    def test_padded_incoming_serial_is_stored_trimmed(self):
+        from unittest.mock import patch
+
+        from dcim.models import Device, DeviceRole, DeviceType, Manufacturer, Site
+
+        from netbox_librenms_plugin.import_utils.device_operations import import_single_device
+
+        mfr, _ = Manufacturer.objects.get_or_create(name="ACME-trimp", slug="acme-trimp")
+        dt, _ = DeviceType.objects.get_or_create(manufacturer=mfr, model="DT-trimp", slug="dt-trimp")
+        role, _ = DeviceRole.objects.get_or_create(name="Role-trimp", slug="role-trimp")
+        site, _ = Site.objects.get_or_create(name="Site-trimp", slug="site-trimp")
+
+        libre_device = {
+            "device_id": 8813,
+            "hostname": "trim-persist-host",
+            "sysName": "trim-persist-host",
+            "hardware": "-",
+            "serial": "  SN-PERSIST-9  ",  # SNMP whitespace padding around the real serial
+            "os": "-",
+            "status": 1,
+            "location": "-",
+        }
+        validation = {
+            "existing_device": None,
+            "resolved_name": "trim-persist-host",
+            "site": {"found": True, "site": site},
+            "device_type": {"matched": True, "device_type": dt},
+            "device_role": {"found": True, "role": role},
+            "platform": {"found": False, "platform": None},
+            "rack": {"rack": None},
+        }
+
+        # Patch only set_librenms_device_id: it writes the librenms_id custom field, which isn't
+        # registered in the isolated test DB and would fail Device.full_clean() — orthogonal to the
+        # serial persistence under test. The real Device is created, full_clean'd, and saved.
+        with (
+            patch("netbox_librenms_plugin.import_utils.device_operations.LibreNMSAPI"),
+            patch("netbox_librenms_plugin.import_utils.device_operations.set_librenms_device_id"),
+        ):
+            result = import_single_device(
+                8813,
+                server_key="default",
+                validation=validation,
+                libre_device=libre_device,
+                sync_options={"sync_interfaces": False},
+            )
+
+        assert result["success"] is True, result.get("error")
+        device = Device.objects.get(name="trim-persist-host")
+        # Stored TRIMMED → a later filter(serial="SN-PERSIST-9") finds it, so no duplicate is minted.
+        assert device.serial == "SN-PERSIST-9"
+
 
 @pytest.mark.django_db
 class TestImportFallbackReadsLive:

--- a/netbox_librenms_plugin/tests/test_coverage_device_operations.py
+++ b/netbox_librenms_plugin/tests/test_coverage_device_operations.py
@@ -2021,6 +2021,86 @@ class TestValidateSerialMatchStripsWhitespace:
         assert result["existing_device"] is not None, "legacy padded stored serial was not matched"
         assert result["existing_device"].pk == device.pk
 
+    def test_padded_stored_serial_on_linked_device_is_confirmed_not_drift(self):
+        """A librenms_id-matched device whose STORED serial is padded must report serial_confirmed, not "hardware may have been replaced"."""
+        from netbox_librenms_plugin.import_utils.device_operations import validate_device_for_import
+
+        device = self._make_device("linked-padded-host", serial=" SN-PAD-1 ")
+        device.custom_field_data["librenms_id"] = {"default": 8817}
+        device.save()
+        libre_device = {
+            "device_id": 8817,
+            "hostname": "linked-padded-host",
+            "sysName": "linked-padded-host",
+            "serial": "SN-PAD-1",  # same serial, only the STORED side carries legacy padding
+            "hardware": "-",
+            "os": "-",
+            "location": "-",
+        }
+
+        result = validate_device_for_import(libre_device, api=None, server_key="default", include_vc_detection=False)
+
+        assert result["existing_match_type"] == "librenms_id"
+        assert result["existing_device"].pk == device.pk
+        assert result["serial_confirmed"] is True, "padded stored serial reported as drift"
+        assert result.get("serial_action") is None
+        assert not any("replaced" in w for w in result.get("warnings", [])), result.get("warnings")
+
+    def test_padded_stored_serial_on_hostname_match_is_not_drift(self):
+        """A hostname-matched device whose STORED serial is padded must not report a serial difference."""
+        from netbox_librenms_plugin.import_utils.device_operations import validate_device_for_import
+
+        device = self._make_device("hostname-padded-host", serial=" SN-PAD-2 ")
+        libre_device = {
+            "device_id": 8818,
+            "hostname": "hostname-padded-host",
+            "sysName": "hostname-padded-host",
+            "serial": "SN-PAD-2",
+            "hardware": "-",
+            "os": "-",
+            "location": "-",
+        }
+
+        result = validate_device_for_import(libre_device, api=None, server_key="default", include_vc_detection=False)
+
+        assert result["existing_match_type"] == "hostname"
+        assert result["existing_device"].pk == device.pk
+        assert result.get("serial_action") is None, "whitespace-only stored/incoming diff flagged as drift"
+        assert not any("differs" in w for w in result.get("warnings", [])), result.get("warnings")
+
+    def test_padded_stored_serial_does_not_leak_into_the_vc_member_name(self):
+        """The stored-serial fallback for the VC member name must be trimmed, or a padded serial suggests a renamed device."""
+        from dcim.models import VirtualChassis
+
+        from netbox_librenms_plugin.import_utils.device_operations import validate_device_for_import
+        from netbox_librenms_plugin.models import LibreNMSSettings
+
+        settings_row = LibreNMSSettings.objects.order_by("pk").first() or LibreNMSSettings()
+        settings_row.vc_member_name_pattern = "-{serial}"
+        settings_row.save()
+
+        device = self._make_device("stack-master-SN-VC-3", serial=" SN-VC-3 ")
+        device.custom_field_data["librenms_id"] = {"default": 8819}
+        vc = VirtualChassis.objects.create(name="vc-padded-serial")
+        device.virtual_chassis = vc
+        device.vc_position = 2
+        device.save()
+
+        libre_device = {
+            "device_id": 8819,
+            "hostname": "stack-master",
+            "sysName": "stack-master",
+            "serial": "-",  # placeholder → the name falls back to the STORED serial
+            "hardware": "-",
+            "os": "-",
+            "location": "-",
+        }
+
+        result = validate_device_for_import(libre_device, api=None, server_key="default", include_vc_detection=False)
+
+        assert result["suggested_name"] is None, result["suggested_name"]
+        assert result["name_matches"] is True, "padded stored serial produced a bogus VC member name"
+
 
 @pytest.mark.django_db
 class TestImportPersistsTrimmedSerial:

--- a/netbox_librenms_plugin/tests/test_coverage_device_operations.py
+++ b/netbox_librenms_plugin/tests/test_coverage_device_operations.py
@@ -2002,10 +2002,20 @@ class TestValidateSerialMatchStripsWhitespace:
         assert not any("Validation error" in i for i in result.get("issues", [])), result.get("issues")
 
     def test_legacy_padded_stored_serial_still_matches(self):
-        """A device row imported before serial normalization may store a padded serial; the trimmed identity match must still bind it instead of minting a duplicate."""
+        """The data migration canonicalizes a legacy padded row before exact identity matching."""
+        import importlib
+        from types import SimpleNamespace
+
+        from django.apps import apps
+        from django.db import connection
+
         from netbox_librenms_plugin.import_utils.device_operations import validate_device_for_import
 
         device = self._make_device("legacy-padded-host", serial=" SN-LEG-7 ")
+        migration = importlib.import_module("netbox_librenms_plugin.migrations.0012_normalize_device_serials")
+        migration.normalize_device_serials(apps, SimpleNamespace(connection=connection))
+        device.refresh_from_db()
+        assert device.serial == "SN-LEG-7"
         libre_device = {
             "device_id": 8816,
             "hostname": "legacy-import-row",
@@ -2018,7 +2028,7 @@ class TestValidateSerialMatchStripsWhitespace:
 
         result = validate_device_for_import(libre_device, api=None, server_key="default", include_vc_detection=False)
 
-        assert result["existing_device"] is not None, "legacy padded stored serial was not matched"
+        assert result["existing_device"] is not None, "migrated serial was not matched exactly"
         assert result["existing_device"].pk == device.pk
 
     def test_padded_stored_serial_on_linked_device_is_confirmed_not_drift(self):
@@ -2104,7 +2114,7 @@ class TestValidateSerialMatchStripsWhitespace:
 
 @pytest.mark.django_db
 class TestImportPersistsTrimmedSerial:
-    """import_single_device must persist a whitespace-trimmed serial, so the next import's trimmed filter(serial=...) matches it instead of minting a duplicate (real DB, real Device.save())."""
+    """import_single_device persists a trimmed serial so the next exact lookup finds it."""
 
     def test_padded_incoming_serial_is_stored_trimmed(self):
         from unittest.mock import patch
@@ -2940,10 +2950,29 @@ class TestDetectSerialMatchRole:
             _describe_existing_librenms_link,
             _detect_serial_match_role,
         )
+        from netbox_librenms_plugin.utils import normalize_serial
 
         existing_link = _describe_existing_librenms_link(existing_device, server_key)
-        serial = str(libre_device.get("serial") or "").strip()
+        serial = normalize_serial(libre_device.get("serial"))
         return _detect_serial_match_role(existing_device, existing_link, hostname, serial, libre_device, server_key)
+
+    def test_zero_serial_is_preserved_in_hostname_difference_warning(self):
+        """The test helper follows production normalization, where numeric zero is a real serial."""
+        from netbox_librenms_plugin.tests.conftest import make_device
+
+        device = make_device("zero-warning-old")
+        libre_device = {
+            "device_id": 7,
+            "os": "linux",
+            "hardware": "server",
+            "hostname": "zero-warning-new",
+            "serial": 0,
+        }
+
+        out = self._role(device, "zero-warning-new", libre_device)
+
+        assert out["serial_action"] == "hostname_differs"
+        assert any("same serial (0)" in warning for warning in out["warnings"])
 
     def test_oob_candidate_default_when_incoming_is_oob_and_name_differs(self):
         # Existing unlinked host; incoming LibreNMS row is clearly an iDRAC whose hostname
@@ -3268,10 +3297,10 @@ class TestValidateDedupsSerialDuplicateQuery:
 
         # The duplicate-detection serial lookup (serial[:2], no .exclude) must run exactly once,
         # not once per stage. The .first() match query is LIMIT 1; the cross-side query has NOT.
-        # filter_by_trimmed_serial() compares TRIM(serial), so match the trimmed predicate.
         serial_dup_queries = [
             q["sql"]
             for q in ctx.captured_queries
-            if 'serial") =' in q["sql"].lower() and "limit 2" in q["sql"].lower() and "not" not in q["sql"].lower()
+            if '."serial" =' in q["sql"].lower() and "limit 2" in q["sql"].lower() and "not" not in q["sql"].lower()
         ]
         assert len(serial_dup_queries) == 1
+        assert all("trim(" not in sql.lower() for sql in serial_dup_queries)

--- a/netbox_librenms_plugin/tests/test_coverage_device_operations.py
+++ b/netbox_librenms_plugin/tests/test_coverage_device_operations.py
@@ -1932,6 +1932,26 @@ class TestValidateSerialMatchStripsWhitespace:
         assert result.get("serial_action") is None, "whitespace-only serial diff wrongly flagged as drift"
         assert not any("differs" in w for w in result.get("warnings", [])), result.get("warnings")
 
+    def test_numeric_serial_is_coerced_not_crashed(self):
+        """A numeric serial (an int, e.g. an all-digit serial parsed from JSON) must be coerced to a string before .strip(), not raise AttributeError, and still match an existing device stored with the string form."""
+        from netbox_librenms_plugin.import_utils.device_operations import validate_device_for_import
+
+        device = self._make_device("numeric-serial-host", serial="123456")
+        libre_device = {
+            "device_id": 8814,
+            "hostname": "numeric-import-row",  # matches no device → falls to the serial-identity match
+            "sysName": "numeric-import-row",
+            "serial": 123456,  # int, not str — .strip() would raise AttributeError without a str() cast
+            "hardware": "-",
+            "os": "-",
+            "location": "-",
+        }
+
+        result = validate_device_for_import(libre_device, api=None, server_key="default", include_vc_detection=False)
+
+        assert result["existing_device"] is not None, "numeric serial was not matched (crash swallowed by validator)"
+        assert result["existing_device"].pk == device.pk
+
 
 @pytest.mark.django_db
 class TestImportPersistsTrimmedSerial:

--- a/netbox_librenms_plugin/tests/test_coverage_sync_views.py
+++ b/netbox_librenms_plugin/tests/test_coverage_sync_views.py
@@ -2798,6 +2798,25 @@ class TestSyncIPAddressesViewSetPrimaryIp:
         obj.refresh_from_db()
         assert obj.primary_ip6_id == ip_obj.pk
 
+    @pytest.mark.django_db
+    def test_set_primary_ip_survives_netbox44_family_property(self):
+        """_set_primary_ip must not read IPAddress.family: on NetBox 4.4 the property raises AttributeError on the in-memory str address of a freshly created IPAddress (forced)."""
+        from ipam.models import IPAddress
+
+        from netbox_librenms_plugin.tests.conftest import make_device, make_interface, make_ip
+        from netbox_librenms_plugin.views.sync.ip_addresses import SyncIPAddressesView as V
+
+        obj = make_device("setprimary-nb44")
+        iface = make_interface(obj, "eth0")
+        ip_obj = make_ip("2001:db8::44/64", assigned_object=iface)
+        ip_obj.address = "2001:db8::44/64"  # in-memory str, as after IPAddress.objects.create()
+        # NetBox 4.4's family property verbatim — 4.5+ added a str-tolerant branch.
+        netbox44_family = property(lambda self: self.address.version if self.address else None)
+        with patch.object(IPAddress, "family", netbox44_family):
+            assert V._set_primary_ip(obj, ip_obj) is True
+        obj.refresh_from_db()
+        assert obj.primary_ip6_id == ip_obj.pk
+
     def _run_process(self, view, cached, *, mgmt_ip, set_primary=True):
         """Drive process_ip_sync against a REAL Device + interface so _build_interface_maps() takes the production Device branch."""
         from netbox_librenms_plugin.tests.conftest import make_device, make_interface

--- a/netbox_librenms_plugin/tests/test_coverage_virtual_chassis.py
+++ b/netbox_librenms_plugin/tests/test_coverage_virtual_chassis.py
@@ -5,6 +5,8 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from netbox_librenms_plugin.tests.conftest import collapse_queryset_chain
+
 
 def _make_master_device(serial="MASTER001"):
     """Build a mock master Device for VC creation tests."""
@@ -59,6 +61,7 @@ class TestCreateVirtualChassisWithMembersPositionConflict:
         mock_filter.exists.return_value = False
         mock_filter.exclude.return_value = mock_filter
         mock_Device.objects.filter.return_value = mock_filter
+        collapse_queryset_chain(mock_Device)
         mock_Device.objects.create.return_value = MagicMock()
 
         # Members: first at position 2, second ALSO at position 2 (conflict)
@@ -109,6 +112,7 @@ class TestCreateVirtualChassisWithMembersPositionConflict:
         mock_filter.exists.return_value = False
         mock_filter.exclude.return_value = mock_filter
         mock_Device.objects.filter.return_value = mock_filter
+        collapse_queryset_chain(mock_Device)
         mock_Device.objects.create.return_value = MagicMock()
 
         # Member A explicitly at position 2
@@ -155,6 +159,7 @@ class TestCreateVirtualChassisWithMembersPositionConflict:
         mock_filter.exists.return_value = False
         mock_filter.exclude.return_value = mock_filter
         mock_Device.objects.filter.return_value = mock_filter
+        collapse_queryset_chain(mock_Device)
         mock_Device.objects.create.return_value = MagicMock()
 
         # Members at positions 2 and 3; then one with no position → should get 4
@@ -199,6 +204,7 @@ class TestCreateVirtualChassisWithMembersPositionConflict:
         mock_filter.exists.return_value = False
         mock_filter.exclude.return_value = mock_filter
         mock_Device.objects.filter.return_value = mock_filter
+        collapse_queryset_chain(mock_Device)
         mock_Device.objects.create.return_value = MagicMock()
 
         members_info = [
@@ -244,6 +250,7 @@ class TestCreateVirtualChassisServerKeyDomain:
         mock_filter.exists.return_value = False
         mock_filter.exclude.return_value = mock_filter
         mock_Device.objects.filter.return_value = mock_filter
+        collapse_queryset_chain(mock_Device)
         mock_Device.objects.create.return_value = MagicMock()
 
         libre_device = {"device_id": 42}
@@ -282,6 +289,7 @@ class TestCreateVirtualChassisServerKeyDomain:
         mock_filter.exists.return_value = False
         mock_filter.exclude.return_value = mock_filter
         mock_Device.objects.filter.return_value = mock_filter
+        collapse_queryset_chain(mock_Device)
         mock_Device.objects.create.return_value = MagicMock()
 
         libre_device = {"device_id": 99}

--- a/netbox_librenms_plugin/tests/test_coverage_virtual_chassis.py
+++ b/netbox_librenms_plugin/tests/test_coverage_virtual_chassis.py
@@ -380,3 +380,24 @@ class TestGenerateVcMemberName:
 
     def test_default_pattern(self):
         assert self._call("switch01", 2, pattern="-M{position}") == "switch01-M2"
+
+
+class TestNormSerial:
+    """_norm_serial(): only None/blank/'-' means missing — a JSON-number serial 0 is real."""
+
+    def test_zero_serial_is_preserved(self):
+        from netbox_librenms_plugin.import_utils.virtual_chassis import _norm_serial
+
+        assert _norm_serial(0) == "0"
+
+    def test_numeric_serial_is_coerced(self):
+        from netbox_librenms_plugin.import_utils.virtual_chassis import _norm_serial
+
+        assert _norm_serial(123456) == "123456"
+
+    def test_none_dash_and_padding(self):
+        from netbox_librenms_plugin.import_utils.virtual_chassis import _norm_serial
+
+        assert _norm_serial(None) == ""
+        assert _norm_serial("-") == ""
+        assert _norm_serial("  SN-1  ") == "SN-1"

--- a/netbox_librenms_plugin/tests/test_coverage_virtual_chassis.py
+++ b/netbox_librenms_plugin/tests/test_coverage_virtual_chassis.py
@@ -5,8 +5,6 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from netbox_librenms_plugin.tests.conftest import collapse_queryset_chain
-
 
 def _make_master_device(serial="MASTER001"):
     """Build a mock master Device for VC creation tests."""
@@ -61,7 +59,6 @@ class TestCreateVirtualChassisWithMembersPositionConflict:
         mock_filter.exists.return_value = False
         mock_filter.exclude.return_value = mock_filter
         mock_Device.objects.filter.return_value = mock_filter
-        collapse_queryset_chain(mock_Device)
         mock_Device.objects.create.return_value = MagicMock()
 
         # Members: first at position 2, second ALSO at position 2 (conflict)
@@ -112,7 +109,6 @@ class TestCreateVirtualChassisWithMembersPositionConflict:
         mock_filter.exists.return_value = False
         mock_filter.exclude.return_value = mock_filter
         mock_Device.objects.filter.return_value = mock_filter
-        collapse_queryset_chain(mock_Device)
         mock_Device.objects.create.return_value = MagicMock()
 
         # Member A explicitly at position 2
@@ -159,7 +155,6 @@ class TestCreateVirtualChassisWithMembersPositionConflict:
         mock_filter.exists.return_value = False
         mock_filter.exclude.return_value = mock_filter
         mock_Device.objects.filter.return_value = mock_filter
-        collapse_queryset_chain(mock_Device)
         mock_Device.objects.create.return_value = MagicMock()
 
         # Members at positions 2 and 3; then one with no position → should get 4
@@ -204,7 +199,6 @@ class TestCreateVirtualChassisWithMembersPositionConflict:
         mock_filter.exists.return_value = False
         mock_filter.exclude.return_value = mock_filter
         mock_Device.objects.filter.return_value = mock_filter
-        collapse_queryset_chain(mock_Device)
         mock_Device.objects.create.return_value = MagicMock()
 
         members_info = [
@@ -250,7 +244,6 @@ class TestCreateVirtualChassisServerKeyDomain:
         mock_filter.exists.return_value = False
         mock_filter.exclude.return_value = mock_filter
         mock_Device.objects.filter.return_value = mock_filter
-        collapse_queryset_chain(mock_Device)
         mock_Device.objects.create.return_value = MagicMock()
 
         libre_device = {"device_id": 42}
@@ -289,7 +282,6 @@ class TestCreateVirtualChassisServerKeyDomain:
         mock_filter.exists.return_value = False
         mock_filter.exclude.return_value = mock_filter
         mock_Device.objects.filter.return_value = mock_filter
-        collapse_queryset_chain(mock_Device)
         mock_Device.objects.create.return_value = MagicMock()
 
         libre_device = {"device_id": 99}

--- a/netbox_librenms_plugin/tests/test_import_utils.py
+++ b/netbox_librenms_plugin/tests/test_import_utils.py
@@ -2693,6 +2693,12 @@ class TestLegacyLibreNMSIdMigration:
 class TestDeviceConflictActionView:
     """Test DeviceConflictActionView conflict resolution actions."""
 
+    @pytest.fixture(autouse=True)
+    def _no_advisory_lock(self):
+        """The serial guard's pg_advisory_xact_lock needs a real connection these mock tests don't have."""
+        with patch("netbox_librenms_plugin.views.imports.actions._acquire_serial_assignment_lock"):
+            yield
+
     def _create_view(self):
         """Create a DeviceConflictActionView instance with mocked dependencies."""
         from netbox_librenms_plugin.views.imports.actions import DeviceConflictActionView
@@ -2786,7 +2792,7 @@ class TestDeviceConflictActionView:
             mock_tx.atomic.return_value = MagicMock()
             mock_device_cls.objects.get.return_value = existing_device
             mock_device_cls.objects.select_for_update.return_value.get.return_value = existing_device
-            mock_device_cls.objects.select_for_update.return_value.filter.return_value.exclude.return_value.first.return_value = None
+            mock_device_cls.objects.filter.return_value.exclude.return_value.first.return_value = None
             mock_device_cls.objects.filter.return_value.first.return_value = None
             mock_device_cls.objects.filter.return_value.exclude.return_value.first.return_value = None
             mock_device_cls.objects.filter.return_value.exclude.return_value.exists.return_value = False
@@ -2877,7 +2883,7 @@ class TestDeviceConflictActionView:
             mock_tx.atomic.return_value = MagicMock()
             mock_device_cls.objects.get.return_value = existing_device
             mock_device_cls.objects.select_for_update.return_value.get.return_value = existing_device
-            mock_device_cls.objects.select_for_update.return_value.filter.return_value.exclude.return_value.first.return_value = None
+            mock_device_cls.objects.filter.return_value.exclude.return_value.first.return_value = None
             mock_device_cls.objects.filter.return_value.first.return_value = None
             mock_device_cls.objects.filter.return_value.exclude.return_value.first.return_value = None
             mock_device_cls.objects.filter.return_value.exclude.return_value.exists.return_value = False
@@ -2928,7 +2934,7 @@ class TestDeviceConflictActionView:
             mock_tx.atomic.return_value = MagicMock()
             mock_device_cls.objects.get.return_value = existing_device
             mock_device_cls.objects.select_for_update.return_value.get.return_value = existing_device
-            mock_device_cls.objects.select_for_update.return_value.filter.return_value.exclude.return_value.first.return_value = None
+            mock_device_cls.objects.filter.return_value.exclude.return_value.first.return_value = None
             mock_device_cls.objects.filter.return_value.first.return_value = None
             mock_device_cls.objects.filter.return_value.exclude.return_value.first.return_value = None
             mock_device_cls.objects.filter.return_value.exclude.return_value.exists.return_value = False
@@ -2968,7 +2974,7 @@ class TestDeviceConflictActionView:
             mock_tx.atomic.return_value = MagicMock()
             mock_device_cls.objects.get.return_value = existing_device
             mock_device_cls.objects.select_for_update.return_value.get.return_value = existing_device
-            mock_device_cls.objects.select_for_update.return_value.filter.return_value.exclude.return_value.first.return_value = None
+            mock_device_cls.objects.filter.return_value.exclude.return_value.first.return_value = None
             mock_device_cls.objects.filter.return_value.first.return_value = None
             mock_device_cls.objects.filter.return_value.exclude.return_value.first.return_value = None
             mock_device_cls.objects.filter.return_value.exclude.return_value.exists.return_value = False
@@ -3012,7 +3018,7 @@ class TestDeviceConflictActionView:
             mock_tx.atomic.return_value = MagicMock()
             mock_device_cls.objects.get.return_value = existing_device
             mock_device_cls.objects.select_for_update.return_value.get.return_value = existing_device
-            mock_device_cls.objects.select_for_update.return_value.filter.return_value.exclude.return_value.first.return_value = None
+            mock_device_cls.objects.filter.return_value.exclude.return_value.first.return_value = None
             mock_device_cls.objects.filter.return_value.exclude.return_value.exists.return_value = False
             mock_validate.return_value = (libre_device, validation, selections)
             mock_render.return_value = MagicMock()
@@ -3053,7 +3059,7 @@ class TestDeviceConflictActionView:
         ):
             mock_device_cls.objects.get.return_value = existing_device
             mock_device_cls.objects.select_for_update.return_value.get.return_value = existing_device
-            mock_device_cls.objects.select_for_update.return_value.filter.return_value.exclude.return_value.first.return_value = None
+            mock_device_cls.objects.filter.return_value.exclude.return_value.first.return_value = None
             # Include existing_device so the validated-conflict-target guard passes;
             # we want to exercise the unknown-action branch, not the missing-device guard.
             mock_validate.return_value = (libre_device, {"existing_device": existing_device}, {})
@@ -3094,7 +3100,7 @@ class TestDeviceConflictActionView:
         ):
             mock_device_cls.objects.get.return_value = existing_device
             mock_device_cls.objects.select_for_update.return_value.get.return_value = existing_device
-            mock_device_cls.objects.select_for_update.return_value.filter.return_value.exclude.return_value.first.return_value = None
+            mock_device_cls.objects.filter.return_value.exclude.return_value.first.return_value = None
             mock_validate.return_value = (libre_device, validation, selections)
             mock_render.return_value = MagicMock()
 
@@ -3128,7 +3134,7 @@ class TestDeviceConflictActionView:
         ):
             mock_device_cls.objects.get.return_value = existing_device
             mock_device_cls.objects.select_for_update.return_value.get.return_value = existing_device
-            mock_device_cls.objects.select_for_update.return_value.filter.return_value.exclude.return_value.first.return_value = None
+            mock_device_cls.objects.filter.return_value.exclude.return_value.first.return_value = None
             mock_validate.return_value = (libre_device, validation, selections)
 
             view.request = request
@@ -3171,7 +3177,7 @@ class TestDeviceConflictActionView:
             mock_tx.atomic.return_value = MagicMock()
             mock_device_cls.objects.get.return_value = existing_device
             mock_device_cls.objects.select_for_update.return_value.get.return_value = existing_device
-            mock_device_cls.objects.select_for_update.return_value.filter.return_value.exclude.return_value.first.return_value = None
+            mock_device_cls.objects.filter.return_value.exclude.return_value.first.return_value = None
             mock_device_cls.objects.filter.return_value.first.return_value = None
             mock_device_cls.objects.filter.return_value.exclude.return_value.first.return_value = None
             mock_device_cls.objects.filter.return_value.exclude.return_value.exists.return_value = False
@@ -3226,7 +3232,7 @@ class TestDeviceConflictActionView:
             mock_tx.atomic.return_value = MagicMock()
             mock_device_cls.objects.get.return_value = existing_device
             mock_device_cls.objects.select_for_update.return_value.get.return_value = existing_device
-            mock_device_cls.objects.select_for_update.return_value.filter.return_value.exclude.return_value.first.return_value = None
+            mock_device_cls.objects.filter.return_value.exclude.return_value.first.return_value = None
             mock_device_cls.objects.filter.return_value.first.return_value = None
             mock_device_cls.objects.filter.return_value.exclude.return_value.first.return_value = None
             mock_device_cls.objects.filter.return_value.exclude.return_value.exists.return_value = False
@@ -3281,7 +3287,7 @@ class TestDeviceConflictActionView:
         ):
             mock_device_cls.objects.get.return_value = existing_device
             mock_device_cls.objects.select_for_update.return_value.get.return_value = existing_device
-            mock_device_cls.objects.select_for_update.return_value.filter.return_value.exclude.return_value.first.return_value = None
+            mock_device_cls.objects.filter.return_value.exclude.return_value.first.return_value = None
             mock_validate.return_value = (libre_device, validation, selections)
             mock_render.return_value = MagicMock()
 
@@ -3316,7 +3322,7 @@ class TestDeviceConflictActionView:
             mock_tx.atomic.return_value = MagicMock()
             mock_device_cls.objects.get.return_value = existing_device
             mock_device_cls.objects.select_for_update.return_value.get.return_value = existing_device
-            mock_device_cls.objects.select_for_update.return_value.filter.return_value.exclude.return_value.first.return_value = None
+            mock_device_cls.objects.filter.return_value.exclude.return_value.first.return_value = None
             mock_device_cls.objects.filter.return_value.first.return_value = None
             mock_device_cls.objects.filter.return_value.exclude.return_value.first.return_value = None
             mock_device_cls.objects.filter.return_value.exclude.return_value.exists.return_value = False
@@ -3356,7 +3362,7 @@ class TestDeviceConflictActionView:
         ):
             mock_device_cls.objects.get.return_value = existing_device
             mock_device_cls.objects.select_for_update.return_value.get.return_value = existing_device
-            mock_device_cls.objects.select_for_update.return_value.filter.return_value.exclude.return_value.first.return_value = None
+            mock_device_cls.objects.filter.return_value.exclude.return_value.first.return_value = None
             mock_find_platform.return_value = {"found": True, "platform": mock_platform, "match_type": "exact"}
             mock_validate.return_value = (libre_device, validation, selections)
             mock_render.return_value = MagicMock()
@@ -3392,7 +3398,7 @@ class TestDeviceConflictActionView:
         ):
             mock_device_cls.objects.get.return_value = existing_device
             mock_device_cls.objects.select_for_update.return_value.get.return_value = existing_device
-            mock_device_cls.objects.select_for_update.return_value.filter.return_value.exclude.return_value.first.return_value = None
+            mock_device_cls.objects.filter.return_value.exclude.return_value.first.return_value = None
             mock_hw_match.return_value = {"matched": True, "device_type": new_device_type}
             mock_validate.return_value = (libre_device, validation, selections)
             mock_render.return_value = MagicMock()

--- a/netbox_librenms_plugin/tests/test_import_utils.py
+++ b/netbox_librenms_plugin/tests/test_import_utils.py
@@ -9,8 +9,6 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from netbox_librenms_plugin.tests.conftest import collapse_queryset_chain
-
 
 def _matchable_filter_result():
     """Return a mock queryset whose ``[:2]`` slice derives from ``.first.return_value``.
@@ -28,12 +26,8 @@ def _matchable_filter_result():
 
 
 def _is_serial_lookup(kwargs):
-    """True for the Device serial lookup in either form.
-
-    filter_by_trimmed_serial() compares a TRIM(serial) annotation, so the lookup arrives
-    as ``_serial_trimmed=`` rather than ``serial=``.
-    """
-    return {"serial", "_serial_trimmed"} & set(kwargs)
+    """True for the exact Device serial lookup."""
+    return "serial" in kwargs
 
 
 # =============================================================================
@@ -1783,7 +1777,6 @@ class TestSerialNumberMatching:
             self.mock_device,
             self.mock_vm,
         ) = mocks
-        collapse_queryset_chain(self.mock_device)
         self.mock_device_type.objects.all.return_value = []
 
     def _stop_patches(self):
@@ -2292,7 +2285,6 @@ class TestNameMatchesWithNamingPreferences:
             self.mock_device,
             self.mock_vm,
         ) = mocks
-        collapse_queryset_chain(self.mock_device)
         self.mock_device_type.objects.all.return_value = []
         self.mock_vm.objects.filter.return_value.first.return_value = None
         self.mock_find_site.return_value = {
@@ -2804,7 +2796,6 @@ class TestDeviceConflictActionView:
         ):
             mock_tx.atomic.return_value = MagicMock()
             mock_device_cls.objects.restrict.return_value.get.return_value = existing_device
-            collapse_queryset_chain(mock_device_cls)
             mock_device_cls.objects.select_for_update.return_value.get.return_value = existing_device
             mock_device_cls.objects.filter.return_value.exclude.return_value.first.return_value = None
             mock_device_cls.objects.filter.return_value.first.return_value = None
@@ -2852,7 +2843,6 @@ class TestDeviceConflictActionView:
         ):
             mock_tx.atomic.return_value = MagicMock()
             mock_device_cls.objects.restrict.return_value.get.return_value = existing_device
-            collapse_queryset_chain(mock_device_cls)
             mock_device_cls.objects.select_for_update.return_value.get.return_value = existing_device
             mock_device_cls.objects.filter.return_value.first.return_value = None
             mock_device_cls.objects.filter.return_value.exclude.return_value.first.return_value = None
@@ -2897,7 +2887,6 @@ class TestDeviceConflictActionView:
         ):
             mock_tx.atomic.return_value = MagicMock()
             mock_device_cls.objects.restrict.return_value.get.return_value = existing_device
-            collapse_queryset_chain(mock_device_cls)
             mock_device_cls.objects.select_for_update.return_value.get.return_value = existing_device
             mock_device_cls.objects.filter.return_value.exclude.return_value.first.return_value = None
             mock_device_cls.objects.filter.return_value.first.return_value = None
@@ -2949,7 +2938,6 @@ class TestDeviceConflictActionView:
         ):
             mock_tx.atomic.return_value = MagicMock()
             mock_device_cls.objects.restrict.return_value.get.return_value = existing_device
-            collapse_queryset_chain(mock_device_cls)
             mock_device_cls.objects.select_for_update.return_value.get.return_value = existing_device
             mock_device_cls.objects.filter.return_value.exclude.return_value.first.return_value = None
             mock_device_cls.objects.filter.return_value.first.return_value = None
@@ -2990,7 +2978,6 @@ class TestDeviceConflictActionView:
         ):
             mock_tx.atomic.return_value = MagicMock()
             mock_device_cls.objects.restrict.return_value.get.return_value = existing_device
-            collapse_queryset_chain(mock_device_cls)
             mock_device_cls.objects.select_for_update.return_value.get.return_value = existing_device
             mock_device_cls.objects.filter.return_value.exclude.return_value.first.return_value = None
             mock_device_cls.objects.filter.return_value.first.return_value = None
@@ -3035,7 +3022,6 @@ class TestDeviceConflictActionView:
         ):
             mock_tx.atomic.return_value = MagicMock()
             mock_device_cls.objects.restrict.return_value.get.return_value = existing_device
-            collapse_queryset_chain(mock_device_cls)
             mock_device_cls.objects.select_for_update.return_value.get.return_value = existing_device
             mock_device_cls.objects.filter.return_value.exclude.return_value.first.return_value = None
             mock_device_cls.objects.filter.return_value.exclude.return_value.exists.return_value = False
@@ -3077,7 +3063,6 @@ class TestDeviceConflictActionView:
             patch("dcim.models.Device") as mock_device_cls,
         ):
             mock_device_cls.objects.restrict.return_value.get.return_value = existing_device
-            collapse_queryset_chain(mock_device_cls)
             mock_device_cls.objects.select_for_update.return_value.get.return_value = existing_device
             mock_device_cls.objects.filter.return_value.exclude.return_value.first.return_value = None
             # Include existing_device so the validated-conflict-target guard passes;
@@ -3119,7 +3104,6 @@ class TestDeviceConflictActionView:
             patch("dcim.models.Device") as mock_device_cls,
         ):
             mock_device_cls.objects.restrict.return_value.get.return_value = existing_device
-            collapse_queryset_chain(mock_device_cls)
             mock_device_cls.objects.select_for_update.return_value.get.return_value = existing_device
             mock_device_cls.objects.filter.return_value.exclude.return_value.first.return_value = None
             mock_validate.return_value = (libre_device, validation, selections)
@@ -3154,7 +3138,6 @@ class TestDeviceConflictActionView:
             patch("dcim.models.Device") as mock_device_cls,
         ):
             mock_device_cls.objects.restrict.return_value.get.return_value = existing_device
-            collapse_queryset_chain(mock_device_cls)
             mock_device_cls.objects.select_for_update.return_value.get.return_value = existing_device
             mock_device_cls.objects.filter.return_value.exclude.return_value.first.return_value = None
             mock_validate.return_value = (libre_device, validation, selections)
@@ -3198,7 +3181,6 @@ class TestDeviceConflictActionView:
         ):
             mock_tx.atomic.return_value = MagicMock()
             mock_device_cls.objects.restrict.return_value.get.return_value = existing_device
-            collapse_queryset_chain(mock_device_cls)
             mock_device_cls.objects.select_for_update.return_value.get.return_value = existing_device
             mock_device_cls.objects.filter.return_value.exclude.return_value.first.return_value = None
             mock_device_cls.objects.filter.return_value.first.return_value = None
@@ -3254,7 +3236,6 @@ class TestDeviceConflictActionView:
         ):
             mock_tx.atomic.return_value = MagicMock()
             mock_device_cls.objects.restrict.return_value.get.return_value = existing_device
-            collapse_queryset_chain(mock_device_cls)
             mock_device_cls.objects.select_for_update.return_value.get.return_value = existing_device
             mock_device_cls.objects.filter.return_value.exclude.return_value.first.return_value = None
             mock_device_cls.objects.filter.return_value.first.return_value = None
@@ -3310,7 +3291,6 @@ class TestDeviceConflictActionView:
             patch("dcim.models.Device") as mock_device_cls,
         ):
             mock_device_cls.objects.restrict.return_value.get.return_value = existing_device
-            collapse_queryset_chain(mock_device_cls)
             mock_device_cls.objects.select_for_update.return_value.get.return_value = existing_device
             mock_device_cls.objects.filter.return_value.exclude.return_value.first.return_value = None
             mock_validate.return_value = (libre_device, validation, selections)
@@ -3346,7 +3326,6 @@ class TestDeviceConflictActionView:
         ):
             mock_tx.atomic.return_value = MagicMock()
             mock_device_cls.objects.restrict.return_value.get.return_value = existing_device
-            collapse_queryset_chain(mock_device_cls)
             mock_device_cls.objects.select_for_update.return_value.get.return_value = existing_device
             mock_device_cls.objects.filter.return_value.exclude.return_value.first.return_value = None
             mock_device_cls.objects.filter.return_value.first.return_value = None
@@ -3387,7 +3366,6 @@ class TestDeviceConflictActionView:
             patch("netbox_librenms_plugin.utils.find_matching_platform") as mock_find_platform,
         ):
             mock_device_cls.objects.restrict.return_value.get.return_value = existing_device
-            collapse_queryset_chain(mock_device_cls)
             mock_device_cls.objects.select_for_update.return_value.get.return_value = existing_device
             mock_device_cls.objects.filter.return_value.exclude.return_value.first.return_value = None
             mock_find_platform.return_value = {"found": True, "platform": mock_platform, "match_type": "exact"}
@@ -3424,7 +3402,6 @@ class TestDeviceConflictActionView:
             patch("netbox_librenms_plugin.utils.match_librenms_hardware_to_device_type") as mock_hw_match,
         ):
             mock_device_cls.objects.restrict.return_value.get.return_value = existing_device
-            collapse_queryset_chain(mock_device_cls)
             mock_device_cls.objects.select_for_update.return_value.get.return_value = existing_device
             mock_device_cls.objects.filter.return_value.exclude.return_value.first.return_value = None
             mock_hw_match.return_value = {"matched": True, "device_type": new_device_type}
@@ -6017,7 +5994,6 @@ class TestVirtualChassisEdgeBranches:
             ),
         ):
             mock_device_cls.objects.filter.side_effect = _filter_exists
-            collapse_queryset_chain(mock_device_cls)
             mock_vc_cls.objects.create.return_value = mock_vc
 
             members_info = [{"serial": "DUP-SERIAL", "position": 2, "name": "sw1-2"}]
@@ -6073,7 +6049,6 @@ class TestVirtualChassisEdgeBranches:
             ),
         ):
             mock_device_cls.objects.filter.side_effect = _filter_side_effect
-            collapse_queryset_chain(mock_device_cls)
             mock_vc_cls.objects.create.return_value = mock_vc
 
             members_info = [{"serial": "NEW-SERIAL", "position": 2, "name": "sw1-2"}]
@@ -6128,7 +6103,6 @@ class TestVirtualChassisEdgeBranches:
             patch("netbox_librenms_plugin.import_utils.virtual_chassis.logger") as mock_logger,
         ):
             mock_device_cls.objects.filter.side_effect = _filter_side_effect
-            collapse_queryset_chain(mock_device_cls)
             mock_vc_cls.objects.create.return_value = mock_vc
 
             # 2 members expected, both skipped → warning
@@ -6195,7 +6169,6 @@ class TestVirtualChassisEdgeBranches:
             ),
         ):
             mock_device_cls.objects.filter.side_effect = _filter_side_effect
-            collapse_queryset_chain(mock_device_cls)
             mock_vc_cls.objects.create.return_value = mock_vc
 
             # position=0 → discovered_pos normalized to None; serial present but name conflicts
@@ -6259,7 +6232,6 @@ class TestVirtualChassisEdgeBranches:
             ),
         ):
             mock_device_cls.objects.filter.side_effect = _filter_side_effect
-            collapse_queryset_chain(mock_device_cls)
             mock_device_cls.objects.create.side_effect = _capture_create
             mock_vc_cls.objects.create.return_value = mock_vc
 

--- a/netbox_librenms_plugin/tests/test_import_utils.py
+++ b/netbox_librenms_plugin/tests/test_import_utils.py
@@ -9,6 +9,8 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from netbox_librenms_plugin.tests.conftest import collapse_queryset_chain
+
 
 def _matchable_filter_result():
     """Return a mock queryset whose ``[:2]`` slice derives from ``.first.return_value``.
@@ -23,6 +25,15 @@ def _matchable_filter_result():
         [result.first.return_value] if result.first.return_value is not None else []
     )
     return result
+
+
+def _is_serial_lookup(kwargs):
+    """True for the Device serial lookup in either form.
+
+    filter_by_trimmed_serial() compares a TRIM(serial) annotation, so the lookup arrives
+    as ``_serial_trimmed=`` rather than ``serial=``.
+    """
+    return {"serial", "_serial_trimmed"} & set(kwargs)
 
 
 # =============================================================================
@@ -1772,6 +1783,7 @@ class TestSerialNumberMatching:
             self.mock_device,
             self.mock_vm,
         ) = mocks
+        collapse_queryset_chain(self.mock_device)
         self.mock_device_type.objects.all.return_value = []
 
     def _stop_patches(self):
@@ -1797,7 +1809,7 @@ class TestSerialNumberMatching:
 
         def device_filter(*args, **kwargs):
             result = _matchable_filter_result()
-            if "serial" in kwargs:
+            if _is_serial_lookup(kwargs):
                 result.first.return_value = existing
             else:
                 result.first.return_value = None
@@ -1824,7 +1836,7 @@ class TestSerialNumberMatching:
 
         def device_filter(*args, **kwargs):
             result = _matchable_filter_result()
-            if "serial" in kwargs:
+            if _is_serial_lookup(kwargs):
                 result.first.return_value = existing
             else:
                 result.first.return_value = None
@@ -1858,7 +1870,7 @@ class TestSerialNumberMatching:
             result = _matchable_filter_result()
             if "name__iexact" in kwargs:
                 result.first.return_value = existing
-            elif "serial" in kwargs:
+            elif _is_serial_lookup(kwargs):
                 result.first.return_value = None
                 result.exclude.return_value.first.return_value = None
             else:
@@ -1938,7 +1950,7 @@ class TestSerialNumberMatching:
             result = _matchable_filter_result()
             if "name__iexact" in kwargs:
                 result.first.return_value = hostname_device
-            elif "serial" in kwargs:
+            elif _is_serial_lookup(kwargs):
                 result.exclude.return_value.first.return_value = serial_conflict_device
             else:
                 result.first.return_value = None
@@ -2021,7 +2033,7 @@ class TestSerialNumberMatching:
                 result.first.return_value = existing
                 # find_by_librenms_id consumes the queryset via list(qs[:2]).
                 result.__getitem__.return_value = [existing]
-            elif "serial" in kwargs:
+            elif _is_serial_lookup(kwargs):
                 result.first.return_value = None
                 result.__getitem__.return_value = []
                 result.exclude.return_value.first.return_value = None
@@ -2114,7 +2126,7 @@ class TestSerialNumberMatching:
 
         def device_filter(*args, **kwargs):
             result = _matchable_filter_result()
-            if "serial" in kwargs:
+            if _is_serial_lookup(kwargs):
                 result.first.return_value = existing
             else:
                 result.first.return_value = None
@@ -2167,7 +2179,7 @@ class TestSerialNumberMatching:
 
         def device_filter(*args, **kwargs):
             result = _matchable_filter_result()
-            if "serial" in kwargs:
+            if _is_serial_lookup(kwargs):
                 result.first.return_value = existing
             else:
                 result.first.return_value = None
@@ -2218,7 +2230,7 @@ class TestSerialNumberMatching:
 
         def device_filter(*args, **kwargs):
             result = _matchable_filter_result()
-            if "serial" in kwargs:
+            if _is_serial_lookup(kwargs):
                 result.first.return_value = existing
             else:
                 result.first.return_value = None
@@ -2280,6 +2292,7 @@ class TestNameMatchesWithNamingPreferences:
             self.mock_device,
             self.mock_vm,
         ) = mocks
+        collapse_queryset_chain(self.mock_device)
         self.mock_device_type.objects.all.return_value = []
         self.mock_vm.objects.filter.return_value.first.return_value = None
         self.mock_find_site.return_value = {
@@ -2791,6 +2804,7 @@ class TestDeviceConflictActionView:
         ):
             mock_tx.atomic.return_value = MagicMock()
             mock_device_cls.objects.restrict.return_value.get.return_value = existing_device
+            collapse_queryset_chain(mock_device_cls)
             mock_device_cls.objects.select_for_update.return_value.get.return_value = existing_device
             mock_device_cls.objects.filter.return_value.exclude.return_value.first.return_value = None
             mock_device_cls.objects.filter.return_value.first.return_value = None
@@ -2838,6 +2852,7 @@ class TestDeviceConflictActionView:
         ):
             mock_tx.atomic.return_value = MagicMock()
             mock_device_cls.objects.restrict.return_value.get.return_value = existing_device
+            collapse_queryset_chain(mock_device_cls)
             mock_device_cls.objects.select_for_update.return_value.get.return_value = existing_device
             mock_device_cls.objects.filter.return_value.first.return_value = None
             mock_device_cls.objects.filter.return_value.exclude.return_value.first.return_value = None
@@ -2882,6 +2897,7 @@ class TestDeviceConflictActionView:
         ):
             mock_tx.atomic.return_value = MagicMock()
             mock_device_cls.objects.restrict.return_value.get.return_value = existing_device
+            collapse_queryset_chain(mock_device_cls)
             mock_device_cls.objects.select_for_update.return_value.get.return_value = existing_device
             mock_device_cls.objects.filter.return_value.exclude.return_value.first.return_value = None
             mock_device_cls.objects.filter.return_value.first.return_value = None
@@ -2933,6 +2949,7 @@ class TestDeviceConflictActionView:
         ):
             mock_tx.atomic.return_value = MagicMock()
             mock_device_cls.objects.restrict.return_value.get.return_value = existing_device
+            collapse_queryset_chain(mock_device_cls)
             mock_device_cls.objects.select_for_update.return_value.get.return_value = existing_device
             mock_device_cls.objects.filter.return_value.exclude.return_value.first.return_value = None
             mock_device_cls.objects.filter.return_value.first.return_value = None
@@ -2973,6 +2990,7 @@ class TestDeviceConflictActionView:
         ):
             mock_tx.atomic.return_value = MagicMock()
             mock_device_cls.objects.restrict.return_value.get.return_value = existing_device
+            collapse_queryset_chain(mock_device_cls)
             mock_device_cls.objects.select_for_update.return_value.get.return_value = existing_device
             mock_device_cls.objects.filter.return_value.exclude.return_value.first.return_value = None
             mock_device_cls.objects.filter.return_value.first.return_value = None
@@ -3017,6 +3035,7 @@ class TestDeviceConflictActionView:
         ):
             mock_tx.atomic.return_value = MagicMock()
             mock_device_cls.objects.restrict.return_value.get.return_value = existing_device
+            collapse_queryset_chain(mock_device_cls)
             mock_device_cls.objects.select_for_update.return_value.get.return_value = existing_device
             mock_device_cls.objects.filter.return_value.exclude.return_value.first.return_value = None
             mock_device_cls.objects.filter.return_value.exclude.return_value.exists.return_value = False
@@ -3058,6 +3077,7 @@ class TestDeviceConflictActionView:
             patch("dcim.models.Device") as mock_device_cls,
         ):
             mock_device_cls.objects.restrict.return_value.get.return_value = existing_device
+            collapse_queryset_chain(mock_device_cls)
             mock_device_cls.objects.select_for_update.return_value.get.return_value = existing_device
             mock_device_cls.objects.filter.return_value.exclude.return_value.first.return_value = None
             # Include existing_device so the validated-conflict-target guard passes;
@@ -3099,6 +3119,7 @@ class TestDeviceConflictActionView:
             patch("dcim.models.Device") as mock_device_cls,
         ):
             mock_device_cls.objects.restrict.return_value.get.return_value = existing_device
+            collapse_queryset_chain(mock_device_cls)
             mock_device_cls.objects.select_for_update.return_value.get.return_value = existing_device
             mock_device_cls.objects.filter.return_value.exclude.return_value.first.return_value = None
             mock_validate.return_value = (libre_device, validation, selections)
@@ -3133,6 +3154,7 @@ class TestDeviceConflictActionView:
             patch("dcim.models.Device") as mock_device_cls,
         ):
             mock_device_cls.objects.restrict.return_value.get.return_value = existing_device
+            collapse_queryset_chain(mock_device_cls)
             mock_device_cls.objects.select_for_update.return_value.get.return_value = existing_device
             mock_device_cls.objects.filter.return_value.exclude.return_value.first.return_value = None
             mock_validate.return_value = (libre_device, validation, selections)
@@ -3176,6 +3198,7 @@ class TestDeviceConflictActionView:
         ):
             mock_tx.atomic.return_value = MagicMock()
             mock_device_cls.objects.restrict.return_value.get.return_value = existing_device
+            collapse_queryset_chain(mock_device_cls)
             mock_device_cls.objects.select_for_update.return_value.get.return_value = existing_device
             mock_device_cls.objects.filter.return_value.exclude.return_value.first.return_value = None
             mock_device_cls.objects.filter.return_value.first.return_value = None
@@ -3231,6 +3254,7 @@ class TestDeviceConflictActionView:
         ):
             mock_tx.atomic.return_value = MagicMock()
             mock_device_cls.objects.restrict.return_value.get.return_value = existing_device
+            collapse_queryset_chain(mock_device_cls)
             mock_device_cls.objects.select_for_update.return_value.get.return_value = existing_device
             mock_device_cls.objects.filter.return_value.exclude.return_value.first.return_value = None
             mock_device_cls.objects.filter.return_value.first.return_value = None
@@ -3286,6 +3310,7 @@ class TestDeviceConflictActionView:
             patch("dcim.models.Device") as mock_device_cls,
         ):
             mock_device_cls.objects.restrict.return_value.get.return_value = existing_device
+            collapse_queryset_chain(mock_device_cls)
             mock_device_cls.objects.select_for_update.return_value.get.return_value = existing_device
             mock_device_cls.objects.filter.return_value.exclude.return_value.first.return_value = None
             mock_validate.return_value = (libre_device, validation, selections)
@@ -3321,6 +3346,7 @@ class TestDeviceConflictActionView:
         ):
             mock_tx.atomic.return_value = MagicMock()
             mock_device_cls.objects.restrict.return_value.get.return_value = existing_device
+            collapse_queryset_chain(mock_device_cls)
             mock_device_cls.objects.select_for_update.return_value.get.return_value = existing_device
             mock_device_cls.objects.filter.return_value.exclude.return_value.first.return_value = None
             mock_device_cls.objects.filter.return_value.first.return_value = None
@@ -3361,6 +3387,7 @@ class TestDeviceConflictActionView:
             patch("netbox_librenms_plugin.utils.find_matching_platform") as mock_find_platform,
         ):
             mock_device_cls.objects.restrict.return_value.get.return_value = existing_device
+            collapse_queryset_chain(mock_device_cls)
             mock_device_cls.objects.select_for_update.return_value.get.return_value = existing_device
             mock_device_cls.objects.filter.return_value.exclude.return_value.first.return_value = None
             mock_find_platform.return_value = {"found": True, "platform": mock_platform, "match_type": "exact"}
@@ -3397,6 +3424,7 @@ class TestDeviceConflictActionView:
             patch("netbox_librenms_plugin.utils.match_librenms_hardware_to_device_type") as mock_hw_match,
         ):
             mock_device_cls.objects.restrict.return_value.get.return_value = existing_device
+            collapse_queryset_chain(mock_device_cls)
             mock_device_cls.objects.select_for_update.return_value.get.return_value = existing_device
             mock_device_cls.objects.filter.return_value.exclude.return_value.first.return_value = None
             mock_hw_match.return_value = {"matched": True, "device_type": new_device_type}
@@ -5989,6 +6017,7 @@ class TestVirtualChassisEdgeBranches:
             ),
         ):
             mock_device_cls.objects.filter.side_effect = _filter_exists
+            collapse_queryset_chain(mock_device_cls)
             mock_vc_cls.objects.create.return_value = mock_vc
 
             members_info = [{"serial": "DUP-SERIAL", "position": 2, "name": "sw1-2"}]
@@ -6044,6 +6073,7 @@ class TestVirtualChassisEdgeBranches:
             ),
         ):
             mock_device_cls.objects.filter.side_effect = _filter_side_effect
+            collapse_queryset_chain(mock_device_cls)
             mock_vc_cls.objects.create.return_value = mock_vc
 
             members_info = [{"serial": "NEW-SERIAL", "position": 2, "name": "sw1-2"}]
@@ -6098,6 +6128,7 @@ class TestVirtualChassisEdgeBranches:
             patch("netbox_librenms_plugin.import_utils.virtual_chassis.logger") as mock_logger,
         ):
             mock_device_cls.objects.filter.side_effect = _filter_side_effect
+            collapse_queryset_chain(mock_device_cls)
             mock_vc_cls.objects.create.return_value = mock_vc
 
             # 2 members expected, both skipped → warning
@@ -6164,6 +6195,7 @@ class TestVirtualChassisEdgeBranches:
             ),
         ):
             mock_device_cls.objects.filter.side_effect = _filter_side_effect
+            collapse_queryset_chain(mock_device_cls)
             mock_vc_cls.objects.create.return_value = mock_vc
 
             # position=0 → discovered_pos normalized to None; serial present but name conflicts
@@ -6227,6 +6259,7 @@ class TestVirtualChassisEdgeBranches:
             ),
         ):
             mock_device_cls.objects.filter.side_effect = _filter_side_effect
+            collapse_queryset_chain(mock_device_cls)
             mock_device_cls.objects.create.side_effect = _capture_create
             mock_vc_cls.objects.create.return_value = mock_vc
 

--- a/netbox_librenms_plugin/tests/test_import_utils.py
+++ b/netbox_librenms_plugin/tests/test_import_utils.py
@@ -2790,7 +2790,7 @@ class TestDeviceConflictActionView:
             patch("netbox_librenms_plugin.views.imports.actions.transaction") as mock_tx,
         ):
             mock_tx.atomic.return_value = MagicMock()
-            mock_device_cls.objects.get.return_value = existing_device
+            mock_device_cls.objects.restrict.return_value.get.return_value = existing_device
             mock_device_cls.objects.select_for_update.return_value.get.return_value = existing_device
             mock_device_cls.objects.filter.return_value.exclude.return_value.first.return_value = None
             mock_device_cls.objects.filter.return_value.first.return_value = None
@@ -2837,7 +2837,7 @@ class TestDeviceConflictActionView:
             patch("netbox_librenms_plugin.views.imports.actions.transaction") as mock_tx,
         ):
             mock_tx.atomic.return_value = MagicMock()
-            mock_device_cls.objects.get.return_value = existing_device
+            mock_device_cls.objects.restrict.return_value.get.return_value = existing_device
             mock_device_cls.objects.select_for_update.return_value.get.return_value = existing_device
             mock_device_cls.objects.filter.return_value.first.return_value = None
             mock_device_cls.objects.filter.return_value.exclude.return_value.first.return_value = None
@@ -2881,7 +2881,7 @@ class TestDeviceConflictActionView:
             patch("netbox_librenms_plugin.views.imports.actions.transaction") as mock_tx,
         ):
             mock_tx.atomic.return_value = MagicMock()
-            mock_device_cls.objects.get.return_value = existing_device
+            mock_device_cls.objects.restrict.return_value.get.return_value = existing_device
             mock_device_cls.objects.select_for_update.return_value.get.return_value = existing_device
             mock_device_cls.objects.filter.return_value.exclude.return_value.first.return_value = None
             mock_device_cls.objects.filter.return_value.first.return_value = None
@@ -2932,7 +2932,7 @@ class TestDeviceConflictActionView:
             patch("netbox_librenms_plugin.views.imports.actions.transaction") as mock_tx,
         ):
             mock_tx.atomic.return_value = MagicMock()
-            mock_device_cls.objects.get.return_value = existing_device
+            mock_device_cls.objects.restrict.return_value.get.return_value = existing_device
             mock_device_cls.objects.select_for_update.return_value.get.return_value = existing_device
             mock_device_cls.objects.filter.return_value.exclude.return_value.first.return_value = None
             mock_device_cls.objects.filter.return_value.first.return_value = None
@@ -2972,7 +2972,7 @@ class TestDeviceConflictActionView:
             patch("netbox_librenms_plugin.views.imports.actions.transaction") as mock_tx,
         ):
             mock_tx.atomic.return_value = MagicMock()
-            mock_device_cls.objects.get.return_value = existing_device
+            mock_device_cls.objects.restrict.return_value.get.return_value = existing_device
             mock_device_cls.objects.select_for_update.return_value.get.return_value = existing_device
             mock_device_cls.objects.filter.return_value.exclude.return_value.first.return_value = None
             mock_device_cls.objects.filter.return_value.first.return_value = None
@@ -3016,7 +3016,7 @@ class TestDeviceConflictActionView:
             patch("netbox_librenms_plugin.views.imports.actions.transaction") as mock_tx,
         ):
             mock_tx.atomic.return_value = MagicMock()
-            mock_device_cls.objects.get.return_value = existing_device
+            mock_device_cls.objects.restrict.return_value.get.return_value = existing_device
             mock_device_cls.objects.select_for_update.return_value.get.return_value = existing_device
             mock_device_cls.objects.filter.return_value.exclude.return_value.first.return_value = None
             mock_device_cls.objects.filter.return_value.exclude.return_value.exists.return_value = False
@@ -3057,7 +3057,7 @@ class TestDeviceConflictActionView:
             patch.object(DeviceConflictActionView, "require_object_permissions", return_value=None),
             patch("dcim.models.Device") as mock_device_cls,
         ):
-            mock_device_cls.objects.get.return_value = existing_device
+            mock_device_cls.objects.restrict.return_value.get.return_value = existing_device
             mock_device_cls.objects.select_for_update.return_value.get.return_value = existing_device
             mock_device_cls.objects.filter.return_value.exclude.return_value.first.return_value = None
             # Include existing_device so the validated-conflict-target guard passes;
@@ -3098,7 +3098,7 @@ class TestDeviceConflictActionView:
             patch.object(DeviceConflictActionView, "render_device_row") as mock_render,
             patch("dcim.models.Device") as mock_device_cls,
         ):
-            mock_device_cls.objects.get.return_value = existing_device
+            mock_device_cls.objects.restrict.return_value.get.return_value = existing_device
             mock_device_cls.objects.select_for_update.return_value.get.return_value = existing_device
             mock_device_cls.objects.filter.return_value.exclude.return_value.first.return_value = None
             mock_validate.return_value = (libre_device, validation, selections)
@@ -3132,7 +3132,7 @@ class TestDeviceConflictActionView:
             patch.object(DeviceConflictActionView, "get_validated_device_with_selections") as mock_validate,
             patch("dcim.models.Device") as mock_device_cls,
         ):
-            mock_device_cls.objects.get.return_value = existing_device
+            mock_device_cls.objects.restrict.return_value.get.return_value = existing_device
             mock_device_cls.objects.select_for_update.return_value.get.return_value = existing_device
             mock_device_cls.objects.filter.return_value.exclude.return_value.first.return_value = None
             mock_validate.return_value = (libre_device, validation, selections)
@@ -3175,7 +3175,7 @@ class TestDeviceConflictActionView:
             patch("netbox_librenms_plugin.views.imports.actions.transaction") as mock_tx,
         ):
             mock_tx.atomic.return_value = MagicMock()
-            mock_device_cls.objects.get.return_value = existing_device
+            mock_device_cls.objects.restrict.return_value.get.return_value = existing_device
             mock_device_cls.objects.select_for_update.return_value.get.return_value = existing_device
             mock_device_cls.objects.filter.return_value.exclude.return_value.first.return_value = None
             mock_device_cls.objects.filter.return_value.first.return_value = None
@@ -3230,7 +3230,7 @@ class TestDeviceConflictActionView:
             patch("netbox_librenms_plugin.views.imports.actions.transaction") as mock_tx,
         ):
             mock_tx.atomic.return_value = MagicMock()
-            mock_device_cls.objects.get.return_value = existing_device
+            mock_device_cls.objects.restrict.return_value.get.return_value = existing_device
             mock_device_cls.objects.select_for_update.return_value.get.return_value = existing_device
             mock_device_cls.objects.filter.return_value.exclude.return_value.first.return_value = None
             mock_device_cls.objects.filter.return_value.first.return_value = None
@@ -3285,7 +3285,7 @@ class TestDeviceConflictActionView:
             patch.object(DeviceConflictActionView, "render_device_row") as mock_render,
             patch("dcim.models.Device") as mock_device_cls,
         ):
-            mock_device_cls.objects.get.return_value = existing_device
+            mock_device_cls.objects.restrict.return_value.get.return_value = existing_device
             mock_device_cls.objects.select_for_update.return_value.get.return_value = existing_device
             mock_device_cls.objects.filter.return_value.exclude.return_value.first.return_value = None
             mock_validate.return_value = (libre_device, validation, selections)
@@ -3320,7 +3320,7 @@ class TestDeviceConflictActionView:
             patch("netbox_librenms_plugin.views.imports.actions.transaction") as mock_tx,
         ):
             mock_tx.atomic.return_value = MagicMock()
-            mock_device_cls.objects.get.return_value = existing_device
+            mock_device_cls.objects.restrict.return_value.get.return_value = existing_device
             mock_device_cls.objects.select_for_update.return_value.get.return_value = existing_device
             mock_device_cls.objects.filter.return_value.exclude.return_value.first.return_value = None
             mock_device_cls.objects.filter.return_value.first.return_value = None
@@ -3360,7 +3360,7 @@ class TestDeviceConflictActionView:
             # it from netbox_librenms_plugin.utils, so that is the correct seam to mock.
             patch("netbox_librenms_plugin.utils.find_matching_platform") as mock_find_platform,
         ):
-            mock_device_cls.objects.get.return_value = existing_device
+            mock_device_cls.objects.restrict.return_value.get.return_value = existing_device
             mock_device_cls.objects.select_for_update.return_value.get.return_value = existing_device
             mock_device_cls.objects.filter.return_value.exclude.return_value.first.return_value = None
             mock_find_platform.return_value = {"found": True, "platform": mock_platform, "match_type": "exact"}
@@ -3396,7 +3396,7 @@ class TestDeviceConflictActionView:
             patch("dcim.models.Device") as mock_device_cls,
             patch("netbox_librenms_plugin.utils.match_librenms_hardware_to_device_type") as mock_hw_match,
         ):
-            mock_device_cls.objects.get.return_value = existing_device
+            mock_device_cls.objects.restrict.return_value.get.return_value = existing_device
             mock_device_cls.objects.select_for_update.return_value.get.return_value = existing_device
             mock_device_cls.objects.filter.return_value.exclude.return_value.first.return_value = None
             mock_hw_match.return_value = {"matched": True, "device_type": new_device_type}

--- a/netbox_librenms_plugin/tests/test_librenms_api.py
+++ b/netbox_librenms_plugin/tests/test_librenms_api.py
@@ -1352,6 +1352,27 @@ class TestLibreNMSAPIPortsAndInventory:
         assert success is True
         assert len(ips) == 0
 
+    @patch("netbox_librenms_plugin.librenms_api.requests.get")
+    def test_get_device_ips_404_is_empty_not_failure(self, mock_get, mock_librenms_config):
+        """LibreNMS 404s /devices/{id}/ip for a device with no IPs — a successful empty result, not a fetch failure."""
+        import requests
+
+        response = mock_get.return_value
+        response.status_code = 404
+        error = requests.exceptions.HTTPError("404 Client Error: Not Found")
+        error.response = response
+        response.raise_for_status.side_effect = error
+
+        from netbox_librenms_plugin.librenms_api import LibreNMSAPI
+
+        api = LibreNMSAPI(server_key="default")
+        success, ips = api.get_device_ips(device_id=123)
+
+        # A device with no IPs must surface as an empty success so the IP tab shows an empty
+        # table, not a red "Failed to fetch IP addresses" error (mirrors get_device_links).
+        assert success is True
+        assert ips == []
+
 
 # =============================================================================
 # Test Class 8: Poller and Devices (4 tests)

--- a/netbox_librenms_plugin/tests/test_modules_view.py
+++ b/netbox_librenms_plugin/tests/test_modules_view.py
@@ -128,6 +128,22 @@ class TestMergeTransceiverDataPortIdentity:
         assert item["_librenms_port_id"] == 99
         assert item["_librenms_ifname"] == "Eth2/1"
 
+    def test_numeric_transceiver_serial_is_coerced_to_a_string(self):
+        """An all-digit transceiver serial can arrive as an int; the merge must coerce it before stripping instead of raising."""
+        view = _make_view()
+        view.librenms_id = 104
+        view._librenms_api.get_device_transceivers.return_value = (
+            True,
+            [{"entity_physical_index": 400, "model": "SFP-10G-SR", "serial": 987654, "type": "SFP", "port_id": 8}],
+        )
+        view._librenms_api.get_ports.return_value = (True, {"ports": [{"port_id": 8, "ifName": "Eth4/1"}]})
+
+        inventory, error = view._merge_transceiver_data([])
+
+        assert error is None
+        assert len(inventory) == 1
+        assert inventory[0]["entPhysicalSerialNum"] == "987654"
+
     def test_string_index_matches_int_transceiver_index_no_duplicate(self):
         # LibreNMS may report the ENTITY index as a string ("300") while the transceiver API
         # returns it as an int (300). Without normalization the merge misses the existing ENTITY

--- a/netbox_librenms_plugin/tests/test_modules_view.py
+++ b/netbox_librenms_plugin/tests/test_modules_view.py
@@ -160,6 +160,51 @@ class TestMergeTransceiverDataPortIdentity:
         assert len(inventory) == 1
         assert inventory[0]["entPhysicalSerialNum"] == "0"
 
+    def test_numeric_transceiver_model_and_type_are_coerced_to_strings(self):
+        """An all-digit model/type arrives as a JSON number too; stripping it raw would 500 the modules refresh."""
+        view = _make_view()
+        view.librenms_id = 105
+        view._librenms_api.get_device_transceivers.return_value = (
+            True,
+            [{"entity_physical_index": 402, "model": 1000, "serial": "TX-402", "type": 40, "port_id": 10}],
+        )
+        view._librenms_api.get_ports.return_value = (True, {"ports": [{"port_id": 10, "ifName": "Eth6/1"}]})
+
+        inventory, error = view._merge_transceiver_data([])
+
+        assert error is None
+        assert len(inventory) == 1
+        assert inventory[0]["entPhysicalModelName"] == "1000"
+        assert inventory[0]["entPhysicalDescr"] == "40"
+
+    def test_numeric_entity_values_on_the_existing_item_are_coerced(self):
+        """The ENTITY-MIB side of the merge can carry numeric model/serial values as well."""
+        view = _make_view()
+        view.librenms_id = 106
+        view._librenms_api.get_device_transceivers.return_value = (
+            True,
+            [{"entity_physical_index": 403, "model": "SFP-10G-SR", "serial": "TX-403", "type": "SFP", "port_id": 11}],
+        )
+        view._librenms_api.get_ports.return_value = (True, {"ports": [{"port_id": 11, "ifName": "Eth7/1"}]})
+        inventory_seed = [
+            {
+                "entPhysicalIndex": 403,
+                "entPhysicalName": "Transceiver slot",
+                "entPhysicalModelName": 1000,  # all-digit model from ENTITY-MIB, delivered as a number
+                "entPhysicalSerialNum": 4242,
+                "entPhysicalClass": "port",
+                "entPhysicalContainedIn": 0,
+            }
+        ]
+
+        inventory, error = view._merge_transceiver_data(inventory_seed)
+
+        assert error is None
+        assert len(inventory) == 1
+        # Both existing values are real (not placeholders), so the transceiver data must not overwrite them.
+        assert inventory[0]["entPhysicalModelName"] == 1000
+        assert inventory[0]["entPhysicalSerialNum"] == 4242
+
     def test_string_index_matches_int_transceiver_index_no_duplicate(self):
         # LibreNMS may report the ENTITY index as a string ("300") while the transceiver API
         # returns it as an int (300). Without normalization the merge misses the existing ENTITY
@@ -5046,3 +5091,45 @@ class TestInterfacePortIdActiveServerScope:
         api = self._real_default_api()
         assert api.get_stored_librenms_id(iface) == 111  # bound (default) key
         assert api.get_stored_librenms_id(iface, server_key="server2") == 222  # explicit override
+
+
+@pytest.mark.django_db
+class TestInferVcMemberSerialNormalization:
+    """VC-member inference keys on serials that LibreNMS may deliver as JSON numbers (real Devices, real VirtualChassis)."""
+
+    def _vc_members(self, serials):
+        from dcim.models import VirtualChassis
+
+        from netbox_librenms_plugin.tests.conftest import make_device
+
+        vc = VirtualChassis.objects.create(name=f"vc-infer-{'-'.join(serials)}")
+        members = []
+        for pos, serial in enumerate(serials, start=1):
+            dev = make_device(f"vc-infer-member-{serial}", serial=serial)
+            dev.virtual_chassis = vc
+            dev.vc_position = pos
+            dev.save()
+            members.append(dev)
+        return members
+
+    def test_numeric_item_serial_matches_the_member_stored_as_text(self):
+        """An all-digit ENTITY serial arriving as an int must still resolve to its VC member instead of raising."""
+        view = _make_view()
+        master, member2 = self._vc_members(["100001", "100002"])
+
+        item = {"entPhysicalIndex": 1, "entPhysicalSerialNum": 100002, "entPhysicalContainedIn": 0}
+        target, source = view._infer_vc_member_for_item(master, item, {}, [master, member2])
+
+        assert target.pk == member2.pk
+        assert source == "serial"
+
+    def test_zero_item_serial_is_not_dropped_as_falsey(self):
+        """A serial of JSON number 0 is real; dropping it silently attributes the item to the wrong VC member."""
+        view = _make_view()
+        master, member2 = self._vc_members(["0", "100003"])
+
+        item = {"entPhysicalIndex": 2, "entPhysicalSerialNum": 0, "entPhysicalContainedIn": 0}
+        target, source = view._infer_vc_member_for_item(member2, item, {}, [master, member2])
+
+        assert target.pk == master.pk
+        assert source == "serial"

--- a/netbox_librenms_plugin/tests/test_modules_view.py
+++ b/netbox_librenms_plugin/tests/test_modules_view.py
@@ -144,6 +144,22 @@ class TestMergeTransceiverDataPortIdentity:
         assert len(inventory) == 1
         assert inventory[0]["entPhysicalSerialNum"] == "987654"
 
+    def test_zero_transceiver_serial_is_preserved(self):
+        """A transceiver serial of JSON number 0 is a real serial and must survive as "0", not be dropped as falsey."""
+        view = _make_view()
+        view.librenms_id = 104
+        view._librenms_api.get_device_transceivers.return_value = (
+            True,
+            [{"entity_physical_index": 401, "model": "SFP-10G-SR", "serial": 0, "type": "SFP", "port_id": 9}],
+        )
+        view._librenms_api.get_ports.return_value = (True, {"ports": [{"port_id": 9, "ifName": "Eth5/1"}]})
+
+        inventory, error = view._merge_transceiver_data([])
+
+        assert error is None
+        assert len(inventory) == 1
+        assert inventory[0]["entPhysicalSerialNum"] == "0"
+
     def test_string_index_matches_int_transceiver_index_no_duplicate(self):
         # LibreNMS may report the ENTITY index as a string ("300") while the transceiver API
         # returns it as an int (300). Without normalization the merge misses the existing ENTITY

--- a/netbox_librenms_plugin/tests/test_utils.py
+++ b/netbox_librenms_plugin/tests/test_utils.py
@@ -1576,6 +1576,52 @@ class TestSetDeviceIpFkFamily:
         device.refresh_from_db()
         assert device.oob_ip_id == v6.pk
 
+    def test_families_accepted_with_netbox44_family_property(self):
+        """The guard must not read IPAddress.family: on NetBox 4.4 the property raises on an in-memory str address and getattr's default turns that into a bogus refusal (forced)."""
+        from unittest.mock import patch
+
+        from ipam.models import IPAddress
+
+        from netbox_librenms_plugin.tests.conftest import ip_on, make_device
+        from netbox_librenms_plugin.utils import set_device_ip_fk
+
+        device = make_device("fam-nb44dev")
+        v4 = ip_on(device, "10.0.0.4/24", "eth0")
+        v4.address = "10.0.0.4/24"  # in-memory str, as after IPAddress.objects.create()
+        # NetBox 4.4's family property verbatim — 4.5+ added a str-tolerant branch.
+        netbox44_family = property(lambda self: self.address.version if self.address else None)
+        with patch.object(IPAddress, "family", netbox44_family):
+            set_device_ip_fk(device, "primary_ip4", v4)
+        device.refresh_from_db()
+        assert device.primary_ip4_id == v4.pk
+
+
+class TestIpFamily:
+    """ip_family(): family read that works on NetBox 4.4, whose IPAddress.family lacks the 4.5+ str-address branch."""
+
+    def test_str_address(self):
+        from ipam.models import IPAddress
+
+        from netbox_librenms_plugin.utils import ip_family
+
+        assert ip_family(IPAddress(address="10.0.0.1/24")) == 4
+        assert ip_family(IPAddress(address="2001:db8::1/64")) == 6
+
+    def test_ipnetwork_address(self):
+        import netaddr
+        from ipam.models import IPAddress
+
+        from netbox_librenms_plugin.utils import ip_family
+
+        assert ip_family(IPAddress(address=netaddr.IPNetwork("10.0.0.1/24"))) == 4
+
+    def test_empty_address_is_none(self):
+        from ipam.models import IPAddress
+
+        from netbox_librenms_plugin.utils import ip_family
+
+        assert ip_family(IPAddress()) is None
+
 
 @pytest.mark.django_db
 class TestGetVirtualChassisMemberNoneName:

--- a/netbox_librenms_plugin/tests/test_utils.py
+++ b/netbox_librenms_plugin/tests/test_utils.py
@@ -1491,6 +1491,26 @@ class TestNormalizeDeviceSerialsMigration:
         assert index["index"] is True
         assert index["columns"] == ["serial"]
 
+    def test_preexisting_valid_serial_index_is_reused(self):
+        """Retrying 0012 accepts an already-valid index without rebuilding it."""
+        import importlib
+
+        from django.apps import apps
+        from django.db import connection
+
+        module = importlib.import_module("netbox_librenms_plugin.migrations.0012_normalize_device_serials")
+
+        with connection.cursor() as cursor:
+            cursor.execute("SELECT to_regclass(%s)::oid", ["nblp_dcim_device_serial_idx"])
+            original_oid = cursor.fetchone()[0]
+
+        with connection.schema_editor(atomic=False) as schema_editor:
+            module.ensure_device_serial_index(apps, schema_editor)
+
+        with connection.cursor() as cursor:
+            cursor.execute("SELECT to_regclass(%s)::oid", ["nblp_dcim_device_serial_idx"])
+            assert cursor.fetchone()[0] == original_oid
+
 
 class TestCacheRemainingTtl:
     """cache_remaining_ttl reads .ttl on django-redis and degrades to None on backends without it."""

--- a/netbox_librenms_plugin/tests/test_utils.py
+++ b/netbox_librenms_plugin/tests/test_utils.py
@@ -1575,3 +1575,25 @@ class TestSetDeviceIpFkFamily:
         set_device_ip_fk(device, "oob_ip", v6)
         device.refresh_from_db()
         assert device.oob_ip_id == v6.pk
+
+
+@pytest.mark.django_db
+class TestGetVirtualChassisMemberNoneName:
+    """A LibreNMS port row can lack the selected name field entirely (port.get(...) -> None)."""
+
+    def test_none_port_name_returns_device_instead_of_typeerror(self):
+        """A None port name falls back to the viewed device instead of raising TypeError (was a 500)."""
+        from dcim.models import Device, DeviceRole, DeviceType, Manufacturer, Site, VirtualChassis
+
+        from netbox_librenms_plugin.utils import get_virtual_chassis_member
+
+        site = Site.objects.create(name="vc-none-site", slug="vc-none-site")
+        mfr = Manufacturer.objects.create(name="vc-none-mfr", slug="vc-none-mfr")
+        dtype = DeviceType.objects.create(manufacturer=mfr, model="vc-none-dt", slug="vc-none-dt")
+        role = DeviceRole.objects.create(name="vc-none-role", slug="vc-none-role")
+        dev = Device.objects.create(name="vc-none-dev", site=site, device_type=dtype, role=role)
+        vc = VirtualChassis.objects.create(name="vc-none", master=dev)
+        Device.objects.filter(pk=dev.pk).update(virtual_chassis=vc, vc_position=1)
+        dev.refresh_from_db()
+
+        assert get_virtual_chassis_member(dev, None) is dev

--- a/netbox_librenms_plugin/tests/test_utils.py
+++ b/netbox_librenms_plugin/tests/test_utils.py
@@ -1446,6 +1446,52 @@ class TestRenormalizeDeviceTypeMappingsMigration:
         assert not DeviceTypeMapping.objects.filter(librenms_hardware="beta").exists()
 
 
+# =============================================================================
+# Device serial canonicalization data migration (0012)
+# =============================================================================
+@pytest.mark.django_db
+class TestNormalizeDeviceSerialsMigration:
+    """The 0012 migration canonicalizes legacy Device serials and indexes exact lookups."""
+
+    @staticmethod
+    def _run_migration():
+        import importlib
+        from types import SimpleNamespace
+
+        from django.apps import apps
+        from django.db import connection
+
+        module = importlib.import_module("netbox_librenms_plugin.migrations.0012_normalize_device_serials")
+        module.normalize_device_serials(apps, SimpleNamespace(connection=connection))
+
+    def test_all_surrounding_whitespace_is_trimmed_and_blank_serials_are_canonicalized(self):
+        """Python strip semantics remove tabs/newlines/Unicode whitespace, including whitespace-only values."""
+        from dcim.models import Device
+
+        from netbox_librenms_plugin.tests.conftest import make_device
+
+        padded = make_device("serial-migration-padded", serial="\t SN-MIG-1 \n")
+        blank = make_device("serial-migration-blank", serial="\u2003\t\n")
+        unchanged = make_device("serial-migration-clean", serial="SN-MIG-2")
+
+        self._run_migration()
+
+        assert Device.objects.get(pk=padded.pk).serial == "SN-MIG-1"
+        assert Device.objects.get(pk=blank.pk).serial == ""
+        assert Device.objects.get(pk=unchanged.pk).serial == "SN-MIG-2"
+
+    def test_plain_serial_index_exists(self):
+        """The migration adds the ordinary B-tree index used by exact serial equality lookups."""
+        from django.db import connection
+
+        with connection.cursor() as cursor:
+            constraints = connection.introspection.get_constraints(cursor, "dcim_device")
+
+        index = constraints["nblp_dcim_device_serial_idx"]
+        assert index["index"] is True
+        assert index["columns"] == ["serial"]
+
+
 class TestCacheRemainingTtl:
     """cache_remaining_ttl reads .ttl on django-redis and degrades to None on backends without it."""
 

--- a/netbox_librenms_plugin/tests/test_verify_views.py
+++ b/netbox_librenms_plugin/tests/test_verify_views.py
@@ -845,3 +845,44 @@ class TestSaveVlanGroupOverridesObjectScope:
             assert isinstance(response, JsonResponse)
         finally:
             real_cache.delete(view.get_vlan_overrides_key(in_scope, self.SERVER_KEY))
+
+
+# ---------------------------------------------------------------------------
+# SingleModuleVerifyView — object-permission ordering (device enumeration guard)
+# ---------------------------------------------------------------------------
+@pytest.mark.django_db
+class TestSingleModuleVerifyPermissionOrder:
+    """SingleModuleVerifyView.post() must reject a caller lacking dcim.view_device before resolving the device (no 404-vs-403 enumeration)."""
+
+    def _view_for(self, user):
+        from django.test import RequestFactory
+
+        from netbox_librenms_plugin.views.object_sync.devices import SingleModuleVerifyView
+
+        request = RequestFactory().post(
+            "/verify-module/",
+            data=json.dumps({"device_id": 999_999_999, "ent_physical_index": 1, "server_key": "default"}),
+            content_type="application/json",
+        )
+        request.user = user
+        view = SingleModuleVerifyView()
+        view.request = request
+        return view, request
+
+    def test_missing_view_device_perm_returns_403_not_404_for_absent_device(self):
+        """A real user without dcim.view_device POSTing a non-existent device_id gets 403, not 404 (real ObjectPermissionBackend decides has_perm)."""
+        from django.contrib.auth import get_user_model
+        from django.http import Http404
+
+        user = get_user_model().objects.create_user("no-view-device")  # non-superuser, no object perms
+        view, request = self._view_for(user)
+
+        try:
+            response = view.post(request)
+        except Http404:
+            pytest.fail(
+                "get_object_or_404(Device) ran before the permission check: a caller without "
+                "dcim.view_device can enumerate devices by observing 404-vs-403."
+            )
+        assert response.status_code == 403
+        assert "view_device" in json.loads(response.content)["error"]

--- a/netbox_librenms_plugin/utils.py
+++ b/netbox_librenms_plugin/utils.py
@@ -1150,6 +1150,24 @@ def check_vlan_group_matches(
     return True
 
 
+def filter_by_trimmed_serial(queryset, serial):
+    """
+    Filter *queryset* to rows whose ``serial`` equals *serial* after DB-side trimming.
+
+    Rows imported before serial normalization landed may store space-padded
+    serials (the old import persisted the raw LibreNMS value), so an exact
+    ``filter(serial=<trimmed>)`` would miss them and let a re-import mint a
+    duplicate or a conflict guard pass. TRIM() covers that legacy padding.
+
+    Args:
+        queryset: The Device (or serial-bearing) queryset to filter.
+        serial: The already-trimmed serial to match.
+    """
+    from django.db.models.functions import Trim
+
+    return queryset.annotate(_serial_trimmed=Trim("serial")).filter(_serial_trimmed=serial)
+
+
 def normalize_serial(value) -> str:
     """
     Return the trimmed str form of a LibreNMS serial; only None means missing.

--- a/netbox_librenms_plugin/utils.py
+++ b/netbox_librenms_plugin/utils.py
@@ -162,6 +162,13 @@ def get_virtual_chassis_member(device: Device, port_name: str) -> Device:
     if not hasattr(device, "virtual_chassis") or not device.virtual_chassis:
         return device
 
+    # A port row can lack the selected name field entirely (port.get(...) -> None) — or carry a
+    # non-string value from a malformed payload. re.match() raises TypeError on those, which the
+    # except tuple below deliberately doesn't cover (it must not mask real bugs), so guard here
+    # and fall back to the viewed device like any other unmatchable name.
+    if not isinstance(port_name, str):
+        return device
+
     try:
         match = re.match(r"^[A-Za-z]+(\d+)", port_name)
         if not match:

--- a/netbox_librenms_plugin/utils.py
+++ b/netbox_librenms_plugin/utils.py
@@ -3,6 +3,7 @@ import re
 import threading
 from typing import Optional
 
+import netaddr
 from dcim.models import Device
 from django.core.exceptions import ObjectDoesNotExist, ValidationError
 from django.db.models import Count, Max, Q
@@ -1843,6 +1844,26 @@ def netbox_resolves_module_token_per_leaf():
     return version >= _MODULE_TOKEN_LEAF_FIX_VERSION
 
 
+def ip_family(ip):
+    """
+    Return the IP family (4 or 6) of an IPAddress, or None when it has no address.
+
+    Mirrors NetBox >= 4.5's ``IPAddress.family``. NetBox 4.4's property lacks the
+    str-tolerant branch, and a freshly constructed ``IPAddress(address="...")``
+    keeps the plain str in memory even after ``save()`` — so reading ``.family``
+    on 4.4 raises AttributeError for exactly the objects the sync flows create.
+
+    Args:
+        ip: The IPAddress whose family to read.
+    """
+    address = ip.address
+    if not address:
+        return None
+    if isinstance(address, str):
+        return netaddr.IPNetwork(address).version
+    return address.version
+
+
 # The device-level IP foreign keys this plugin re-homes during OOB linking, merges, and the
 # Stage-2b "move to winner" actions. NetBox requires each to reference an address assigned to
 # one of THAT device's own interfaces.
@@ -1898,10 +1919,12 @@ def set_device_ip_fk(device, field, ip, *, save=True):
         # NetBox's Device.clean() requires primary_ip4 to be IPv4 and primary_ip6 to be IPv6;
         # update_fields skips full_clean(), so enforce the family here too (oob_ip is family-
         # agnostic). Otherwise an IPv6 address could be silently stored as primary_ip4.
-        ip_family = getattr(ip, "family", None)
-        if field == "primary_ip4" and ip_family != 4:
+        # ip_family(), not ip.family: NetBox 4.4's property raises on in-memory str addresses,
+        # and getattr's default would turn that crash into a bogus refusal of a valid address.
+        family = ip_family(ip)
+        if field == "primary_ip4" and family != 4:
             raise ValueError(f"set_device_ip_fk: refusing to set primary_ip4 to non-IPv4 address {ip}")
-        if field == "primary_ip6" and ip_family != 6:
+        if field == "primary_ip6" and family != 6:
             raise ValueError(f"set_device_ip_fk: refusing to set primary_ip6 to non-IPv6 address {ip}")
     setattr(device, field, ip)
     if save:

--- a/netbox_librenms_plugin/utils.py
+++ b/netbox_librenms_plugin/utils.py
@@ -1150,6 +1150,21 @@ def check_vlan_group_matches(
     return True
 
 
+def normalize_serial(value) -> str:
+    """
+    Return the trimmed str form of a LibreNMS serial; only None means missing.
+
+    LibreNMS returns all-digit serials as JSON numbers, so the value must be
+    coerced before stripping — and ``str(value or "")`` would silently drop the
+    real-but-falsey serial ``0``. Call sites keep their own ``"-"`` placeholder
+    guards.
+
+    Args:
+        value: The raw serial as returned by LibreNMS (str, number, or None).
+    """
+    return "" if value is None else str(value).strip()
+
+
 def coerce_librenms_id(value) -> int | None:
     """
     Coerce a raw LibreNMS ID value (int or string-digit) to int, or None.

--- a/netbox_librenms_plugin/utils.py
+++ b/netbox_librenms_plugin/utils.py
@@ -1150,24 +1150,6 @@ def check_vlan_group_matches(
     return True
 
 
-def filter_by_trimmed_serial(queryset, serial):
-    """
-    Filter *queryset* to rows whose ``serial`` equals *serial* after DB-side trimming.
-
-    Rows imported before serial normalization landed may store space-padded
-    serials (the old import persisted the raw LibreNMS value), so an exact
-    ``filter(serial=<trimmed>)`` would miss them and let a re-import mint a
-    duplicate or a conflict guard pass. TRIM() covers that legacy padding.
-
-    Args:
-        queryset: The Device (or serial-bearing) queryset to filter.
-        serial: The already-trimmed serial to match.
-    """
-    from django.db.models.functions import Trim
-
-    return queryset.annotate(_serial_trimmed=Trim("serial")).filter(_serial_trimmed=serial)
-
-
 def normalize_serial(value) -> str:
     """
     Return the trimmed str form of a LibreNMS serial; only None means missing.

--- a/netbox_librenms_plugin/views/base/cables_view.py
+++ b/netbox_librenms_plugin/views/base/cables_view.py
@@ -533,7 +533,11 @@ class BaseCableTableView(LibreNMSPermissionMixin, LibreNMSAPIMixin, CacheMixin, 
                 link["netbox_remote_interface_id"] = netbox_remote_interface.pk
                 link["remote_port_name"] = netbox_remote_interface.name
 
-            return link
+        # Return the link even when remote_port is empty (or unresolved): callers assign the
+        # result back (link = process_remote_device(...)) and then dereference it, so returning
+        # None here would crash enrich_links_data with an AttributeError and take down the whole
+        # Cables tab for LLDP/CDP neighbors that advertise a remote device but no remote port.
+        return link
 
     def check_cable_status(self, link):
         """Check cable status and add cable URL if cable exists in NetBox"""

--- a/netbox_librenms_plugin/views/base/modules_view.py
+++ b/netbox_librenms_plugin/views/base/modules_view.py
@@ -57,6 +57,23 @@ _SKIP_TRANSCEIVER_TYPES = {"Port Container", "Port", ""}
 _NON_HARDWARE_CLASSES = {"sensor", "backplane", "stack"}
 
 
+def _clean_librenms_value(value) -> str:
+    """
+    Return a LibreNMS model/serial/type value trimmed, with placeholders blanked.
+
+    Coerces through ``normalize_serial`` because all-digit values arrive as JSON
+    numbers, which a bare ``.strip()`` would crash on (and ``or ""`` would drop 0).
+
+    Args:
+        value: The raw value as returned by LibreNMS.
+
+    Returns:
+        The cleaned string, or "" for a missing/placeholder value.
+    """
+    text = normalize_serial(value)
+    return "" if text.lower() in _PLACEHOLDER_VALUES else text
+
+
 def _oob_item_offsettable(item: dict) -> bool:
     """
     Return True if an OOB inventory item's index fields can be offset arithmetically.
@@ -216,10 +233,7 @@ class BaseModuleTableView(LibreNMSPermissionMixin, LibreNMSAPIMixin, CacheMixin,
     @staticmethod
     def _normalize_serial(value):
         """Normalize serial values for reliable cross-source comparison."""
-        serial = (value or "").strip()
-        if serial.lower() in _PLACEHOLDER_VALUES:
-            return ""
-        return serial
+        return _clean_librenms_value(value)
 
     def _get_interface_port_id(self, interface):
         """
@@ -1306,11 +1320,7 @@ class BaseModuleTableView(LibreNMSPermissionMixin, LibreNMSAPIMixin, CacheMixin,
         inv_by_index = {
             idx: item for item in inventory_data if (idx := _coerce_idx(item.get("entPhysicalIndex"))) is not None
         }
-        inv_serials = {
-            s
-            for item in inventory_data
-            if (s := (item.get("entPhysicalSerialNum") or "").strip()) and s.lower() not in _PLACEHOLDER_VALUES
-        }
+        inv_serials = {s for item in inventory_data if (s := _clean_librenms_value(item.get("entPhysicalSerialNum")))}
 
         # Build port_id → interface label lookup for better synthetic item naming
         port_name_map = self._build_port_name_map(transceivers, ports_data=ports_data)
@@ -1331,15 +1341,9 @@ class BaseModuleTableView(LibreNMSPermissionMixin, LibreNMSAPIMixin, CacheMixin,
             ifname = (port_meta.get("ifName") or "").strip() or None
             ifdescr = (port_meta.get("ifDescr") or "").strip() or None
 
-            model = (txr.get("model") or "").strip()
-            if model.lower() in _PLACEHOLDER_VALUES:
-                model = ""
-            serial = normalize_serial(txr.get("serial"))
-            if serial.lower() in _PLACEHOLDER_VALUES:
-                serial = ""
-            txr_type = (txr.get("type") or "").strip()
-            if txr_type.lower() in _PLACEHOLDER_VALUES:
-                txr_type = ""
+            model = _clean_librenms_value(txr.get("model"))
+            serial = _clean_librenms_value(txr.get("serial"))
+            txr_type = _clean_librenms_value(txr.get("type"))
 
             # Skip containers and entries with no useful data
             if txr_type in _SKIP_TRANSCEIVER_TYPES and not model and not serial:
@@ -1351,13 +1355,11 @@ class BaseModuleTableView(LibreNMSPermissionMixin, LibreNMSAPIMixin, CacheMixin,
             if ent_idx in inv_by_index:
                 # Supplement existing inventory item if model/serial is missing or a placeholder
                 existing = inv_by_index[ent_idx]
-                existing_model = (existing.get("entPhysicalModelName") or "").strip()
-                if (
-                    existing_model.lower() in _PLACEHOLDER_VALUES or existing_model.lower() == "builtin"
-                ) and display_model:
+                existing_model = _clean_librenms_value(existing.get("entPhysicalModelName"))
+                if (not existing_model or existing_model.lower() == "builtin") and display_model:
                     existing["entPhysicalModelName"] = display_model
-                existing_serial = (existing.get("entPhysicalSerialNum") or "").strip()
-                if (existing_serial.lower() in _PLACEHOLDER_VALUES or existing_serial.lower() == "builtin") and serial:
+                existing_serial = _clean_librenms_value(existing.get("entPhysicalSerialNum"))
+                if (not existing_serial or existing_serial.lower() == "builtin") and serial:
                     existing["entPhysicalSerialNum"] = serial
                     inv_serials.add(serial)
                 if port_id:

--- a/netbox_librenms_plugin/views/base/modules_view.py
+++ b/netbox_librenms_plugin/views/base/modules_view.py
@@ -16,6 +16,7 @@ from netbox_librenms_plugin.utils import (
     get_module_template_interface_names,
     is_valid_ports_payload,
     normalize_librenms_port_id,
+    normalize_serial,
 )
 from netbox_librenms_plugin.views.mixins import (
     CacheMixin,
@@ -1333,7 +1334,7 @@ class BaseModuleTableView(LibreNMSPermissionMixin, LibreNMSAPIMixin, CacheMixin,
             model = (txr.get("model") or "").strip()
             if model.lower() in _PLACEHOLDER_VALUES:
                 model = ""
-            serial = str(txr.get("serial") or "").strip()
+            serial = normalize_serial(txr.get("serial"))
             if serial.lower() in _PLACEHOLDER_VALUES:
                 serial = ""
             txr_type = (txr.get("type") or "").strip()

--- a/netbox_librenms_plugin/views/base/modules_view.py
+++ b/netbox_librenms_plugin/views/base/modules_view.py
@@ -1333,7 +1333,7 @@ class BaseModuleTableView(LibreNMSPermissionMixin, LibreNMSAPIMixin, CacheMixin,
             model = (txr.get("model") or "").strip()
             if model.lower() in _PLACEHOLDER_VALUES:
                 model = ""
-            serial = (txr.get("serial") or "").strip()
+            serial = str(txr.get("serial") or "").strip()
             if serial.lower() in _PLACEHOLDER_VALUES:
                 serial = ""
             txr_type = (txr.get("type") or "").strip()

--- a/netbox_librenms_plugin/views/imports/actions.py
+++ b/netbox_librenms_plugin/views/imports/actions.py
@@ -221,6 +221,26 @@ def _rebind_or_htmx_error(view, request) -> HttpResponse | None:
     return None
 
 
+def _acquire_serial_assignment_lock(serial: str) -> None:
+    """
+    Serialize serial-assignment guards on the serial value (transaction-scoped advisory lock).
+
+    Concurrent writers of the SAME serial contend on one lock, and the second writer's
+    conflict check then sees the first one's committed row — closing the both-pass race a
+    conflict-row lock never covered (it locks nothing while the serial is unassigned).
+    It also replaces that second row lock: with own-row locks already held, two
+    swap-direction requests locking each other's conflict row deadlock (A→B / B→A).
+    Must be called inside ``transaction.atomic()``; the lock releases on commit/rollback.
+
+    Args:
+        serial: The trimmed serial being assigned.
+    """
+    from django.db import connection
+
+    with connection.cursor() as cursor:
+        cursor.execute("SELECT pg_advisory_xact_lock(hashtext(%s))", [serial])
+
+
 def _platform_device_type_mismatch(device) -> HttpResponse | None:
     """
     Mirror NetBox Device.clean()'s platform/device-type manufacturer rule for save paths.
@@ -1341,7 +1361,8 @@ class DeviceValidationDetailsView(LibreNMSPermissionMixin, LibreNMSAPIMixin, Dev
     @staticmethod
     def _build_sync_info(libre_device, existing_device):
         """Build sync comparison data between LibreNMS device and existing NetBox device."""
-        librenms_serial = libre_device.get("serial") or "-"
+        # Trimmed so a padded LibreNMS serial doesn't report drift against the stored trimmed value.
+        librenms_serial = str(libre_device.get("serial") or "").strip() or "-"
         librenms_os = libre_device.get("os") or "-"
         librenms_hardware = libre_device.get("hardware") or "-"
 
@@ -1636,17 +1657,17 @@ class DeviceConflictActionView(
                 elif action == "update":
                     # Update hostname, serial, and link to LibreNMS
                     hostname = _get_hostname_for_action(request, validation, libre_device)
-                    incoming_serial = libre_device.get("serial") or ""
+                    # Trimmed like validate/import_single_device, so the stored value and the
+                    # conflict lookup can't disagree with the match paths on whitespace.
+                    incoming_serial = str(libre_device.get("serial") or "").strip()
                     fields = ["custom_field_data", "name"]
                     if incoming_serial and incoming_serial != "-":
-                        # Lock any conflicting device under the same transaction to reduce
-                        # the serial-assignment race window (best-effort; a DB unique
-                        # constraint on serial would give full protection).
+                        # Advisory lock on the serial VALUE, not a conflict-row lock: two
+                        # swap-direction requests each holding their own device row would
+                        # deadlock on each other's conflict row (A→B / B→A).
+                        _acquire_serial_assignment_lock(incoming_serial)
                         conflict_device = (
-                            Device.objects.select_for_update()
-                            .filter(serial=incoming_serial)
-                            .exclude(pk=existing_device.pk)
-                            .first()
+                            Device.objects.filter(serial=incoming_serial).exclude(pk=existing_device.pk).first()
                         )
                         if conflict_device:
                             return _htmx_error_response(
@@ -1669,17 +1690,14 @@ class DeviceConflictActionView(
 
                 elif action == "update_serial":
                     # Update only the serial and link to LibreNMS
-                    incoming_serial = libre_device.get("serial") or ""
+                    # Trimmed like validate/import_single_device (see the update branch above).
+                    incoming_serial = str(libre_device.get("serial") or "").strip()
                     fields = ["custom_field_data"]
                     if incoming_serial and incoming_serial != "-":
-                        # Lock any conflicting device under the same transaction to reduce
-                        # the serial-assignment race window (best-effort; a DB unique
-                        # constraint on serial would give full protection).
+                        # Advisory lock, not a conflict-row lock — see the update branch above.
+                        _acquire_serial_assignment_lock(incoming_serial)
                         conflict_device = (
-                            Device.objects.select_for_update()
-                            .filter(serial=incoming_serial)
-                            .exclude(pk=existing_device.pk)
-                            .first()
+                            Device.objects.filter(serial=incoming_serial).exclude(pk=existing_device.pk).first()
                         )
                         if conflict_device:
                             return _htmx_error_response(
@@ -1721,29 +1739,23 @@ class DeviceConflictActionView(
             # Sync serial number from LibreNMS.
             # Wrap conflict-check-and-write in a transaction with a row lock so
             # concurrent requests cannot both pass the serial uniqueness guard.
-            incoming_serial = libre_device.get("serial") or ""
+            # Trimmed like validate/import_single_device (see the update branch above).
+            incoming_serial = str(libre_device.get("serial") or "").strip()
             if incoming_serial and incoming_serial != "-":
                 with transaction.atomic():
                     try:
                         locked_device = Device.objects.select_for_update().get(pk=existing_device.pk)
                     except Device.DoesNotExist:
                         return _htmx_error_response("Device no longer exists; it may have been deleted concurrently.")
-                    # Re-check for serial ownership conflict under lock.
+                    # Re-check for serial ownership conflict under the locks.
                     # Note: We intentionally do NOT enforce a DB-level uniqueness constraint on
                     # Device.serial. During device moves/replacements, multiple devices may
                     # temporarily share a serial (old record gets updated later). A unique
-                    # constraint would block those valid workflows. Instead, we rely on this
-                    # in-transaction row-lock check to guard concurrent sync of the SAME serial,
-                    # and flag conflicts via a 409 response for the user to resolve manually.
-                    # Lock the conflicting row too (like the link/update/update_serial checks):
-                    # a concurrent action re-pointing that row's serial then serializes against
-                    # this check instead of racing it.
-                    conflict_device = (
-                        Device.objects.select_for_update()
-                        .filter(serial=incoming_serial)
-                        .exclude(pk=locked_device.pk)
-                        .first()
-                    )
+                    # constraint would block those valid workflows. Instead, concurrent writers
+                    # of the same serial serialize on the advisory lock, and conflicts surface
+                    # as an error response for the user to resolve manually.
+                    _acquire_serial_assignment_lock(incoming_serial)
+                    conflict_device = Device.objects.filter(serial=incoming_serial).exclude(pk=locked_device.pk).first()
                     if conflict_device:
                         logger.warning(
                             f"Serial sync blocked: '{incoming_serial}' already assigned to "

--- a/netbox_librenms_plugin/views/imports/actions.py
+++ b/netbox_librenms_plugin/views/imports/actions.py
@@ -1558,15 +1558,19 @@ class DeviceConflictActionView(
         else:
             existing_model = Device
 
-        try:
-            existing_device = existing_model.objects.get(pk=int(existing_device_id))
-        except (existing_model.DoesNotExist, ValueError):
-            return _htmx_error_response("Existing device not found")
-
-        # Object-level change permission for the specific model being mutated.
+        # Object-level change permission for the specific model being mutated. Runs BEFORE the
+        # lookup so an unauthorized caller can't probe pks, and so a caller holding no change
+        # perm at all still gets the named-permission error rather than a bare "not found".
         self.required_object_permissions = {"POST": [("change", existing_model)]}
         if error := self.require_object_permissions("POST"):
             return error
+
+        try:
+            # Scope by "change": the gate above only asks the model-level perm, so a constrained
+            # grant would otherwise mutate any object by raw pk.
+            existing_device = self.restricted_queryset(existing_model, "change").get(pk=int(existing_device_id))
+        except (existing_model.DoesNotExist, ValueError):
+            return _htmx_error_response("Existing device not found")
 
         libre_device, validation, selections = self.get_validated_device_with_selections(device_id, request)
         if not libre_device:
@@ -2461,14 +2465,16 @@ class AddAsOOBView(
         if err := _rebind_or_htmx_error(self, request):
             return err
 
-        try:
-            existing_device = Device.objects.get(pk=int(existing_device_id))
-        except (Device.DoesNotExist, ValueError):
-            return _htmx_error_response("Existing device not found")
-
+        # Gate before the lookup (see DeviceConflictActionView.post).
         self.required_object_permissions = {"POST": [("change", Device)]}
         if error := self.require_object_permissions("POST"):
             return error
+
+        try:
+            # Scope by "change" so a constrained grant can't attach an OOB link by raw pk.
+            existing_device = self.restricted_queryset(Device, "change").get(pk=int(existing_device_id))
+        except (Device.DoesNotExist, ValueError):
+            return _htmx_error_response("Existing device not found")
 
         libre_device, validation, selections = self.get_validated_device_with_selections(device_id, request)
         if not libre_device:

--- a/netbox_librenms_plugin/views/imports/actions.py
+++ b/netbox_librenms_plugin/views/imports/actions.py
@@ -241,6 +241,43 @@ def _acquire_serial_assignment_lock(serial: str) -> None:
         cursor.execute("SELECT pg_advisory_xact_lock(hashtext(%s))", [serial])
 
 
+def _apply_conflict_checked_serial(device, incoming_serial: str) -> HttpResponse | None:
+    """
+    Assign *incoming_serial* to *device* under the serial advisory lock, or report the conflict.
+
+    Shared by the conflict view's update / update_serial / sync_serial actions so the three can't
+    drift on the lock, the ownership guard, or the message. Must be called inside
+    ``transaction.atomic()`` — the advisory lock is transaction-scoped, so the read-then-write is
+    only serialized while the caller's transaction is open.
+
+    NetBox deliberately has no DB-level uniqueness on ``Device.serial``: during moves and
+    replacements two devices may temporarily share one. Conflicts therefore surface as an error
+    for the user to resolve rather than a constraint violation.
+
+    Args:
+        device: The Device to mutate. ``serial`` is set in memory only; the caller persists it.
+        incoming_serial: The already-trimmed serial from LibreNMS.
+
+    Returns:
+        HttpResponse | None: An HTMX error toast when another device owns the serial, else None.
+    """
+    from dcim.models import Device
+
+    _acquire_serial_assignment_lock(incoming_serial)
+    conflict_device = Device.objects.filter(serial=incoming_serial).exclude(pk=device.pk).first()
+    if conflict_device:
+        logger.warning(
+            f"Serial assignment blocked: '{incoming_serial}' already assigned to "
+            f"'{conflict_device.name}' (pk={conflict_device.pk})"
+        )
+        return _htmx_error_response(
+            f"Serial conflict: '{incoming_serial}' is already assigned to device "
+            f"'{conflict_device.name}' (ID: {conflict_device.pk})"
+        )
+    device.serial = incoming_serial
+    return None
+
+
 def _platform_device_type_mismatch(device) -> HttpResponse | None:
     """
     Mirror NetBox Device.clean()'s platform/device-type manufacturer rule for save paths.
@@ -1666,19 +1703,8 @@ class DeviceConflictActionView(
                     incoming_serial = str(libre_device.get("serial") or "").strip()
                     fields = ["custom_field_data", "name"]
                     if incoming_serial and incoming_serial != "-":
-                        # Advisory lock on the serial VALUE, not a conflict-row lock: two
-                        # swap-direction requests each holding their own device row would
-                        # deadlock on each other's conflict row (A→B / B→A).
-                        _acquire_serial_assignment_lock(incoming_serial)
-                        conflict_device = (
-                            Device.objects.filter(serial=incoming_serial).exclude(pk=existing_device.pk).first()
-                        )
-                        if conflict_device:
-                            return _htmx_error_response(
-                                f"Serial conflict: '{incoming_serial}' is already assigned to device "
-                                f"'{conflict_device.name}' (ID: {conflict_device.pk})"
-                            )
-                        existing_device.serial = incoming_serial
+                        if err := _apply_conflict_checked_serial(existing_device, incoming_serial):
+                            return err
                         fields.append("serial")
                     existing_device.name = hostname
                     if librenms_device_type:
@@ -1698,17 +1724,8 @@ class DeviceConflictActionView(
                     incoming_serial = str(libre_device.get("serial") or "").strip()
                     fields = ["custom_field_data"]
                     if incoming_serial and incoming_serial != "-":
-                        # Advisory lock, not a conflict-row lock — see the update branch above.
-                        _acquire_serial_assignment_lock(incoming_serial)
-                        conflict_device = (
-                            Device.objects.filter(serial=incoming_serial).exclude(pk=existing_device.pk).first()
-                        )
-                        if conflict_device:
-                            return _htmx_error_response(
-                                f"Serial conflict: '{incoming_serial}' is already assigned to device "
-                                f"'{conflict_device.name}' (ID: {conflict_device.pk})"
-                            )
-                        existing_device.serial = incoming_serial
+                        if err := _apply_conflict_checked_serial(existing_device, incoming_serial):
+                            return err
                         fields.append("serial")
                     if librenms_device_type:
                         existing_device.device_type = librenms_device_type
@@ -1751,25 +1768,9 @@ class DeviceConflictActionView(
                         locked_device = Device.objects.select_for_update().get(pk=existing_device.pk)
                     except Device.DoesNotExist:
                         return _htmx_error_response("Device no longer exists; it may have been deleted concurrently.")
-                    # Re-check for serial ownership conflict under the locks.
-                    # Note: We intentionally do NOT enforce a DB-level uniqueness constraint on
-                    # Device.serial. During device moves/replacements, multiple devices may
-                    # temporarily share a serial (old record gets updated later). A unique
-                    # constraint would block those valid workflows. Instead, concurrent writers
-                    # of the same serial serialize on the advisory lock, and conflicts surface
-                    # as an error response for the user to resolve manually.
-                    _acquire_serial_assignment_lock(incoming_serial)
-                    conflict_device = Device.objects.filter(serial=incoming_serial).exclude(pk=locked_device.pk).first()
-                    if conflict_device:
-                        logger.warning(
-                            f"Serial sync blocked: '{incoming_serial}' already assigned to "
-                            f"'{conflict_device.name}' (pk={conflict_device.pk})"
-                        )
-                        return _htmx_error_response(
-                            f"Serial conflict: '{incoming_serial}' is already assigned to device "
-                            f"'{conflict_device.name}' (ID: {conflict_device.pk})"
-                        )
-                    locked_device.serial = incoming_serial
+                    # Re-check for serial ownership conflict under the locks, on the LOCKED row.
+                    if err := _apply_conflict_checked_serial(locked_device, incoming_serial):
+                        return err
                     if err := _save_device(locked_device, update_fields=["serial"], request=request):
                         return err
                     logger.info(f"Synced serial on '{locked_device.name}' to {incoming_serial}")

--- a/netbox_librenms_plugin/views/imports/actions.py
+++ b/netbox_librenms_plugin/views/imports/actions.py
@@ -2503,6 +2503,14 @@ class AddAsOOBView(
         # row, so the common path is unchanged. The candidate-match check above stays on the
         # user-selected existing_device (it validates the POST, not the linkage target).
         sync_device = get_librenms_sync_device(existing_device, server_key=server_key) or existing_device
+        # The sync device is DERIVED (a VC sibling of the scoped existing_device), and the block
+        # below locks and saves it. Authorize it too, or a grant covering only the selected member
+        # writes the OOB link onto a sibling it cannot see. Skipped when they are the same row.
+        if (
+            sync_device.pk != existing_device.pk
+            and not self.restricted_queryset(Device, "change").filter(pk=sync_device.pk).exists()
+        ):
+            return _htmx_error_response("Existing device not found")
 
         # coerce_librenms_id centralizes the bool/int/str/positive checks (rejects bools,
         # non-numeric strings, zero/negatives) in one place.

--- a/netbox_librenms_plugin/views/imports/actions.py
+++ b/netbox_librenms_plugin/views/imports/actions.py
@@ -43,6 +43,7 @@ from netbox_librenms_plugin.utils import (
     coerce_librenms_id,
     get_librenms_sync_device,
     is_legacy_librenms_id,
+    normalize_serial,
     resolve_naming_preferences,
     resolve_server_mapping_display_id,
     same_host,
@@ -1399,7 +1400,7 @@ class DeviceValidationDetailsView(LibreNMSPermissionMixin, LibreNMSAPIMixin, Dev
     def _build_sync_info(libre_device, existing_device):
         """Build sync comparison data between LibreNMS device and existing NetBox device."""
         # Trimmed so a padded LibreNMS serial doesn't report drift against the stored trimmed value.
-        librenms_serial = str(libre_device.get("serial") or "").strip() or "-"
+        librenms_serial = normalize_serial(libre_device.get("serial")) or "-"
         librenms_os = libre_device.get("os") or "-"
         librenms_hardware = libre_device.get("hardware") or "-"
 
@@ -1700,7 +1701,7 @@ class DeviceConflictActionView(
                     hostname = _get_hostname_for_action(request, validation, libre_device)
                     # Trimmed like validate/import_single_device, so the stored value and the
                     # conflict lookup can't disagree with the match paths on whitespace.
-                    incoming_serial = str(libre_device.get("serial") or "").strip()
+                    incoming_serial = normalize_serial(libre_device.get("serial"))
                     fields = ["custom_field_data", "name"]
                     if incoming_serial and incoming_serial != "-":
                         if err := _apply_conflict_checked_serial(existing_device, incoming_serial):
@@ -1721,7 +1722,7 @@ class DeviceConflictActionView(
                 elif action == "update_serial":
                     # Update only the serial and link to LibreNMS
                     # Trimmed like validate/import_single_device (see the update branch above).
-                    incoming_serial = str(libre_device.get("serial") or "").strip()
+                    incoming_serial = normalize_serial(libre_device.get("serial"))
                     fields = ["custom_field_data"]
                     if incoming_serial and incoming_serial != "-":
                         if err := _apply_conflict_checked_serial(existing_device, incoming_serial):
@@ -1761,7 +1762,7 @@ class DeviceConflictActionView(
             # Wrap conflict-check-and-write in a transaction with a row lock so
             # concurrent requests cannot both pass the serial uniqueness guard.
             # Trimmed like validate/import_single_device (see the update branch above).
-            incoming_serial = str(libre_device.get("serial") or "").strip()
+            incoming_serial = normalize_serial(libre_device.get("serial"))
             if incoming_serial and incoming_serial != "-":
                 with transaction.atomic():
                     try:

--- a/netbox_librenms_plugin/views/imports/actions.py
+++ b/netbox_librenms_plugin/views/imports/actions.py
@@ -43,7 +43,6 @@ from netbox_librenms_plugin.utils import (
     coerce_librenms_id,
     get_librenms_sync_device,
     is_legacy_librenms_id,
-    filter_by_trimmed_serial,
     normalize_serial,
     resolve_naming_preferences,
     resolve_server_mapping_display_id,
@@ -271,7 +270,7 @@ def _apply_conflict_checked_serial(device, incoming_serial: str) -> HttpResponse
     from dcim.models import Device
 
     _acquire_serial_assignment_lock(incoming_serial)
-    conflict_device = filter_by_trimmed_serial(Device.objects.all(), incoming_serial).exclude(pk=device.pk).first()
+    conflict_device = Device.objects.filter(serial=incoming_serial).exclude(pk=device.pk).first()
     if conflict_device:
         logger.warning(
             f"Serial assignment blocked: '{incoming_serial}' already assigned to "

--- a/netbox_librenms_plugin/views/imports/actions.py
+++ b/netbox_librenms_plugin/views/imports/actions.py
@@ -1405,8 +1405,9 @@ class DeviceValidationDetailsView(LibreNMSPermissionMixin, LibreNMSAPIMixin, Dev
         librenms_os = libre_device.get("os") or "-"
         librenms_hardware = libre_device.get("hardware") or "-"
 
-        # Serial comparison (VMs may not have serial in all NetBox versions)
-        netbox_serial = getattr(existing_device, "serial", None) or ""
+        # Serial comparison (VMs may not have serial in all NetBox versions). The stored side
+        # is normalized too, so a legacy padded serial doesn't render as drift.
+        netbox_serial = normalize_serial(getattr(existing_device, "serial", None))
         serial_synced = netbox_serial == librenms_serial or librenms_serial == "-"
 
         # Platform comparison

--- a/netbox_librenms_plugin/views/imports/actions.py
+++ b/netbox_librenms_plugin/views/imports/actions.py
@@ -1735,7 +1735,15 @@ class DeviceConflictActionView(
                     # constraint would block those valid workflows. Instead, we rely on this
                     # in-transaction row-lock check to guard concurrent sync of the SAME serial,
                     # and flag conflicts via a 409 response for the user to resolve manually.
-                    conflict_device = Device.objects.filter(serial=incoming_serial).exclude(pk=locked_device.pk).first()
+                    # Lock the conflicting row too (like the link/update/update_serial checks):
+                    # a concurrent action re-pointing that row's serial then serializes against
+                    # this check instead of racing it.
+                    conflict_device = (
+                        Device.objects.select_for_update()
+                        .filter(serial=incoming_serial)
+                        .exclude(pk=locked_device.pk)
+                        .first()
+                    )
                     if conflict_device:
                         logger.warning(
                             f"Serial sync blocked: '{incoming_serial}' already assigned to "

--- a/netbox_librenms_plugin/views/imports/actions.py
+++ b/netbox_librenms_plugin/views/imports/actions.py
@@ -236,9 +236,14 @@ def _acquire_serial_assignment_lock(serial: str) -> None:
 
     Args:
         serial: The trimmed serial being assigned.
+
+    Raises:
+        RuntimeError: When called in autocommit — the lock would release immediately.
     """
     from django.db import connection
 
+    if not connection.in_atomic_block:
+        raise RuntimeError("_acquire_serial_assignment_lock() requires an open transaction")
     with connection.cursor() as cursor:
         cursor.execute("SELECT pg_advisory_xact_lock(hashtext(%s))", [serial])
 

--- a/netbox_librenms_plugin/views/imports/actions.py
+++ b/netbox_librenms_plugin/views/imports/actions.py
@@ -43,6 +43,7 @@ from netbox_librenms_plugin.utils import (
     coerce_librenms_id,
     get_librenms_sync_device,
     is_legacy_librenms_id,
+    filter_by_trimmed_serial,
     normalize_serial,
     resolve_naming_preferences,
     resolve_server_mapping_display_id,
@@ -265,7 +266,7 @@ def _apply_conflict_checked_serial(device, incoming_serial: str) -> HttpResponse
     from dcim.models import Device
 
     _acquire_serial_assignment_lock(incoming_serial)
-    conflict_device = Device.objects.filter(serial=incoming_serial).exclude(pk=device.pk).first()
+    conflict_device = filter_by_trimmed_serial(Device.objects.all(), incoming_serial).exclude(pk=device.pk).first()
     if conflict_device:
         logger.warning(
             f"Serial assignment blocked: '{incoming_serial}' already assigned to "

--- a/netbox_librenms_plugin/views/sync/device_fields.py
+++ b/netbox_librenms_plugin/views/sync/device_fields.py
@@ -182,7 +182,7 @@ class UpdateDeviceSerialView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixi
             messages.error(request, "Failed to retrieve device info from LibreNMS")
             return _device_sync_redirect(request, pk, server_key)
 
-        serial = device_info.get("serial")
+        serial = normalize_serial(device_info.get("serial"))
 
         if not serial or serial == "-":
             messages.warning(request, "No serial number available in LibreNMS")
@@ -684,7 +684,7 @@ class AssignVCSerialView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixin, L
 
         counter = 1
         while f"serial_{counter}" in request.POST:
-            serial = request.POST.get(f"serial_{counter}")
+            serial = normalize_serial(request.POST.get(f"serial_{counter}"))
             member_id = request.POST.get(f"member_id_{counter}")
 
             if not member_id:

--- a/netbox_librenms_plugin/views/sync/device_fields.py
+++ b/netbox_librenms_plugin/views/sync/device_fields.py
@@ -24,6 +24,7 @@ from netbox_librenms_plugin.utils import (
     is_legacy_librenms_id,
     match_librenms_hardware_to_device_type,
     migrate_legacy_librenms_id,
+    normalize_serial,
     resolve_naming_preferences,
 )
 from netbox_librenms_plugin.views.mixins import (
@@ -946,7 +947,7 @@ class ConvertLegacyLibreNMSIdView(LibreNMSPermissionMixin, NetBoxObjectPermissio
             messages.error(request, "Could not retrieve device info from LibreNMS to verify serial.")
             return self._sync_url(object_type, pk)
 
-        librenms_serial = str(device_info.get("serial") or "").strip()
+        librenms_serial = normalize_serial(device_info.get("serial"))
         netbox_serial = (getattr(obj, "serial", None) or "").strip()
         # VMs have no serial field in NetBox; skip the serial gate for them.
         is_vm = object_type == "vm"

--- a/netbox_librenms_plugin/views/sync/device_fields.py
+++ b/netbox_librenms_plugin/views/sync/device_fields.py
@@ -946,7 +946,7 @@ class ConvertLegacyLibreNMSIdView(LibreNMSPermissionMixin, NetBoxObjectPermissio
             messages.error(request, "Could not retrieve device info from LibreNMS to verify serial.")
             return self._sync_url(object_type, pk)
 
-        librenms_serial = (device_info.get("serial") or "").strip()
+        librenms_serial = str(device_info.get("serial") or "").strip()
         netbox_serial = (getattr(obj, "serial", None) or "").strip()
         # VMs have no serial field in NetBox; skip the serial gate for them.
         is_vm = object_type == "vm"

--- a/netbox_librenms_plugin/views/sync/ip_addresses.py
+++ b/netbox_librenms_plugin/views/sync/ip_addresses.py
@@ -15,6 +15,7 @@ from virtualization.models import VirtualMachine
 from netbox_librenms_plugin.utils import (
     get_librenms_device_id,
     get_virtual_chassis_members,
+    ip_family,
     resolve_set_primary_ip,
     same_host,
 )
@@ -296,7 +297,9 @@ class SyncIPAddressesView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixin, 
         Returns:
             bool: True if the primary IP changed, False if it was already set.
         """
-        field = "primary_ip6" if ip_obj.family == 6 else "primary_ip4"
+        # ip_family(), not ip_obj.family: NetBox 4.4's property raises AttributeError on the
+        # in-memory str address of a freshly created IPAddress, failing the whole IP sync row.
+        field = "primary_ip6" if ip_family(ip_obj) == 6 else "primary_ip4"
         if getattr(obj, f"{field}_id") == ip_obj.pk:
             return False
         setattr(obj, field, ip_obj)


### PR DESCRIPTION
## Summary
Hardening pass over `develop`: 23 self-contained fixes to the sync/import paths.

- **NetBox 4.4**: `IPAddress.family` raises for freshly created addresses on 4.4 (4.5 added a str-tolerant branch), breaking primary-IP sync and the `set_device_ip_fk` family guard. New `ip_family()` helper fixes both — this is the current `NetBox v4.4.0` CI failure on develop
- **Serials**: one shared `normalize_serial()` at every read site — handles whitespace padding and JSON-number serials (including `0`); values persist trimmed. A data migration trims existing Device serials and adds a plain serial index concurrently, allowing exact indexed lookups instead of DB-side `TRIM()` comparisons.
- **Serial-conflict guard**: the conflicting-row lock could deadlock two swap-direction requests; replaced with a transaction-scoped `pg_advisory_xact_lock` on the serial value, which also closes the both-pass race on unassigned serials.
- **Object permissions**: `DeviceConflictActionView` / `AddAsOOBView` resolved client-supplied pks with plain `.get()`; now `restricted_queryset()`, including the VC sync sibling AddAsOOB writes.
- Smaller fixes: 404-as-empty IP list; missing port name in `get_virtual_chassis_member` (was a 500); `enrich_remote_port` returning None (500 on portless LLDP neighbors); `view_device` check in `SingleModuleVerifyView`; fail-closed bulk-import duplicate re-check; VM cluster display; screenshot alt text.

## Motivation / Problem
- Bug (several, including the NetBox 4.4 CI failure on develop)

## Scope of Change
- Sync/Import logic
- LibreNMS API interaction
- Tests

## How Was This Tested?
- Unit tests: yes — every fix has a red-first regression test; the 4.4 bugs are pinned by tests that reproduce 4.4's `IPAddress.family` behavior, so they run on any NetBox version. 
- Manual testing: no.

## Risk Assessment
- The serial migration trims existing values in batches and creates a plain serial index concurrently; new writes are normalized before persistence.
- The advisory-lock guard changes concurrency behavior only (clean conflict message instead of a possible database error).

## Backwards Compatibility
- No breaking changes

## Other Notes
. #315/#318/#319 are already rebased on top of this branch; merging this first shrinks their diffs to their own commits.
