### PR TITLE
Fix: object scoped lookups

### DIFF
--- a/netbox_librenms_plugin/import_utils/__init__.py
+++ b/netbox_librenms_plugin/import_utils/__init__.py
@@ -36,7 +36,7 @@ from .device_operations import (  # noqa: F401
     import_single_device,
     validate_device_for_import,
 )
-from .collisions import detect_bulk_collisions  # noqa: F401
+from .collisions import detect_bulk_collisions, scope_bulk_collisions  # noqa: F401
 from .filters import (  # noqa: F401
     _apply_client_filters,
     get_device_count_for_filters,

--- a/netbox_librenms_plugin/import_utils/bulk_import.py
+++ b/netbox_librenms_plugin/import_utils/bulk_import.py
@@ -307,12 +307,14 @@ def classify_bulk_precheck(collisions, unresolved, device_ids, vm_imports) -> Bu
 
     block_message = ""
     if collisions:
+        scoped = any("target_visible" in group for group in collisions)
         visible_pks = [group["nb_device_pk"] for group in collisions if group.get("target_visible") is True]
-        target_detail = (
-            f" Visible pk(s): {', '.join(str(pk) for pk in visible_pks)}."
-            if visible_pks
-            else " Target details are omitted when they are outside your view scope."
-        )
+        if visible_pks:
+            target_detail = f" Visible pk(s): {', '.join(str(pk) for pk in visible_pks)}."
+        elif scoped:
+            target_detail = " Target details are omitted when they are outside your view scope."
+        else:
+            target_detail = ""
         block_message = (
             f"Bulk import blocked: {len(collisions)} NetBox object collision(s) in this batch."
             f"{target_detail} Two or more selected LibreNMS devices resolve to the same NetBox "

--- a/netbox_librenms_plugin/import_utils/bulk_import.py
+++ b/netbox_librenms_plugin/import_utils/bulk_import.py
@@ -25,7 +25,7 @@ from ..utils import (
     row_identity_matches,
 )
 from .cache import get_cache_metadata_key, get_import_device_cache_key, get_validated_device_cache_key
-from .collisions import detect_bulk_collisions
+from .collisions import detect_bulk_collisions, scope_bulk_collisions
 from .device_operations import (
     VALIDATION_ERROR_ISSUE_PREFIX,
     _describe_existing_librenms_link,
@@ -91,7 +91,13 @@ def _is_job_cancelled(job) -> bool:
 
 
 def detect_collisions_for_device_ids(
-    device_ids, api, libre_devices_cache=None, sync_options=None, job=None, vm_device_ids=None
+    device_ids,
+    api,
+    libre_devices_cache=None,
+    sync_options=None,
+    job=None,
+    vm_device_ids=None,
+    user=None,
 ) -> tuple[list[dict], list]:
     """
     Detect same-NetBox-device collisions for a batch of LibreNMS device ids.
@@ -120,6 +126,8 @@ def detect_collisions_for_device_ids(
             the Device-only serial/IP matching that ``bulk_import_vms`` intentionally skips,
             and could fabricate a collision (blocking a valid batch) against a Device it
             will never touch.
+        user: Optional requesting user. Production callers pass this so collision targets outside
+            the user's view scope are redacted before the result reaches a template or job log.
 
     Returns:
         tuple[list[dict], list]: ``(collisions, unresolved_ids)`` — the collision groups from
@@ -205,6 +213,7 @@ def detect_collisions_for_device_ids(
             strip_domain=strip_domain,
             server_key=api.server_key,
             include_vc_detection=False,
+            collision_only=True,
         )
         if any(str(issue).startswith(VALIDATION_ERROR_ISSUE_PREFIX) for issue in validation.get("issues", [])):
             # validate_device_for_import() caught an exception and returned only a partial result
@@ -222,7 +231,10 @@ def detect_collisions_for_device_ids(
                 "validation": validation,
             }
         )
-    return detect_bulk_collisions(devices), unresolved_ids
+    collisions = detect_bulk_collisions(devices)
+    if user is not None:
+        collisions = scope_bulk_collisions(collisions, user)
+    return collisions, unresolved_ids
 
 
 @dataclass
@@ -289,15 +301,21 @@ def classify_bulk_precheck(collisions, unresolved, device_ids, vm_imports) -> Bu
         skip_message = (
             f"Skipped {len(unresolved)} selected row(s) (id(s): {ids}): their LibreNMS device info "
             f"couldn't be fetched to verify collisions, so they were not imported. The remaining "
-            f"rows were imported; retry those rows individually."
+            f"selected rows continue through normal import checks; review the final result for "
+            f"their outcome, then retry the skipped rows individually."
         )
 
     block_message = ""
     if collisions:
-        pks = ", ".join(str(group["nb_device_pk"]) for group in collisions)
+        visible_pks = [group["nb_device_pk"] for group in collisions if group.get("target_visible") is True]
+        target_detail = (
+            f" Visible pk(s): {', '.join(str(pk) for pk in visible_pks)}."
+            if visible_pks
+            else " Target details are omitted when they are outside your view scope."
+        )
         block_message = (
-            f"Bulk import blocked: {len(collisions)} NetBox object collision(s) in this batch "
-            f"(pk(s): {pks}). Two or more selected LibreNMS devices resolve to the same NetBox "
+            f"Bulk import blocked: {len(collisions)} NetBox object collision(s) in this batch."
+            f"{target_detail} Two or more selected LibreNMS devices resolve to the same NetBox "
             f"object; resolve each individually, or deselect the duplicates."
         )
 

--- a/netbox_librenms_plugin/import_utils/collisions.py
+++ b/netbox_librenms_plugin/import_utils/collisions.py
@@ -26,6 +26,42 @@ _TERMINAL_AMBIGUOUS_MATCH_TYPES = frozenset({"ambiguous_hostname_or_serial", "am
 _MERGE_SLOT_ROLES = {"host_named": "merge_host_named", "oob_named": "merge_oob_named"}
 
 
+def scope_bulk_collisions(collisions: list[dict], user) -> list[dict]:
+    """Redact collision targets the requesting user cannot view."""
+    from dcim.models import Device
+    from virtualization.models import VirtualMachine
+
+    models = {"device": Device, "virtualmachine": VirtualMachine}
+    visible_pks: dict[str, set[int]] = {}
+    for model_name, model in models.items():
+        candidate_pks = {
+            group.get("nb_device_pk")
+            for group in collisions
+            if group.get("nb_model_name") == model_name and group.get("nb_device_pk") is not None
+        }
+        visible_pks[model_name] = set(
+            model.objects.restrict(user, "view").filter(pk__in=candidate_pks).values_list("pk", flat=True)
+        )
+
+    scoped = []
+    for group in collisions:
+        model_name = group.get("nb_model_name")
+        if group.get("nb_device_pk") in visible_pks.get(model_name, set()):
+            scoped.append({**group, "target_visible": True})
+            continue
+        scoped.append(
+            {
+                **group,
+                "nb_device_pk": None,
+                "nb_device_name": "restricted NetBox object",
+                "nb_model_name": None,
+                "nb_kind": "object",
+                "target_visible": False,
+            }
+        )
+    return scoped
+
+
 def _model_name_of(obj) -> str:
     """
     Return the NetBox model name (``"device"`` / ``"virtualmachine"``) for *obj*.

--- a/netbox_librenms_plugin/import_utils/device_operations.py
+++ b/netbox_librenms_plugin/import_utils/device_operations.py
@@ -482,6 +482,7 @@ def validate_device_for_import(
     *,
     server_key: str = "default",
     include_vc_detection: bool = True,
+    collision_only: bool = False,
     force_vc_refresh: bool = False,
     use_sysname: bool = True,
     strip_domain: bool = False,
@@ -503,6 +504,8 @@ def validate_device_for_import(
         import_as_vm: If True, validate for VM import instead of device import
         api: Optional LibreNMSAPI instance for virtual chassis detection
         include_vc_detection: Skip VC detection when False to speed up bulk operations
+        collision_only: Return after existing-object and collision-candidate matching. This skips
+            site, device type, role, platform, rack, and virtual-chassis import prerequisites.
         force_vc_refresh: When True, bypass cached VC data and re-query LibreNMS
         use_sysname: If True, prefer sysName over hostname (matches import behaviour)
         strip_domain: If True, strip domain suffix from device name
@@ -1253,6 +1256,9 @@ def validate_device_for_import(
         if result["ambiguous_librenms_id"]:
             result["can_import"] = False
             result["is_ready"] = False
+            return result
+
+        if collision_only:
             return result
 
         # Validate based on import type (Device or VM)

--- a/netbox_librenms_plugin/jobs.py
+++ b/netbox_librenms_plugin/jobs.py
@@ -251,6 +251,7 @@ class ImportDevicesJob(JobRunner):
                     # mode would run the serial/IP matching bulk_import_vms skips and could
                     # fabricate a collision that blocks a valid batch.
                     vm_device_ids=vm_imports,
+                    user=self.job.user,
                 )
                 if len(collision_check_ids) >= 2
                 else ([], [])

--- a/netbox_librenms_plugin/templates/netbox_librenms_plugin/htmx/bulk_import_collision.html
+++ b/netbox_librenms_plugin/templates/netbox_librenms_plugin/htmx/bulk_import_collision.html
@@ -25,16 +25,20 @@
       <div class="d-flex flex-wrap align-items-center gap-2 mb-2">
         <span class="badge bg-danger text-white">Collision</span>
         <span class="text-muted small">NetBox {{ group.nb_kind }}:</span>
-        {% if group.nb_model_name == 'virtualmachine' %}
-          <a href="{% url 'virtualization:virtualmachine' pk=group.nb_device_pk %}" target="_blank" rel="noopener" class="fw-bold">
-            {{ group.nb_device_name }}
-          </a>
+        {% if group.target_visible %}
+          {% if group.nb_model_name == 'virtualmachine' %}
+            <a href="{% url 'virtualization:virtualmachine' pk=group.nb_device_pk %}" target="_blank" rel="noopener" class="fw-bold">
+              {{ group.nb_device_name }}
+            </a>
+          {% else %}
+            <a href="{% url 'dcim:device' pk=group.nb_device_pk %}" target="_blank" rel="noopener" class="fw-bold">
+              {{ group.nb_device_name }}
+            </a>
+          {% endif %}
+          <span class="text-muted small">(pk {{ group.nb_device_pk }})</span>
         {% else %}
-          <a href="{% url 'dcim:device' pk=group.nb_device_pk %}" target="_blank" rel="noopener" class="fw-bold">
-            {{ group.nb_device_name }}
-          </a>
+          <span class="fw-bold">restricted NetBox object</span>
         {% endif %}
-        <span class="text-muted small">(pk {{ group.nb_device_pk }})</span>
       </div>
       <div class="text-muted small mb-1">Selected LibreNMS rows targeting this {{ group.nb_kind }}:</div>
       <ul class="list-unstyled mb-0 ps-2 small">

--- a/netbox_librenms_plugin/tests/test_background_jobs.py
+++ b/netbox_librenms_plugin/tests/test_background_jobs.py
@@ -914,41 +914,6 @@ class TestImportDevicesJob:
         assert job.job.data["errors"] == []
         assert job.job.data["failed_count"] == 0
 
-    @patch("netbox_librenms_plugin.import_utils.detect_collisions_for_device_ids")
-    @patch("netbox_librenms_plugin.import_utils.bulk_import_vms")
-    @patch("netbox_librenms_plugin.import_utils.bulk_import_devices_shared")
-    @patch("netbox_librenms_plugin.librenms_api.LibreNMSAPI")
-    def test_collision_block_skips_vm_import(self, mock_api_class, mock_bulk_devices, mock_bulk_vms, mock_detect):
-        """A same-NetBox-device collision blocks the batch and skips the VM section too.
-
-        Collision DETECTION has its own real-DB tests; here the detector is stubbed to isolate
-        the job's collisions-branch block flow (the symmetric counterpart of the unresolved one).
-        """
-        from netbox_librenms_plugin.jobs import ImportDevicesJob
-
-        mock_api = MagicMock()
-        mock_api.server_key = "default"
-        mock_api_class.return_value = mock_api
-        mock_detect.return_value = ([{"nb_device_pk": 5}], [])  # one collision group, no unresolved
-        mock_bulk_devices.return_value = {"success": [], "failed": [], "skipped": [], "virtual_chassis_created": 0}
-        mock_bulk_vms.return_value = {"success": [], "failed": [], "skipped": []}
-
-        job = create_mock_job_runner(ImportDevicesJob, job_pk=812)
-        job.run(device_ids=[1, 2], vm_imports={10: {"cluster_id": 1}}, server_key="default")
-
-        mock_bulk_devices.assert_not_called()
-        mock_bulk_vms.assert_not_called()
-        errors = job.job.data["errors"]
-        assert {e["device_id"] for e in errors} == {1, 2, 10}
-        # Shared block wording (classify_bulk_precheck), identical to the sync view.
-        assert all("Bulk import blocked" in e["error"] for e in errors)
-        # The gate spans device + VM ids (vm_imports here), so the block message must be
-        # object-neutral — a VM collision must not be mislabelled a "NetBox device" collision.
-        assert all("NetBox object collision" in e["error"] for e in errors)
-        assert not any("NetBox device collision" in e["error"] for e in errors)
-        assert job.job.data["failed_count"] == 3
-        assert job.job.data["success_count"] == 0
-
     def test_job_meta_name(self):
         """Job has correct Meta.name."""
         from netbox_librenms_plugin.jobs import ImportDevicesJob

--- a/netbox_librenms_plugin/tests/test_bulk_import_review_regressions.py
+++ b/netbox_librenms_plugin/tests/test_bulk_import_review_regressions.py
@@ -164,7 +164,12 @@ def test_collision_scope_handles_virtual_machines_with_real_permissions():
 
 @pytest.mark.django_db
 def test_background_collision_gate_uses_job_user_scope(monkeypatch):
-    """The real job runner scopes collision details and blocks device and VM imports."""
+    """The real job runner scopes collision details and blocks device and VM imports.
+
+    The batch collides on two targets, one of them outside the job user's view grant. Only the
+    visible pk may appear: an unscoped resolution would name the hidden target as well, so the
+    scoping is what the pk list pins.
+    """
     from core.models import Job
     from dcim.models import Device
     from virtualization.models import VirtualMachine
@@ -173,12 +178,14 @@ def test_background_collision_gate_uses_job_user_scope(monkeypatch):
     from netbox_librenms_plugin import librenms_api as librenms_api_module
 
     target = make_device("visible-job-collision-target")
+    hidden = make_device("hidden-job-collision-target")
     user = make_user_with_perms("job-collision-scope", [])
     user = grant(user, "add", Device)
     user = grant(user, "change", Device, constraints={"pk": target.pk})
     user = grant(user, "view", Device, constraints={"pk": target.pk})
     user = grant(user, "add", VirtualMachine)
     rows = _collision_rows(96301, 96302, target.name)
+    rows.update(_collision_rows(96304, 96305, hidden.name))
     rows[96303] = {
         "device_id": 96303,
         "hostname": "unique-job-vm-row",
@@ -200,19 +207,24 @@ def test_background_collision_gate_uses_job_user_scope(monkeypatch):
     vm_count = VirtualMachine.objects.count()
 
     ImportDevicesJob(job_row).run(
-        device_ids=[96301, 96302],
+        device_ids=[96301, 96302, 96304, 96305],
         vm_imports={96303: {"cluster_id": 1}},
         server_key="default",
         libre_devices_cache=rows,
     )
 
     job_row.refresh_from_db()
+    errors = job_row.data["errors"]
     assert Device.objects.count() == device_count
     assert VirtualMachine.objects.count() == vm_count
-    assert {entry["device_id"] for entry in job_row.data["errors"]} == {96301, 96302, 96303}
-    assert all("Bulk import blocked" in entry["error"] for entry in job_row.data["errors"])
-    assert all(f"Visible pk(s): {target.pk}" in entry["error"] for entry in job_row.data["errors"])
-    assert job_row.data["failed_count"] == 3
+    assert {entry["device_id"] for entry in errors} == {96301, 96302, 96303, 96304, 96305}
+    assert all("Bulk import blocked" in entry["error"] for entry in errors)
+    # Both collisions block the batch...
+    assert all("2 NetBox object collision(s)" in entry["error"] for entry in errors)
+    # ...and the trailing period pins the list to the visible pk alone.
+    assert all(f"Visible pk(s): {target.pk}." in entry["error"] for entry in errors)
+    assert all(hidden.name not in entry["error"] for entry in errors)
+    assert job_row.data["failed_count"] == 5
     assert job_row.data["success_count"] == 0
 
 

--- a/netbox_librenms_plugin/tests/test_bulk_import_review_regressions.py
+++ b/netbox_librenms_plugin/tests/test_bulk_import_review_regressions.py
@@ -1,0 +1,306 @@
+"""Regression coverage for bulk-import collision review findings."""
+
+from uuid import uuid4
+
+import pytest
+from django.core.cache import cache
+from django.db import connection
+from django.test.utils import CaptureQueriesContext
+from django.urls import reverse
+
+from netbox_librenms_plugin.import_utils.cache import get_import_device_cache_key
+from netbox_librenms_plugin.tests.conftest import make_device, make_superuser, make_vm
+from netbox_librenms_plugin.tests.view_test_helpers import grant, make_request, make_user_with_perms, post
+
+
+class _LibreNMSBoundary:
+    """Real-shape stand-in for the external LibreNMS HTTP boundary."""
+
+    server_key = "default"
+    cache_timeout = 300
+
+    def __init__(self, rows):
+        self.rows = rows
+        self.calls = []
+
+    def get_device_info(self, device_id, **kwargs):
+        self.calls.append((device_id, kwargs))
+        row = self.rows.get(device_id)
+        return (row is not None, row)
+
+    def get_inventory_filtered(self, _device_id, **_kwargs):
+        return True, []
+
+
+def _cache_rows(rows):
+    for device_id, row in rows.items():
+        cache.set(get_import_device_cache_key(device_id, "default"), row, timeout=300)
+
+
+def _collision_rows(first_id, second_id, target_name):
+    return {
+        first_id: {
+            "device_id": first_id,
+            "hostname": target_name,
+            "sysName": target_name,
+            "serial": "",
+            "hardware": "Review hardware",
+            "location": "Review location",
+            "os": "review-os",
+        },
+        second_id: {
+            "device_id": second_id,
+            "hostname": target_name,
+            "sysName": target_name,
+            "serial": "",
+            "hardware": "Review hardware",
+            "location": "Review location",
+            "os": "review-os",
+        },
+    }
+
+
+def _serial_collision_rows(first_id, second_id, serial, suffix):
+    return {
+        first_id: {
+            "device_id": first_id,
+            "hostname": f"librenms-row-a-{suffix}",
+            "sysName": f"librenms-row-a-{suffix}",
+            "serial": serial,
+            "hardware": "Review hardware",
+            "location": "Review location",
+        },
+        second_id: {
+            "device_id": second_id,
+            "hostname": f"librenms-row-b-{suffix}",
+            "sysName": f"librenms-row-b-{suffix}",
+            "serial": serial,
+            "hardware": "Review hardware",
+            "location": "Review location",
+        },
+    }
+
+
+def _scoped_import_user(visible_device, username):
+    from dcim.models import Device
+
+    user = make_user_with_perms(username, [])
+    user = grant(user, "add", Device)
+    user = grant(user, "change", Device, constraints={"pk": visible_device.pk})
+    return grant(user, "view", Device, constraints={"pk": visible_device.pk})
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("view_name", ["confirm", "direct"])
+def test_collision_response_redacts_target_outside_view_scope(view_name):
+    """Collision responses must block without exposing a hidden target's name, PK, or URL."""
+    from netbox_librenms_plugin.views.imports.actions import BulkImportConfirmView, BulkImportDevicesView
+
+    visible = make_device(f"visible-collision-scope-{view_name}")
+    hidden = make_device(f"hidden-collision-target-{view_name}", serial=f"HIDDEN-SERIAL-{view_name}")
+    user = _scoped_import_user(visible, f"collision-scope-{view_name}")
+    rows = _serial_collision_rows(96001, 96002, hidden.serial, view_name)
+    _cache_rows(rows)
+    api = _LibreNMSBoundary(rows)
+    request = make_request(
+        data={"select": ["96001", "96002"]},
+        user=user,
+        path="/bulk-import/",
+        HTTP_HX_REQUEST="true",
+    )
+    view_class = BulkImportConfirmView if view_name == "confirm" else BulkImportDevicesView
+    view = view_class()
+    view._librenms_api = api
+
+    response = post(view, request)
+
+    html = response.content.decode()
+    assert response.status_code == 200
+    assert "Bulk import blocked" in html
+    assert "restricted NetBox object" in html
+    assert hidden.name not in html
+    assert f"(pk {hidden.pk})" not in html
+    assert reverse("dcim:device", kwargs={"pk": hidden.pk}) not in html
+
+
+@pytest.mark.django_db
+def test_collision_scope_handles_virtual_machines_with_real_permissions():
+    """VM collision details follow the requester's constrained view grant."""
+    from virtualization.models import VirtualMachine
+
+    from netbox_librenms_plugin.import_utils.collisions import scope_bulk_collisions
+
+    visible = make_vm("visible-collision-vm")
+    hidden = make_vm("hidden-collision-vm")
+    user = make_user_with_perms("collision-vm-scope", [], plugin_write=False)
+    user = grant(user, "view", VirtualMachine, constraints={"pk": visible.pk})
+    collisions = [
+        {
+            "nb_device_pk": visible.pk,
+            "nb_device_name": visible.name,
+            "nb_model_name": "virtualmachine",
+            "nb_kind": "virtual machine",
+            "librenms_rows": [],
+        },
+        {
+            "nb_device_pk": hidden.pk,
+            "nb_device_name": hidden.name,
+            "nb_model_name": "virtualmachine",
+            "nb_kind": "virtual machine",
+            "librenms_rows": [],
+        },
+    ]
+
+    scoped = scope_bulk_collisions(collisions, user)
+
+    assert scoped[0]["target_visible"] is True
+    assert scoped[0]["nb_device_pk"] == visible.pk
+    assert scoped[0]["nb_device_name"] == visible.name
+    assert scoped[1]["target_visible"] is False
+    assert scoped[1]["nb_device_pk"] is None
+    assert scoped[1]["nb_device_name"] == "restricted NetBox object"
+    assert scoped[1]["nb_model_name"] is None
+
+
+@pytest.mark.django_db
+def test_background_collision_gate_uses_job_user_scope(monkeypatch):
+    """The real job runner scopes collision details and blocks device and VM imports."""
+    from core.models import Job
+    from dcim.models import Device
+    from virtualization.models import VirtualMachine
+
+    from netbox_librenms_plugin.jobs import ImportDevicesJob
+    from netbox_librenms_plugin import librenms_api as librenms_api_module
+
+    target = make_device("visible-job-collision-target")
+    user = make_user_with_perms("job-collision-scope", [])
+    user = grant(user, "add", Device)
+    user = grant(user, "change", Device, constraints={"pk": target.pk})
+    user = grant(user, "view", Device, constraints={"pk": target.pk})
+    user = grant(user, "add", VirtualMachine)
+    rows = _collision_rows(96301, 96302, target.name)
+    rows[96303] = {
+        "device_id": 96303,
+        "hostname": "unique-job-vm-row",
+        "sysName": "unique-job-vm-row",
+        "serial": "",
+        "hardware": "Review hardware",
+        "location": "Review location",
+        "os": "review-os",
+    }
+    api = _LibreNMSBoundary(rows)
+    monkeypatch.setattr(librenms_api_module, "LibreNMSAPI", lambda server_key=None: api)
+    job_row = Job.objects.create(
+        name="Bulk collision scope regression",
+        user=user,
+        job_id=uuid4(),
+        queue_name="default",
+        data={},
+    )
+    device_count = Device.objects.count()
+    vm_count = VirtualMachine.objects.count()
+
+    ImportDevicesJob(job_row).run(
+        device_ids=[96301, 96302],
+        vm_imports={96303: {"cluster_id": 1}},
+        server_key="default",
+        libre_devices_cache=rows,
+    )
+
+    job_row.refresh_from_db()
+    assert Device.objects.count() == device_count
+    assert VirtualMachine.objects.count() == vm_count
+    assert {entry["device_id"] for entry in job_row.data["errors"]} == {96301, 96302, 96303}
+    assert all("Bulk import blocked" in entry["error"] for entry in job_row.data["errors"])
+    assert all(f"Visible pk(s): {target.pk}" in entry["error"] for entry in job_row.data["errors"])
+    assert job_row.data["failed_count"] == 3
+    assert job_row.data["success_count"] == 0
+
+
+@pytest.mark.django_db
+def test_unresolved_warning_does_not_claim_an_existing_row_imported(monkeypatch):
+    """The precheck warning must not report success before the real importer finishes."""
+    from dcim.models import Device
+
+    from netbox_librenms_plugin.import_utils import bulk_import as bulk_import_module
+    from netbox_librenms_plugin.views.imports.actions import BulkImportDevicesView
+
+    existing = make_device("existing-row-is-skipped")
+    rows = _collision_rows(96101, 96102, existing.name)
+    rows.pop(96102)
+    _cache_rows(rows)
+    api = _LibreNMSBoundary(rows)
+    monkeypatch.setattr(bulk_import_module, "LibreNMSAPI", lambda server_key=None: api)
+    request = make_request(
+        data={"select": ["96101", "96102"]},
+        user=make_superuser("bulk-result-superuser"),
+        path="/bulk-import/",
+        HTTP_HX_REQUEST="true",
+    )
+    view = BulkImportDevicesView()
+    view._librenms_api = api
+    device_count = Device.objects.count()
+
+    response = post(view, request)
+
+    html = response.content.decode()
+    assert response.status_code == 200
+    assert Device.objects.count() == device_count
+    assert "Successfully imported" not in html
+    assert "Skipped 1 selected row(s) (id(s): 96102)" in html
+    assert "Skipped 1 existing device" in html
+    assert "remaining rows were imported" not in html
+    assert "continue through normal import checks" in html
+
+
+@pytest.mark.django_db
+def test_collision_precheck_skips_import_prerequisite_queries():
+    """Collision matching must not query site, type, role, or platform import prerequisites."""
+    from netbox_librenms_plugin.import_utils.bulk_import import detect_collisions_for_device_ids
+
+    target_a = make_device("collision-query-target-a")
+    make_device("collision-query-target-b")
+    rows = {
+        96201: _collision_rows(96201, 96202, "collision-query-target-a")[96201],
+        96202: _collision_rows(96201, 96202, "collision-query-target-b")[96202],
+        96203: {
+            "device_id": 96203,
+            "hostname": "unmatched-collision-query-vm",
+            "sysName": "unmatched-collision-query-vm",
+            "serial": "",
+            "hardware": "Review hardware",
+            "location": "Review location",
+            "os": "review-os",
+        },
+    }
+    rows[96201]["location"] = target_a.site.name
+    api = _LibreNMSBoundary(rows)
+
+    with CaptureQueriesContext(connection) as captured:
+        collisions, unresolved = detect_collisions_for_device_ids(
+            [96201, 96202, 96203],
+            api,
+            libre_devices_cache=rows,
+            sync_options={"use_sysname": True},
+            vm_device_ids={96203},
+        )
+
+    assert collisions == []
+    assert unresolved == []
+    import_prerequisite_tables = {
+        "dcim_devicetype",
+        "dcim_devicerole",
+        "dcim_platform",
+        "dcim_rack",
+        "dcim_site",
+        "netbox_librenms_plugin_devicetypemapping",
+        "netbox_librenms_plugin_normalizationrule",
+        "netbox_librenms_plugin_platformmapping",
+        "virtualization_cluster",
+    }
+    unexpected = [
+        query["sql"]
+        for query in captured.captured_queries
+        if any(table in query["sql"].lower() for table in import_prerequisite_tables)
+    ]
+    assert unexpected == []

--- a/netbox_librenms_plugin/tests/test_bulk_import_review_regressions.py
+++ b/netbox_librenms_plugin/tests/test_bulk_import_review_regressions.py
@@ -194,7 +194,6 @@ def test_background_collision_gate_uses_job_user_scope(monkeypatch):
         name="Bulk collision scope regression",
         user=user,
         job_id=uuid4(),
-        queue_name="default",
         data={},
     )
     device_count = Device.objects.count()

--- a/netbox_librenms_plugin/tests/test_collisions.py
+++ b/netbox_librenms_plugin/tests/test_collisions.py
@@ -346,6 +346,7 @@ def test_collision_template_renders_correct_link_targets_and_escapes():
             "nb_device_name": "srv-collide",
             "nb_model_name": "device",
             "nb_kind": "device",
+            "target_visible": True,
             "librenms_rows": [
                 {"device_id": 1, "hostname": "<script>alpha</script>", "role": "host"},
                 {"device_id": 2, "hostname": "beta", "role": "oob"},
@@ -356,6 +357,7 @@ def test_collision_template_renders_correct_link_targets_and_escapes():
             "nb_device_name": "vm-collide",
             "nb_model_name": "virtualmachine",
             "nb_kind": "VM",
+            "target_visible": True,
             "librenms_rows": [
                 {"device_id": 3, "hostname": "gamma", "role": "merge_host_named"},
                 {"device_id": 4, "hostname": "delta", "role": "merge_oob_named"},
@@ -445,13 +447,28 @@ def test_classify_unresolved_rows_are_skipped_not_blocked():
 
 def test_classify_collisions_block_whole_batch():
     """A genuine collision blocks the whole batch: blocked=True, block_message names the NetBox object pk(s)."""
-    outcome = classify_bulk_precheck([{"nb_device_pk": 7}], [], device_ids=[1, 2], vm_imports={})
+    outcome = classify_bulk_precheck(
+        [{"nb_device_pk": 7, "target_visible": True}],
+        [],
+        device_ids=[1, 2],
+        vm_imports={},
+    )
     assert outcome.blocked is True
     assert "Bulk import blocked" in outcome.block_message
     assert "1 NetBox object collision" in outcome.block_message
-    assert "pk(s): 7" in outcome.block_message
+    assert "Visible pk(s): 7" in outcome.block_message
     # Object-neutral: never mislabel a VM collision as a "NetBox device".
     assert "NetBox device collision" not in outcome.block_message
+
+
+def test_classify_collision_without_visibility_metadata_omits_pk():
+    """An unscoped collision payload must not expose its target PK."""
+    outcome = classify_bulk_precheck([{"nb_device_pk": 77}], [], device_ids=[1, 2], vm_imports={})
+
+    assert outcome.blocked is True
+    assert "Visible pk(s)" not in outcome.block_message
+    assert "77" not in outcome.block_message
+    assert "Target details are omitted" in outcome.block_message
 
 
 def test_classify_blocked_batch_omits_imported_rows_message():

--- a/netbox_librenms_plugin/tests/test_collisions.py
+++ b/netbox_librenms_plugin/tests/test_collisions.py
@@ -462,13 +462,13 @@ def test_classify_collisions_block_whole_batch():
 
 
 def test_classify_collision_without_visibility_metadata_omits_pk():
-    """An unscoped collision payload must not expose its target PK."""
+    """An unscoped collision payload must not claim that permission scoping hid its target."""
     outcome = classify_bulk_precheck([{"nb_device_pk": 77}], [], device_ids=[1, 2], vm_imports={})
 
     assert outcome.blocked is True
     assert "Visible pk(s)" not in outcome.block_message
     assert "77" not in outcome.block_message
-    assert "Target details are omitted" in outcome.block_message
+    assert "Target details are omitted" not in outcome.block_message
 
 
 def test_classify_blocked_batch_omits_imported_rows_message():

--- a/netbox_librenms_plugin/tests/test_coverage_actions.py
+++ b/netbox_librenms_plugin/tests/test_coverage_actions.py
@@ -5625,32 +5625,6 @@ class TestBulkImportConfirmCollisions:
                 )
                 return view.post(request)
 
-    def test_collision_path_renders_collision_template(self):
-        """A host row and an OOB row resolving to one real NetBox device render the collision modal."""
-        from django.urls import reverse
-
-        nb_device = make_device("srv-collide-confirm")
-        validation_a = {
-            "status": "importable",
-            "resolved_name": "alpha",
-            "virtual_chassis": {},
-            "existing_device": nb_device,
-        }
-        validation_b = {
-            "status": "importable",
-            "resolved_name": "beta",
-            "virtual_chassis": {},
-            "oob_candidate": {"device": nb_device, "type": "idrac"},
-        }
-        # Real render: the real collision template + real detect_bulk_collisions + real
-        # _model_name_of(real Device) must produce a dcim:device link for the colliding device.
-        response = self._run_with_two_devices(validation_a, validation_b, real_render=True)
-        assert response.status_code == 200
-        html = response.content.decode()
-        assert "Bulk import blocked" in html
-        assert reverse("dcim:device", kwargs={"pk": nb_device.pk}) in html
-        assert "srv-collide-confirm" in html
-
     def test_clean_batch_renders_normal_confirm_template(self):
         """Two rows resolving to distinct real NetBox devices fall through to the confirm template."""
         validation_a = {
@@ -5683,45 +5657,6 @@ class TestBulkImportDevicesViewCollisionGate:
         view = object.__new__(BulkImportDevicesView)
         view._librenms_api = _make_api()
         return view
-
-    def test_colliding_batch_blocked_before_import(self):
-        """Two selected LibreNMS rows resolving to one real device → collision modal, importer never called."""
-        from django.urls import reverse
-
-        view = self._make_view()
-        request = _make_request(post={"select": ["1", "2"]}, headers={"HX-Request": "true"})
-        request.POST.getlist = MagicMock(return_value=["1", "2"])
-        request.user = _import_authorized_user()
-
-        nb = make_device("gate-collide-host")
-        libre = {
-            1: {"device_id": 1, "sysName": "gate-collide-host", "hostname": "gate-collide-host"},
-            2: {"device_id": 2, "sysName": "gate-collide-host", "hostname": "gate-collide-host"},
-        }
-        # The collision pre-check reads the seeded libre cache (cold Django cache in the test) and
-        # falls back to api.get_device_info for the misses — stub that seam so the misses resolve.
-        view._librenms_api.get_device_info = lambda did, *a, **k: (True, libre[did]) if did in libre else (False, None)
-        with (
-            patch.object(view, "require_write_permission", return_value=None),
-            patch(
-                "netbox_librenms_plugin.views.imports.actions.resolve_naming_preferences", return_value=(True, False)
-            ),
-            patch(
-                "netbox_librenms_plugin.views.imports.actions.fetch_device_with_cache",
-                side_effect=lambda did, _api: libre.get(did),
-            ),
-            patch("netbox_librenms_plugin.views.imports.actions.bulk_import_devices") as mock_import,
-        ):
-            response = view.post(request)
-
-        # Real validate + real detect via the gate → real collision template, importer never reached.
-        assert response.status_code == 200
-        html = response.content.decode()
-        assert "Bulk import blocked" in html
-        assert reverse("dcim:device", kwargs={"pk": nb.pk}) in html
-        assert 'id="htmx-modal-content"' in html
-        assert 'hx-swap-oob="innerHTML"' in html
-        mock_import.assert_not_called()
 
     def test_clean_batch_passes_gate_and_imports(self):
         """Two rows resolving to distinct real devices clear the gate and reach the importer."""
@@ -5761,44 +5696,6 @@ class TestBulkImportDevicesViewCollisionGate:
 
         # Gate cleared (distinct devices) → the importer ran.
         mock_import.assert_called_once()
-
-    def test_unfetchable_id_is_skipped_rest_imports(self):
-        """A selected id whose LibreNMS info can't be fetched (not cached + get_device_info fails) is SKIPPED, not a whole-batch block: the fetchable rows still import and the skipped row is surfaced. Restores the per-device resilience the old fail-closed block removed."""
-        view = self._make_view()
-        make_device("gate-unresolved-host")
-        libre = {1: {"device_id": 1, "sysName": "gate-unresolved-host", "hostname": "gate-unresolved-host"}}
-        # id 2 isn't cached and its info fetch fails → it can't be collision-checked → skipped.
-        view._librenms_api.get_device_info = lambda did, *a, **k: (True, libre[did]) if did in libre else (False, None)
-        request = _make_request(post={"select": ["1", "2"]}, headers={"HX-Request": "true"})
-        request.POST.getlist = MagicMock(return_value=["1", "2"])
-        request.user = _import_authorized_user()
-
-        import_result = {"success": [], "failed": [], "skipped": [], "virtual_chassis_created": 0}
-        with (
-            patch.object(view, "require_write_permission", return_value=None),
-            patch(
-                "netbox_librenms_plugin.views.imports.actions.resolve_naming_preferences", return_value=(True, False)
-            ),
-            patch(
-                "netbox_librenms_plugin.views.imports.actions.fetch_device_with_cache",
-                side_effect=lambda did, _api, **_kw: libre.get(did),
-            ),
-            patch(
-                "netbox_librenms_plugin.views.imports.actions.bulk_import_devices", return_value=import_result
-            ) as mock_import,
-        ):
-            response = view.post(request)
-
-        # The fetchable id 1 imports; only the unresolved id 2 is dropped (not a whole-batch block).
-        assert response.status_code == 200
-        mock_import.assert_called_once()
-        assert mock_import.call_args.kwargs["device_ids"] == [1]
-        html = response.content.decode()
-        # The skipped row is surfaced, object-neutral ("row(s)", never "device(s)").
-        assert "Skipped" in html
-        assert "verify collisions" in html
-        assert "selected row(s)" in html
-        assert "selected device(s)" not in html
 
     def test_background_batch_defers_collision_precheck_to_job(self):
         """A batch routed to a background job must NOT run the collision pre-check synchronously — it's deferred to ImportDevicesJob (which re-runs it), so the request doesn't pay the validation cost. The job is enqueued and the sync detector is never called."""

--- a/netbox_librenms_plugin/tests/test_coverage_actions.py
+++ b/netbox_librenms_plugin/tests/test_coverage_actions.py
@@ -7530,21 +7530,32 @@ class TestAttachOOBIp:
         assert not IPAddress.objects.filter(address__net_host="10.0.0.9").exists()
 
     def test_locks_candidate_row_with_select_for_update(self):
-        """The candidate IPAddress row must be locked (load-bearing TOCTOU mitigation)."""
+        """The candidate IPAddress row must be locked, and only through the caller's change scope.
+
+        Asserting on the emitted SQL rather than on a patched manager: a mock records whichever
+        call the code happens to make, so it stayed green when the lock ran through an
+        unrestricted queryset and pinned rows the caller had no grant for.
+        """
+        from django.db import connection, transaction
+        from django.test.utils import CaptureQueriesContext
+        from ipam.models import IPAddress
+
+        from netbox_librenms_plugin.tests.view_test_helpers import make_request, make_user_with_perms
+
         view = self._view()
-        iface = MagicMock(device_id=1)
-        existing = MagicMock()
-        existing.assigned_object = None
-        with (
-            patch("ipam.models.IPAddress") as mock_ip_cls,
-            patch("dcim.models.Device") as mock_device_cls,
-        ):
-            mock_ip_cls.objects.select_for_update.return_value.filter.return_value.__getitem__.return_value = [existing]
-            # The cross-device FK guard must see no OTHER device referencing this IP, so the row
-            # is treated as re-homeable and the lock path under test runs.
-            mock_device_cls.objects.filter.return_value.exclude.return_value.exists.return_value = False
-            view._attach_oob_ip(_make_request(post={}), "10.0.0.9", iface)
-        mock_ip_cls.objects.select_for_update.assert_called_once()
+        dev = make_device("oob-ip-lock-sql")
+        iface = make_interface(dev, "idrac0")
+        existing = make_ip("10.0.0.9/24")
+        user = make_user_with_perms("oob-ip-lock-sql", [("change", IPAddress)])
+        with transaction.atomic(), CaptureQueriesContext(connection) as captured:
+            ip, reason = view._attach_oob_ip(make_request("post", user=user), "10.0.0.9", iface)
+
+        assert reason is None and ip.pk == existing.pk
+        locking = [q["sql"] for q in captured.captured_queries if "FOR UPDATE" in q["sql"].upper()]
+        assert locking, "the candidate row was never locked"
+        # The lock must carry the permission join, i.e. it ran through restrict(), and must lock
+        # only the address row rather than the joined permission tables.
+        assert any("OF " in sql.upper() for sql in locking), "the lock did not restrict itself to the row"
 
 
 @pytest.mark.django_db

--- a/netbox_librenms_plugin/tests/test_coverage_actions.py
+++ b/netbox_librenms_plugin/tests/test_coverage_actions.py
@@ -7393,17 +7393,48 @@ class TestResolveOOBInterface:
 
     def test_new_reuses_existing_locked_interface(self):
         """An interface with the requested (device, name) already exists → it is reused, no create, regardless of the 'add' permission."""
+        from dcim.models import Interface
         from django.db import transaction
+
+        from netbox_librenms_plugin.tests.view_test_helpers import make_request, make_user_with_perms
 
         view = self._view()
         dev = make_device("oob-res-reuse")
         existing = make_interface(dev, "idrac0")
-        req = _make_request(post={"oob_interface_id": "__new__", "oob_new_interface_name": "idrac0"})
-        # Deny add to prove the reuse path never needs it.
-        req.user.has_perm.side_effect = lambda perm: "add_interface" not in perm
+        user = make_user_with_perms("oob-res-reuse", [("view", Interface)])
+        req = make_request(
+            "post",
+            {"oob_interface_id": "__new__", "oob_new_interface_name": "idrac0"},
+            user=user,
+        )
+        assert not user.has_perm("dcim.add_interface")
         with transaction.atomic():
             result_iface, reason = view._resolve_oob_interface(req, dev)
         assert result_iface.pk == existing.pk and reason is None
+
+    def test_new_does_not_reuse_an_interface_outside_the_view_grant(self):
+        """The name-based reuse path must match the scoped explicit-PK path."""
+        from dcim.models import Interface
+        from django.db import transaction
+
+        from netbox_librenms_plugin.tests.view_test_helpers import grant, make_request, make_user_with_perms
+
+        view = self._view()
+        device = make_device("oob-res-name-scope")
+        hidden = make_interface(device, "idrac0")
+        allowed = make_interface(device, "eth0")
+        user = make_user_with_perms("oob-interface-view-scope", [("add", Interface)])
+        user = grant(user, "view", Interface, constraints={"pk": allowed.pk})
+        request = make_request(
+            "post",
+            {"oob_interface_id": "__new__", "oob_new_interface_name": hidden.name},
+            user=user,
+        )
+
+        with transaction.atomic():
+            result_iface, reason = view._resolve_oob_interface(request, device)
+
+        assert result_iface is None and reason is None
 
     def test_create_without_add_perm_returns_permission_add(self):
         """No existing row + user lacks Interface 'add' → the write-time re-check refuses the create rather than silently creating it."""
@@ -7458,13 +7489,17 @@ class TestAttachOOBIp:
 
     def test_rehomes_existing_unassigned_ip(self):
         from django.db import transaction
+        from ipam.models import IPAddress
+
+        from netbox_librenms_plugin.tests.view_test_helpers import make_request, make_user_with_perms
 
         view = self._view()
         dev = make_device("oob-ip-rehome")
         iface = make_interface(dev, "idrac0")
         existing = make_ip("10.0.0.9/24")  # unassigned host match
+        user = make_user_with_perms("oob-ip-rehome", [("change", IPAddress)])
         with transaction.atomic():
-            ip, reason = view._attach_oob_ip(_make_request(post={}), "10.0.0.9", iface)
+            ip, reason = view._attach_oob_ip(make_request("post", user=user), "10.0.0.9", iface)
         assert ip.pk == existing.pk and reason is None
         existing.refresh_from_db()
         assert existing.assigned_object == iface
@@ -7498,13 +7533,16 @@ class TestAttachOOBIp:
 
         from ipam.models import VRF, IPAddress
 
+        from netbox_librenms_plugin.tests.view_test_helpers import make_request, make_user_with_perms
+
         view = self._view()
         dev = make_device("oob-ip-vrf-ambig")
         iface = make_interface(dev, "idrac0")
         existing = make_ip("10.0.0.9/24")  # global, unassigned → the legitimate candidate
         IPAddress.objects.create(address="10.0.0.9/24", vrf=VRF.objects.create(name="cust-b"), status="active")
+        user = make_user_with_perms("oob-ip-vrf-ambig", [("change", IPAddress)])
         with transaction.atomic():
-            ip, reason = view._attach_oob_ip(_make_request(post={}), "10.0.0.9", iface)
+            ip, reason = view._attach_oob_ip(make_request("post", user=user), "10.0.0.9", iface)
         assert reason is None and ip.pk == existing.pk
         existing.refresh_from_db()
         assert existing.assigned_object == iface
@@ -7554,6 +7592,29 @@ class TestAttachOOBIp:
         assert ip is None and reason == "permission_change"
         existing.refresh_from_db()
         assert existing.assigned_object is None  # not re-homed
+
+    def test_rehome_denied_outside_the_constrained_change_grant(self):
+        """A model-level change permission must not re-home an excluded IP row."""
+        from django.db import transaction
+        from ipam.models import IPAddress
+
+        from netbox_librenms_plugin.tests.view_test_helpers import grant, make_request, make_user_with_perms
+
+        view = self._view()
+        device = make_device("oob-ip-change-scope")
+        interface = make_interface(device, "idrac0")
+        hidden = make_ip("10.0.0.9/24")
+        allowed = make_ip("10.0.0.10/24")
+        user = make_user_with_perms("oob-ip-change-scope", [])
+        user = grant(user, "change", IPAddress, constraints={"pk": allowed.pk})
+        request = make_request("post", user=user)
+
+        with transaction.atomic():
+            ip, reason = view._attach_oob_ip(request, "10.0.0.9", interface)
+
+        assert ip is None and reason == "permission_change"
+        hidden.refresh_from_db()
+        assert hidden.assigned_object is None
 
     def test_create_denied_without_add_permission(self):
         """TOCTOU backstop on the create path: the locked create re-verifies 'add' and refuses an add-lacking user rather than creating the IP."""
@@ -8134,6 +8195,96 @@ class TestAddDeviceTypeMappingSingleUpfrontQuery:
         assert not count_qs, f"upfront ambiguity check must use [:2], not COUNT(): {count_qs}"
         # Sanity: the path ran to completion and created the mapping (normalized to lowercase).
         assert DeviceTypeMapping.objects.filter(librenms_hardware="widgetx").exists()
+
+
+@pytest.mark.django_db
+class TestMappingChangeScope:
+    """Natural-key mapping updates must remain inside constrained change grants."""
+
+    @staticmethod
+    def _request(user, **data):
+        from netbox_librenms_plugin.tests.view_test_helpers import make_request
+
+        return make_request("post", data, user=user)
+
+    def test_device_type_mapping_outside_change_grant_is_not_updated(self):
+        from dcim.models import DeviceType
+        from django.http import HttpResponse
+
+        from netbox_librenms_plugin.models import DeviceTypeMapping
+        from netbox_librenms_plugin.tests.view_test_helpers import grant, make_user_with_perms
+        from netbox_librenms_plugin.utils import apply_normalization_rules
+        from netbox_librenms_plugin.views.imports.actions import AddDeviceTypeMappingView
+
+        old_type = make_device("mapping-scope-old").device_type
+        new_type = DeviceType.objects.create(
+            manufacturer=old_type.manufacturer,
+            model="Mapping Scope New Type",
+            slug="mapping-scope-new-type",
+        )
+        allowed = DeviceTypeMapping.objects.create(librenms_hardware="allowed-hw", netbox_device_type=old_type)
+        raw_hardware = "Hidden Hardware Scope"
+        mapping_hardware = apply_normalization_rules(value=raw_hardware, scope="device_type")
+        hidden = DeviceTypeMapping.objects.create(librenms_hardware=mapping_hardware, netbox_device_type=old_type)
+        user = make_user_with_perms("mapping-change-scope", [("view", type(old_type))])
+        user = grant(user, "change", DeviceTypeMapping, constraints={"pk": allowed.pk})
+        request = self._request(user, device_type_id=str(new_type.pk), server_key="default")
+        view = AddDeviceTypeMappingView()
+        view.setup(request)
+        view._librenms_api = MagicMock(server_key="default", cache_timeout=300)
+
+        with (
+            patch.object(view, "rebind_api_for_server", return_value="default"),
+            patch(
+                "netbox_librenms_plugin.views.imports.actions.fetch_device_with_cache",
+                return_value={"hardware": raw_hardware},
+            ),
+            patch(
+                "netbox_librenms_plugin.views.imports.actions.DeviceValidationDetailsView.get",
+                return_value=HttpResponse(b"<div></div>"),
+            ),
+            patch.object(view, "validate_and_apply_selections", return_value=(None, None)),
+        ):
+            view.post(request, device_id=1)
+
+        hidden.refresh_from_db()
+        assert hidden.netbox_device_type_id == old_type.pk
+
+    def test_platform_mapping_outside_change_grant_is_not_updated(self):
+        from dcim.models import Platform
+        from django.http import HttpResponse
+
+        from netbox_librenms_plugin.models import PlatformMapping
+        from netbox_librenms_plugin.tests.view_test_helpers import grant, make_user_with_perms
+        from netbox_librenms_plugin.views.imports.actions import AddPlatformMappingView
+
+        old_platform = Platform.objects.create(name="Mapping Scope Old", slug="mapping-scope-old")
+        new_platform = Platform.objects.create(name="Mapping Scope New", slug="mapping-scope-new")
+        allowed = PlatformMapping.objects.create(librenms_os="allowed-os", netbox_platform=old_platform)
+        hidden = PlatformMapping.objects.create(librenms_os="hidden-os", netbox_platform=old_platform)
+        user = make_user_with_perms("platform-mapping-change-scope", [("view", Platform)])
+        user = grant(user, "change", PlatformMapping, constraints={"pk": allowed.pk})
+        request = self._request(user, platform_id=str(new_platform.pk), server_key="default")
+        view = AddPlatformMappingView()
+        view.setup(request)
+        view._librenms_api = MagicMock(server_key="default", cache_timeout=300)
+
+        with (
+            patch.object(view, "rebind_api_for_server", return_value="default"),
+            patch(
+                "netbox_librenms_plugin.views.imports.actions.fetch_device_with_cache",
+                return_value={"os": "hidden-os"},
+            ),
+            patch(
+                "netbox_librenms_plugin.views.imports.actions.DeviceValidationDetailsView.get",
+                return_value=HttpResponse(b"<div></div>"),
+            ),
+            patch.object(view, "get_validated_device_with_selections", return_value=(None, None, None)),
+        ):
+            view.post(request, device_id=1)
+
+        hidden.refresh_from_db()
+        assert hidden.netbox_platform_id == old_platform.pk
 
 
 # ---------------------------------------------------------------------------

--- a/netbox_librenms_plugin/tests/test_coverage_actions.py
+++ b/netbox_librenms_plugin/tests/test_coverage_actions.py
@@ -7331,7 +7331,58 @@ class TestResolveOOBInterface:
         with transaction.atomic():
             result_iface, reason = view._resolve_oob_interface(request, device)
 
-        assert result_iface is None and reason is None
+        # A dedicated reason, not the "no selection made" pair: the caller DID choose a name, and
+        # the message chain would otherwise tell the operator to choose one.
+        assert result_iface is None and reason == "name_out_of_scope"
+
+    def test_out_of_scope_name_tells_the_operator_what_actually_blocked_it(self):
+        """The whole view: the refusal must not surface as "choose an interface" when one was chosen."""
+        from dcim.models import Interface
+        from django.http import HttpResponse
+        from ipam.models import IPAddress
+
+        from netbox_librenms_plugin.tests.view_test_helpers import grant, make_request, messages_on
+        from netbox_librenms_plugin.views.imports.actions import AddAsOOBView
+
+        device = make_device("oob-msg-name-scope")
+        make_interface(device, "idrac0")  # exists, and the caller gets no view grant for it
+        user = _scoped_device_writer(device, "oob-msg-name-scope-writer")
+        user = grant(user, "add", Interface)
+        user = grant(user, "add", IPAddress)
+        request = make_request(
+            "post",
+            {
+                "existing_device_id": str(device.pk),
+                "server_key": "default",
+                "oob_interface_id": "__new__",
+                "oob_new_interface_name": "idrac0",
+            },
+            user=user,
+            path="/add-as-oob/",
+        )
+        view = AddAsOOBView()
+        view.kwargs = {}
+        view._librenms_api = _make_api()
+        view.request = request
+        libre_device = {"device_id": 4444, "hostname": f"{device.name}-oob", "sysName": f"{device.name}-oob"}
+        validation = {"oob_candidate": {"device": device, "type": "idrac", "ip": "10.88.0.7"}}
+
+        with (
+            patch.object(
+                AddAsOOBView, "get_validated_device_with_selections", return_value=(libre_device, validation, {})
+            ),
+            patch.object(AddAsOOBView, "render_device_row", return_value=HttpResponse(b"row-ok")),
+            patch.object(AddAsOOBView, "rebind_api_for_server", return_value=view._librenms_api),
+        ):
+            view.post(request, device_id=4444)
+
+        warnings = [text for level, text in messages_on(request) if level == "warning"]
+        assert any("outside your view scope" in text for text in warnings), warnings
+        assert not any("Choose an interface" in text for _level, text in messages_on(request))
+        # The link still committed; only the IP set was skipped.
+        device.refresh_from_db()
+        assert device.custom_field_data["librenms_id"]["default"]["oob"]["id"] == 4444
+        assert device.oob_ip_id is None
 
     def test_create_without_add_perm_returns_permission_add(self):
         """No existing row + user lacks Interface 'add' → the write-time re-check refuses the create rather than silently creating it."""
@@ -8153,8 +8204,11 @@ class TestMappingChangeScope:
             ),
             patch.object(view, "validate_and_apply_selections", return_value=(None, None)),
         ):
-            view.post(request, device_id=1)
+            response = view.post(request, device_id=1)
 
+        # The refusal text, not just the unchanged row: a failed permission gate, a rebind
+        # failure and the broad except all leave the mapping alone too.
+        assert b"Existing mapping is no longer available." in response.content
         hidden.refresh_from_db()
         assert hidden.netbox_device_type_id == old_type.pk
 
@@ -8189,8 +8243,9 @@ class TestMappingChangeScope:
             ),
             patch.object(view, "get_validated_device_with_selections", return_value=(None, None, None)),
         ):
-            view.post(request, device_id=1)
+            response = view.post(request, device_id=1)
 
+        assert b"Existing mapping is no longer available." in response.content
         hidden.refresh_from_db()
         assert hidden.netbox_platform_id == old_platform.pk
 

--- a/netbox_librenms_plugin/tests/test_coverage_base_views.py
+++ b/netbox_librenms_plugin/tests/test_coverage_base_views.py
@@ -3743,11 +3743,13 @@ class TestSingleCableVerifyViewPermissionGate:
         request.user.has_perm.return_value = False  # unauthorized → real gate returns 403
         view.request = request  # check_object_permissions reads self.request.user
 
-        with patch("netbox_librenms_plugin.views.base.cables_view.BaseCableTableView.get_object") as mock_get_obj:
+        # post() resolves through restrict_object_or_404, not get_object: patching the latter
+        # made this assertion vacuous.
+        with patch.object(view, "restrict_object_or_404") as mock_resolve:
             response = view.post(request)
 
         assert response.status_code == 403
-        mock_get_obj.assert_not_called()  # device never resolved → no arbitrary-ID probing
+        mock_resolve.assert_not_called()  # device never resolved → no arbitrary-ID probing
 
 
 # ---------------------------------------------------------------------------

--- a/netbox_librenms_plugin/tests/test_coverage_base_views.py
+++ b/netbox_librenms_plugin/tests/test_coverage_base_views.py
@@ -16,7 +16,10 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from dcim.models import Device
+
 from netbox_librenms_plugin.tests.conftest import make_device, make_interface, make_ip
+from netbox_librenms_plugin.tests.view_test_helpers import make_user_with_perms
 
 # =============================================================================
 # Helpers
@@ -2097,6 +2100,8 @@ class TestBaseInterfaceTablePostCoercesLibreNMSId:
             api.get_ports = MagicMock(name="get_ports", return_value=(False, "should-not-be-called"))
 
             request = RequestFactory().post(f"/plugins/librenms/devices/{device.pk}/interface-sync/", data={})
+            # get_object now scopes by request.user, so the request needs a real permitted user.
+            request.user = make_user_with_perms("coerce-iface-viewer", [("view", Device)])
             view.request = request
 
             with patch("netbox_librenms_plugin.views.base.interfaces_view.messages") as mock_messages:
@@ -2152,6 +2157,8 @@ class TestBaseVLANTablePostCoercesLibreNMSId:
             api.get_device_vlans = MagicMock(name="get_device_vlans", return_value=(False, "should-not-be-called"))
 
             request = RequestFactory().post(f"/plugins/librenms/devices/{device.pk}/vlan-sync/", data={})
+            # get_object now scopes by request.user, so the request needs a real permitted user.
+            request.user = make_user_with_perms("coerce-vlan-viewer", [("view", Device)])
             view.request = request
             # The error-path render moves up the stack: this branch returns render(...), but a
             # higher branch routes the same exit through self.render_sync_partial(). Patch BOTH with
@@ -2200,6 +2207,8 @@ class TestBaseModuleTablePostCoercesLibreNMSId:
             )
 
             request = RequestFactory().post(f"/plugins/librenms/devices/{device.pk}/module-sync/", data={})
+            # get_object now scopes by request.user, so the request needs a real permitted user.
+            request.user = make_user_with_perms("coerce-module-viewer", [("view", Device)])
             view.request = request
             # The error-path render moves up the stack (return render(...) here vs
             # self.render_sync_partial() on a higher branch); patch BOTH with create=True so the
@@ -3446,21 +3455,29 @@ class TestBaseInterfaceTableViewMissingLines:
         view.interface_name_field = None
         return view
 
-    def test_get_object_calls_get_object_or_404(self):
-        """get_object delegates to get_object_or_404(self.model, pk=pk)."""
-        from unittest.mock import MagicMock, patch
+    @pytest.mark.django_db
+    def test_get_object_resolves_through_a_restricted_queryset(self):
+        """get_object returns a permitted object and 404s on one outside the caller's grant."""
+        from dcim.models import Device
+        from django.http import Http404
 
-        view = self._make_view()
-        mock_obj = MagicMock()
+        from netbox_librenms_plugin.tests.conftest import make_device
+        from netbox_librenms_plugin.tests.view_test_helpers import (
+            make_request,
+            make_user_with_perms,
+            make_view,
+        )
+        from netbox_librenms_plugin.views.base.interfaces_view import BaseInterfaceTableView
 
-        with patch(
-            "netbox_librenms_plugin.views.base.interfaces_view.get_object_or_404",
-            return_value=mock_obj,
-        ) as mock_404:
-            result = view.get_object(42)
+        allowed = make_device("getobj-allowed-iface")
+        hidden = make_device("getobj-hidden-iface")
+        user = make_user_with_perms("getobj-viewer-iface", [("view", Device)], constraints={"name": allowed.name})
+        view = make_view(BaseInterfaceTableView, make_request("get", user=user))
+        view.model = Device
 
-        mock_404.assert_called_once_with(view.model, pk=42)
-        assert result is mock_obj
+        assert view.get_object(allowed.pk).pk == allowed.pk
+        with pytest.raises(Http404):
+            view.get_object(hidden.pk)
 
     def test_get_interfaces_raises_not_implemented(self):
         """get_interfaces raises NotImplementedError — must be overridden."""
@@ -3726,7 +3743,7 @@ class TestSingleCableVerifyViewPermissionGate:
         request.user.has_perm.return_value = False  # unauthorized → real gate returns 403
         view.request = request  # check_object_permissions reads self.request.user
 
-        with patch("netbox_librenms_plugin.views.base.cables_view.get_object_or_404") as mock_get_obj:
+        with patch("netbox_librenms_plugin.views.base.cables_view.BaseCableTableView.get_object") as mock_get_obj:
             response = view.post(request)
 
         assert response.status_code == 403

--- a/netbox_librenms_plugin/tests/test_coverage_base_views2.py
+++ b/netbox_librenms_plugin/tests/test_coverage_base_views2.py
@@ -239,19 +239,29 @@ class TestGetObjectAndIpAddress:
         view.model = MagicMock()
         return view
 
-    def test_get_object_calls_get_object_or_404(self):
-        """get_object calls get_object_or_404 with view.model and given pk."""
-        view = self._make_view()
-        mock_device = MagicMock()
+    @pytest.mark.django_db
+    def test_get_object_resolves_through_a_restricted_queryset(self):
+        """get_object returns a permitted object and 404s on one outside the caller's grant."""
+        from dcim.models import Device
+        from django.http import Http404
 
-        with patch(
-            "netbox_librenms_plugin.views.base.cables_view.get_object_or_404",
-            return_value=mock_device,
-        ) as mock_get:
-            result = view.get_object(42)
+        from netbox_librenms_plugin.tests.conftest import make_device
+        from netbox_librenms_plugin.tests.view_test_helpers import (
+            make_request,
+            make_user_with_perms,
+            make_view,
+        )
+        from netbox_librenms_plugin.views.base.cables_view import BaseCableTableView
 
-        mock_get.assert_called_once_with(view.model, pk=42)
-        assert result is mock_device
+        allowed = make_device("getobj-allowed-cable")
+        hidden = make_device("getobj-hidden-cable")
+        user = make_user_with_perms("getobj-viewer-cable", [("view", Device)], constraints={"name": allowed.name})
+        view = make_view(BaseCableTableView, make_request("get", user=user))
+        view.model = Device
+
+        assert view.get_object(allowed.pk).pk == allowed.pk
+        with pytest.raises(Http404):
+            view.get_object(hidden.pk)
 
     def test_get_ip_address_with_primary_ip(self):
         """get_ip_address returns the string representation of primary_ip when present."""
@@ -1378,19 +1388,29 @@ class TestIpAddressViewMethods:
         assert view._get_port_info(7, cache, "ifName") == row
         assert cache[7] == row
 
-    def test_get_object_calls_get_object_or_404(self):
-        """get_object delegates to get_object_or_404 with the view's model."""
-        view = self._make_view()
-        mock_device = MagicMock()
+    @pytest.mark.django_db
+    def test_get_object_resolves_through_a_restricted_queryset(self):
+        """get_object returns a permitted object and 404s on one outside the caller's grant."""
+        from dcim.models import Device
+        from django.http import Http404
 
-        with patch(
-            "netbox_librenms_plugin.views.base.ip_addresses_view.get_object_or_404",
-            return_value=mock_device,
-        ) as mock_get:
-            result = view.get_object(42)
+        from netbox_librenms_plugin.tests.conftest import make_device
+        from netbox_librenms_plugin.tests.view_test_helpers import (
+            make_request,
+            make_user_with_perms,
+            make_view,
+        )
+        from netbox_librenms_plugin.views.base.ip_addresses_view import BaseIPAddressTableView
 
-        mock_get.assert_called_once_with(view.model, pk=42)
-        assert result is mock_device
+        allowed = make_device("getobj-allowed-ip")
+        hidden = make_device("getobj-hidden-ip")
+        user = make_user_with_perms("getobj-viewer-ip", [("view", Device)], constraints={"name": allowed.name})
+        view = make_view(BaseIPAddressTableView, make_request("get", user=user))
+        view.model = Device
+
+        assert view.get_object(allowed.pk).pk == allowed.pk
+        with pytest.raises(Http404):
+            view.get_object(hidden.pk)
 
     def test_get_ip_addresses_calls_api(self):
         """get_ip_addresses calls get_librenms_id then get_device_ips; stores librenms_id."""

--- a/netbox_librenms_plugin/tests/test_coverage_device_fields.py
+++ b/netbox_librenms_plugin/tests/test_coverage_device_fields.py
@@ -1090,6 +1090,27 @@ class TestCreateAndAssignPlatformView:
         mock_msg.success.assert_called_once()
         assert "already existed" in mock_msg.success.call_args[0][1].lower()
 
+    def test_existing_platform_outside_the_view_grant_is_not_assigned(self):
+        """Name-based reuse must not expose and assign a hidden Platform."""
+        from dcim.models import Device, Platform
+
+        hidden = Platform.objects.create(name="Hidden Reuse Platform", slug="hidden-reuse-platform")
+        allowed = Platform.objects.create(name="Allowed Reuse Platform", slug="allowed-reuse-platform")
+        device = make_device("platform-reuse-view-scope")
+        user = make_user_with_perms("platform-reuse-view-scope", [("change", Device)])
+        user = grant(user, "view", Platform, constraints={"pk": allowed.pk})
+        request = _make_request(
+            {"platform_name": hidden.name, "manufacturer": "", "create_mapping": ""},
+            user=user,
+        )
+        view = self._view(request)
+
+        _post(view, request, pk=device.pk)
+
+        device.refresh_from_db()
+        assert device.platform_id is None
+        assert message_texts(request, "error") == ["Selected platform is not available."]
+
     def test_platform_already_exists_creates_missing_mapping(self):
         """When the platform exists and create_mapping is on, the missing mapping is added (real)."""
         from dcim.models import Device, Platform
@@ -1454,7 +1475,7 @@ class TestCreateAndAssignPlatformView:
 
         platform = Platform.objects.create(name="Cisco IOS", slug="cisco-ios")
         PlatformMapping.objects.create(librenms_os="ios", netbox_platform=platform)
-        user = make_user_with_perms("perms-mapexists", [("change", Device)])
+        user = make_user_with_perms("perms-mapexists", [("change", Device), ("view", Platform)])
         view, req, dev = self._success_setup(
             platform_name="Cisco IOS", librenms_os="ios", create_mapping="1", user=user
         )

--- a/netbox_librenms_plugin/tests/test_coverage_sync_view.py
+++ b/netbox_librenms_plugin/tests/test_coverage_sync_view.py
@@ -1193,7 +1193,6 @@ class TestFullPageMigratedContextServerScope:
         request.user = make_user_with_perms("stale-key-viewer", [("view", Device)])
         # Calling get() directly skips View.setup(), and get_object() scopes by request.user.
         view.request = request
-        request.user = MagicMock(is_superuser=True)
 
         captured = {}
 

--- a/netbox_librenms_plugin/tests/test_coverage_sync_view.py
+++ b/netbox_librenms_plugin/tests/test_coverage_sync_view.py
@@ -3,6 +3,9 @@
 from unittest.mock import MagicMock, patch
 
 import pytest
+from dcim.models import Device
+
+from netbox_librenms_plugin.tests.view_test_helpers import make_user_with_perms
 from django.test import RequestFactory
 
 
@@ -27,7 +30,7 @@ class TestBaseLibreNMSSyncViewGet:
     """Tests for get() method (lines 29-53)."""
 
     @patch("netbox_librenms_plugin.views.base.librenms_sync_view.render")
-    @patch("netbox_librenms_plugin.views.base.librenms_sync_view.get_object_or_404")
+    @patch("netbox_librenms_plugin.views.base.librenms_sync_view.BaseLibreNMSSyncView.get_object")
     def test_get_non_vc_device(self, mock_get_obj, mock_render):
         """Non-VC device: librenms_lookup_device stays as obj."""
         view = _make_view()
@@ -50,7 +53,7 @@ class TestBaseLibreNMSSyncViewGet:
         assert view._librenms_lookup_device is obj
 
     @patch("netbox_librenms_plugin.views.base.librenms_sync_view.render")
-    @patch("netbox_librenms_plugin.views.base.librenms_sync_view.get_object_or_404")
+    @patch("netbox_librenms_plugin.views.base.librenms_sync_view.BaseLibreNMSSyncView.get_object")
     def test_get_rebinds_header_to_request_server_key(self, mock_get_obj, mock_render, mock_multi_server_config):
         """The page header must rebind to ?server_key so it matches the server the tabs render for."""
         view = _make_view()
@@ -72,7 +75,7 @@ class TestBaseLibreNMSSyncViewGet:
         assert view._librenms_api.server_key == "secondary"
 
     @patch("netbox_librenms_plugin.views.base.librenms_sync_view.render")
-    @patch("netbox_librenms_plugin.views.base.librenms_sync_view.get_object_or_404")
+    @patch("netbox_librenms_plugin.views.base.librenms_sync_view.BaseLibreNMSSyncView.get_object")
     @patch("netbox_librenms_plugin.views.base.librenms_sync_view.get_librenms_sync_device")
     def test_get_unresolved_server_key_fails_closed(self, mock_get_sync, mock_get_obj, mock_render):
         """Stale ?server_key fails closed: no default-server librenms_id, VC delegation skipped."""
@@ -100,7 +103,7 @@ class TestBaseLibreNMSSyncViewGet:
         assert view.librenms_id is None  # no default-server mapping attributed to the gone server
 
     @patch("netbox_librenms_plugin.views.base.librenms_sync_view.render")
-    @patch("netbox_librenms_plugin.views.base.librenms_sync_view.get_object_or_404")
+    @patch("netbox_librenms_plugin.views.base.librenms_sync_view.BaseLibreNMSSyncView.get_object")
     @patch("netbox_librenms_plugin.views.base.librenms_sync_view.get_librenms_sync_device")
     def test_get_vc_member_always_delegates_to_sync_device(self, mock_get_sync, mock_get_obj, mock_render):
         """VC member: no own librenms_id - get_librenms_sync_device returns VC primary."""
@@ -129,7 +132,7 @@ class TestBaseLibreNMSSyncViewGet:
         assert view._librenms_lookup_device is vc_primary
 
     @patch("netbox_librenms_plugin.views.base.librenms_sync_view.render")
-    @patch("netbox_librenms_plugin.views.base.librenms_sync_view.get_object_or_404")
+    @patch("netbox_librenms_plugin.views.base.librenms_sync_view.BaseLibreNMSSyncView.get_object")
     @patch("netbox_librenms_plugin.views.base.librenms_sync_view.get_librenms_sync_device")
     def test_get_vc_member_with_own_librenms_id_uses_itself(self, mock_get_sync, mock_get_obj, mock_render):
         """VC member: has own librenms_id - get_librenms_sync_device still called, returns member itself."""
@@ -157,7 +160,7 @@ class TestBaseLibreNMSSyncViewGet:
         assert view._librenms_lookup_device is obj
 
     @patch("netbox_librenms_plugin.views.base.librenms_sync_view.render")
-    @patch("netbox_librenms_plugin.views.base.librenms_sync_view.get_object_or_404")
+    @patch("netbox_librenms_plugin.views.base.librenms_sync_view.BaseLibreNMSSyncView.get_object")
     @patch("netbox_librenms_plugin.views.base.librenms_sync_view.get_librenms_sync_device")
     def test_get_vc_member_no_sync_device_falls_back_to_obj(self, mock_get_sync, mock_get_obj, mock_render):
         """VC member: when get_librenms_sync_device returns None, keeps obj."""
@@ -1187,6 +1190,9 @@ class TestFullPageMigratedContextServerScope:
         view._get_platform_info = MagicMock(return_value={})
 
         request = RequestFactory().get("/?server_key=edgelondon")
+        request.user = make_user_with_perms("stale-key-viewer", [("view", Device)])
+        # Calling get() directly skips View.setup(), and get_object() scopes by request.user.
+        view.request = request
         request.user = MagicMock(is_superuser=True)
 
         captured = {}

--- a/netbox_librenms_plugin/tests/test_coverage_sync_views.py
+++ b/netbox_librenms_plugin/tests/test_coverage_sync_views.py
@@ -1364,6 +1364,7 @@ class TestDeleteNetBoxInterfacesViewPost:
         result = _post(view, req, object_type="device", object_id=obj.pk)
         data = json.loads(result.content)
         assert data["deleted_count"] == 0
+        assert data["errors"] == [f"Interface {iface.name} does not belong to this device"]
         assert other.interfaces.filter(pk=iface.pk).exists()  # not deleted
 
     @pytest.mark.django_db
@@ -1383,6 +1384,7 @@ class TestDeleteNetBoxInterfacesViewPost:
         result = _post(view, req, object_type="virtualmachine", object_id=vm.pk)
         data = json.loads(result.content)
         assert data["deleted_count"] == 0
+        assert data["errors"] == [f"Interface {vmiface.name} does not belong to this virtual machine"]
         assert VMInterface.objects.filter(pk=vmiface.pk).exists()
 
     @pytest.mark.django_db
@@ -1448,6 +1450,7 @@ class TestDeleteNetBoxInterfacesViewPost:
         result = _post(view, req, object_type="device", object_id=member.pk)
         data = json.loads(result.content)
         assert data["deleted_count"] == 0
+        assert data["errors"] == [f"Interface {iface.name} does not belong to this device or its virtual chassis"]
         assert Interface.objects.filter(pk=iface.pk).exists()  # not deleted (not a VC member's)
 
 

--- a/netbox_librenms_plugin/tests/test_coverage_sync_views2.py
+++ b/netbox_librenms_plugin/tests/test_coverage_sync_views2.py
@@ -1961,47 +1961,6 @@ class TestSyncIPAddressesViewInterfaceResolution:
         assert "no longer exists" in results["errors"]["10.0.0.1"]
         assert not IPAddress.objects.filter(address="10.0.0.1/24").exists()
 
-    def test_primary_ip_row_locks_the_device_before_writing_the_address(self):
-        """The primary-IP row writes the address and then the device (primary_ip4), while the migrate move views lock Device then IPAddress — so this path must take the device row lock FIRST or the two orders close a deadlock cycle."""
-        from django.db import connection
-        from django.test.utils import CaptureQueriesContext
-
-        from netbox_librenms_plugin.utils import set_librenms_device_id
-
-        dev = make_device("ipres-lockorder")
-        iface = make_interface(dev, "eth0")
-        set_librenms_device_id(iface, 5, "default")
-        iface.save()
-
-        view = self._view()
-        view._post_server_key = "default"
-        view.get_management_ip = MagicMock(return_value="10.0.0.1")
-
-        ip_data = {
-            "ip_address": "10.0.0.1",
-            "ip_with_mask": "10.0.0.1/24",
-            "interface_url": None,
-            "port_id": 5,
-            "interface_name": "eth0",
-        }
-        request = _make_request(post_data={"select": ["10.0.0.1"]})
-        with (
-            patch(
-                "netbox_librenms_plugin.views.sync.ip_addresses.resolve_set_primary_ip",
-                return_value=True,
-            ),
-            CaptureQueriesContext(connection) as ctx,
-        ):
-            results = view.process_ip_sync(request, ["10.0.0.1"], [ip_data], dev, "device")
-
-        assert results["primary_set"] == ["10.0.0.1"]
-        sqls = [q["sql"] for q in ctx.captured_queries]
-        device_locks = [i for i, sql in enumerate(sqls) if 'FROM "dcim_device"' in sql and "FOR UPDATE" in sql]
-        address_writes = [i for i, sql in enumerate(sqls) if 'INSERT INTO "ipam_ipaddress"' in sql]
-        assert device_locks, "the primary-IP row must lock the device row (SELECT ... FOR UPDATE)"
-        assert address_writes, "the address must be written"
-        assert min(device_locks) < min(address_writes), "the device lock must precede the address write"
-
     def test_build_interface_maps_vc_shared_name_prefers_viewed_member(self):
         """A name shared across VC members resolves to the VIEWED member's own interface (matching the rendered table), not ambiguous."""
         _vc, members = self._make_vc("ipres-vcdup", [1, 2])

--- a/netbox_librenms_plugin/tests/test_coverage_sync_views2.py
+++ b/netbox_librenms_plugin/tests/test_coverage_sync_views2.py
@@ -2404,6 +2404,28 @@ class TestSyncVLANsViewWithGroup:
         assert any("name is invalid" in text for text in message_texts(req, "error"))
         assert any("1 skipped (invalid VLAN name)" in text for text in message_texts(req, "success"))
 
+    def test_invalid_vlan_vid_does_not_abort_the_batch(self):
+        """An out-of-range LibreNMS VID is skipped while the next valid VLAN is created."""
+        from ipam.models import VLAN
+
+        dev = make_device("vlan-invalid-vid")
+        req = _make_request(post_data={"action": "create_vlans", "select": ["0", "401"]})
+        view = _vlan_view(
+            req,
+            dev,
+            [
+                {"vlan_vlan": 0, "vlan_name": "Invalid VID"},
+                {"vlan_vlan": 401, "vlan_name": "Valid VID"},
+            ],
+        )
+
+        _post(view, req, object_type="device", object_id=dev.pk)
+
+        assert not VLAN.objects.filter(vid=0).exists()
+        assert VLAN.objects.filter(vid=401, name="Valid VID").exists()
+        assert any("VID is invalid" in text for text in message_texts(req, "error"))
+        assert any("1 skipped (invalid VLAN VID)" in text for text in message_texts(req, "success"))
+
 
 class TestSyncVLANsViewGroupedUpdateSkip:
     """Lines 134-139: grouped VLAN update (elif) and unchanged (else) paths."""

--- a/netbox_librenms_plugin/tests/test_coverage_sync_views2.py
+++ b/netbox_librenms_plugin/tests/test_coverage_sync_views2.py
@@ -2029,7 +2029,13 @@ class TestSyncIPAddressesViewInterfaceResolution:
         assert min(device_locks) < min(address_writes), "the device lock must precede the address write"
 
     def test_primary_ip_row_fails_if_owner_disappears_before_lock(self):
-        """A concurrent owner deletion must not write an orphan address or recreate stale owner data."""
+        """A concurrent owner deletion must not write an orphan address or recreate stale owner data.
+
+        The owner is deleted for real, from inside the query wrapper, just before its lock runs. A
+        stubbed ``select_for_update()`` chain would instead pin the exact call shape the code
+        happens to use today and break on any equivalent rewrite.
+        """
+        from django.db import connection
         from ipam.models import IPAddress
 
         from netbox_librenms_plugin.utils import set_librenms_device_id
@@ -2051,16 +2057,31 @@ class TestSyncIPAddressesViewInterfaceResolution:
         }
         request = _make_request(post_data={"select": ["10.0.0.1"]})
 
+        class _DeleteOwnerBeforeItsLock:
+            """Delete the device row as the sync is about to lock it."""
+
+            def __init__(self, device_pk):
+                self.device_pk = device_pk
+                self.fired = False
+
+            def __call__(self, execute, sql, params, many, context):
+                if not self.fired and 'FROM "dcim_device"' in sql and "FOR UPDATE" in sql.upper():
+                    # Set first: the cascade below re-enters this wrapper.
+                    self.fired = True
+                    type(dev).objects.filter(pk=self.device_pk).delete()
+                return execute(sql, params, many, context)
+
+        deleter = _DeleteOwnerBeforeItsLock(dev.pk)
         with (
             patch(
                 "netbox_librenms_plugin.views.sync.ip_addresses.resolve_set_primary_ip",
                 return_value=True,
             ),
-            patch.object(type(dev).objects, "select_for_update") as select_for_update,
+            connection.execute_wrapper(deleter),
         ):
-            select_for_update.return_value.filter.return_value.first.return_value = None
             results = view.process_ip_sync(request, ["10.0.0.1"], [ip_data], dev, "device")
 
+        assert deleter.fired, "the sync never reached the device lock"
         assert results["failed"] == ["10.0.0.1"]
         assert "no longer exists" in results["errors"]["10.0.0.1"]
         assert not IPAddress.objects.filter(address="10.0.0.1/24").exists()

--- a/netbox_librenms_plugin/tests/test_coverage_sync_views2.py
+++ b/netbox_librenms_plugin/tests/test_coverage_sync_views2.py
@@ -1961,6 +1961,47 @@ class TestSyncIPAddressesViewInterfaceResolution:
         assert "no longer exists" in results["errors"]["10.0.0.1"]
         assert not IPAddress.objects.filter(address="10.0.0.1/24").exists()
 
+    def test_primary_ip_row_locks_the_device_before_writing_the_address(self):
+        """The primary-IP row writes the address and then the device (primary_ip4), while the migrate move views lock Device then IPAddress — so this path must take the device row lock FIRST or the two orders close a deadlock cycle."""
+        from django.db import connection
+        from django.test.utils import CaptureQueriesContext
+
+        from netbox_librenms_plugin.utils import set_librenms_device_id
+
+        dev = make_device("ipres-lockorder")
+        iface = make_interface(dev, "eth0")
+        set_librenms_device_id(iface, 5, "default")
+        iface.save()
+
+        view = self._view()
+        view._post_server_key = "default"
+        view.get_management_ip = MagicMock(return_value="10.0.0.1")
+
+        ip_data = {
+            "ip_address": "10.0.0.1",
+            "ip_with_mask": "10.0.0.1/24",
+            "interface_url": None,
+            "port_id": 5,
+            "interface_name": "eth0",
+        }
+        request = _make_request(post_data={"select": ["10.0.0.1"]})
+        with (
+            patch(
+                "netbox_librenms_plugin.views.sync.ip_addresses.resolve_set_primary_ip",
+                return_value=True,
+            ),
+            CaptureQueriesContext(connection) as ctx,
+        ):
+            results = view.process_ip_sync(request, ["10.0.0.1"], [ip_data], dev, "device")
+
+        assert results["primary_set"] == ["10.0.0.1"]
+        sqls = [q["sql"] for q in ctx.captured_queries]
+        device_locks = [i for i, sql in enumerate(sqls) if 'FROM "dcim_device"' in sql and "FOR UPDATE" in sql]
+        address_writes = [i for i, sql in enumerate(sqls) if 'INSERT INTO "ipam_ipaddress"' in sql]
+        assert device_locks, "the primary-IP row must lock the device row (SELECT ... FOR UPDATE)"
+        assert address_writes, "the address must be written"
+        assert min(device_locks) < min(address_writes), "the device lock must precede the address write"
+
     def test_build_interface_maps_vc_shared_name_prefers_viewed_member(self):
         """A name shared across VC members resolves to the VIEWED member's own interface (matching the rendered table), not ambiguous."""
         _vc, members = self._make_vc("ipres-vcdup", [1, 2])

--- a/netbox_librenms_plugin/tests/test_coverage_sync_views2.py
+++ b/netbox_librenms_plugin/tests/test_coverage_sync_views2.py
@@ -2296,6 +2296,19 @@ class TestSyncVLANsViewWithGroup:
         assert vlan.name == "Production"
         assert vlan.status == "active"
 
+    def test_leading_zero_selection_uses_the_canonical_cached_vid(self):
+        """A canonical group field must sync a leading-zero selection."""
+        from ipam.models import VLAN
+
+        dev = make_device("vlan-group-canonical")
+        group = _vlan_group("Canonical Group")
+        req = _make_request(post_data={"action": "create_vlans", "select": ["0200"], "vlan_group_200": str(group.pk)})
+        view = _vlan_view(req, dev, [{"vlan_vlan": 200, "vlan_name": "Canonical"}])
+
+        _post(view, req, object_type="device", object_id=dev.pk)
+
+        assert VLAN.objects.filter(vid=200, group=group, name="Canonical").exists()
+
     def test_invalid_vlan_group_id_is_rejected(self):
         """A requested-but-missing VLAN group fails closed: no VLAN is created (not even a global one) and an error is surfaced."""
         from ipam.models import VLAN, VLANGroup

--- a/netbox_librenms_plugin/tests/test_coverage_sync_views2.py
+++ b/netbox_librenms_plugin/tests/test_coverage_sync_views2.py
@@ -11,6 +11,7 @@ import pytest
 
 from netbox_librenms_plugin.tests.conftest import make_device, make_interface, make_vm
 from netbox_librenms_plugin.tests.view_test_helpers import (
+    assert_locked_before_update,
     grant,
     make_request,
     make_user_with_perms,
@@ -1780,12 +1781,7 @@ class TestSyncIPAddressesViewInterfaceResolution:
         with CaptureQueriesContext(connection) as ctx:
             results = view.process_ip_sync(request, ["10.9.9.9"], [ip_data], dev, "device")
 
-        locked_ip = [
-            q["sql"]
-            for q in ctx.captured_queries
-            if "ipam_ipaddress" in q["sql"].lower() and "for update" in q["sql"].lower()
-        ]
-        assert locked_ip, "the existing IPAddress must be SELECT ... FOR UPDATE before it is rewritten"
+        assert_locked_before_update(ctx, "ipam_ipaddress")
 
         existing.refresh_from_db()
         assert existing.assigned_object == iface

--- a/netbox_librenms_plugin/tests/test_coverage_sync_views2.py
+++ b/netbox_librenms_plugin/tests/test_coverage_sync_views2.py
@@ -1745,6 +1745,52 @@ class TestSyncIPAddressesViewInterfaceResolution:
         )
         assert result is None
 
+    def test_existing_ip_is_locked_before_it_is_rewritten(self):
+        """The authorized existing row must be SELECT ... FOR UPDATE before its FK/VRF are rewritten.
+
+        The scope check that authorizes the row takes no lock, so without a re-lock a concurrent
+        assignment or VRF change can commit between the check and the save and be silently
+        overwritten.
+        """
+        from django.db import connection
+        from django.test.utils import CaptureQueriesContext
+        from ipam.models import IPAddress
+
+        from netbox_librenms_plugin.utils import set_librenms_device_id
+
+        view = self._view()
+        view._post_server_key = "default"
+
+        dev = make_device("iplock-existing")
+        iface = make_interface(dev, "eth9")
+        set_librenms_device_id(iface, 91, "default")
+        iface.save()
+        # Pre-existing row for the same address, not yet bound to this interface.
+        existing = IPAddress.objects.create(address="10.9.9.9/24")
+
+        ip_data = {
+            "ip_address": "10.9.9.9",
+            "ip_with_mask": "10.9.9.9/24",
+            "interface_url": None,
+            "port_id": 91,
+            "interface_name": "eth9",
+        }
+        request = _make_request(post_data={"select": ["10.9.9.9"]})
+
+        with CaptureQueriesContext(connection) as ctx:
+            results = view.process_ip_sync(request, ["10.9.9.9"], [ip_data], dev, "device")
+
+        locked_ip = [
+            q["sql"]
+            for q in ctx.captured_queries
+            if "ipam_ipaddress" in q["sql"].lower() and "for update" in q["sql"].lower()
+        ]
+        assert locked_ip, "the existing IPAddress must be SELECT ... FOR UPDATE before it is rewritten"
+
+        existing.refresh_from_db()
+        assert existing.assigned_object == iface
+        assert results["updated"] == ["10.9.9.9"]
+
     def test_stale_interface_url_still_assigns_after_interface_synced(self):
         """Regression: cached row was enriched before the interface existed (``interface_url`` is None), but the interface has since been synced."""
         from ipam.models import IPAddress

--- a/netbox_librenms_plugin/tests/test_coverage_sync_views2.py
+++ b/netbox_librenms_plugin/tests/test_coverage_sync_views2.py
@@ -1319,6 +1319,37 @@ class TestSyncIPAddressesViewIPWrites:
         ip.refresh_from_db()
         assert ip.assigned_object_id == eth0.pk  # re-homed to the port_id-resolved interface
 
+    def test_existing_ip_outside_the_change_grant_is_not_rehomed(self):
+        """An address matched by natural key must remain outside a constrained change grant."""
+        from dcim.models import Interface
+        from ipam.models import IPAddress
+
+        from netbox_librenms_plugin.utils import set_librenms_device_id
+
+        device = make_device("ip-update-change-scope")
+        target = make_interface(device, "eth0")
+        original = make_interface(device, "eth1")
+        set_librenms_device_id(target, 5, "default")
+        target.save()
+        hidden_ip = IPAddress.objects.create(address="10.0.0.1/24", assigned_object=original, status="active")
+        allowed_ip = IPAddress.objects.create(address="10.0.0.2/24", status="active")
+        user = make_user_with_perms(
+            "ip-update-change-scope",
+            [("view", Interface), ("add", IPAddress)],
+        )
+        user = grant(user, "change", IPAddress, constraints={"pk": allowed_ip.pk})
+        request = _make_request(post_data={"select": ["10.0.0.1"]}, user=user)
+        view = make_view(_sync_ip_view_class(), request)
+        view._post_server_key = "default"
+        cached = [{"ip_address": "10.0.0.1", "ip_with_mask": "10.0.0.1/24", "port_id": 5}]
+
+        with patch("netbox_librenms_plugin.views.sync.ip_addresses.resolve_set_primary_ip", return_value=False):
+            results = view.process_ip_sync(request, ["10.0.0.1"], cached, device, "device")
+
+        hidden_ip.refresh_from_db()
+        assert hidden_ip.assigned_object_id == original.pk
+        assert results["failed"] == ["10.0.0.1"]
+
     def test_unchanged_ip_shows_warning(self):
         from ipam.models import IPAddress
 
@@ -1377,6 +1408,33 @@ class TestSyncIPAddressesViewHelpers:
         second = view._required_permissions("device")
 
         assert second == first
+
+    def test_set_primary_requires_change_scope_on_the_owner(self):
+        """The primary-IP toggle must resolve the owner through its change grant."""
+        from dcim.models import Device, Interface
+        from django.core.cache import cache
+        from django.http import Http404
+        from ipam.models import IPAddress
+
+        target = make_device("primary-owner-hidden")
+        decoy = make_device("primary-owner-allowed")
+        user = make_user_with_perms(
+            "primary-owner-change-scope",
+            [("add", IPAddress), ("change", IPAddress), ("view", Interface)],
+        )
+        user = grant(user, "view", Device, constraints={"pk": target.pk})
+        user = grant(user, "change", Device, constraints={"pk": decoy.pk})
+        request = _make_request(
+            post_data={"select": ["10.0.0.1"], "set-primary-ip-toggle": "on"},
+            user=user,
+        )
+        view = make_view(_sync_ip_view_class(), request)
+        view.rebind_api_for_server = MagicMock(return_value="default")
+        view.get_cache_key = MagicMock(return_value="primary-owner-change-scope")
+        cache.delete("primary-owner-change-scope")
+
+        with pytest.raises(Http404):
+            _post(view, request, object_type="device", pk=target.pk)
 
     def test_get_object_device(self):
         from netbox_librenms_plugin.views.sync.ip_addresses import SyncIPAddressesView

--- a/netbox_librenms_plugin/tests/test_coverage_sync_views3.py
+++ b/netbox_librenms_plugin/tests/test_coverage_sync_views3.py
@@ -386,6 +386,26 @@ class TestSyncInterface:
         assert not Interface.objects.filter(device=sibling, name="eth0").exists()
         assert v._skipped_conflicts == ["eth0 (selected target unavailable)"]
 
+    def test_existing_interface_outside_the_change_grant_is_skipped(self):
+        """A natural-key match must not bypass the caller's constrained change grant."""
+        from dcim.models import Device, Interface
+
+        device = make_device("sync-interface-change-scope")
+        hidden = make_interface(device, "eth0")
+        allowed = make_interface(device, "eth1")
+        user = make_user_with_perms(
+            "sync-interface-change-scope",
+            [("view", Device), ("add", Interface)],
+        )
+        user = grant(user, "change", Interface, constraints={"pk": allowed.pk})
+        request = make_request("post", user=user)
+        view = self._v(request)
+
+        view.sync_interface(device, {"ifName": hidden.name}, [], "ifName")
+
+        view.update_interface_attributes.assert_not_called()
+        assert view._skipped_conflicts == ["eth0 (port already mapped elsewhere or ambiguous)"]
+
     def test_vm_uses_vminterface(self):
         from virtualization.models import VMInterface
 

--- a/netbox_librenms_plugin/tests/test_coverage_sync_views3.py
+++ b/netbox_librenms_plugin/tests/test_coverage_sync_views3.py
@@ -275,11 +275,9 @@ class TestSyncInterfacesPost:
 
 class TestSyncSelectedInterfaces:
     def test_only_selected_processed(self):
-        from dcim.models import Device
-
         v = _make_iv()
         v.sync_interface = MagicMock()
-        obj = MagicMock(spec=Device)
+        obj = make_device("sync-selected")
         ports = [{"ifName": "eth0"}, {"ifName": "eth1"}]
         with patch("netbox_librenms_plugin.views.sync.interfaces.transaction"):
             v.sync_selected_interfaces(obj, ["eth0"], ports, [], "ifName")

--- a/netbox_librenms_plugin/tests/test_module_adoption_concurrency.py
+++ b/netbox_librenms_plugin/tests/test_module_adoption_concurrency.py
@@ -1,0 +1,97 @@
+"""Concurrency coverage for automatic module interface adoption."""
+
+from concurrent.futures import ThreadPoolExecutor
+from threading import Event
+from types import SimpleNamespace
+
+import pytest
+from django.apps import apps
+
+from netbox_librenms_plugin.tests.conftest import make_device, make_interface
+
+pytestmark = pytest.mark.django_db(
+    transaction=True,
+    available_apps=[app.name for app in apps.get_app_configs()],
+)
+
+
+def test_concurrent_hidden_interface_is_not_adopted(monkeypatch):
+    """Authorize the interface that Module.save adopts after its internal lookup."""
+    from dcim.models import Device, Interface, InterfaceTemplate, Module, ModuleBay, ModuleType
+    from django.contrib.auth import get_user_model
+    from django.db import close_old_connections, connection
+
+    from netbox_librenms_plugin.tests.view_test_helpers import grant, make_request, make_user_with_perms
+    from netbox_librenms_plugin.views.sync.modules import InstallModuleView
+
+    device = make_device("module-adoption-race")
+    bay = ModuleBay.objects.create(device=device, name="Adoption Race Bay")
+    module_type = ModuleType.objects.create(
+        manufacturer=device.device_type.manufacturer,
+        model="Adoption Race Type",
+    )
+    InterfaceTemplate.objects.create(
+        module_type=module_type,
+        name="Te1/1/1",
+        type="10gbase-x-sfpp",
+    )
+    allowed = make_interface(device, "Te1/1/2", iface_type="10gbase-x-sfpp")
+    user = make_user_with_perms(
+        "module-adoption-race",
+        [
+            ("view", Device),
+            ("view", ModuleBay),
+            ("view", ModuleType),
+            ("add", Module),
+            ("add", Interface),
+            ("delete", Interface),
+        ],
+    )
+    user = grant(user, "change", Interface, constraints={"pk": allowed.pk})
+    install_ready = Event()
+    winner_committed = Event()
+    original_full_clean = Module.full_clean
+
+    def pause_before_save(module, *args, **kwargs):
+        result = original_full_clean(module, *args, **kwargs)
+        if module.device_id == device.pk and module.module_bay_id == bay.pk and module.pk is None:
+            install_ready.set()
+            assert winner_committed.wait(5), "test did not commit the competing interface"
+        return result
+
+    monkeypatch.setattr(Module, "full_clean", pause_before_save)
+
+    def install_module():
+        close_old_connections()
+        try:
+            with connection.cursor() as cursor:
+                cursor.execute("SET lock_timeout = '5s'")
+                cursor.execute("SET statement_timeout = '5s'")
+            thread_device = Device.objects.get(pk=device.pk)
+            thread_user = get_user_model().objects.get(pk=user.pk)
+            request = make_request(
+                "post",
+                {
+                    "module_bay_id": str(bay.pk),
+                    "module_type_id": str(module_type.pk),
+                    "server_key": "default",
+                },
+                user=thread_user,
+            )
+            view = InstallModuleView()
+            view._librenms_api = SimpleNamespace(server_key="default")
+            view.setup(request, pk=thread_device.pk)
+            return view.post(request, pk=thread_device.pk)
+        finally:
+            close_old_connections()
+
+    with ThreadPoolExecutor(max_workers=1) as executor:
+        future = executor.submit(install_module)
+        assert install_ready.wait(5), "module install did not reach the adoption race window"
+        winner = Interface.objects.create(device=device, name="Te1/1/1", type="10gbase-x-sfpp")
+        winner_committed.set()
+        future.result(timeout=10)
+
+    winner.refresh_from_db()
+    assert winner.module_id is None
+    assert not Module.objects.filter(device=device, module_bay=bay).exists()

--- a/netbox_librenms_plugin/tests/test_module_replace.py
+++ b/netbox_librenms_plugin/tests/test_module_replace.py
@@ -404,140 +404,220 @@ class TestReplaceModuleView:
         mock_msg.error.assert_called_once()
         mock_redirect.assert_called_once()
 
+    @pytest.mark.django_db
     def test_replace_deletes_old_and_creates_new(self):
         """POST with valid data deletes old module and creates new one."""
-        view = self._view()
-        device = _make_device()
-        sync_device = _make_device(pk=999, name="vc-sync-device")
-        installed = _make_module(serial="OLD", type_id=5)
-        request = _make_request("POST", data={"module_id": "42", "ent_index": "100", "server_key": "prod"})
-        cached = [{"entPhysicalIndex": 100, "entPhysicalModelName": "XCM-7s", "entPhysicalSerialNum": "NEW"}]
-        matched_type = MagicMock()
-        matched_type.model = "XCM-7s"
+        from types import SimpleNamespace
 
-        new_module = MagicMock()
+        from dcim.models import Module
+        from django.core.cache import cache
 
-        with (
-            patch(
-                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
-                side_effect=[device, installed],
-            ),
-            patch.object(view, "require_all_permissions", return_value=None),
-            # "prod" must be a configured server for resolve_posted_server_key to honour the posted key
-            # (else it degrades to the active "default"); mirrors a real multi-server deployment.
-            patch(
-                "netbox_librenms_plugin.librenms_api.LibreNMSAPI.get_available_servers",
-                return_value={"prod": "Prod", "default": "Default"},
-            ),
-            patch.object(view, "get_cache_key", return_value="ck") as mock_get_cache_key,
-            patch(
-                "netbox_librenms_plugin.views.sync.modules._get_sync_device_for_inventory",
-                return_value=sync_device,
-            ) as mock_get_sync_device,
-            patch("netbox_librenms_plugin.views.sync.modules.reverse", return_value="/sync/"),
-            patch("netbox_librenms_plugin.views.sync.modules.cache") as mock_cache,
-            patch(
-                "netbox_librenms_plugin.views.sync.modules.get_module_types_indexed",
-                return_value={"XCM-7s": matched_type},
-            ),
-            patch("netbox_librenms_plugin.utils.apply_normalization_rules", return_value="XCM-7s"),
-            patch("netbox_librenms_plugin.views.sync.modules.transaction") as mock_tx,
-            patch("netbox_librenms_plugin.views.sync.modules.messages") as mock_msg,
-            patch("netbox_librenms_plugin.views.sync.modules.redirect"),
-            patch("dcim.models.Module") as mock_module_cls,
-        ):
-            mock_cache.get.return_value = {"inventory": cached, "librenms_id": "test"}
-            mock_tx.atomic.return_value.__enter__ = lambda s: s
-            mock_tx.atomic.return_value.__exit__ = MagicMock(return_value=False)
-            mock_module_cls.return_value = new_module
-            # New code does TWO select_for_update() calls inside the atomic
-            # block — one for the installed-module re-fetch, one for the
-            # serial-conflict re-derivation (returns empty list here).
-            installed_chain = MagicMock()
-            installed_chain.filter.return_value.select_related.return_value.first.return_value = installed
-            conflict_chain = MagicMock()
-            conflict_chain.filter.return_value.exclude.return_value.select_related.return_value.__iter__ = lambda s: (
-                iter([])
-            )
-            mock_module_cls.objects.restrict.return_value = mock_module_cls.objects
-            mock_module_cls.objects.select_for_update.side_effect = [installed_chain, conflict_chain]
-            mock_module_cls.objects.filter.return_value.exclude.return_value.count.return_value = 0
+        from netbox_librenms_plugin.tests.conftest import make_device, make_module_bay, make_module_type
+        from netbox_librenms_plugin.tests.view_test_helpers import make_request, make_view, message_texts
+        from netbox_librenms_plugin.views.sync.modules import ReplaceModuleView
 
-            _post(view, request, pk=24)
+        device = make_device("replace-real-device")
+        old_type = make_module_type("REPLACE-REAL-OLD")
+        new_type = make_module_type("REPLACE-REAL-NEW")
+        bay = make_module_bay(device, "Replace Real Bay")
+        installed = Module.objects.create(
+            device=device,
+            module_bay=bay,
+            module_type=old_type,
+            serial="REPLACE-REAL-OLD-SERIAL",
+        )
+        request = make_request(
+            "post",
+            {"module_id": str(installed.pk), "ent_index": "100", "server_key": "default"},
+        )
+        view = make_view(
+            ReplaceModuleView,
+            request,
+            librenms_api=SimpleNamespace(server_key="default"),
+        )
+        cache_key = view.get_cache_key(device, "inventory", server_key="default")
+        cache.set(
+            cache_key,
+            {
+                "inventory": [
+                    {
+                        "entPhysicalIndex": 100,
+                        "entPhysicalModelName": new_type.model,
+                        "entPhysicalSerialNum": "REPLACE-REAL-NEW-SERIAL",
+                    }
+                ],
+                "librenms_id": 1,
+            },
+            timeout=300,
+        )
+        try:
+            response = _post(view, request, pk=device.pk)
+        finally:
+            cache.delete(cache_key)
 
-        installed.delete.assert_called_once()
-        new_module.full_clean.assert_called_once()
-        new_module.save.assert_called_once()
-        mock_msg.success.assert_called_once()
-        # server_key from POST must be forwarded to the cache key lookup
-        mock_get_sync_device.assert_called_with(device, "prod")
-        mock_get_cache_key.assert_called_with(sync_device, "inventory", server_key="prod")
+        assert response.status_code == 302
+        assert not Module.objects.filter(pk=installed.pk).exists()
+        replacement = Module.objects.get(device=device, module_bay=bay)
+        assert replacement.module_type == new_type
+        assert replacement.serial == "REPLACE-REAL-NEW-SERIAL"
+        assert any("Replaced REPLACE-REAL-OLD with REPLACE-REAL-NEW" in text for text in message_texts(request))
 
+    @pytest.mark.django_db
     def test_replace_removes_serial_conflict_from_db(self):
         """POST re-derives the conflicting module from serial, not from conflict_module_id."""
-        view = self._view()
-        device = _make_device()
-        installed = _make_module(serial="OLD", type_id=5)
-        # No conflict_module_id in POST — conflict must be derived from serial
-        request = _make_request("POST", data={"module_id": "42", "ent_index": "100", "server_key": "prod"})
-        cached = [
-            {"entPhysicalIndex": 100, "entPhysicalModelName": "XCM-7s", "entPhysicalSerialNum": "CONFLICT_SERIAL"}
-        ]
-        matched_type = MagicMock()
-        matched_type.model = "XCM-7s"
+        from types import SimpleNamespace
 
-        conflict = _make_module(pk=55, serial="CONFLICT_SERIAL", bay_name="Slot 3")
-        new_module = MagicMock()
+        from dcim.models import Module
+        from django.core.cache import cache
 
-        with (
-            patch(
-                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
-                side_effect=[device, installed],
-            ),
-            patch.object(view, "require_all_permissions", return_value=None),
-            patch.object(view, "get_cache_key", return_value="ck"),
-            patch("netbox_librenms_plugin.views.sync.modules.reverse", return_value="/sync/"),
-            patch("netbox_librenms_plugin.views.sync.modules.cache") as mock_cache,
-            patch(
-                "netbox_librenms_plugin.views.sync.modules.get_module_types_indexed",
-                return_value={"XCM-7s": matched_type},
-            ),
-            patch("netbox_librenms_plugin.utils.apply_normalization_rules", return_value="XCM-7s"),
-            patch("netbox_librenms_plugin.views.sync.modules.transaction") as mock_tx,
-            patch("netbox_librenms_plugin.views.sync.modules.messages") as mock_msg,
-            patch("netbox_librenms_plugin.views.sync.modules.redirect"),
-            patch("dcim.models.Module") as mock_module_cls,
-        ):
-            mock_cache.get.return_value = {"inventory": cached, "librenms_id": "test"}
-            mock_tx.atomic.return_value.__enter__ = lambda s: s
-            mock_tx.atomic.return_value.__exit__ = MagicMock(return_value=False)
-            mock_module_cls.return_value = new_module
-            # New code: both the installed re-fetch and the serial-conflict
-            # re-derivation use select_for_update() to lock both rows inside
-            # the atomic block.  Configure the chained mocks accordingly:
-            #   1. installed = Module.objects.select_for_update()
-            #                    .filter(pk=, device=).select_related().first()
-            #   2. conflicts = list(Module.objects.select_for_update()
-            #                    .filter(serial=).exclude(pk=).select_related(...))
-            installed_chain = MagicMock()
-            installed_chain.filter.return_value.select_related.return_value.first.return_value = installed
-            conflict_chain = MagicMock()
-            conflict_chain.filter.return_value.exclude.return_value.select_related.return_value.__iter__ = lambda s: (
-                iter([conflict])
-            )
-            mock_module_cls.objects.restrict.return_value = mock_module_cls.objects
-            mock_module_cls.objects.select_for_update.side_effect = [installed_chain, conflict_chain]
-            mock_module_cls.objects.filter.return_value.exclude.return_value.count.return_value = 1
+        from netbox_librenms_plugin.tests.conftest import make_device, make_module_bay, make_module_type
+        from netbox_librenms_plugin.tests.view_test_helpers import make_request, make_view, message_texts
+        from netbox_librenms_plugin.views.sync.modules import ReplaceModuleView
 
-            _post(view, request, pk=24)
+        device = make_device("replace-conflict-target")
+        conflict_device = make_device("replace-conflict-source")
+        old_type = make_module_type("REPLACE-CONFLICT-OLD")
+        new_type = make_module_type("REPLACE-CONFLICT-NEW")
+        conflict_type = make_module_type("REPLACE-CONFLICT-SOURCE")
+        target_bay = make_module_bay(device, "Replace Conflict Target Bay")
+        conflict_bay = make_module_bay(conflict_device, "Replace Conflict Source Bay")
+        installed = Module.objects.create(
+            device=device,
+            module_bay=target_bay,
+            module_type=old_type,
+            serial="REPLACE-CONFLICT-OLD-SERIAL",
+        )
+        conflict = Module.objects.create(
+            device=conflict_device,
+            module_bay=conflict_bay,
+            module_type=conflict_type,
+            serial="REPLACE-CONFLICT-NEW-SERIAL",
+        )
+        request = make_request(
+            "post",
+            {"module_id": str(installed.pk), "ent_index": "100", "server_key": "default"},
+        )
+        view = make_view(
+            ReplaceModuleView,
+            request,
+            librenms_api=SimpleNamespace(server_key="default"),
+        )
+        cache_key = view.get_cache_key(device, "inventory", server_key="default")
+        cache.set(
+            cache_key,
+            {
+                "inventory": [
+                    {
+                        "entPhysicalIndex": 100,
+                        "entPhysicalModelName": new_type.model,
+                        "entPhysicalSerialNum": conflict.serial,
+                    }
+                ],
+                "librenms_id": 1,
+            },
+            timeout=300,
+        )
+        try:
+            response = _post(view, request, pk=device.pk)
+        finally:
+            cache.delete(cache_key)
 
-        # Conflict module must be deleted, then the installed module, then new one saved
-        conflict.delete.assert_called_once()
-        installed.delete.assert_called_once()
-        new_module.save.assert_called_once()
-        mock_module_cls.objects.restrict.assert_any_call(request.user, "delete")
-        mock_msg.info.assert_called_once()
-        mock_msg.success.assert_called_once()
+        assert response.status_code == 302
+        assert not Module.objects.filter(pk__in=[installed.pk, conflict.pk]).exists()
+        replacement = Module.objects.get(device=device, module_bay=target_bay)
+        assert replacement.module_type == new_type
+        assert replacement.serial == "REPLACE-CONFLICT-NEW-SERIAL"
+        assert any("Removed REPLACE-CONFLICT-SOURCE" in text for text in message_texts(request, "info"))
+
+    @pytest.mark.django_db
+    def test_denied_interface_adoption_rolls_back_the_replacement(self):
+        from types import SimpleNamespace
+
+        from dcim.models import Device, Interface, InterfaceTemplate, Module, ModuleType
+        from django.core.cache import cache
+
+        from netbox_librenms_plugin.tests.conftest import (
+            make_device,
+            make_interface,
+            make_module_bay,
+            make_module_type,
+        )
+        from netbox_librenms_plugin.tests.view_test_helpers import (
+            grant,
+            make_request,
+            make_user_with_perms,
+            make_view,
+            message_texts,
+        )
+        from netbox_librenms_plugin.views.sync.modules import ReplaceModuleView
+
+        device = make_device("replace-adoption-scope")
+        old_type = make_module_type("REPLACE-ADOPTION-OLD")
+        new_type = make_module_type("REPLACE-ADOPTION-NEW")
+        InterfaceTemplate.objects.create(
+            module_type=new_type,
+            name="Te1/1/1",
+            type="10gbase-x-sfpp",
+        )
+        bay = make_module_bay(device, "Replace Adoption Scope Bay")
+        installed = Module.objects.create(
+            device=device,
+            module_bay=bay,
+            module_type=old_type,
+            serial="REPLACE-ADOPTION-OLD-SERIAL",
+        )
+        hidden = make_interface(device, "Te1/1/1", iface_type="10gbase-x-sfpp")
+        allowed = make_interface(device, "Te1/1/2", iface_type="10gbase-x-sfpp")
+        user = make_user_with_perms(
+            "replace-adoption-scope",
+            [
+                ("view", Device),
+                ("view", ModuleType),
+                ("add", Module),
+                ("change", Module),
+                ("delete", Module),
+                ("add", Interface),
+                ("delete", Interface),
+            ],
+        )
+        user = grant(user, "change", Interface, constraints={"pk": allowed.pk})
+        request = make_request(
+            "post",
+            {"module_id": str(installed.pk), "ent_index": "100", "server_key": "default"},
+            user=user,
+        )
+        view = make_view(
+            ReplaceModuleView,
+            request,
+            librenms_api=SimpleNamespace(server_key="default"),
+        )
+        cache_key = view.get_cache_key(device, "inventory", server_key="default")
+        cache.set(
+            cache_key,
+            {
+                "inventory": [
+                    {
+                        "entPhysicalIndex": 100,
+                        "entPhysicalModelName": new_type.model,
+                        "entPhysicalSerialNum": "REPLACE-ADOPTION-NEW-SERIAL",
+                    }
+                ],
+                "librenms_id": 1,
+            },
+            timeout=300,
+        )
+        try:
+            response = _post(view, request, pk=device.pk)
+        finally:
+            cache.delete(cache_key)
+
+        assert response.status_code == 302
+        assert Module.objects.filter(pk=installed.pk, module_type=old_type, module_bay=bay).exists()
+        assert not Module.objects.filter(device=device, module_type=new_type).exists()
+        hidden.refresh_from_db()
+        assert hidden.module_id is None
+        recorded_messages = message_texts(request)
+        assert any("not available for module adoption" in text for text in recorded_messages), recorded_messages
 
     def test_requires_all_permissions(self):
         """POST returns early when require_all_permissions returns a response."""

--- a/netbox_librenms_plugin/tests/test_module_replace.py
+++ b/netbox_librenms_plugin/tests/test_module_replace.py
@@ -530,7 +530,7 @@ class TestReplaceModuleView:
         assert any("Removed REPLACE-CONFLICT-SOURCE" in text for text in message_texts(request, "info"))
 
     @pytest.mark.django_db
-    def test_denied_interface_adoption_rolls_back_the_replacement(self):
+    def test_replacement_checks_interface_scope_before_deleting_the_old_module(self):
         from types import SimpleNamespace
 
         from dcim.models import Device, Interface, InterfaceTemplate, Module, ModuleType
@@ -567,7 +567,6 @@ class TestReplaceModuleView:
             serial="REPLACE-ADOPTION-OLD-SERIAL",
         )
         hidden = make_interface(device, "Te1/1/1", iface_type="10gbase-x-sfpp")
-        allowed = make_interface(device, "Te1/1/2", iface_type="10gbase-x-sfpp")
         user = make_user_with_perms(
             "replace-adoption-scope",
             [
@@ -580,7 +579,7 @@ class TestReplaceModuleView:
                 ("delete", Interface),
             ],
         )
-        user = grant(user, "change", Interface, constraints={"pk": allowed.pk})
+        user = grant(user, "change", Interface, constraints={"device__modules__isnull": True})
         request = make_request(
             "post",
             {"module_id": str(installed.pk), "ent_index": "100", "server_key": "default"},

--- a/netbox_librenms_plugin/tests/test_modules_view.py
+++ b/netbox_librenms_plugin/tests/test_modules_view.py
@@ -4260,7 +4260,8 @@ class TestFindIntegratingAncestor:
 
         assert BaseModuleTableView._find_integrating_ancestor(mda, self._index([xiom, mda])) is xiom
 
-    def test_numeric_model_finds_integrating_ancestor(self):
+    @pytest.mark.parametrize("model", [123456, 0])
+    def test_numeric_model_finds_integrating_ancestor(self, model):
         """Numeric ENTITY models are normalized on both sides of the integrated-card comparison."""
         from netbox_librenms_plugin.views.base.modules_view import BaseModuleTableView
 
@@ -4268,14 +4269,14 @@ class TestFindIntegratingAncestor:
             "entPhysicalIndex": 100,
             "entPhysicalClass": "xioModule",
             "entPhysicalSerialNum": "NS241462069",
-            "entPhysicalModelName": 123456,
+            "entPhysicalModelName": model,
             "entPhysicalContainedIn": 0,
         }
         mda = {
             "entPhysicalIndex": 200,
             "entPhysicalClass": "mdaModule",
             "entPhysicalSerialNum": "NS241462069",
-            "entPhysicalModelName": 123456,
+            "entPhysicalModelName": model,
             "entPhysicalContainedIn": 100,
         }
 

--- a/netbox_librenms_plugin/tests/test_oob_interface_concurrency.py
+++ b/netbox_librenms_plugin/tests/test_oob_interface_concurrency.py
@@ -117,3 +117,71 @@ def test_an_interface_outside_the_view_scope_is_never_locked():
     # The name is taken by a row this caller cannot see, so it is refused — without ever locking it.
     assert resolved is None
     assert reason is None
+
+
+def test_hidden_ip_row_is_not_locked_by_an_out_of_scope_caller():
+    """A caller who cannot see the matching IP must refuse without locking its row.
+
+    Locking first lets a caller pin a row it has no grant for, stalling the request that owns it
+    for the rest of the enclosing transaction. The hidden row here is held from a second
+    connection, so an unscoped lock blocks until lock_timeout instead of returning.
+    """
+    from dcim.models import Device, Interface
+    from django.contrib.auth import get_user_model
+    from django.db import close_old_connections, connection, transaction
+    from ipam.models import IPAddress
+
+    from netbox_librenms_plugin.tests.view_test_helpers import grant, make_request, make_user_with_perms
+    from netbox_librenms_plugin.views.imports.actions import AddAsOOBView
+
+    device = make_device("oob-ip-scope")
+    target = make_interface(device, "idrac0")
+    hidden_ip = IPAddress.objects.create(address="10.77.0.5/32")
+    visible_ip = IPAddress.objects.create(address="10.77.0.9/32")
+    user = make_user_with_perms("oob-ip-scope", [("add", IPAddress)])
+    # The grant deliberately excludes hidden_ip, so the caller may not change it.
+    user = grant(user, "change", IPAddress, constraints={"pk": visible_ip.pk})
+
+    row_locked = Event()
+    release_row = Event()
+
+    def hold_hidden_row():
+        close_old_connections()
+        try:
+            with transaction.atomic():
+                IPAddress.objects.select_for_update().get(pk=hidden_ip.pk)
+                row_locked.set()
+                assert release_row.wait(10), "test did not release the hidden row"
+        finally:
+            close_old_connections()
+
+    def attach_as_caller():
+        close_old_connections()
+        try:
+            with connection.cursor() as cursor:
+                cursor.execute("SET lock_timeout = '2s'")
+                cursor.execute("SET statement_timeout = '10s'")
+            thread_user = get_user_model().objects.get(pk=user.pk)
+            thread_iface = Interface.objects.get(pk=target.pk)
+            request = make_request("post", {}, user=thread_user)
+            with transaction.atomic():
+                return AddAsOOBView._attach_oob_ip(request, "10.77.0.5", thread_iface)
+        finally:
+            close_old_connections()
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        holder = executor.submit(hold_hidden_row)
+        assert row_locked.wait(10), "the hidden row was never locked"
+        caller = executor.submit(attach_as_caller)
+        try:
+            resolved, reason = caller.result(timeout=20)
+        finally:
+            release_row.set()
+            holder.result(timeout=10)
+
+    # Refused on scope, not blocked on the lock, and the hidden row is untouched.
+    assert resolved is None
+    assert reason == "permission_change"
+    hidden_ip.refresh_from_db()
+    assert hidden_ip.assigned_object_id is None
+    assert Device.objects.filter(pk=device.pk, oob_ip__isnull=True).exists()

--- a/netbox_librenms_plugin/tests/test_oob_interface_concurrency.py
+++ b/netbox_librenms_plugin/tests/test_oob_interface_concurrency.py
@@ -1,0 +1,69 @@
+"""Concurrency coverage for OOB interface name reuse."""
+
+from concurrent.futures import ThreadPoolExecutor
+from threading import Event
+
+import pytest
+from django.apps import apps
+
+from netbox_librenms_plugin.tests.conftest import make_device, make_interface
+
+pytestmark = pytest.mark.django_db(
+    transaction=True,
+    available_apps=[app.name for app in apps.get_app_configs()],
+)
+
+
+def test_concurrent_hidden_interface_winner_is_not_reused(monkeypatch):
+    """The uniqueness-race winner must stay inside the caller's Interface view grant."""
+    from dcim.models import Device, Interface
+    from django.contrib.auth import get_user_model
+    from django.db import close_old_connections, connection, transaction
+
+    from netbox_librenms_plugin.tests.view_test_helpers import grant, make_request, make_user_with_perms
+    from netbox_librenms_plugin.views.imports.actions import AddAsOOBView
+
+    device = make_device("oob-interface-race")
+    allowed = make_interface(device, "eth0")
+    user = make_user_with_perms("oob-interface-race", [("add", Interface)])
+    user = grant(user, "view", Interface, constraints={"pk": allowed.pk})
+    create_ready = Event()
+    winner_committed = Event()
+    original_full_clean = Interface.full_clean
+
+    def pause_before_create(interface, *args, **kwargs):
+        result = original_full_clean(interface, *args, **kwargs)
+        if interface.device_id == device.pk and interface.name == "idrac0" and interface.pk is None:
+            create_ready.set()
+            assert winner_committed.wait(5), "test did not commit the competing interface"
+        return result
+
+    monkeypatch.setattr(Interface, "full_clean", pause_before_create)
+
+    def resolve_interface():
+        close_old_connections()
+        try:
+            with connection.cursor() as cursor:
+                cursor.execute("SET lock_timeout = '5s'")
+                cursor.execute("SET statement_timeout = '5s'")
+            thread_device = Device.objects.get(pk=device.pk)
+            thread_user = get_user_model().objects.get(pk=user.pk)
+            request = make_request(
+                "post",
+                {"oob_interface_id": "__new__", "oob_new_interface_name": "idrac0"},
+                user=thread_user,
+            )
+            with transaction.atomic():
+                return AddAsOOBView._resolve_oob_interface(request, thread_device)
+        finally:
+            close_old_connections()
+
+    with ThreadPoolExecutor(max_workers=1) as executor:
+        future = executor.submit(resolve_interface)
+        assert create_ready.wait(5), "OOB resolution did not reach the create race window"
+        winner = Interface.objects.create(device=device, name="idrac0", type="other")
+        winner_committed.set()
+        resolved, reason = future.result(timeout=10)
+
+    assert resolved is None and reason is None
+    assert Interface.objects.filter(pk=winner.pk).exists()

--- a/netbox_librenms_plugin/tests/test_oob_interface_concurrency.py
+++ b/netbox_librenms_plugin/tests/test_oob_interface_concurrency.py
@@ -67,3 +67,53 @@ def test_concurrent_hidden_interface_winner_is_not_reused(monkeypatch):
 
     assert resolved is None and reason is None
     assert Interface.objects.filter(pk=winner.pk).exists()
+
+
+def test_an_interface_outside_the_view_scope_is_never_locked():
+    """Locking must happen inside the caller's view scope, not before it.
+
+    The resolver used to lock the (device, name) row and only hide it afterwards, so a caller could
+    take a row lock on an interface it cannot see and stall whoever legitimately owns it. Hold that
+    row from a second connection: the scoped resolver must return without waiting on it.
+    """
+    from dcim.models import Interface
+    from django.db import close_old_connections, connection, transaction
+
+    from netbox_librenms_plugin.tests.view_test_helpers import make_request, make_user_with_perms
+    from netbox_librenms_plugin.views.imports.actions import AddAsOOBView
+
+    device = make_device("oob-lock-scope")
+    hidden = make_interface(device, "idrac0")  # exists, but the user gets no view grant for it
+    user = make_user_with_perms("oob-lock-scope", [("add", Interface)])
+
+    holder_has_lock = Event()
+    release_holder = Event()
+
+    def hold_the_row():
+        close_old_connections()
+        try:
+            with transaction.atomic():
+                Interface.objects.select_for_update().filter(pk=hidden.pk).first()
+                holder_has_lock.set()
+                release_holder.wait(10)
+        finally:
+            close_old_connections()
+
+    request = make_request("post", {"oob_interface_id": "__new__", "oob_new_interface_name": "idrac0"}, user=user)
+
+    with ThreadPoolExecutor(max_workers=1) as executor:
+        holder = executor.submit(hold_the_row)
+        assert holder_has_lock.wait(10), "helper thread never took the row lock"
+        try:
+            with transaction.atomic():
+                # Fail fast rather than hang: the unfixed resolver blocks here on the held row.
+                with connection.cursor() as cursor:
+                    cursor.execute("SET LOCAL lock_timeout = '2s'")
+                resolved, reason = AddAsOOBView._resolve_oob_interface(request, device)
+        finally:
+            release_holder.set()
+            holder.result(timeout=10)
+
+    # The name is taken by a row this caller cannot see, so it is refused — without ever locking it.
+    assert resolved is None
+    assert reason is None

--- a/netbox_librenms_plugin/tests/test_oob_interface_concurrency.py
+++ b/netbox_librenms_plugin/tests/test_oob_interface_concurrency.py
@@ -65,7 +65,9 @@ def test_concurrent_hidden_interface_winner_is_not_reused(monkeypatch):
         winner_committed.set()
         resolved, reason = future.result(timeout=10)
 
-    assert resolved is None and reason is None
+    # The race winner sits outside the caller's view grant, so it is refused with the same
+    # reason as the pre-create check rather than the "no selection made" pair.
+    assert resolved is None and reason == "name_out_of_scope"
     assert Interface.objects.filter(pk=winner.pk).exists()
 
 
@@ -116,7 +118,7 @@ def test_an_interface_outside_the_view_scope_is_never_locked():
 
     # The name is taken by a row this caller cannot see, so it is refused — without ever locking it.
     assert resolved is None
-    assert reason is None
+    assert reason == "name_out_of_scope"
 
 
 def test_hidden_ip_row_is_not_locked_by_an_out_of_scope_caller():

--- a/netbox_librenms_plugin/tests/test_sync_interface_concurrency.py
+++ b/netbox_librenms_plugin/tests/test_sync_interface_concurrency.py
@@ -1,0 +1,92 @@
+"""Concurrency coverage for interface target validation."""
+
+from concurrent.futures import ThreadPoolExecutor
+from threading import Event
+
+import pytest
+from django.apps import apps
+
+from netbox_librenms_plugin.tests.conftest import make_virtual_chassis_members
+
+pytestmark = pytest.mark.django_db(
+    transaction=True,
+    # Include every installed app so transaction cleanup cascades through other
+    # plugins whose M2M tables are outside Django's default flush list.
+    available_apps=[app.name for app in apps.get_app_configs()],
+)
+
+
+def test_selected_vc_target_is_locked_through_interface_sync():
+    """A membership update must wait until target validation and sync commit."""
+    from dcim.models import Device, Interface
+    from django.contrib.auth import get_user_model
+    from django.db import close_old_connections, connection
+
+    from netbox_librenms_plugin.tests.view_test_helpers import make_request, make_superuser, make_view
+    from netbox_librenms_plugin.views.sync.interfaces import SyncInterfacesView
+
+    _vc, (page_device, target_device) = make_virtual_chassis_members("sync-target-lock")
+    user = make_superuser("sync-target-lock-user")
+    validation_done = Event()
+    release_sync = Event()
+    membership_changed = Event()
+
+    port = {
+        "ifName": "Gi0/1",
+        "ifType": "ethernetCsmacd",
+        "ifSpeed": 1_000_000_000,
+        "ifAlias": "uplink",
+        "ifMtu": 1500,
+        "ifAdminStatus": "up",
+        "port_id": None,
+    }
+
+    def sync_interface():
+        close_old_connections()
+        try:
+            with connection.cursor() as cursor:
+                cursor.execute("SET lock_timeout = '5s'")
+                cursor.execute("SET statement_timeout = '5s'")
+            page = Device.objects.get(pk=page_device.pk)
+            thread_user = get_user_model().objects.get(pk=user.pk)
+            request = make_request(
+                "post",
+                {"device_selection_Gi0/1": str(target_device.pk)},
+                user=thread_user,
+            )
+            view = make_view(SyncInterfacesView, request)
+            view._post_server_key = "default"
+            real_resolve = view._resolve_device_interface
+
+            def pause_after_validation(*args, **kwargs):
+                validation_done.set()
+                assert release_sync.wait(5), "test did not release the sync transaction"
+                return real_resolve(*args, **kwargs)
+
+            view._resolve_device_interface = pause_after_validation
+            view.sync_selected_interfaces(page, ["Gi0/1"], [port], ["vlans"], "ifName")
+        finally:
+            close_old_connections()
+
+    def move_target_out_of_chassis():
+        close_old_connections()
+        try:
+            with connection.cursor() as cursor:
+                cursor.execute("SET lock_timeout = '5s'")
+                cursor.execute("SET statement_timeout = '5s'")
+            Device.objects.filter(pk=target_device.pk).update(virtual_chassis=None, vc_position=None)
+            membership_changed.set()
+        finally:
+            close_old_connections()
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        sync_future = executor.submit(sync_interface)
+        assert validation_done.wait(5), "interface sync did not reach target validation"
+        move_future = executor.submit(move_target_out_of_chassis)
+        changed_during_sync = membership_changed.wait(0.5)
+        release_sync.set()
+        sync_future.result(timeout=10)
+        move_future.result(timeout=10)
+
+    assert not changed_during_sync
+    assert Interface.objects.filter(device=target_device, name="Gi0/1").exists()

--- a/netbox_librenms_plugin/tests/test_sync_interface_concurrency.py
+++ b/netbox_librenms_plugin/tests/test_sync_interface_concurrency.py
@@ -30,6 +30,7 @@ def test_selected_vc_target_is_locked_through_interface_sync():
     validation_done = Event()
     release_sync = Event()
     membership_changed = Event()
+    move_started = Event()
 
     port = {
         "ifName": "Gi0/1",
@@ -74,6 +75,7 @@ def test_selected_vc_target_is_locked_through_interface_sync():
             with connection.cursor() as cursor:
                 cursor.execute("SET lock_timeout = '5s'")
                 cursor.execute("SET statement_timeout = '5s'")
+            move_started.set()
             Device.objects.filter(pk=target_device.pk).update(virtual_chassis=None, vc_position=None)
             membership_changed.set()
         finally:
@@ -83,6 +85,9 @@ def test_selected_vc_target_is_locked_through_interface_sync():
         sync_future = executor.submit(sync_interface)
         assert validation_done.wait(5), "interface sync did not reach target validation"
         move_future = executor.submit(move_target_out_of_chassis)
+        # Without this the 0.5s window also covers thread start-up and the two SET
+        # statements, so the negative assertion below could pass with no lock held.
+        assert move_started.wait(5), "membership update thread did not start"
         changed_during_sync = membership_changed.wait(0.5)
         release_sync.set()
         sync_future.result(timeout=10)

--- a/netbox_librenms_plugin/tests/test_sync_modules.py
+++ b/netbox_librenms_plugin/tests/test_sync_modules.py
@@ -6296,10 +6296,29 @@ class TestStandaloneAdoptionAcrossEveryComponentType:
     unnoticed. Drive all eight against the real ORM.
     """
 
+    BAY_POSITION = "A1"
+
     @staticmethod
-    def _module_with_one_template(spec, name):
+    def _couples_a_rear_port(model):
+        """True while this NetBox still gives *model* a mandatory rear-port foreign key."""
+        # NetBox 4.5 replaced the front-port rear_port FK with PortTemplateMapping, so the field
+        # decides the shape and the test stays correct on both sides of that change.
+        return any(field.name == "rear_port" for field in model._meta.get_fields())
+
+    @staticmethod
+    def _type_kwargs(model_name):
+        """Return the mandatory ``type`` for the component models that require one."""
+        if "Interface" in model_name:
+            return {"type": "1000base-t"}
+        if "FrontPort" in model_name or "RearPort" in model_name:
+            return {"type": "8p8c"}
+        return {}
+
+    @classmethod
+    def _module_with_one_template(cls, spec, name):
         """Build a real Device + ModuleType carrying exactly one template for *spec*."""
-        from dcim.models import Manufacturer, Module, ModuleBay, ModuleType
+        from dcim.constants import MODULE_TOKEN
+        from dcim.models import Manufacturer, Module, ModuleBay, ModuleType, RearPortTemplate
 
         from netbox_librenms_plugin.tests.conftest import make_device
 
@@ -6309,18 +6328,30 @@ class TestStandaloneAdoptionAcrossEveryComponentType:
         module_type = ModuleType.objects.create(manufacturer=manufacturer, model=f"AdoptType-{name}")
 
         template_model = getattr(ModuleType, template_attribute).rel.related_model
-        template_kwargs = {"module_type": module_type, "name": f"adopt-{name}-0"}
-        if template_model.__name__ == "FrontPortTemplate":
-            # This NetBox decouples the front-port TEMPLATE from a rear-port template: it carries
-            # only type/color/positions. The standalone FrontPort below still needs a rear port.
-            template_kwargs["type"] = "8p8c"
-        elif template_model.__name__ in ("RearPortTemplate", "InterfaceTemplate"):
-            template_kwargs["type"] = "8p8c" if "Port" in template_model.__name__ else "1000base-t"
+        # The {module} token makes the module argument load-bearing in the name resolution.
+        template_kwargs = {"module_type": module_type, "name": f"{MODULE_TOKEN}-adopt-{name}-0"}
+        template_kwargs |= cls._type_kwargs(template_model.__name__)
+        if template_model.__name__ == "FrontPortTemplate" and cls._couples_a_rear_port(template_model):
+            template_kwargs["rear_port"] = RearPortTemplate.objects.create(
+                module_type=module_type, name=f"rear-for-{name}", type="8p8c"
+            )
+            template_kwargs["rear_port_position"] = 1
         template = template_model.objects.create(**template_kwargs)
 
-        bay = ModuleBay.objects.create(device=device, name=f"bay-{name}")
+        bay = ModuleBay.objects.create(device=device, name=f"bay-{name}", position=cls.BAY_POSITION)
         module = Module(device=device, module_bay=bay, module_type=module_type)
         return device, module, template, component_attribute, component_model
+
+    @classmethod
+    def _standalone_kwargs(cls, component_model, device, expected_name):
+        """Return the kwargs a standalone *component_model* needs on the running NetBox."""
+        from dcim.models import RearPort
+
+        kwargs = {"device": device, "name": expected_name} | cls._type_kwargs(component_model.__name__)
+        if component_model.__name__ == "FrontPort" and cls._couples_a_rear_port(component_model):
+            kwargs["rear_port"] = RearPort.objects.create(device=device, name=f"rear-for-{expected_name}", type="8p8c")
+            kwargs["rear_port_position"] = 1
+        return kwargs
 
     @pytest.mark.django_db
     @pytest.mark.parametrize("spec_index", range(8))
@@ -6341,13 +6372,13 @@ class TestStandaloneAdoptionAcrossEveryComponentType:
         # This is the call CodeRabbit questioned for NetBox 4.4/4.5: exercise it for every type.
         expected_name = _module_template_adoption_name(template_attribute, template, module)
         assert expected_name, f"{template_attribute} resolved an empty adoption name"
+        # The token only resolves when the module argument reaches NetBox, so this is what proves
+        # the version-compatible call is right rather than merely self-consistent.
+        assert expected_name == f"{self.BAY_POSITION}-adopt-{component_model.__name__.lower()}-0", (
+            f"{template_attribute} did not resolve the module placeholder from the installed bay"
+        )
 
-        standalone_kwargs = {"device": device, "name": expected_name}
-        if component_model.__name__ == "Interface":
-            standalone_kwargs["type"] = "1000base-t"
-        elif component_model.__name__ in ("RearPort", "FrontPort"):
-            standalone_kwargs["type"] = "8p8c"
-        standalone = component_model.objects.create(**standalone_kwargs)
+        standalone = component_model.objects.create(**self._standalone_kwargs(component_model, device, expected_name))
 
         allowed = {model: model.objects.all() for _, _, model in _module_component_specs()}
         expected = _authorize_adoptable_module_components(module, allowed)
@@ -6374,12 +6405,7 @@ class TestStandaloneAdoptionAcrossEveryComponentType:
         )
         expected_name = _module_template_adoption_name(template_attribute, template, module)
 
-        standalone_kwargs = {"device": device, "name": expected_name}
-        if component_model.__name__ == "Interface":
-            standalone_kwargs["type"] = "1000base-t"
-        elif component_model.__name__ in ("RearPort", "FrontPort"):
-            standalone_kwargs["type"] = "8p8c"
-        component_model.objects.create(**standalone_kwargs)
+        component_model.objects.create(**self._standalone_kwargs(component_model, device, expected_name))
 
         # Every model is in scope EXCEPT the one under test.
         allowed = {

--- a/netbox_librenms_plugin/tests/test_sync_modules.py
+++ b/netbox_librenms_plugin/tests/test_sync_modules.py
@@ -36,6 +36,26 @@ def _make_install_branch_view():
     return view
 
 
+def _run_install_single(device, item, index_map, module_types, **kwargs):
+    """Run the shared installer against real NetBox models and querysets."""
+    from dcim.models import Interface, ModuleBay
+
+    from netbox_librenms_plugin.views.sync.modules import InstallBranchView
+
+    allowed_type_ids = {module_type.pk for module_type in module_types.values()}
+    return InstallBranchView._install_single(
+        device,
+        item,
+        index_map,
+        module_types,
+        module_bays=ModuleBay.objects.all(),
+        allowed_module_type_ids=allowed_type_ids,
+        changeable_interfaces=Interface.objects.all(),
+        deletable_interfaces=Interface.objects.all(),
+        **kwargs,
+    )
+
+
 class TestInstallBranchViewCollectBranch:
     """_collect_branch correctly collects parent + children depth-first."""
 
@@ -823,54 +843,14 @@ class TestMatchModuleBayExactFallback:
 class TestInstallSingleStatus:
     """_install_single returns the correct status dict in each path."""
 
-    def _make_args(self):
-        """Return (device, item, index_map, module_types, ModuleBay, ModuleType, Module)."""
-        device = MagicMock()
-        device.device_type.manufacturer = None
-
-        item = {
-            "entPhysicalIndex": 10,
-            "entPhysicalModelName": "WS-X4748",
-            "entPhysicalSerialNum": "SN123",
-            "entPhysicalName": "Line Card",
-            "entPhysicalContainedIn": 0,
-        }
-
-        mt = MagicMock()
-        mt.model = "WS-X4748"
-        mt.pk = 1
-        mt.interfacetemplates.all.return_value = []
-
-        bay = _bay("Slot 1")
-        bay.installed_module = None
-        bay.module_id = None
-
-        index_map = {10: item}
-        module_types = {"WS-X4748": mt}
-
-        ModuleBay = MagicMock()
-        ModuleBay.objects.restrict.return_value = ModuleBay.objects
-        ModuleBay.objects.filter.return_value.select_related.return_value = [bay]
-        # Support select_for_update chain used in _install_single
-        locked_bay = _bay("Slot 1")
-        locked_bay.installed_module = None
-        locked_bay.pk = bay.pk
-        locked_bay.module_id = None
-        ModuleBay.objects.select_for_update.return_value.select_related.return_value.get.return_value = locked_bay
-        ModuleType = MagicMock()
-        Module = MagicMock()
-
-        return device, item, index_map, module_types, ModuleBay, ModuleType, Module, bay, mt
-
     @pytest.mark.django_db
     def test_returns_installed_on_success(self):
         """A real Module is created in the matched bay and persisted (the create was faked before)."""
-        from dcim.models import Module, ModuleBay, ModuleType
+        from dcim.models import Module
 
         from netbox_librenms_plugin.tests.conftest import make_device, make_module_bay, make_module_type
         from netbox_librenms_plugin.views.sync.modules import InstallBranchView
 
-        view = _make_install_branch_view()
         device = make_device("install-ok-dev")
         bay = make_module_bay(device, "Slot 1")
         mt = make_module_type("WS-X4748")
@@ -887,7 +867,7 @@ class TestInstallSingleStatus:
             patch.object(InstallBranchView, "_find_parent_module_id", return_value=None),
             patch.object(InstallBranchView, "_match_bay", return_value=bay),
         ):
-            result = view._install_single(device, item, {10: item}, {"WS-X4748": mt}, ModuleBay, ModuleType, Module)
+            result = _run_install_single(device, item, {10: item}, {"WS-X4748": mt})
 
         assert result["status"] == "installed"
         assert "WS-X4748" in result["name"]
@@ -900,11 +880,8 @@ class TestInstallSingleStatus:
     @pytest.mark.django_db
     def test_returns_skipped_when_no_type(self):
         """No module type matches the model → skipped, no Module created."""
-        from dcim.models import Module, ModuleBay, ModuleType
-
         from netbox_librenms_plugin.tests.conftest import make_device, make_module_bay
 
-        view = _make_install_branch_view()
         device = make_device("install-notype-dev")
         make_module_bay(device, "Slot 1")
         item = {
@@ -915,7 +892,7 @@ class TestInstallSingleStatus:
             "entPhysicalContainedIn": 0,
         }
 
-        result = view._install_single(device, item, {10: item}, {}, ModuleBay, ModuleType, Module)
+        result = _run_install_single(device, item, {10: item}, {})
 
         assert result["status"] == "skipped"
         assert "no matching type" in result["reason"]
@@ -923,11 +900,10 @@ class TestInstallSingleStatus:
     @pytest.mark.django_db
     def test_oob_sourced_item_is_never_installed(self):
         """An OOB-sourced inventory row must be skipped (read-only), even with a matching type+bay — a crafted POST must not install OOB inventory onto the host."""
-        from dcim.models import Module, ModuleBay, ModuleType
+        from dcim.models import Module
 
         from netbox_librenms_plugin.tests.conftest import make_device, make_module_bay, make_module_type
 
-        view = _make_install_branch_view()
         device = make_device("install-oob-dev")
         make_module_bay(device, "Slot 1")
         mt = make_module_type("WS-X4748")
@@ -941,7 +917,7 @@ class TestInstallSingleStatus:
             "_source": "oob",
         }
 
-        result = view._install_single(device, item, {1010: item}, {"WS-X4748": mt}, ModuleBay, ModuleType, Module)
+        result = _run_install_single(device, item, {1010: item}, {"WS-X4748": mt})
 
         assert result["status"] == "skipped"
         assert "OOB controller inventory is read-only" in result["reason"]
@@ -950,12 +926,11 @@ class TestInstallSingleStatus:
     @pytest.mark.django_db
     def test_returns_skipped_when_no_bay(self):
         """A matching type but no matching bay → skipped, no Module created."""
-        from dcim.models import Module, ModuleBay, ModuleType
+        from dcim.models import Module
 
         from netbox_librenms_plugin.tests.conftest import make_device, make_module_bay, make_module_type
         from netbox_librenms_plugin.views.sync.modules import InstallBranchView
 
-        view = _make_install_branch_view()
         device = make_device("install-nobay-dev")
         make_module_bay(device, "Slot 1")
         mt = make_module_type("WS-X4748")
@@ -972,7 +947,7 @@ class TestInstallSingleStatus:
             patch.object(InstallBranchView, "_find_parent_module_id", return_value=None),
             patch.object(InstallBranchView, "_match_bay", return_value=None),
         ):
-            result = view._install_single(device, item, {10: item}, {"WS-X4748": mt}, ModuleBay, ModuleType, Module)
+            result = _run_install_single(device, item, {10: item}, {"WS-X4748": mt})
 
         assert result["status"] == "skipped"
         assert "no matching bay" in result["reason"]
@@ -981,12 +956,11 @@ class TestInstallSingleStatus:
     @pytest.mark.django_db
     def test_returns_skipped_when_bay_already_occupied(self):
         """The matched bay already holds a real module → skipped, returns the occupant's pk."""
-        from dcim.models import Module, ModuleBay, ModuleType
+        from dcim.models import Module
 
         from netbox_librenms_plugin.tests.conftest import make_device, make_module_bay, make_module_type
         from netbox_librenms_plugin.views.sync.modules import InstallBranchView
 
-        view = _make_install_branch_view()
         device = make_device("install-occupied-dev")
         bay = make_module_bay(device, "Slot 1")
         mt = make_module_type("WS-X4748")
@@ -1005,616 +979,408 @@ class TestInstallSingleStatus:
             patch.object(InstallBranchView, "_find_parent_module_id", return_value=None),
             patch.object(InstallBranchView, "_match_bay", return_value=bay),
         ):
-            result = view._install_single(device, item, {10: item}, {"WS-X4748": mt}, ModuleBay, ModuleType, Module)
+            result = _run_install_single(device, item, {10: item}, {"WS-X4748": mt})
 
         assert result["status"] == "skipped"
         assert "already occupied" in result["reason"]
         assert result["module_pk"] == occupied.pk
 
-    def test_infers_port_bay_from_interface_label_suffix(self):
-        """_install_single should install port rows by inferring bay index from interface labels."""
-        from contextlib import contextmanager
+    @pytest.mark.django_db
+    def test_installed_name_includes_real_adoption_count(self):
+        from dcim.models import Interface, InterfaceTemplate, Module
 
+        from netbox_librenms_plugin.tests.conftest import make_device, make_module_bay, make_module_type
         from netbox_librenms_plugin.views.sync.modules import InstallBranchView
 
-        view = _make_install_branch_view()
-        device, item, index_map, module_types, ModuleBay, ModuleType, Module, bay, mt = self._make_args()
-
-        # Force a port-class row where positional slot differs from interface suffix.
-        item.update(
-            {
-                "entPhysicalClass": "port",
-                "entPhysicalName": "Te1/1/1",
-                "entPhysicalDescr": "TenGigabitEthernet1/1/1",
-                "entPhysicalContainedIn": 105,
-            }
-        )
-
-        inventory = [
-            {
-                "entPhysicalIndex": 1,
-                "entPhysicalModelName": "REAL-CHASSIS",
-                "entPhysicalClass": "chassis",
-                "entPhysicalContainedIn": 0,
-                "entPhysicalParentRelPos": 0,
-            },
-        ]
-        for n in range(1, 6):
-            inventory.append(
-                {
-                    "entPhysicalIndex": 100 + n,
-                    "entPhysicalModelName": "",
-                    "entPhysicalClass": "container",
-                    "entPhysicalContainedIn": 1,
-                    "entPhysicalParentRelPos": n,
-                }
-            )
-        inventory.append(item)
-        index_map = {entry["entPhysicalIndex"]: entry for entry in inventory}
-
-        bay.name = "SFP 1"
-        bay.module_id = None
-        ModuleBay.objects.restrict.return_value = ModuleBay.objects
-        ModuleBay.objects.filter.return_value.select_related.return_value = [bay]
-
-        locked_bay = _bay("SFP 1")
-        locked_bay.pk = bay.pk
-        locked_bay.module_id = None
-        locked_bay.installed_module = None
-        ModuleBay.objects.select_for_update.return_value.select_related.return_value.get.return_value = locked_bay
-
-        module_instance = MagicMock()
-        module_instance.pk = 321
-        Module.return_value = module_instance
-
-        @contextmanager
-        def noop_atomic():
-            yield
-
-        with patch("netbox_librenms_plugin.views.sync.modules.transaction.atomic", noop_atomic):
-            with patch("netbox_librenms_plugin.utils.resolve_module_type", side_effect=lambda m, t, **kw: t.get(m)):
-                with patch("netbox_librenms_plugin.utils.load_bay_mappings", return_value=([], [])):
-                    with patch.object(InstallBranchView, "_find_parent_module_id", return_value=None):
-                        result = view._install_single(
-                            device,
-                            item,
-                            index_map,
-                            module_types,
-                            ModuleBay,
-                            ModuleType,
-                            Module,
-                        )
-
-        assert result["status"] == "installed"
-        assert "SFP 1" in result["name"]
-        assert result["module_pk"] == 321
-        assert module_instance._adopt_components is True
-
-    def test_missing_port_child_bay_returns_no_matching_bay(self):
-        """Port rows under installed parents should not auto-create child bays when missing."""
-        from contextlib import contextmanager
-
-        from netbox_librenms_plugin.views.sync.modules import InstallBranchView
-
-        view = _make_install_branch_view()
-        device, item, index_map, module_types, ModuleBay, ModuleType, Module, bay, mt = self._make_args()
-
-        item.update(
-            {
-                "entPhysicalClass": "port",
-                "entPhysicalName": "Te1/1/2",
-                "entPhysicalDescr": "TenGigabitEthernet1/1/2",
-            }
-        )
-
-        # No bays under parent module scope.
-        ModuleBay.objects.restrict.return_value = ModuleBay.objects
-        ModuleBay.objects.filter.return_value.select_related.return_value = []
-        ModuleBay.objects.filter.return_value.first.return_value = None
-
-        @contextmanager
-        def noop_atomic():
-            yield
-
-        with patch("netbox_librenms_plugin.views.sync.modules.transaction.atomic", noop_atomic):
-            with patch("netbox_librenms_plugin.utils.resolve_module_type", side_effect=lambda m, t, **kw: t.get(m)):
-                with patch("netbox_librenms_plugin.utils.load_bay_mappings", return_value=([], [])):
-                    with patch.object(InstallBranchView, "_find_parent_module_id", return_value=999):
-                        with patch.object(InstallBranchView, "_match_bay", return_value=None):
-                            result = view._install_single(
-                                device,
-                                item,
-                                index_map,
-                                module_types,
-                                ModuleBay,
-                                ModuleType,
-                                Module,
-                            )
-
-        assert result["status"] == "skipped"
-        assert result["reason"] == "no matching bay"
-        ModuleBay.assert_not_called()
-
-    def test_installed_name_includes_adoption_count(self):
-        """Install result should include adoption summary when standalone interfaces are claimed."""
-        from contextlib import contextmanager
-
-        from netbox_librenms_plugin.views.sync.modules import InstallBranchView
-
-        view = _make_install_branch_view()
-        device, item, index_map, module_types, ModuleBay, ModuleType, Module, bay, mt = self._make_args()
-        module_instance = MagicMock()
-        module_instance.pk = 222
-        Module.return_value = module_instance
-
-        @contextmanager
-        def noop_atomic():
-            yield
-
-        with patch("netbox_librenms_plugin.views.sync.modules.transaction.atomic", noop_atomic):
-            with patch("netbox_librenms_plugin.utils.resolve_module_type", side_effect=lambda m, t, **kw: t.get(m)):
-                with patch("netbox_librenms_plugin.utils.load_bay_mappings", return_value=([], [])):
-                    with patch("netbox_librenms_plugin.views.sync.modules._count_adoptable_interfaces", return_value=3):
-                        with patch.object(InstallBranchView, "_find_parent_module_id", return_value=None):
-                            with patch.object(InstallBranchView, "_match_bay", return_value=bay):
-                                result = view._install_single(
-                                    device, item, index_map, module_types, ModuleBay, ModuleType, Module
-                                )
-
-        assert result["status"] == "installed"
-        assert "adopted 3 existing interface(s)" in result["name"]
-        assert result["adopted_interfaces"] == 3
-
-    def test_returns_failed_on_exception(self):
-        from contextlib import contextmanager
-
-        from django.db import IntegrityError
-
-        from netbox_librenms_plugin.views.sync.modules import InstallBranchView
-
-        view = _make_install_branch_view()
-        device, item, index_map, module_types, ModuleBay, ModuleType, Module, bay, mt = self._make_args()
-        Module.side_effect = IntegrityError("DB error")
-
-        @contextmanager
-        def noop_atomic():
-            yield
-
-        with patch("netbox_librenms_plugin.views.sync.modules.transaction.atomic", noop_atomic):
-            with patch("netbox_librenms_plugin.utils.resolve_module_type", side_effect=lambda m, t, **kw: t.get(m)):
-                with patch("netbox_librenms_plugin.utils.load_bay_mappings", return_value=([], [])):
-                    with patch.object(InstallBranchView, "_find_parent_module_id", return_value=None):
-                        with patch.object(InstallBranchView, "_match_bay", return_value=bay):
-                            result = view._install_single(
-                                device, item, index_map, module_types, ModuleBay, ModuleType, Module
-                            )
-
-        assert result["status"] == "failed"
-
-    def test_dash_serial_normalized_to_empty_on_install(self):
-        """When LibreNMS reports serial '-', _install_single normalizes it to '' before Module()."""
-        from contextlib import contextmanager
-
-        from netbox_librenms_plugin.views.sync.modules import InstallBranchView
-
-        view = _make_install_branch_view()
-        device, item, index_map, module_types, ModuleBay, ModuleType, Module, bay, mt = self._make_args()
-        # Override the serial to "-"
-        item["entPhysicalSerialNum"] = "-"
-        module_instance = MagicMock()
-        Module.return_value = module_instance
-
-        @contextmanager
-        def noop_atomic():
-            yield
-
-        with patch("netbox_librenms_plugin.views.sync.modules.transaction.atomic", noop_atomic):
-            with patch("netbox_librenms_plugin.utils.resolve_module_type", side_effect=lambda m, t, **kw: t.get(m)):
-                with patch("netbox_librenms_plugin.utils.load_bay_mappings", return_value=([], [])):
-                    with patch.object(InstallBranchView, "_find_parent_module_id", return_value=None):
-                        with patch.object(InstallBranchView, "_match_bay", return_value=bay):
-                            result = view._install_single(
-                                device, item, index_map, module_types, ModuleBay, ModuleType, Module
-                            )
-
-        assert result["status"] == "installed"
-        # Verify Module was constructed with serial="" (not "-")
-        Module.assert_called_once()
-        assert Module.call_args.kwargs["serial"] == "", (
-            f"Expected serial='' but Module was called with serial={Module.call_args.kwargs['serial']!r}"
-        )
-
-
-class TestBindInterfaceLibrenmsId:
-    """Covers post-install interface librenms_id binding helper behaviour."""
-
-    def test_returns_none_without_port_identity(self):
-        from netbox_librenms_plugin.views.sync.modules import _bind_interface_librenms_id
-
-        device = MagicMock()
-        device.pk = 1
-        result = _bind_interface_librenms_id(device, {"entPhysicalName": "SFP"}, module_pk=10, server_key="default")
-        assert result is None
-
-
-class TestAdoptExistingTemplateInterfaces:
-    """Covers adopting standalone interfaces into already-installed modules."""
-
-    def test_adopts_matching_standalone_interfaces(self):
-        from netbox_librenms_plugin.views.sync.modules import _adopt_existing_template_interfaces
-
-        device = MagicMock()
-        module = MagicMock()
-        module.module_type.interfacetemplates.all.return_value = [MagicMock(), MagicMock()]
-
-        instantiated_a = MagicMock()
-        instantiated_a.name = "Te1/1/1"
-        instantiated_b = MagicMock()
-        instantiated_b.name = "Te1/1/2"
-        module.module_type.interfacetemplates.all.return_value[0].instantiate.return_value = instantiated_a
-        module.module_type.interfacetemplates.all.return_value[1].instantiate.return_value = instantiated_b
-
-        iface_a = MagicMock()
-        iface_a.name = "Te1/1/1"
-        iface_b = MagicMock()
-        iface_b.name = "Te1/1/2"
-
-        @contextmanager
-        def noop_atomic():
-            yield
+        device = make_device("install-adoption-count")
+        bay = make_module_bay(device, "Slot 1")
+        module_type = make_module_type("ADOPT-MODULE")
+        InterfaceTemplate.objects.create(module_type=module_type, name="Te1/1/1", type="10gbase-x-sfpp")
+        standalone = Interface.objects.create(device=device, name="Te1/1/1", type="10gbase-x-sfpp")
+        item = {
+            "entPhysicalIndex": 10,
+            "entPhysicalModelName": module_type.model,
+            "entPhysicalSerialNum": "SN-ADOPT",
+            "entPhysicalName": "Line Card",
+            "entPhysicalContainedIn": 0,
+        }
 
         with (
-            patch("dcim.models.Interface") as mock_interface_model,
-            patch("netbox_librenms_plugin.views.sync.modules.transaction") as mock_tx,
+            patch("netbox_librenms_plugin.utils.load_bay_mappings", return_value=([], [])),
+            patch.object(InstallBranchView, "_find_parent_module_id", return_value=None),
+            patch.object(InstallBranchView, "_match_bay", return_value=bay),
         ):
-            mock_tx.atomic = noop_atomic
-            mock_interface_model.objects.restrict.return_value = mock_interface_model.objects
-            mock_interface_model.objects.filter.return_value = [iface_a, iface_b]
-            result = _adopt_existing_template_interfaces(device, module)
+            result = _run_install_single(device, item, {10: item}, {module_type.model: module_type})
+
+        assert result["status"] == "installed"
+        assert result["adopted_interfaces"] == 1
+        standalone.refresh_from_db()
+        assert standalone.module_id == result["module_pk"]
+        assert Module.objects.filter(pk=result["module_pk"]).exists()
+
+    @pytest.mark.django_db
+    def test_validation_error_returns_failed_without_creating_a_module(self):
+        from dcim.models import Module
+
+        from netbox_librenms_plugin.tests.conftest import make_device, make_module_bay, make_module_type
+        from netbox_librenms_plugin.views.sync.modules import InstallBranchView
+
+        device = make_device("install-validation-failure")
+        bay = make_module_bay(device, "Slot 1")
+        module_type = make_module_type("INVALID-SERIAL-MODULE")
+        item = {
+            "entPhysicalIndex": 10,
+            "entPhysicalModelName": module_type.model,
+            "entPhysicalSerialNum": "x" * 500,
+            "entPhysicalName": "Line Card",
+            "entPhysicalContainedIn": 0,
+        }
+
+        with (
+            patch("netbox_librenms_plugin.utils.load_bay_mappings", return_value=([], [])),
+            patch.object(InstallBranchView, "_find_parent_module_id", return_value=None),
+            patch.object(InstallBranchView, "_match_bay", return_value=bay),
+        ):
+            result = _run_install_single(device, item, {10: item}, {module_type.model: module_type})
+
+        assert result["status"] == "failed"
+        assert not Module.objects.filter(device=device).exists()
+
+    @pytest.mark.django_db
+    def test_dash_serial_is_persisted_as_empty(self):
+        from dcim.models import Module
+
+        from netbox_librenms_plugin.tests.conftest import make_device, make_module_bay, make_module_type
+        from netbox_librenms_plugin.views.sync.modules import InstallBranchView
+
+        device = make_device("install-empty-serial")
+        bay = make_module_bay(device, "Slot 1")
+        module_type = make_module_type("EMPTY-SERIAL-MODULE")
+        item = {
+            "entPhysicalIndex": 10,
+            "entPhysicalModelName": module_type.model,
+            "entPhysicalSerialNum": "-",
+            "entPhysicalName": "Line Card",
+            "entPhysicalContainedIn": 0,
+        }
+
+        with (
+            patch("netbox_librenms_plugin.utils.load_bay_mappings", return_value=([], [])),
+            patch.object(InstallBranchView, "_find_parent_module_id", return_value=None),
+            patch.object(InstallBranchView, "_match_bay", return_value=bay),
+        ):
+            result = _run_install_single(device, item, {10: item}, {module_type.model: module_type})
+
+        assert result["status"] == "installed"
+        assert Module.objects.get(pk=result["module_pk"]).serial == ""
+
+
+@pytest.mark.django_db
+class TestModuleInterfaceHelpers:
+    """Exercise module interface adoption and binding against the real ORM."""
+
+    @staticmethod
+    def _module(suffix):
+        from dcim.models import Module, ModuleBay, ModuleType
+
+        from netbox_librenms_plugin.tests.conftest import make_device
+
+        device = make_device(f"module-helper-{suffix}")
+        bay = ModuleBay.objects.create(device=device, name=f"Helper Bay {suffix}")
+        module_type = ModuleType.objects.create(
+            manufacturer=device.device_type.manufacturer,
+            model=f"Helper Module {suffix}",
+        )
+        module = Module.objects.create(
+            device=device,
+            module_bay=bay,
+            module_type=module_type,
+            status="active",
+        )
+        return device, module
+
+    def test_bind_returns_none_without_port_identity(self):
+        from dcim.models import Interface
+
+        from netbox_librenms_plugin.views.sync.modules import _bind_interface_librenms_id
+
+        device, module = self._module("no-port")
+        result = _bind_interface_librenms_id(
+            device,
+            {"entPhysicalName": "SFP"},
+            module.pk,
+            "default",
+            Interface.objects.all(),
+        )
+
+        assert result is None
+
+    def test_adopts_matching_standalone_interfaces(self):
+        from dcim.models import Interface, InterfaceTemplate
+
+        from netbox_librenms_plugin.views.sync.modules import _adopt_existing_template_interfaces
+
+        device, module = self._module("adopt")
+        InterfaceTemplate.objects.create(
+            module_type=module.module_type,
+            name="Te1/1/1",
+            type="10gbase-x-sfpp",
+        )
+        InterfaceTemplate.objects.create(
+            module_type=module.module_type,
+            name="Te1/1/2",
+            type="10gbase-x-sfpp",
+        )
+        first = Interface.objects.create(device=device, name="Te1/1/1", type="10gbase-x-sfpp")
+        second = Interface.objects.create(device=device, name="Te1/1/2", type="10gbase-x-sfpp")
+
+        result = _adopt_existing_template_interfaces(device, module, Interface.objects.all())
 
         assert result["status"] == "bound"
         assert result["adopted_count"] == 2
-        assert iface_a.module is module
-        assert iface_b.module is module
-        iface_a.save.assert_called_once_with(update_fields=["module"])
-        iface_b.save.assert_called_once_with(update_fields=["module"])
+        first.refresh_from_db()
+        second.refresh_from_db()
+        assert first.module_id == module.pk
+        assert second.module_id == module.pk
 
-    def test_adoption_runs_inside_atomic_transaction(self):
+    def test_adopts_vc_rewritten_template_interface(self):
+        from dcim.models import Interface, InterfaceTemplate, Module, ModuleBay, ModuleType
+
+        from netbox_librenms_plugin.tests.conftest import make_virtual_chassis_members
         from netbox_librenms_plugin.views.sync.modules import _adopt_existing_template_interfaces
 
-        device = MagicMock()
-        module = MagicMock()
-        module.module_type.interfacetemplates.all.return_value = [MagicMock(), MagicMock()]
-
-        instantiated_a = MagicMock()
-        instantiated_a.name = "Te1/1/1"
-        instantiated_b = MagicMock()
-        instantiated_b.name = "Te1/1/2"
-        module.module_type.interfacetemplates.all.return_value[0].instantiate.return_value = instantiated_a
-        module.module_type.interfacetemplates.all.return_value[1].instantiate.return_value = instantiated_b
-
-        iface_a = MagicMock()
-        iface_a.name = "Te1/1/1"
-        iface_b = MagicMock()
-        iface_b.name = "Te1/1/2"
-        iface_a.save.side_effect = RuntimeError("boom")
-
-        atomic_events = []
-
-        @contextmanager
-        def tracking_atomic():
-            atomic_events.append("enter")
-            try:
-                yield
-            finally:
-                atomic_events.append("exit")
-
-        with (
-            patch("dcim.models.Interface") as mock_interface_model,
-            patch("netbox_librenms_plugin.views.sync.modules.transaction") as mock_tx,
-        ):
-            mock_tx.atomic = tracking_atomic
-            mock_interface_model.objects.restrict.return_value = mock_interface_model.objects
-            mock_interface_model.objects.filter.return_value = [iface_a, iface_b]
-
-            try:
-                _adopt_existing_template_interfaces(device, module)
-                assert False, "Expected adoption failure to propagate"
-            except RuntimeError as exc:
-                assert str(exc) == "boom"
-
-        assert atomic_events == ["enter", "exit"]
-        iface_a.save.assert_called_once_with(update_fields=["module"])
-        iface_b.save.assert_not_called()
-
-    def test_adopts_matching_vc_rewritten_template_interfaces(self):
-        from netbox_librenms_plugin.views.sync.modules import _adopt_existing_template_interfaces
-
-        device = MagicMock()
-        device.vc_position = 3
-        device.virtual_chassis_id = 11
-        device.virtual_chassis = MagicMock()
-        device.virtual_chassis.members.values_list.return_value = [1, 2, 3]
-
-        module = MagicMock()
-        template = MagicMock()
-        instantiated = MagicMock()
-        instantiated.name = "TenGigabitEthernet1/1/1"
-        template.instantiate.return_value = instantiated
-        module.module_type.interfacetemplates.all.return_value = [template]
-
-        iface = MagicMock()
-        iface.name = "TenGigabitEthernet3/1/1"
-
-        @contextmanager
-        def noop_atomic():
-            yield
-
-        with (
-            patch("dcim.models.Interface") as mock_interface_model,
-            patch("netbox_librenms_plugin.views.sync.modules.transaction") as mock_tx,
-        ):
-            mock_tx.atomic = noop_atomic
-            mock_interface_model.objects.restrict.return_value = mock_interface_model.objects
-            mock_interface_model.objects.filter.return_value = [iface]
-            result = _adopt_existing_template_interfaces(device, module)
-
-        assert result["status"] == "bound"
-        assert result["adopted_count"] == 1
-        assert result["interfaces"] == ["TenGigabitEthernet3/1/1"]
-        mock_interface_model.objects.filter.assert_called_once_with(
+        _vc, (_page, device) = make_virtual_chassis_members("module-helper-vc-adopt")
+        bay = ModuleBay.objects.create(device=device, name="Helper VC Bay")
+        module_type = ModuleType.objects.create(
+            manufacturer=device.device_type.manufacturer,
+            model="Helper VC Module",
+        )
+        module = Module.objects.create(
             device=device,
-            module__isnull=True,
-            name__in=["TenGigabitEthernet3/1/1"],
+            module_bay=bay,
+            module_type=module_type,
+            status="active",
+        )
+        InterfaceTemplate.objects.create(
+            module_type=module_type,
+            name="TenGigabitEthernet1/1/1",
+            type="10gbase-x-sfpp",
+        )
+        interface = Interface.objects.create(
+            device=device,
+            name=f"TenGigabitEthernet{device.vc_position}/1/1",
+            type="10gbase-x-sfpp",
         )
 
+        result = _adopt_existing_template_interfaces(device, module, Interface.objects.all())
+
+        assert result["status"] == "bound"
+        interface.refresh_from_db()
+        assert interface.module_id == module.pk
+
     def test_binds_unique_module_interface(self):
+        from dcim.models import Interface
+
+        from netbox_librenms_plugin.utils import get_librenms_device_id
         from netbox_librenms_plugin.views.sync.modules import _bind_interface_librenms_id
 
-        device = MagicMock()
-        device.pk = 1
+        device, module = self._module("bind-name")
+        interface = Interface.objects.create(
+            device=device,
+            module=module,
+            name="Te1/0/1",
+            type="10gbase-x-sfpp",
+        )
 
-        candidate = MagicMock()
-        candidate.name = "Te1/0/1"
-        candidate.module_id = 123
+        result = _bind_interface_librenms_id(
+            device,
+            {"_librenms_port_id": 42, "_librenms_ifname": interface.name},
+            module.pk,
+            "default",
+            Interface.objects.all(),
+        )
 
-        by_name_qs = MagicMock()
-        by_name_qs.first.return_value = None
+        assert result == {
+            "status": "bound",
+            "interface": interface.name,
+            "port_id": 42,
+            "changed": True,
+        }
+        interface.refresh_from_db()
+        assert get_librenms_device_id(interface, "default") == 42
 
-        module_qs = MagicMock()
-        module_qs.filter.return_value.first.return_value = candidate
+    def test_binds_only_module_interface_when_names_do_not_match(self):
+        from dcim.models import Interface
 
-        with (
-            patch("dcim.models.Interface") as mock_interface_model,
-            patch("netbox_librenms_plugin.views.sync.modules.find_by_librenms_id", return_value=None),
-            patch("netbox_librenms_plugin.views.sync.modules.get_librenms_device_id", return_value=None),
-            patch("netbox_librenms_plugin.views.sync.modules.set_librenms_device_id") as mock_set,
-        ):
-            mock_interface_model.objects.restrict.return_value = mock_interface_model.objects
-            mock_interface_model.objects.filter.side_effect = [by_name_qs, module_qs]
-            result = _bind_interface_librenms_id(
-                device,
-                {"_librenms_port_id": 42, "_librenms_ifname": "Te1/0/1"},
-                module_pk=123,
-                server_key="default",
-            )
+        from netbox_librenms_plugin.utils import get_librenms_device_id
+        from netbox_librenms_plugin.views.sync.modules import _bind_interface_librenms_id
+
+        device, module = self._module("bind-only")
+        interface = Interface.objects.create(
+            device=device,
+            module=module,
+            name="uplink-a",
+            type="10gbase-x-sfpp",
+        )
+
+        result = _bind_interface_librenms_id(
+            device,
+            {"_librenms_port_id": 43, "_librenms_ifname": "Unknown-Port"},
+            module.pk,
+            "default",
+            Interface.objects.all(),
+        )
 
         assert result["status"] == "bound"
-        assert result["port_id"] == 42
-        assert result["interface"] == "Te1/0/1"
-        mock_set.assert_called_once_with(candidate, 42, "default")
-        candidate.save.assert_called_once_with(update_fields=["custom_field_data"])
+        assert result["interface"] == interface.name
+        interface.refresh_from_db()
+        assert get_librenms_device_id(interface, "default") == 43
 
-    def test_binds_single_iterable_module_interface(self):
+    def test_reports_conflict_when_port_id_belongs_to_another_device(self):
+        from dcim.models import Interface
+
+        from netbox_librenms_plugin.tests.conftest import make_device, make_interface
+        from netbox_librenms_plugin.utils import set_librenms_device_id
         from netbox_librenms_plugin.views.sync.modules import _bind_interface_librenms_id
 
-        device = MagicMock()
-        device.pk = 1
+        device, module = self._module("bind-conflict")
+        other = make_device("module-helper-bind-other")
+        owner = make_interface(other, "Eth1/1")
+        set_librenms_device_id(owner, 55, "default")
+        owner.save()
 
-        candidate = MagicMock()
-        candidate.name = "uplink-a"
-        candidate.module_id = 123
-
-        by_name_qs = MagicMock()
-        by_name_qs.first.return_value = None
-
-        module_qs = MagicMock()
-        module_qs.filter.return_value.first.return_value = None
-        module_qs.__iter__.return_value = iter([candidate])
-
-        with (
-            patch("dcim.models.Interface") as mock_interface_model,
-            patch("netbox_librenms_plugin.views.sync.modules.find_by_librenms_id", return_value=None),
-            patch("netbox_librenms_plugin.views.sync.modules.get_librenms_device_id", return_value=None),
-            patch("netbox_librenms_plugin.views.sync.modules.set_librenms_device_id") as mock_set,
-        ):
-            mock_interface_model.objects.restrict.return_value = mock_interface_model.objects
-            mock_interface_model.objects.filter.side_effect = [by_name_qs, module_qs]
-            result = _bind_interface_librenms_id(
-                device,
-                {"_librenms_port_id": 43, "_librenms_ifname": "Unknown-Port"},
-                module_pk=123,
-                server_key="default",
-            )
-
-        assert result["status"] == "bound"
-        assert result["interface"] == "uplink-a"
-        mock_set.assert_called_once_with(candidate, 43, "default")
-        candidate.save.assert_called_once_with(update_fields=["custom_field_data"])
-
-    def test_conflict_when_port_id_owned_by_other_device(self):
-        from netbox_librenms_plugin.views.sync.modules import _bind_interface_librenms_id
-
-        device = MagicMock()
-        device.pk = 1
-
-        existing_owner = MagicMock()
-        existing_owner.device_id = 2
-        existing_owner.name = "Eth1/1"
-        existing_owner.device.name = "other-device"
-
-        with patch("netbox_librenms_plugin.views.sync.modules.find_by_librenms_id", return_value=existing_owner):
-            result = _bind_interface_librenms_id(
-                device,
-                {"_librenms_port_id": 55, "_librenms_ifname": "Te1/0/2"},
-                module_pk=999,
-                server_key="default",
-            )
+        result = _bind_interface_librenms_id(
+            device,
+            {"_librenms_port_id": 55, "_librenms_ifname": "Te1/0/2"},
+            module.pk,
+            "default",
+            Interface.objects.all(),
+        )
 
         assert result["status"] == "conflict"
         assert "not reassigning" in result["reason"]
 
-    def test_reparents_standalone_interface_when_module_known(self):
-        """When the resolved interface has no module, bind should attach it to installed module."""
+    def test_reparents_standalone_interface_when_module_is_known(self):
+        from dcim.models import Interface
+
+        from netbox_librenms_plugin.tests.conftest import make_interface
+        from netbox_librenms_plugin.utils import get_librenms_device_id, set_librenms_device_id
         from netbox_librenms_plugin.views.sync.modules import _bind_interface_librenms_id
 
-        device = MagicMock()
-        device.pk = 1
+        device, module = self._module("bind-reparent")
+        interface = make_interface(device, "Te1/0/1")
+        set_librenms_device_id(interface, 77, "default")
+        interface.save()
 
-        candidate = MagicMock()
-        candidate.name = "Te1/0/1"
-        candidate.device_id = 1
-        candidate.module_id = None
-
-        with (
-            patch("netbox_librenms_plugin.views.sync.modules.find_by_librenms_id", return_value=candidate),
-            patch("netbox_librenms_plugin.views.sync.modules.get_librenms_device_id", return_value=None),
-            patch("netbox_librenms_plugin.views.sync.modules.set_librenms_device_id") as mock_set,
-        ):
-            result = _bind_interface_librenms_id(
-                device,
-                {"_librenms_port_id": 77, "_librenms_ifname": "Te1/0/1"},
-                module_pk=555,
-                server_key="default",
-            )
+        result = _bind_interface_librenms_id(
+            device,
+            {"_librenms_port_id": 77, "_librenms_ifname": interface.name},
+            module.pk,
+            "default",
+            Interface.objects.all(),
+        )
 
         assert result["status"] == "bound"
-        assert candidate.module_id == 555
-        mock_set.assert_called_once_with(candidate, 77, "default")
-        candidate.save.assert_called_once_with(update_fields=["custom_field_data", "module"])
+        interface.refresh_from_db()
+        assert interface.module_id == module.pk
+        assert get_librenms_device_id(interface, "default") == 77
 
     def test_uses_ifdescr_when_ifname_differs(self):
-        """Name fallback should include long-form ifDescr values when matching interfaces."""
+        from dcim.models import Interface
+
+        from netbox_librenms_plugin.tests.conftest import make_interface
+        from netbox_librenms_plugin.utils import get_librenms_device_id
         from netbox_librenms_plugin.views.sync.modules import _bind_interface_librenms_id
 
-        device = MagicMock()
-        device.pk = 1
+        device, _module = self._module("bind-ifdescr")
+        interface = make_interface(device, "TenGigabitEthernet1/0/1")
 
-        candidate = MagicMock()
-        candidate.name = "TenGigabitEthernet1/0/1"
-        candidate.module_id = None
-
-        by_name_qs = MagicMock()
-        by_name_qs.first.return_value = candidate
-
-        with (
-            patch("dcim.models.Interface") as mock_interface_model,
-            patch("netbox_librenms_plugin.views.sync.modules.find_by_librenms_id", return_value=None),
-            patch("netbox_librenms_plugin.views.sync.modules.get_librenms_device_id", return_value=None),
-            patch("netbox_librenms_plugin.views.sync.modules.set_librenms_device_id") as mock_set,
-        ):
-            mock_interface_model.objects.restrict.return_value = mock_interface_model.objects
-            mock_interface_model.objects.filter.return_value = by_name_qs
-            result = _bind_interface_librenms_id(
-                device,
-                {
-                    "_librenms_port_id": 88,
-                    "_librenms_ifname": "Te1/0/1",
-                    "_librenms_ifdescr": "TenGigabitEthernet1/0/1",
-                    "entPhysicalName": "Unknown-Port",
-                },
-                module_pk=None,
-                server_key="default",
-            )
+        result = _bind_interface_librenms_id(
+            device,
+            {
+                "_librenms_port_id": 88,
+                "_librenms_ifname": "Te1/0/1",
+                "_librenms_ifdescr": interface.name,
+                "entPhysicalName": "Unknown-Port",
+            },
+            None,
+            "default",
+            Interface.objects.all(),
+        )
 
         assert result["status"] == "bound"
-        call_kwargs = mock_interface_model.objects.filter.call_args.kwargs
-        assert "TenGigabitEthernet1/0/1" in call_kwargs["name__in"]
-        mock_set.assert_called_once_with(candidate, 88, "default")
+        interface.refresh_from_db()
+        assert get_librenms_device_id(interface, "default") == 88
 
-    def test_uses_coordinate_fallback_when_multiple_module_interfaces_exist(self):
+    def test_uses_coordinate_fallback_for_multiple_module_interfaces(self):
+        from dcim.models import Interface
+
+        from netbox_librenms_plugin.utils import get_librenms_device_id
         from netbox_librenms_plugin.views.sync.modules import _bind_interface_librenms_id
 
-        device = MagicMock()
-        device.pk = 1
-        device.vc_position = None
+        device, module = self._module("bind-coordinate")
+        first = Interface.objects.create(
+            device=device,
+            module=module,
+            name="GigabitEthernet1/1/23",
+            type="1000base-t",
+        )
+        second = Interface.objects.create(
+            device=device,
+            module=module,
+            name="GigabitEthernet1/1/24",
+            type="1000base-t",
+        )
 
-        iface_a = MagicMock()
-        iface_a.name = "GigabitEthernet1/1/23"
-        iface_a.module_id = 123
-
-        iface_b = MagicMock()
-        iface_b.name = "GigabitEthernet1/1/24"
-        iface_b.module_id = 123
-
-        by_name_qs = MagicMock()
-        by_name_qs.first.return_value = None
-
-        module_qs = MagicMock()
-        module_qs.filter.return_value.first.return_value = None
-        module_qs.__iter__.return_value = iter([iface_a, iface_b])
-
-        with (
-            patch("dcim.models.Interface") as mock_interface_model,
-            patch("netbox_librenms_plugin.views.sync.modules.find_by_librenms_id", return_value=None),
-            patch("netbox_librenms_plugin.views.sync.modules.get_librenms_device_id", return_value=None),
-            patch("netbox_librenms_plugin.views.sync.modules.set_librenms_device_id") as mock_set,
-        ):
-            mock_interface_model.objects.restrict.return_value = mock_interface_model.objects
-            mock_interface_model.objects.filter.side_effect = [by_name_qs, module_qs]
-            result = _bind_interface_librenms_id(
-                device,
-                {
-                    "_librenms_port_id": 4242,
-                    "_librenms_ifname": "GigabitEthernet5/1/24",
-                    "_librenms_ifdescr": "Gi5/1/24",
-                },
-                module_pk=123,
-                server_key="default",
-            )
+        result = _bind_interface_librenms_id(
+            device,
+            {
+                "_librenms_port_id": 4242,
+                "_librenms_ifname": "GigabitEthernet5/1/24",
+                "_librenms_ifdescr": "Gi5/1/24",
+            },
+            module.pk,
+            "default",
+            Interface.objects.all(),
+        )
 
         assert result["status"] == "bound"
-        assert result["interface"] == "GigabitEthernet1/1/24"
-        mock_set.assert_called_once_with(iface_b, 4242, "default")
+        assert result["interface"] == second.name
+        first.refresh_from_db()
+        second.refresh_from_db()
+        assert get_librenms_device_id(first, "default") is None
+        assert get_librenms_device_id(second, "default") == 4242
 
-    def test_coordinate_fallback_skips_when_top_score_is_ambiguous(self):
+    def test_coordinate_fallback_skips_an_ambiguous_top_score(self):
+        from dcim.models import Interface
+
         from netbox_librenms_plugin.views.sync.modules import _bind_interface_librenms_id
 
-        device = MagicMock()
-        device.pk = 1
-        device.vc_position = None
+        device, module = self._module("bind-ambiguous")
+        Interface.objects.create(
+            device=device,
+            module=module,
+            name="TenGigabitEthernet1/1/24",
+            type="10gbase-x-sfpp",
+        )
+        Interface.objects.create(
+            device=device,
+            module=module,
+            name="HundredGigE2/1/24",
+            type="100gbase-x-qsfp28",
+        )
 
-        iface_a = MagicMock()
-        iface_a.name = "TenGigabitEthernet1/1/24"
-        iface_a.module_id = 123
-
-        iface_b = MagicMock()
-        iface_b.name = "HundredGigE2/1/24"
-        iface_b.module_id = 123
-
-        by_name_qs = MagicMock()
-        by_name_qs.first.return_value = None
-
-        module_qs = MagicMock()
-        module_qs.filter.return_value.first.return_value = None
-        module_qs.__iter__.return_value = iter([iface_a, iface_b])
-
-        with (
-            patch("dcim.models.Interface") as mock_interface_model,
-            patch("netbox_librenms_plugin.views.sync.modules.find_by_librenms_id", return_value=None),
-        ):
-            mock_interface_model.objects.restrict.return_value = mock_interface_model.objects
-            mock_interface_model.objects.filter.side_effect = [by_name_qs, module_qs]
-            result = _bind_interface_librenms_id(
-                device,
-                {
-                    "_librenms_port_id": 4343,
-                    "_librenms_ifname": "Port5/0/24",
-                    "_librenms_ifdescr": "Port5/0/24",
-                },
-                module_pk=123,
-                server_key="default",
-            )
+        result = _bind_interface_librenms_id(
+            device,
+            {
+                "_librenms_port_id": 4343,
+                "_librenms_ifname": "Port5/0/24",
+                "_librenms_ifdescr": "Port5/0/24",
+            },
+            module.pk,
+            "default",
+            Interface.objects.all(),
+        )
 
         assert result["status"] == "skipped"
         assert "multiple module interfaces found" in result["reason"]
@@ -2111,125 +1877,52 @@ class TestSingleInstallInterfaceBinding:
         assert "No interface changes were needed" in mock_messages.success.call_args.args[1]
         assert response == "redirected"
 
-    def test_update_module_interface_view_adopts_template_interfaces_when_no_port_binding_exists(self):
+    @pytest.mark.django_db
+    def test_update_module_interface_view_adopts_real_template_interfaces(self):
+        from dcim.models import Device, Interface, InterfaceTemplate, Module, ModuleBay, ModuleType
+
+        from netbox_librenms_plugin.tests.conftest import make_device
+        from netbox_librenms_plugin.tests.view_test_helpers import make_request, make_user_with_perms
         from netbox_librenms_plugin.views.sync.modules import UpdateModuleInterfaceView
 
-        view = object.__new__(UpdateModuleInterfaceView)
-        view.required_object_permissions = {}
-        view._librenms_api = MagicMock(server_key="production")
-        device = _make_device()
-
-        module = MagicMock()
-        module.pk = 321
-        module.module_type.model = "Linecard-24x10G"
-        module.module_bay.name = "Slot 1"
-
-        request = _make_request(
-            "POST",
-            data={
-                "module_id": "321",
-                "server_key": "production",
-                "ent_index": "77",
-                "inventory_name": "Slot 1",
-            },
+        device = make_device("update-module-interface-adopt")
+        bay = ModuleBay.objects.create(device=device, name="Update Interface Bay")
+        module_type = ModuleType.objects.create(
+            manufacturer=device.device_type.manufacturer,
+            model="Update Interface Module",
         )
-
-        with (
-            patch.object(view, "require_all_permissions", return_value=None),
-            patch(
-                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
-                side_effect=[device, module],
-            ),
-            patch("netbox_librenms_plugin.views.sync.modules.reverse", return_value="/sync/"),
-            patch.object(view, "get_cache_key", return_value="inv-key"),
-            patch("netbox_librenms_plugin.views.sync.modules.cache") as mock_cache,
-            patch("netbox_librenms_plugin.views.sync.modules.get_librenms_device_id", return_value=999),
-            patch(
-                "netbox_librenms_plugin.views.sync.modules._bind_interface_librenms_id",
-                return_value=None,
-            ) as mock_bind,
-            patch(
-                "netbox_librenms_plugin.views.sync.modules._adopt_existing_template_interfaces",
-                return_value={"status": "bound", "adopted_count": 2, "interfaces": ["Te1/1/1", "Te1/1/2"]},
-            ) as mock_adopt,
-            patch("netbox_librenms_plugin.views.sync.modules.messages") as mock_messages,
-            patch("netbox_librenms_plugin.views.sync.modules._modules_redirect_response", return_value="redirected"),
-        ):
-            mock_cache.get.return_value = {
-                "inventory": [{"entPhysicalIndex": 77, "entPhysicalName": "Slot 1"}],
-                "librenms_id": 999,
-            }
-            view.request = request
-            response = view.post(request, pk=24)
-
-        mock_bind.assert_called_once()
-        mock_adopt.assert_called_once_with(device, module)
-        mock_messages.success.assert_called_once()
-        assert "adopted 2 existing standalone interface(s)" in mock_messages.success.call_args[0][1]
-        assert response is not None
-
-    def test_update_module_interface_view_keeps_bind_when_adoption_raises(self):
-        """A committed primary bind must not be downgraded to 'failed' if the (separately executed) template-adoption step raises afterward: the interface is bound regardless, so the user gets the success toast plus a warning that adoption failed — not a misleading failure that makes a retry look like a fresh conflict."""
-        from netbox_librenms_plugin.views.sync.modules import UpdateModuleInterfaceView
-
-        view = object.__new__(UpdateModuleInterfaceView)
-        view.required_object_permissions = {}
-        view._librenms_api = MagicMock(server_key="production")
-        device = _make_device()
-
-        module = MagicMock()
-        module.pk = 321
-        module.module_type.model = "SFP-10G-SR"
-        module.module_bay.name = "SFP 1"
-
-        request = _make_request(
-            "POST",
-            data={"module_id": "321", "server_key": "production", "ent_index": "77"},
+        module = Module.objects.create(
+            device=device,
+            module_bay=bay,
+            module_type=module_type,
+            status="active",
         )
+        InterfaceTemplate.objects.create(
+            module_type=module_type,
+            name="Te1/1/1",
+            type="10gbase-x-sfpp",
+        )
+        standalone = Interface.objects.create(
+            device=device,
+            name="Te1/1/1",
+            type="10gbase-x-sfpp",
+        )
+        user = make_user_with_perms(
+            "update-module-interface-adopt",
+            [("view", Device), ("view", Module), ("change", Interface)],
+        )
+        request = make_request(
+            "post",
+            {"module_id": str(module.pk), "server_key": "default"},
+            user=user,
+        )
+        view = UpdateModuleInterfaceView()
+        view._librenms_api = MagicMock(server_key="default")
 
-        with (
-            patch.object(view, "require_all_permissions", return_value=None),
-            patch(
-                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
-                side_effect=[device, module],
-            ),
-            patch("netbox_librenms_plugin.views.sync.modules.reverse", return_value="/sync/"),
-            patch.object(view, "get_cache_key", return_value="inv-key"),
-            patch("netbox_librenms_plugin.views.sync.modules.cache") as mock_cache,
-            patch("netbox_librenms_plugin.views.sync.modules.get_librenms_device_id", return_value=999),
-            patch(
-                "netbox_librenms_plugin.views.sync.modules._bind_interface_librenms_id",
-                # changed=True: the primary bind wrote update_fields, so it stays a success even
-                # after adoption raises; the success toast is gated on `changed`.
-                return_value={"status": "bound", "interface": "Te1/1/1", "port_id": 42, "changed": True},
-            ) as mock_bind,
-            patch(
-                "netbox_librenms_plugin.views.sync.modules._adopt_existing_template_interfaces",
-                side_effect=RuntimeError("adoption blew up"),
-            ) as mock_adopt,
-            patch("netbox_librenms_plugin.views.sync.modules.messages") as mock_messages,
-            patch("netbox_librenms_plugin.views.sync.modules.logger") as mock_logger,
-            patch("netbox_librenms_plugin.views.sync.modules._modules_redirect_response", return_value="redirected"),
-        ):
-            mock_cache.get.return_value = {
-                "inventory": [{"entPhysicalIndex": 77, "_librenms_port_id": 42, "_librenms_ifname": "Te1/1/1"}],
-                "librenms_id": 999,
-            }
-            view.request = request
-            response = view.post(request, pk=24)
+        _post(view, request, pk=device.pk)
 
-        mock_bind.assert_called_once()
-        mock_adopt.assert_called_once_with(device, module)
-        # Bind preserved → success toast, not downgraded to a failure.
-        mock_messages.success.assert_called_once()
-        mock_messages.error.assert_not_called()
-        # Adoption failure surfaced separately as a warning.
-        mock_messages.warning.assert_called_once()
-        assert "adopting standalone" in mock_messages.warning.call_args[0][1].lower()
-        # The suppressed adoption traceback must be logged server-side (the toast says
-        # "see server logs for details"), not silently swallowed.
-        mock_logger.exception.assert_called_once()
-        assert response is not None
+        standalone.refresh_from_db()
+        assert standalone.module_id == module.pk
 
     def test_update_module_interface_view_no_server_key_does_not_fake_adoption_success(self):
         """bind_item resolves but server_key degrades to blank (no active server), so the bind is skipped."""
@@ -2280,60 +1973,81 @@ class TestSingleInstallInterfaceBinding:
         assert "server context" in mock_messages.warning.call_args[0][1].lower()
         assert response is not None
 
-    def test_update_module_interface_view_adopts_templates_even_when_port_bind_is_a_noop(self):
-        """Regression: the port_id bind and template adoption are complementary, not either/or."""
+    @pytest.mark.django_db
+    def test_update_module_interface_view_adopts_templates_after_a_real_bind_noop(self):
+        from dcim.models import Device, Interface, InterfaceTemplate, Module, ModuleBay, ModuleType
+        from django.core.cache import cache
+
+        from netbox_librenms_plugin.tests.conftest import make_device
+        from netbox_librenms_plugin.tests.view_test_helpers import make_request, make_user_with_perms
+        from netbox_librenms_plugin.utils import get_librenms_device_id, set_librenms_device_id
         from netbox_librenms_plugin.views.sync.modules import UpdateModuleInterfaceView
 
-        view = object.__new__(UpdateModuleInterfaceView)
-        view.required_object_permissions = {}
-        view._librenms_api = MagicMock(server_key="production")
-        device = _make_device()
-
-        module = MagicMock()
-        module.pk = 967
-        module.module_type.model = "QSFP-DD-400G-ZR+"
-        module.module_bay.name = "2/x1/1/c2"
-
-        request = _make_request(
-            "POST",
-            data={"module_id": "967", "server_key": "production", "ent_index": "77"},
+        device = make_device("update-module-interface-noop")
+        bay = ModuleBay.objects.create(device=device, name="Update No-op Bay")
+        module_type = ModuleType.objects.create(
+            manufacturer=device.device_type.manufacturer,
+            model="Update No-op Module",
         )
+        module = Module.objects.create(
+            device=device,
+            module_bay=bay,
+            module_type=module_type,
+            status="active",
+        )
+        InterfaceTemplate.objects.create(
+            module_type=module_type,
+            name="Te1/1/2",
+            type="10gbase-x-sfpp",
+        )
+        primary = Interface.objects.create(
+            device=device,
+            module=module,
+            name="Te1/1/1",
+            type="10gbase-x-sfpp",
+        )
+        set_librenms_device_id(primary, 587, "default")
+        primary.save()
+        standalone = Interface.objects.create(
+            device=device,
+            name="Te1/1/2",
+            type="10gbase-x-sfpp",
+        )
+        user = make_user_with_perms(
+            "update-module-interface-noop",
+            [("view", Device), ("view", Module), ("change", Interface)],
+        )
+        request = make_request(
+            "post",
+            {"module_id": str(module.pk), "server_key": "default", "ent_index": "77"},
+            user=user,
+        )
+        view = UpdateModuleInterfaceView()
+        view.setup(request, pk=device.pk)
+        view._librenms_api = MagicMock(server_key="default")
+        cache_key = view.get_cache_key(device, "inventory", server_key="default")
+        cache.set(
+            cache_key,
+            {
+                "inventory": [
+                    {
+                        "entPhysicalIndex": 77,
+                        "_librenms_port_id": 587,
+                        "_librenms_ifname": primary.name,
+                    }
+                ]
+            },
+            timeout=300,
+        )
+        try:
+            view.post(request, pk=device.pk)
+        finally:
+            cache.delete(cache_key)
 
-        with (
-            patch.object(view, "require_all_permissions", return_value=None),
-            patch(
-                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
-                side_effect=[device, module],
-            ),
-            patch("netbox_librenms_plugin.views.sync.modules.reverse", return_value="/sync/"),
-            patch.object(view, "get_cache_key", return_value="inv-key"),
-            patch("netbox_librenms_plugin.views.sync.modules.cache") as mock_cache,
-            patch("netbox_librenms_plugin.views.sync.modules.get_librenms_device_id", return_value=999),
-            patch(
-                "netbox_librenms_plugin.views.sync.modules._bind_interface_librenms_id",
-                return_value={"status": "bound", "interface": "2/x1/1/c2", "port_id": 587},
-            ) as mock_bind,
-            patch(
-                "netbox_librenms_plugin.views.sync.modules._adopt_existing_template_interfaces",
-                return_value={"status": "bound", "adopted_count": 1, "interfaces": ["2/x1/1/c2/1"]},
-            ) as mock_adopt,
-            patch("netbox_librenms_plugin.views.sync.modules.messages") as mock_messages,
-            patch("netbox_librenms_plugin.views.sync.modules._modules_redirect_response", return_value="redirected"),
-        ):
-            mock_cache.get.return_value = {
-                "inventory": [{"entPhysicalIndex": 77, "_librenms_port_id": 587, "_librenms_ifname": "2/x1/1/c2"}],
-                "librenms_id": 999,
-            }
-            view.request = request
-            response = view.post(request, pk=24)
-
-        # Bind no-op'd on the already-bound interface, but adoption still ran...
-        mock_bind.assert_called_once()
-        mock_adopt.assert_called_once_with(device, module)
-        # ...and the merged result surfaces the adoption so the user sees real progress.
-        mock_messages.success.assert_called_once()
-        assert "adopted 1 existing standalone interface(s)" in mock_messages.success.call_args[0][1]
-        assert response is not None
+        primary.refresh_from_db()
+        standalone.refresh_from_db()
+        assert get_librenms_device_id(primary, "default") == 587
+        assert standalone.module_id == module.pk
 
     def test_update_module_interface_view_skips_adoption_on_bind_conflict(self):
         """A hard bind conflict must NOT trigger template adoption — we don't mutate past an unresolved problem (e.g. an interface bound to another module)."""
@@ -2452,8 +2166,29 @@ class TestSingleInstallInterfaceBinding:
         assert any("Bound Te1/1/1 to LibreNMS port_id 42" in text for text in message_texts(request, "info"))
 
 
+@pytest.mark.django_db
 class TestVCMemberInterfaceNormalization:
-    """Covers VC member-aware module interface renaming/adoption helpers."""
+    """Covers VC member-aware interface normalization against real rows."""
+
+    @staticmethod
+    def _module(suffix):
+        from dcim.models import Module, ModuleBay, ModuleType
+
+        from netbox_librenms_plugin.tests.conftest import make_virtual_chassis_members
+
+        _vc, (_page, device) = make_virtual_chassis_members(f"vc-normalize-{suffix}")
+        bay = ModuleBay.objects.create(device=device, name=f"VC Normalize Bay {suffix}")
+        module_type = ModuleType.objects.create(
+            manufacturer=device.device_type.manufacturer,
+            model=f"VC Normalize Type {suffix}",
+        )
+        module = Module.objects.create(
+            device=device,
+            module_bay=bay,
+            module_type=module_type,
+            status="active",
+        )
+        return device, module
 
     def test_rewrite_interface_name_for_vc_member(self):
         from netbox_librenms_plugin.views.sync.modules import _rewrite_interface_name_for_vc_member
@@ -2473,165 +2208,436 @@ class TestVCMemberInterfaceNormalization:
         assert result is None
 
     def test_normalize_skips_non_vc_device(self):
+        from dcim.models import Interface, Module, ModuleBay, ModuleType
+
+        from netbox_librenms_plugin.tests.conftest import make_device
         from netbox_librenms_plugin.views.sync.modules import _normalize_module_interface_names_for_vc_member
 
-        device = MagicMock()
-        device.vc_position = None
-        device.virtual_chassis_id = None
+        device = make_device("normalize-non-vc")
+        bay = ModuleBay.objects.create(device=device, name="Normalize Non-VC Bay")
+        module_type = ModuleType.objects.create(
+            manufacturer=device.device_type.manufacturer,
+            model="Normalize Non-VC Type",
+        )
+        module = Module.objects.create(device=device, module_bay=bay, module_type=module_type, status="active")
 
-        result = _normalize_module_interface_names_for_vc_member(device, MagicMock())
+        result = _normalize_module_interface_names_for_vc_member(
+            device,
+            module,
+            Interface.objects.all(),
+            Interface.objects.all(),
+        )
+
         assert result == {"renamed": 0, "adopted": 0, "removed": 0, "skipped": 0}
 
-    def test_normalize_renames_module_interfaces_for_vc_member(self):
+    def test_normalize_renames_module_interface_for_vc_member(self):
+        from dcim.models import Interface
+
         from netbox_librenms_plugin.views.sync.modules import _normalize_module_interface_names_for_vc_member
 
-        device = MagicMock()
-        device.vc_position = 3
-        device.virtual_chassis_id = 11
-        device.virtual_chassis.members.values_list.return_value = [1, 2, 3]
-        module = MagicMock()
+        device, module = self._module("rename")
+        interface = Interface.objects.create(
+            device=device,
+            module=module,
+            name="TenGigabitEthernet1/1/1",
+            type="10gbase-x-sfpp",
+        )
+        expected = f"TenGigabitEthernet{device.vc_position}/1/1"
 
-        iface = MagicMock()
-        iface.pk = 1
-        iface.name = "TenGigabitEthernet1/1/1"
-
-        module_qs = MagicMock()
-        module_qs.order_by.return_value = [iface]
-
-        conflict_qs = MagicMock()
-        conflict_qs.exclude.return_value.first.return_value = None
-
-        with patch("dcim.models.Interface") as mock_interface:
-            mock_interface.objects.restrict.return_value = mock_interface.objects
-            mock_interface.objects.filter.side_effect = [module_qs, conflict_qs]
-            result = _normalize_module_interface_names_for_vc_member(device, module)
+        result = _normalize_module_interface_names_for_vc_member(
+            device,
+            module,
+            Interface.objects.all(),
+            Interface.objects.all(),
+        )
 
         assert result["renamed"] == 1
-        assert iface.name == "TenGigabitEthernet3/1/1"
-        iface.save.assert_called_once_with(update_fields=["name"])
+        interface.refresh_from_db()
+        assert interface.name == expected
 
     def test_normalize_adopts_existing_standalone_conflict(self):
+        from dcim.models import Interface
+
         from netbox_librenms_plugin.views.sync.modules import _normalize_module_interface_names_for_vc_member
 
-        device = MagicMock()
-        device.vc_position = 5
-        device.virtual_chassis_id = 44
-        device.virtual_chassis.members.values_list.return_value = [1, 2, 5]
-        module = MagicMock()
+        device, module = self._module("adopt")
+        created = Interface.objects.create(
+            device=device,
+            module=module,
+            name="TenGigabitEthernet1/1/1",
+            type="10gbase-x-sfpp",
+        )
+        existing = Interface.objects.create(
+            device=device,
+            name=f"TenGigabitEthernet{device.vc_position}/1/1",
+            type="10gbase-x-sfpp",
+        )
 
-        created_iface = MagicMock()
-        created_iface.pk = 5
-        created_iface.name = "TenGigabitEthernet1/1/1"
-
-        existing_iface = MagicMock()
-        existing_iface.module_id = None
-
-        module_qs = MagicMock()
-        module_qs.order_by.return_value = [created_iface]
-
-        conflict_qs = MagicMock()
-        conflict_qs.exclude.return_value.first.return_value = existing_iface
-
-        with patch("dcim.models.Interface") as mock_interface:
-            mock_interface.objects.restrict.return_value = mock_interface.objects
-            mock_interface.objects.filter.side_effect = [module_qs, conflict_qs]
-            result = _normalize_module_interface_names_for_vc_member(device, module)
+        result = _normalize_module_interface_names_for_vc_member(
+            device,
+            module,
+            Interface.objects.all(),
+            Interface.objects.all(),
+        )
 
         assert result["adopted"] == 1
         assert result["removed"] == 1
-        existing_iface.save.assert_called_once_with(update_fields=["module"])
-        created_iface.delete.assert_called_once()
+        existing.refresh_from_db()
+        assert existing.module_id == module.pk
+        assert not Interface.objects.filter(pk=created.pk).exists()
 
-    def test_normalize_skips_non_member_prefixed_interfaces(self):
+    def test_normalize_skips_non_member_prefixed_interface(self):
+        from dcim.models import Interface
+
         from netbox_librenms_plugin.views.sync.modules import _normalize_module_interface_names_for_vc_member
 
-        device = MagicMock()
-        device.vc_position = 3
-        device.virtual_chassis_id = 11
-        device.virtual_chassis.members.values_list.return_value = [1, 2, 3]
-        module = MagicMock()
+        device, module = self._module("non-member")
+        interface = Interface.objects.create(
+            device=device,
+            module=module,
+            name="TenGigabitEthernet9/1/1",
+            type="10gbase-x-sfpp",
+        )
 
-        iface = MagicMock()
-        iface.pk = 1
-        iface.name = "TenGigabitEthernet9/1/1"
-
-        module_qs = MagicMock()
-        module_qs.order_by.return_value = [iface]
-
-        with patch("dcim.models.Interface") as mock_interface:
-            mock_interface.objects.restrict.return_value = mock_interface.objects
-            mock_interface.objects.filter.side_effect = [module_qs]
-            result = _normalize_module_interface_names_for_vc_member(device, module)
+        result = _normalize_module_interface_names_for_vc_member(
+            device,
+            module,
+            Interface.objects.all(),
+            Interface.objects.all(),
+        )
 
         assert result == {"renamed": 0, "adopted": 0, "removed": 0, "skipped": 0}
-        iface.save.assert_not_called()
+        interface.refresh_from_db()
+        assert interface.name == "TenGigabitEthernet9/1/1"
 
 
+@pytest.mark.django_db
 class TestResolveTargetDevice:
-    """Target device selection must remain constrained to VC membership."""
+    """Target device selection must remain constrained to visible VC members."""
 
     def test_non_vc_device_ignores_selected_member(self):
+        from dcim.models import Device
+
+        from netbox_librenms_plugin.tests.conftest import make_device
         from netbox_librenms_plugin.views.sync.modules import _resolve_target_device
 
-        page_device = MagicMock()
-        page_device.virtual_chassis = None
+        page_device = make_device("target-non-vc")
 
-        result = _resolve_target_device(page_device, "123")
+        result = _resolve_target_device(page_device, "123", Device.objects.all())
 
-        assert result is page_device
+        assert result == page_device
 
     def test_vc_member_selection_accepts_valid_member(self):
+        from dcim.models import Device
+
+        from netbox_librenms_plugin.tests.conftest import make_virtual_chassis_members
         from netbox_librenms_plugin.views.sync.modules import _resolve_target_device
 
-        page_device = MagicMock()
-        member = MagicMock()
-        page_device.virtual_chassis.members.filter.return_value.first.return_value = member
+        _vc, (page_device, member) = make_virtual_chassis_members("target-valid-vc")
 
-        result = _resolve_target_device(page_device, "55")
+        result = _resolve_target_device(page_device, str(member.pk), Device.objects.all())
 
-        assert result is member
+        assert result == member
 
-    def test_vc_member_selection_falls_back_to_page_device(self):
+    def test_vc_member_selection_falls_back_for_a_nonmember(self):
+        from dcim.models import Device
+
+        from netbox_librenms_plugin.tests.conftest import make_device, make_virtual_chassis_members
         from netbox_librenms_plugin.views.sync.modules import _resolve_target_device
 
-        page_device = MagicMock()
-        page_device.virtual_chassis.members.filter.return_value.first.return_value = None
+        _vc, (page_device, _member) = make_virtual_chassis_members("target-wrong-vc")
+        nonmember = make_device("target-nonmember")
 
-        result = _resolve_target_device(page_device, "55")
+        result = _resolve_target_device(page_device, str(nonmember.pk), Device.objects.all())
 
-        assert result is page_device
+        assert result == page_device
 
     def test_invalid_selected_device_id_falls_back(self):
+        from dcim.models import Device
+
+        from netbox_librenms_plugin.tests.conftest import make_device
         from netbox_librenms_plugin.views.sync.modules import _resolve_target_device
 
-        page_device = MagicMock()
+        page_device = make_device("target-invalid-id")
 
-        result = _resolve_target_device(page_device, "not-an-int")
+        result = _resolve_target_device(page_device, "not-an-int", Device.objects.all())
 
-        assert result is page_device
+        assert result == page_device
 
-    def test_resolve_target_device_with_validation_marks_invalid_for_non_vc_selection(self):
+    def test_validation_marks_non_vc_selection_invalid(self):
+        from dcim.models import Device
+
+        from netbox_librenms_plugin.tests.conftest import make_device
         from netbox_librenms_plugin.views.sync.modules import _resolve_target_device_with_validation
 
-        page_device = MagicMock()
-        page_device.pk = 7
-        page_device.virtual_chassis = None
+        page_device = make_device("target-validation-non-vc")
+        other = make_device("target-validation-other")
 
-        resolved, invalid = _resolve_target_device_with_validation(page_device, "123")
+        resolved, invalid = _resolve_target_device_with_validation(
+            page_device,
+            str(other.pk),
+            Device.objects.all(),
+        )
 
-        assert resolved is page_device
+        assert resolved == page_device
         assert invalid is True
 
-    def test_resolve_target_device_with_validation_accepts_page_device_id(self):
+    def test_validation_accepts_page_device_id(self):
+        from dcim.models import Device
+
+        from netbox_librenms_plugin.tests.conftest import make_device
         from netbox_librenms_plugin.views.sync.modules import _resolve_target_device_with_validation
 
-        page_device = MagicMock()
-        page_device.pk = 7
+        page_device = make_device("target-page-id")
 
-        resolved, invalid = _resolve_target_device_with_validation(page_device, "7")
+        resolved, invalid = _resolve_target_device_with_validation(
+            page_device,
+            str(page_device.pk),
+            Device.objects.all(),
+        )
 
-        assert resolved is page_device
+        assert resolved == page_device
         assert invalid is False
+
+
+@pytest.mark.django_db
+class TestModuleMutationScopes:
+    """Module sync must scope every derived Device, bay, type, and Interface mutation."""
+
+    @staticmethod
+    def _module(device, suffix):
+        from dcim.models import Module, ModuleBay, ModuleType
+
+        bay = ModuleBay.objects.create(device=device, name=f"Scope Bay {suffix}")
+        module_type = ModuleType.objects.create(
+            manufacturer=device.device_type.manufacturer,
+            model=f"Scope Module {suffix}",
+        )
+        module = Module.objects.create(
+            device=device,
+            module_bay=bay,
+            module_type=module_type,
+            status="active",
+        )
+        return module
+
+    def test_selected_vc_member_outside_device_view_grant_is_not_mutated(self):
+        from dcim.models import Device, Module
+
+        from netbox_librenms_plugin.tests.conftest import make_virtual_chassis_members
+        from netbox_librenms_plugin.tests.view_test_helpers import grant, make_request, make_user_with_perms
+        from netbox_librenms_plugin.views.sync.modules import UpdateModuleSerialView
+
+        _vc, (page, hidden) = make_virtual_chassis_members("module-device-scope")
+        module = self._module(hidden, "device")
+        user = make_user_with_perms("module-device-scope", [])
+        user = grant(user, "view", Device, constraints={"pk": page.pk})
+        user = grant(user, "change", Module, constraints={"pk": module.pk})
+        request = make_request(
+            "post",
+            {
+                "selected_device_id": str(hidden.pk),
+                "module_id": str(module.pk),
+                "serial": "REPLACEMENT-SERIAL",
+            },
+            user=user,
+        )
+        view = UpdateModuleSerialView()
+
+        _post(view, request, pk=page.pk)
+
+        module.refresh_from_db()
+        assert module.serial == ""
+
+    def test_branch_install_does_not_use_hidden_bay_or_module_type(self):
+        from types import SimpleNamespace
+
+        from dcim.models import Device, Interface, Module, ModuleBay, ModuleType
+        from django.core.cache import cache
+
+        from netbox_librenms_plugin.tests.conftest import make_device
+        from netbox_librenms_plugin.tests.view_test_helpers import grant, make_request, make_user_with_perms
+        from netbox_librenms_plugin.views.sync.modules import InstallBranchView
+
+        device = make_device("module-catalog-scope")
+        hidden_bay = ModuleBay.objects.create(device=device, name="Hidden Scope Bay")
+        allowed_bay = ModuleBay.objects.create(device=device, name="Allowed Scope Bay")
+        hidden_type = ModuleType.objects.create(
+            manufacturer=device.device_type.manufacturer,
+            model="Hidden Scope Module Type",
+        )
+        allowed_type = ModuleType.objects.create(
+            manufacturer=device.device_type.manufacturer,
+            model="Allowed Scope Module Type",
+        )
+        user = make_user_with_perms(
+            "module-catalog-scope",
+            [("view", Device), ("add", Module), ("add", Interface), ("change", Interface), ("delete", Interface)],
+        )
+        user = grant(user, "view", ModuleBay, constraints={"pk": allowed_bay.pk})
+        user = grant(user, "view", ModuleType, constraints={"pk": allowed_type.pk})
+        request = make_request(
+            "post",
+            {"parent_index": "100", "server_key": "default"},
+            user=user,
+        )
+        view = InstallBranchView()
+        view.setup(request, pk=device.pk)
+        view._librenms_api = SimpleNamespace(server_key="default")
+        inventory = [
+            {
+                "entPhysicalIndex": 100,
+                "entPhysicalClass": "module",
+                "entPhysicalModelName": hidden_type.model,
+                "entPhysicalContainedIn": 0,
+                "entPhysicalName": hidden_bay.name,
+            }
+        ]
+        cache_key = view.get_cache_key(device, "inventory", server_key="default")
+        cache.set(cache_key, {"inventory": inventory}, timeout=300)
+        try:
+            view.post(request, pk=device.pk)
+        finally:
+            cache.delete(cache_key)
+
+        assert not Module.objects.filter(module_bay=hidden_bay).exists()
+
+    def test_interface_outside_change_grant_is_not_bound_to_module(self):
+        from types import SimpleNamespace
+
+        from dcim.models import Device, Interface, Module
+        from django.core.cache import cache
+
+        from netbox_librenms_plugin.tests.conftest import make_device, make_interface
+        from netbox_librenms_plugin.tests.view_test_helpers import grant, make_request, make_user_with_perms
+        from netbox_librenms_plugin.utils import set_librenms_device_id
+        from netbox_librenms_plugin.views.sync.modules import UpdateModuleInterfaceView
+
+        device = make_device("module-interface-scope")
+        module = self._module(device, "interface")
+        hidden = make_interface(device, "Te1/1/1")
+        allowed = make_interface(device, "Te1/1/2")
+        set_librenms_device_id(hidden, 42, "default")
+        hidden.save()
+        user = make_user_with_perms("module-interface-scope", [("view", Device), ("view", Module)])
+        user = grant(user, "change", Interface, constraints={"pk": allowed.pk})
+        request = make_request(
+            "post",
+            {"module_id": str(module.pk), "server_key": "default", "ent_index": "77"},
+            user=user,
+        )
+        view = UpdateModuleInterfaceView()
+        view.setup(request, pk=device.pk)
+        view._librenms_api = SimpleNamespace(server_key="default")
+        cache_key = view.get_cache_key(device, "inventory", server_key="default")
+        cache.set(
+            cache_key,
+            {
+                "inventory": [
+                    {
+                        "entPhysicalIndex": 77,
+                        "_librenms_port_id": 42,
+                        "_librenms_ifname": hidden.name,
+                    }
+                ]
+            },
+            timeout=300,
+        )
+        try:
+            view.post(request, pk=device.pk)
+        finally:
+            cache.delete(cache_key)
+
+        hidden.refresh_from_db()
+        assert hidden.module_id is None
+
+    def test_install_does_not_adopt_an_interface_outside_change_grant(self):
+        from types import SimpleNamespace
+
+        from dcim.models import Device, Interface, InterfaceTemplate, Module, ModuleBay, ModuleType
+
+        from netbox_librenms_plugin.tests.conftest import make_device, make_interface
+        from netbox_librenms_plugin.tests.view_test_helpers import grant, make_request, make_user_with_perms
+        from netbox_librenms_plugin.views.sync.modules import InstallModuleView
+
+        device = make_device("module-adoption-scope")
+        bay = ModuleBay.objects.create(device=device, name="Adoption Scope Bay")
+        module_type = ModuleType.objects.create(
+            manufacturer=device.device_type.manufacturer,
+            model="Adoption Scope Type",
+        )
+        InterfaceTemplate.objects.create(
+            module_type=module_type,
+            name="Te1/1/1",
+            type="10gbase-x-sfpp",
+        )
+        hidden = make_interface(device, "Te1/1/1", iface_type="10gbase-x-sfpp")
+        allowed = make_interface(device, "Te1/1/2", iface_type="10gbase-x-sfpp")
+        user = make_user_with_perms(
+            "module-adoption-scope",
+            [
+                ("view", Device),
+                ("view", ModuleBay),
+                ("view", ModuleType),
+                ("add", Module),
+                ("add", Interface),
+                ("delete", Interface),
+            ],
+        )
+        user = grant(user, "change", Interface, constraints={"pk": allowed.pk})
+        request = make_request(
+            "post",
+            {
+                "module_bay_id": str(bay.pk),
+                "module_type_id": str(module_type.pk),
+                "server_key": "default",
+            },
+            user=user,
+        )
+        view = InstallModuleView()
+        view._librenms_api = SimpleNamespace(server_key="default")
+
+        _post(view, request, pk=device.pk)
+
+        hidden.refresh_from_db()
+        assert hidden.module_id is None
+        assert not Module.objects.filter(device=device, module_bay=bay).exists()
+
+    @pytest.mark.parametrize("excluded_action", ["change_conflict", "delete_generated"])
+    def test_vc_normalization_does_not_cross_interface_grants(self, excluded_action):
+        from dcim.models import Interface
+
+        from netbox_librenms_plugin.tests.conftest import make_interface, make_virtual_chassis_members
+        from netbox_librenms_plugin.tests.view_test_helpers import grant, make_user_with_perms
+        from netbox_librenms_plugin.views.sync.modules import _normalize_module_interface_names_for_vc_member
+
+        _vc, (_page, device) = make_virtual_chassis_members(f"module-normalize-{excluded_action}")
+        module = self._module(device, excluded_action)
+        generated = make_interface(device, "TenGigabitEthernet1/1/1", iface_type="10gbase-x-sfpp")
+        generated.module = module
+        generated.save(update_fields=["module"])
+        conflict = make_interface(device, "TenGigabitEthernet2/1/1", iface_type="10gbase-x-sfpp")
+        unrelated = make_interface(device, "TenGigabitEthernet2/1/2", iface_type="10gbase-x-sfpp")
+        user = make_user_with_perms(f"module-normalize-{excluded_action}", [])
+        user = grant(user, "change", Interface, constraints={"pk": generated.pk})
+        if excluded_action == "delete_generated":
+            user = grant(user, "change", Interface, constraints={"pk": conflict.pk})
+            user = grant(user, "delete", Interface, constraints={"pk": unrelated.pk})
+        else:
+            user = grant(user, "delete", Interface, constraints={"pk": generated.pk})
+
+        result = _normalize_module_interface_names_for_vc_member(
+            device,
+            module,
+            Interface.objects.restrict(user, "change"),
+            Interface.objects.restrict(user, "delete"),
+        )
+
+        generated.refresh_from_db()
+        conflict.refresh_from_db()
+        assert result == {"renamed": 0, "adopted": 0, "removed": 0, "skipped": 1}
+        assert generated.name == "TenGigabitEthernet1/1/1"
+        assert conflict.module_id is None
 
 
 class TestNoBayWarningCopy:
@@ -2936,464 +2942,184 @@ class TestParentRowIdxVsEntityIndex:
 # ---------------------------------------------------------------------------
 
 
-class TestInstallViewsDoNotDeleteCache:
-    """
-    Install views must not call cache.delete after a successful install.
+@pytest.mark.django_db
+class TestInstallViewsPreserveInventoryCache:
+    """Install views preserve valid inventory and reject stale inventory."""
 
-    The LibreNMS inventory cache stores what LibreNMS reports (hardware list).
-    It is unaffected by NetBox module installs; _get_module_bays() is a live DB
-    query so the next render correctly shows the "Installed" state without any
-    cache invalidation.  Deleting the cache after install caused an empty modules
-    tab (regression).
+    @staticmethod
+    def _objects(suffix):
+        from dcim.models import ModuleBay, ModuleType
 
-    Each test exercises the view's success path and asserts that cache.delete
-    was never called.
-    """
+        from netbox_librenms_plugin.tests.conftest import make_device
 
-    def test_install_module_view_no_cache_delete(self):
-        """InstallModuleView.post success path must not call cache.delete."""
-        from contextlib import contextmanager
+        device = make_device(f"cache-install-{suffix}")
+        bay = ModuleBay.objects.create(device=device, name=f"Slot {suffix}")
+        module_type = ModuleType.objects.create(
+            manufacturer=device.device_type.manufacturer,
+            model=f"Cache Module {suffix}",
+        )
+        inventory = [
+            {
+                "entPhysicalIndex": 100,
+                "entPhysicalClass": "module",
+                "entPhysicalModelName": module_type.model,
+                "entPhysicalContainedIn": 0,
+                "entPhysicalName": bay.name,
+            }
+        ]
+        return device, bay, module_type, inventory
 
-        from dcim.models import ModuleBay
+    @staticmethod
+    def _user(suffix):
+        from dcim.models import Device, Interface, Module, ModuleBay, ModuleType
 
+        from netbox_librenms_plugin.tests.view_test_helpers import make_user_with_perms
+
+        return make_user_with_perms(
+            f"cache-install-{suffix}",
+            [
+                ("view", Device),
+                ("view", ModuleBay),
+                ("view", ModuleType),
+                ("add", Module),
+                ("add", Interface),
+                ("change", Interface),
+                ("delete", Interface),
+            ],
+        )
+
+    def test_install_module_preserves_inventory_cache(self):
+        from types import SimpleNamespace
+
+        from dcim.models import Module
+        from django.core.cache import cache
+
+        from netbox_librenms_plugin.tests.view_test_helpers import make_request
         from netbox_librenms_plugin.views.sync.modules import InstallModuleView
 
-        view = object.__new__(InstallModuleView)
-        view.required_object_permissions = {}
-        view._librenms_api = MagicMock(server_key="production")
-        device = _make_device()
-
-        module_bay = MagicMock()
-        module_bay.name = "Slot 1"
-        module_bay.installed_module = None
-
-        module_type = MagicMock()
-        module_type.pk = 5
-        module_type.model = "XCM-7s"
-
-        new_module = MagicMock()
-        request = _make_request("POST", data={"module_bay_id": "10", "module_type_id": "5", "serial": "SN1"})
-
-        @contextmanager
-        def noop_atomic():
-            yield
-
-        mock_qs = MagicMock()
-        mock_qs.filter.return_value.first.return_value = module_bay
-
-        with (
-            patch.object(view, "require_all_permissions", return_value=None),
-            patch(
-                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
-                side_effect=[device, module_bay, module_type],
-            ),
-            patch("netbox_librenms_plugin.views.sync.modules.reverse", return_value="/sync/"),
-            patch("netbox_librenms_plugin.views.sync.modules.transaction") as mock_tx,
-            patch("netbox_librenms_plugin.views.sync.modules.messages") as mock_messages,
-            patch("netbox_librenms_plugin.views.sync.modules.redirect"),
-            patch("dcim.models.Module") as mock_module_cls,
-            patch.object(ModuleBay, "objects") as mock_objects,
-            patch("netbox_librenms_plugin.views.sync.modules.cache") as mock_cache,
-        ):
-            mock_tx.atomic = noop_atomic
-            mock_module_cls.return_value = new_module
-            # The locked re-fetch goes through restrict(user, ...), so hand back the same manager.
-            mock_objects.restrict.return_value = mock_objects
-            mock_objects.select_for_update.return_value = mock_qs
-            view.request = request
-            view.post(request, pk=24)
-
-        mock_messages.success.assert_called_once()
-        mock_cache.delete.assert_not_called()
-
-    def test_install_branch_view_no_cache_delete(self):
-        """InstallBranchView.post success path must not call cache.delete."""
-        from netbox_librenms_plugin.views.sync.modules import InstallBranchView
-
-        view = object.__new__(InstallBranchView)
-        view.required_object_permissions = {}
-        view._librenms_api = MagicMock(server_key="default")
-        device = _make_device()
-
-        request = _make_request("POST", data={"parent_index": "100", "server_key": "default"})
-
-        cached_inventory = [
+        device, bay, module_type, inventory = self._objects("single")
+        request = make_request(
+            "post",
             {
-                "entPhysicalIndex": 100,
-                "entPhysicalClass": "module",
-                "entPhysicalModelName": "MOD-A",
-                "entPhysicalContainedIn": 0,
-                "entPhysicalName": "Slot 0",
+                "module_bay_id": str(bay.pk),
+                "module_type_id": str(module_type.pk),
+                "serial": "TEST-SERIAL",
+                "server_key": "default",
             },
-        ]
+            user=self._user("single"),
+        )
+        view = InstallModuleView()
+        view._librenms_api = SimpleNamespace(server_key="default")
+        cache_key = view.get_cache_key(device, "inventory", server_key="default")
+        payload = {"inventory": inventory}
+        cache.set(cache_key, payload, timeout=300)
+        try:
+            response = _post(view, request, pk=device.pk)
 
-        install_result = {"status": "installed", "name": "Slot 0"}
+            assert response.status_code == 302
+            assert Module.objects.filter(device=device, module_bay=bay, module_type=module_type).exists()
+            assert cache.get(cache_key) == payload
+        finally:
+            cache.delete(cache_key)
 
-        with (
-            patch.object(view, "require_all_permissions", return_value=None),
-            patch(
-                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
-                return_value=device,
-            ),
-            patch("netbox_librenms_plugin.views.sync.modules.reverse", return_value="/sync/"),
-            patch("netbox_librenms_plugin.views.sync.modules.cache") as mock_cache,
-            patch.object(view, "get_cache_key", return_value="test-key"),
-            patch.object(InstallBranchView, "_collect_branch", return_value=cached_inventory),
-            patch.object(InstallBranchView, "_install_single", return_value=install_result),
-            patch("netbox_librenms_plugin.views.sync.modules.get_module_types_indexed", return_value={}),
-            patch("netbox_librenms_plugin.utils.load_bay_mappings", return_value=([], [])),
-            patch("netbox_librenms_plugin.utils.preload_normalization_rules", return_value={}),
-            patch("netbox_librenms_plugin.utils.get_enabled_ignore_rules", return_value=[]),
-            patch("netbox_librenms_plugin.views.sync.modules.transaction") as mock_tx,
-            patch("netbox_librenms_plugin.views.sync.modules.messages") as mock_messages,
-            patch("netbox_librenms_plugin.views.sync.modules.redirect"),
-        ):
-            mock_cache.get.return_value = {"inventory": cached_inventory, "librenms_id": "test"}
-            mock_tx.atomic = lambda *a, **kw: MagicMock(__enter__=MagicMock(), __exit__=MagicMock(return_value=False))
-            view.request = request
-            view.post(request, pk=24)
+    @pytest.mark.parametrize(
+        ("view_name", "request_data"),
+        [
+            ("branch", {"parent_index": "100", "server_key": "default"}),
+            ("selected", {"select": ["100"], "server_key": "default"}),
+        ],
+    )
+    def test_bulk_install_preserves_inventory_cache(self, view_name, request_data):
+        from types import SimpleNamespace
 
-        mock_messages.success.assert_called_once()
-        mock_cache.delete.assert_not_called()
+        from dcim.models import Module
+        from django.core.cache import cache
 
-    def test_install_selected_view_no_cache_delete(self):
-        """InstallSelectedView.post success path must not call cache.delete."""
+        from netbox_librenms_plugin.tests.view_test_helpers import make_request
         from netbox_librenms_plugin.views.sync.modules import InstallBranchView, InstallSelectedView
 
-        view = object.__new__(InstallSelectedView)
-        view.required_object_permissions = {}
-        view._librenms_api = MagicMock(server_key="default")
-        device = _make_device()
+        device, bay, module_type, inventory = self._objects(view_name)
+        request = make_request("post", request_data, user=self._user(view_name))
+        view_class = InstallBranchView if view_name == "branch" else InstallSelectedView
+        view = view_class()
+        view._librenms_api = SimpleNamespace(server_key="default")
+        cache_key = view.get_cache_key(device, "inventory", server_key="default")
+        payload = {"inventory": inventory}
+        cache.set(cache_key, payload, timeout=300)
+        try:
+            response = _post(view, request, pk=device.pk)
 
-        request = _make_request("POST", data={"server_key": "default"})
-        post_mock = MagicMock()
-        post_mock.get = MagicMock(side_effect=lambda k, d=None: {"server_key": "default"}.get(k, d))
-        post_mock.getlist = MagicMock(return_value=["100"])
-        request.POST = post_mock
+            assert response.status_code == 302
+            assert Module.objects.filter(device=device, module_bay=bay, module_type=module_type).exists()
+            assert cache.get(cache_key) == payload
+        finally:
+            cache.delete(cache_key)
 
-        cached_inventory = [
-            {
-                "entPhysicalIndex": 100,
-                "entPhysicalClass": "module",
-                "entPhysicalModelName": "MOD-A",
-                "entPhysicalContainedIn": 0,
-                "entPhysicalName": "Slot 0",
-            },
-        ]
+    @pytest.mark.parametrize(
+        ("view_name", "request_data"),
+        [
+            ("branch-stale", {"parent_index": "100", "server_key": "default"}),
+            ("selected-stale", {"select": ["100"], "server_key": "default"}),
+        ],
+    )
+    def test_bulk_install_rejects_stale_inventory_and_preserves_cache(self, view_name, request_data):
+        from types import SimpleNamespace
 
-        install_result = {"status": "installed", "name": "Slot 0"}
+        from dcim.models import Module
+        from django.core.cache import cache
 
-        with (
-            patch.object(view, "require_all_permissions", return_value=None),
-            patch(
-                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
-                return_value=device,
-            ),
-            patch("netbox_librenms_plugin.views.sync.modules.reverse", return_value="/sync/"),
-            patch("netbox_librenms_plugin.views.sync.modules.cache") as mock_cache,
-            patch.object(view, "get_cache_key", return_value="test-key"),
-            patch.object(InstallBranchView, "_install_single", return_value=install_result),
-            patch("netbox_librenms_plugin.views.sync.modules.get_module_types_indexed", return_value={}),
-            patch("netbox_librenms_plugin.utils.get_enabled_ignore_rules", return_value=[]),
-            patch("netbox_librenms_plugin.utils.load_bay_mappings", return_value=([], [])),
-            patch("netbox_librenms_plugin.utils.preload_normalization_rules", return_value={}),
-            patch("netbox_librenms_plugin.views.sync.modules.transaction") as mock_tx,
-            patch("netbox_librenms_plugin.views.sync.modules.messages") as mock_messages,
-            patch("netbox_librenms_plugin.views.sync.modules.redirect"),
-        ):
-            mock_cache.get.return_value = {"inventory": cached_inventory, "librenms_id": "test"}
-            mock_tx.atomic = lambda *a, **kw: MagicMock(__enter__=MagicMock(), __exit__=MagicMock(return_value=False))
-            view.request = request
-            view.post(request, pk=24)
-
-        mock_messages.success.assert_called_once()
-        mock_cache.delete.assert_not_called()
-
-    def test_install_branch_rejects_stale_cached_inventory_context(self):
-        """Branch install should fail closed when cached inventory librenms_id mismatches target device context."""
-        from netbox_librenms_plugin.views.sync.modules import InstallBranchView
-
-        view = object.__new__(InstallBranchView)
-        view.required_object_permissions = {}
-        view._librenms_api = MagicMock(server_key="default")
-        device = _make_device()
-
-        request = _make_request("POST", data={"parent_index": "100", "server_key": "default"})
-
-        with (
-            patch.object(view, "require_all_permissions", return_value=None),
-            patch(
-                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
-                return_value=device,
-            ),
-            patch("netbox_librenms_plugin.views.sync.modules.reverse", return_value="/sync/"),
-            patch("netbox_librenms_plugin.views.sync.modules.cache") as mock_cache,
-            patch.object(view, "get_cache_key", return_value="test-key"),
-            patch("netbox_librenms_plugin.views.sync.modules.get_librenms_device_id", return_value=999),
-            patch("netbox_librenms_plugin.views.sync.modules.messages") as mock_messages,
-            patch("netbox_librenms_plugin.views.sync.modules.redirect"),
-            patch.object(InstallBranchView, "_collect_branch") as mock_collect,
-        ):
-            mock_cache.get.return_value = {"inventory": [{"entPhysicalIndex": 100}], "librenms_id": 555}
-            view.request = request
-            view.post(request, pk=24)
-
-        mock_collect.assert_not_called()
-        mock_messages.error.assert_called_once()
-
-    def test_install_selected_rejects_stale_cached_inventory_context(self):
-        """Selected install should fail closed when cached inventory context mismatches device librenms_id."""
-        from netbox_librenms_plugin.views.sync.modules import InstallSelectedView
-
-        view = object.__new__(InstallSelectedView)
-        view.required_object_permissions = {}
-        view._librenms_api = MagicMock(server_key="default")
-        device = _make_device()
-
-        request = _make_request("POST", data={"server_key": "default"})
-        post_mock = MagicMock()
-        post_mock.get = MagicMock(side_effect=lambda k, d=None: {"server_key": "default"}.get(k, d))
-        post_mock.getlist = MagicMock(return_value=["100"])
-        request.POST = post_mock
-
-        with (
-            patch.object(view, "require_all_permissions", return_value=None),
-            patch(
-                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
-                return_value=device,
-            ),
-            patch("netbox_librenms_plugin.views.sync.modules.reverse", return_value="/sync/"),
-            patch("netbox_librenms_plugin.views.sync.modules.cache") as mock_cache,
-            patch.object(view, "get_cache_key", return_value="test-key"),
-            patch("netbox_librenms_plugin.views.sync.modules.get_librenms_device_id", return_value=999),
-            patch("netbox_librenms_plugin.views.sync.modules.messages") as mock_messages,
-            patch("netbox_librenms_plugin.views.sync.modules.redirect"),
-            patch("netbox_librenms_plugin.views.sync.modules.InstallBranchView._install_single") as mock_install,
-        ):
-            mock_cache.get.return_value = {"inventory": [{"entPhysicalIndex": 100}], "librenms_id": 555}
-            view.request = request
-            view.post(request, pk=24)
-
-        mock_install.assert_not_called()
-        mock_messages.error.assert_called_once()
-
-    def test_install_branch_skipped_rows_do_not_bind_interfaces(self):
-        """Skipped branch rows must not trigger interface binding side effects."""
-        from netbox_librenms_plugin.views.sync.modules import InstallBranchView
-
-        view = object.__new__(InstallBranchView)
-        view.required_object_permissions = {}
-        view._librenms_api = MagicMock(server_key="default")
-        device = _make_device()
-
-        request = _make_request("POST", data={"parent_index": "100", "server_key": "default"})
-        cached_inventory = [
-            {
-                "entPhysicalIndex": 100,
-                "entPhysicalClass": "module",
-                "entPhysicalModelName": "MOD-A",
-                "entPhysicalContainedIn": 0,
-                "entPhysicalName": "Slot 0",
-            },
-        ]
-        install_result = {"status": "skipped", "name": "Slot 0", "reason": "no matching bay", "module_pk": 999}
-
-        with (
-            patch.object(view, "require_all_permissions", return_value=None),
-            patch(
-                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
-                return_value=device,
-            ),
-            patch("netbox_librenms_plugin.views.sync.modules.reverse", return_value="/sync/"),
-            patch("netbox_librenms_plugin.views.sync.modules.cache") as mock_cache,
-            patch.object(view, "get_cache_key", return_value="test-key"),
-            patch.object(InstallBranchView, "_collect_branch", return_value=cached_inventory),
-            patch.object(InstallBranchView, "_install_single", return_value=install_result),
-            patch("netbox_librenms_plugin.views.sync.modules.get_module_types_indexed", return_value={}),
-            patch("netbox_librenms_plugin.utils.load_bay_mappings", return_value=([], [])),
-            patch("netbox_librenms_plugin.utils.preload_normalization_rules", return_value={}),
-            patch("netbox_librenms_plugin.utils.get_enabled_ignore_rules", return_value=[]),
-            patch("netbox_librenms_plugin.views.sync.modules._bind_interface_librenms_id") as mock_bind,
-            patch("netbox_librenms_plugin.views.sync.modules.transaction") as mock_tx,
-            patch("netbox_librenms_plugin.views.sync.modules.messages"),
-            patch("netbox_librenms_plugin.views.sync.modules.redirect"),
-        ):
-            mock_cache.get.return_value = {"inventory": cached_inventory, "librenms_id": "test"}
-            mock_tx.atomic = lambda: MagicMock(__enter__=MagicMock(), __exit__=MagicMock(return_value=False))
-            view.request = request
-            view.post(request, pk=24)
-
-        mock_bind.assert_not_called()
-
-    def test_install_selected_skipped_rows_do_not_bind_interfaces(self):
-        """Skipped selected rows must not trigger interface binding side effects."""
+        from netbox_librenms_plugin.tests.view_test_helpers import make_request, message_texts
+        from netbox_librenms_plugin.utils import set_librenms_device_id
         from netbox_librenms_plugin.views.sync.modules import InstallBranchView, InstallSelectedView
 
-        view = object.__new__(InstallSelectedView)
-        view.required_object_permissions = {}
-        view._librenms_api = MagicMock(server_key="default")
-        device = _make_device()
+        device, _bay, _module_type, inventory = self._objects(view_name)
+        set_librenms_device_id(device, 999, "default")
+        device.save()
+        request = make_request("post", request_data, user=self._user(view_name))
+        view_class = InstallBranchView if view_name == "branch-stale" else InstallSelectedView
+        view = view_class()
+        view._librenms_api = SimpleNamespace(server_key="default")
+        cache_key = view.get_cache_key(device, "inventory", server_key="default")
+        payload = {"inventory": inventory, "librenms_id": 555}
+        cache.set(cache_key, payload, timeout=300)
+        try:
+            response = _post(view, request, pk=device.pk)
 
-        request = _make_request("POST", data={"server_key": "default"})
-        post_mock = MagicMock()
-        post_mock.get = MagicMock(side_effect=lambda k, d=None: {"server_key": "default"}.get(k, d))
-        post_mock.getlist = MagicMock(return_value=["100"])
-        request.POST = post_mock
+            assert response.status_code == 302
+            assert not Module.objects.filter(device=device).exists()
+            assert cache.get(cache_key) == payload
+            assert any("No cached inventory data" in text for text in message_texts(request, "error"))
+        finally:
+            cache.delete(cache_key)
 
-        cached_inventory = [
-            {
-                "entPhysicalIndex": 100,
-                "entPhysicalClass": "module",
-                "entPhysicalModelName": "MOD-A",
-                "entPhysicalContainedIn": 0,
-                "entPhysicalName": "Slot 0",
-            },
-        ]
-        install_result = {"status": "skipped", "name": "Slot 0", "reason": "no matching bay", "module_pk": 999}
 
-        with (
-            patch.object(view, "require_all_permissions", return_value=None),
-            patch(
-                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
-                return_value=device,
-            ),
-            patch("netbox_librenms_plugin.views.sync.modules.reverse", return_value="/sync/"),
-            patch("netbox_librenms_plugin.views.sync.modules.cache") as mock_cache,
-            patch.object(view, "get_cache_key", return_value="test-key"),
-            patch.object(InstallBranchView, "_install_single", return_value=install_result),
-            patch("netbox_librenms_plugin.views.sync.modules.get_module_types_indexed", return_value={}),
-            patch("netbox_librenms_plugin.utils.get_enabled_ignore_rules", return_value=[]),
-            patch("netbox_librenms_plugin.utils.load_bay_mappings", return_value=([], [])),
-            patch("netbox_librenms_plugin.utils.preload_normalization_rules", return_value={}),
-            patch("netbox_librenms_plugin.views.sync.modules._bind_interface_librenms_id") as mock_bind,
-            patch("netbox_librenms_plugin.views.sync.modules.transaction") as mock_tx,
-            patch("netbox_librenms_plugin.views.sync.modules.messages"),
-            patch("netbox_librenms_plugin.views.sync.modules.redirect"),
-        ):
-            mock_cache.get.return_value = {"inventory": cached_inventory, "librenms_id": "test"}
-            mock_tx.atomic = lambda: MagicMock(__enter__=MagicMock(), __exit__=MagicMock(return_value=False))
-            view.request = request
-            view.post(request, pk=24)
+class TestShouldAttemptModuleInterfaceBind:
+    """Interface binding runs only when the install result identifies a usable module."""
 
-        mock_bind.assert_not_called()
+    @pytest.mark.parametrize(
+        "result",
+        [
+            {"status": "installed", "module_pk": None},
+            {"status": "skipped", "module_pk": 12, "reason": "no matching bay"},
+            {"status": "failed", "module_pk": 12, "reason": "validation failed"},
+        ],
+    )
+    def test_rejects_results_without_bindable_module_context(self, result):
+        from netbox_librenms_plugin.views.sync.modules import _should_attempt_bind_for_result
 
-    def test_install_branch_occupied_rows_attempt_bind_interfaces(self):
-        """When bay is already occupied and module_pk is known, branch install still attempts bind."""
-        from netbox_librenms_plugin.views.sync.modules import InstallBranchView
+        assert _should_attempt_bind_for_result(result) is False
 
-        view = object.__new__(InstallBranchView)
-        view.required_object_permissions = {}
-        view._librenms_api = MagicMock(server_key="default")
-        device = _make_device()
+    @pytest.mark.parametrize(
+        "result",
+        [
+            {"status": "installed", "module_pk": 12},
+            {"status": "skipped", "module_pk": 12, "reason": "bay already occupied"},
+        ],
+    )
+    def test_accepts_installed_or_known_occupied_module(self, result):
+        from netbox_librenms_plugin.views.sync.modules import _should_attempt_bind_for_result
 
-        request = _make_request("POST", data={"parent_index": "100", "server_key": "default"})
-        cached_inventory = [
-            {
-                "entPhysicalIndex": 100,
-                "entPhysicalClass": "module",
-                "entPhysicalModelName": "MOD-A",
-                "entPhysicalContainedIn": 0,
-                "entPhysicalName": "Slot 0",
-                "_librenms_port_id": 42,
-            },
-        ]
-        install_result = {
-            "status": "skipped",
-            "name": "Slot 0",
-            "reason": "bay already occupied",
-            "module_pk": 999,
-        }
-
-        with (
-            patch.object(view, "require_all_permissions", return_value=None),
-            patch(
-                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
-                return_value=device,
-            ),
-            patch("netbox_librenms_plugin.views.sync.modules.reverse", return_value="/sync/"),
-            patch("netbox_librenms_plugin.views.sync.modules.cache") as mock_cache,
-            patch.object(view, "get_cache_key", return_value="test-key"),
-            patch.object(InstallBranchView, "_collect_branch", return_value=cached_inventory),
-            patch.object(InstallBranchView, "_install_single", return_value=install_result),
-            patch("netbox_librenms_plugin.views.sync.modules.get_module_types_indexed", return_value={}),
-            patch("netbox_librenms_plugin.utils.load_bay_mappings", return_value=([], [])),
-            patch("netbox_librenms_plugin.utils.preload_normalization_rules", return_value={}),
-            patch("netbox_librenms_plugin.utils.get_enabled_ignore_rules", return_value=[]),
-            patch(
-                "netbox_librenms_plugin.views.sync.modules._bind_interface_librenms_id",
-                return_value={"status": "bound"},
-            ) as mock_bind,
-            patch("netbox_librenms_plugin.views.sync.modules.transaction") as mock_tx,
-            patch("netbox_librenms_plugin.views.sync.modules.messages"),
-            patch("netbox_librenms_plugin.views.sync.modules.redirect"),
-        ):
-            mock_cache.get.return_value = {"inventory": cached_inventory, "librenms_id": "test"}
-            mock_tx.atomic = lambda: MagicMock(__enter__=MagicMock(), __exit__=MagicMock(return_value=False))
-            view.request = request
-            view.post(request, pk=24)
-
-        mock_bind.assert_called_once()
-
-    def test_install_selected_occupied_rows_attempt_bind_interfaces(self):
-        """When selected install hits occupied bay with module_pk, binding still runs."""
-        from netbox_librenms_plugin.views.sync.modules import InstallBranchView, InstallSelectedView
-
-        view = object.__new__(InstallSelectedView)
-        view.required_object_permissions = {}
-        view._librenms_api = MagicMock(server_key="default")
-        device = _make_device()
-
-        request = _make_request("POST", data={"server_key": "default"})
-        post_mock = MagicMock()
-        post_mock.get = MagicMock(side_effect=lambda k, d=None: {"server_key": "default"}.get(k, d))
-        post_mock.getlist = MagicMock(return_value=["100"])
-        request.POST = post_mock
-
-        cached_inventory = [
-            {
-                "entPhysicalIndex": 100,
-                "entPhysicalClass": "module",
-                "entPhysicalModelName": "MOD-A",
-                "entPhysicalContainedIn": 0,
-                "entPhysicalName": "Slot 0",
-                "_librenms_port_id": 42,
-            },
-        ]
-        install_result = {
-            "status": "skipped",
-            "name": "Slot 0",
-            "reason": "bay already occupied",
-            "module_pk": 999,
-        }
-
-        with (
-            patch.object(view, "require_all_permissions", return_value=None),
-            patch(
-                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
-                return_value=device,
-            ),
-            patch("netbox_librenms_plugin.views.sync.modules.reverse", return_value="/sync/"),
-            patch("netbox_librenms_plugin.views.sync.modules.cache") as mock_cache,
-            patch.object(view, "get_cache_key", return_value="test-key"),
-            patch.object(InstallBranchView, "_install_single", return_value=install_result),
-            patch("netbox_librenms_plugin.views.sync.modules.get_module_types_indexed", return_value={}),
-            patch("netbox_librenms_plugin.utils.get_enabled_ignore_rules", return_value=[]),
-            patch("netbox_librenms_plugin.utils.load_bay_mappings", return_value=([], [])),
-            patch("netbox_librenms_plugin.utils.preload_normalization_rules", return_value={}),
-            patch(
-                "netbox_librenms_plugin.views.sync.modules._bind_interface_librenms_id",
-                return_value={"status": "bound"},
-            ) as mock_bind,
-            patch("netbox_librenms_plugin.views.sync.modules.transaction") as mock_tx,
-            patch("netbox_librenms_plugin.views.sync.modules.messages"),
-            patch("netbox_librenms_plugin.views.sync.modules.redirect"),
-        ):
-            mock_cache.get.return_value = {"inventory": cached_inventory, "librenms_id": "test"}
-            mock_tx.atomic = lambda: MagicMock(__enter__=MagicMock(), __exit__=MagicMock(return_value=False))
-            view.request = request
-            view.post(request, pk=24)
-
-        mock_bind.assert_called_once()
+        assert _should_attempt_bind_for_result(result) is True
 
 
 # ---------------------------------------------------------------------------
@@ -5684,22 +5410,19 @@ class TestVCNormalizationReportView:
         module = Module.objects.create(device=device, module_bay=bay, module_type=mtype, status="active")
         return device, module
 
+    @pytest.mark.django_db
     def test_get_returns_400_when_module_id_missing(self):
+        from dcim.models import Device, Module
+
+        from netbox_librenms_plugin.tests.conftest import make_device
+        from netbox_librenms_plugin.tests.view_test_helpers import make_request, make_user_with_perms
         from netbox_librenms_plugin.views.sync.modules import VCNormalizationReportView
 
-        view = object.__new__(VCNormalizationReportView)
-        view.required_object_permissions = {}
-        device = _make_device()
-        request = _make_request("GET", data={})
+        device = make_device("vc-report-missing-id")
+        user = make_user_with_perms("vc-report-missing-id", [("view", Device), ("view", Module)])
+        request = make_request("get", user=user)
 
-        with (
-            patch.object(view, "require_object_permissions", return_value=None),
-            patch(
-                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
-                return_value=device,
-            ),
-        ):
-            response = view.get(request, pk=24)
+        response = _get(VCNormalizationReportView(), request, pk=device.pk)
 
         assert response.status_code == 400
         assert b"module_id" in response.content
@@ -5783,23 +5506,20 @@ class TestVCNormalizationReportView:
         mock_warn.assert_called_once_with(request)
         assert response.status_code == 400
 
+    @pytest.mark.django_db
     def test_get_returns_400_when_module_id_non_numeric(self):
         """Non-numeric module_id is treated the same as missing — returns 400."""
+        from dcim.models import Device, Module
+
+        from netbox_librenms_plugin.tests.conftest import make_device
+        from netbox_librenms_plugin.tests.view_test_helpers import make_request, make_user_with_perms
         from netbox_librenms_plugin.views.sync.modules import VCNormalizationReportView
 
-        view = object.__new__(VCNormalizationReportView)
-        view.required_object_permissions = {}
-        device = _make_device()
-        request = _make_request("GET", data={"module_id": "not-a-number"})
+        device = make_device("vc-report-invalid-id")
+        user = make_user_with_perms("vc-report-invalid-id", [("view", Device), ("view", Module)])
+        request = make_request("get", {"module_id": "not-a-number"}, user=user)
 
-        with (
-            patch.object(view, "require_object_permissions", return_value=None),
-            patch(
-                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
-                return_value=device,
-            ),
-        ):
-            response = view.get(request, pk=24)
+        response = _get(VCNormalizationReportView(), request, pk=device.pk)
 
         assert response.status_code == 400
 
@@ -6098,121 +5818,118 @@ class TestModuleInterfaceUpdateMessage:
         assert msg == "No interface changes were needed for QSFP-100G in Bay 1."
 
 
+@pytest.mark.django_db
 class TestReplaceModuleRedirectServerKey:
-    """ReplaceModuleView computes `server_key = POST or self.librenms_api.server_key`, so its redirects must pass that computed key — otherwise the helper falls back to POST/GET only and drops the active-server context when the POST field is absent, landing on a blank/default modules tab and reading/mutating a different cache namespace."""
+    """ReplaceModuleView keeps its active server on a real validation redirect."""
 
-    def _run_missing_module_id(self):
+    def test_missing_module_id_preserves_fallback_server_key(self):
+        from types import SimpleNamespace
+
+        from dcim.models import Device, Interface, Module, ModuleType
+
+        from netbox_librenms_plugin.tests.conftest import make_device
+        from netbox_librenms_plugin.tests.view_test_helpers import make_request, make_user_with_perms
         from netbox_librenms_plugin.views.sync.modules import ReplaceModuleView
 
-        view = object.__new__(ReplaceModuleView)
-        view.require_all_permissions = MagicMock(return_value=None)
-        mock_api = MagicMock(server_key="prod")
+        device = make_device("replace-redirect-invalid")
+        user = make_user_with_perms(
+            "replace-redirect-invalid",
+            [
+                ("view", Device),
+                ("view", ModuleType),
+                ("add", Module),
+                ("change", Module),
+                ("delete", Module),
+                ("add", Interface),
+                ("change", Interface),
+                ("delete", Interface),
+            ],
+        )
+        request = make_request(
+            "post",
+            {},
+            user=user,
+            path="/replace-module/",
+            HTTP_HX_REQUEST="true",
+        )
+        view = ReplaceModuleView()
+        view._librenms_api = SimpleNamespace(server_key="prod")
 
-        request = MagicMock()
-        # POST carries no server_key and no module_id → fallback to api.server_key, then the
-        # int(module_id) parse fails and we hit the early "Missing or invalid" redirect.
-        request.POST.get.return_value = None
-        request.headers.get.return_value = "true"  # HX-Request → HX-Redirect header
+        response = _post(view, request, pk=device.pk)
 
-        with (
-            patch.object(type(view), "librenms_api", new_callable=lambda: property(lambda s: mock_api)),
-            patch(
-                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
-                return_value=MagicMock(pk=1),
-            ),
-            patch(
-                "netbox_librenms_plugin.views.sync.modules._resolve_target_device_with_validation",
-                return_value=(MagicMock(), False),
-            ),
-            patch("netbox_librenms_plugin.views.sync.modules.reverse", return_value="/sync/url/"),
-            patch("netbox_librenms_plugin.views.sync.modules.messages"),
-        ):
-            view.request = request
-            return view.post(request, pk=1)
-
-    def test_missing_module_id_redirect_preserves_fallback_server_key(self):
-        resp = self._run_missing_module_id()
-        # Pre-fix the redirect dropped the computed fallback (POST had no server_key); now it
-        # carries server_key=prod so the action stays on the active server's modules tab.
-        assert "server_key=prod" in resp["HX-Redirect"]
-
-
-class TestUpdateModuleInterfaceRedirectServerKey:
-    """UpdateModuleInterfaceView must redirect under its resolved active server scope."""
-
-    @staticmethod
-    def _view():
-        from netbox_librenms_plugin.views.sync.modules import UpdateModuleInterfaceView
-
-        view = object.__new__(UpdateModuleInterfaceView)
-        view.required_object_permissions = {}
-        view._librenms_api = MagicMock(server_key="prod")
-        return view
-
-    @staticmethod
-    def _request(data):
-        from django.test import RequestFactory
-
-        return RequestFactory().post("/update-interface/", data, HTTP_HX_REQUEST="true")
-
-    def test_invalid_module_id_redirect_preserves_fallback_server_key(self):
-        view = self._view()
-        request = self._request({"ent_index": "77"})
-        device = _make_device()
-
-        with (
-            patch.object(view, "require_all_permissions", return_value=None),
-            patch(
-                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
-                return_value=device,
-            ),
-            patch(
-                "netbox_librenms_plugin.views.sync.modules._resolve_target_device_with_validation",
-                return_value=(device, False),
-            ),
-            patch(
-                "netbox_librenms_plugin.views.sync.modules._resolve_single_install_binding_item",
-                return_value=None,
-            ),
-            patch("netbox_librenms_plugin.views.sync.modules.reverse", return_value="/sync/url/"),
-            patch("netbox_librenms_plugin.views.sync.modules.messages"),
-        ):
-            view.request = request
-            response = view.post(request, pk=device.pk)
-
+        assert response.status_code == 204
         assert "server_key=prod" in response["HX-Redirect"]
 
-    def test_success_redirect_preserves_fallback_server_key(self):
-        view = self._view()
-        request = self._request({"module_id": "321", "ent_index": "77"})
-        device = _make_device()
-        module = MagicMock()
-        module.pk = 321
-        module.module_type.model = "SFP-10G-SR"
-        module.module_bay.name = "SFP 1"
 
-        with (
-            patch.object(view, "require_all_permissions", return_value=None),
-            patch(
-                "netbox_librenms_plugin.views.mixins.NetBoxObjectPermissionMixin.restrict_object_or_404",
-                side_effect=[device, module],
-            ),
-            patch(
-                "netbox_librenms_plugin.views.sync.modules._resolve_target_device_with_validation",
-                return_value=(device, False),
-            ),
-            patch(
-                "netbox_librenms_plugin.views.sync.modules._resolve_single_install_binding_item",
-                return_value=None,
-            ),
-            patch(
-                "netbox_librenms_plugin.views.sync.modules._adopt_existing_template_interfaces",
-                return_value={"status": "bound", "adopted_count": 0},
-            ),
-            patch("netbox_librenms_plugin.views.sync.modules.reverse", return_value="/sync/url/"),
-            patch("netbox_librenms_plugin.views.sync.modules.messages"),
-        ):
-            view.request = request
-            response = view.post(request, pk=device.pk)
+@pytest.mark.django_db
+class TestUpdateModuleInterfaceRedirectServerKey:
+    """UpdateModuleInterfaceView keeps its resolved server on real redirects."""
 
+    @staticmethod
+    def _request(user, data):
+        from netbox_librenms_plugin.tests.view_test_helpers import make_request
+
+        return make_request(
+            "post",
+            data,
+            user=user,
+            path="/update-interface/",
+            HTTP_HX_REQUEST="true",
+        )
+
+    def test_invalid_module_id_preserves_fallback_server_key(self):
+        from types import SimpleNamespace
+
+        from dcim.models import Device, Interface, Module
+
+        from netbox_librenms_plugin.tests.conftest import make_device
+        from netbox_librenms_plugin.tests.view_test_helpers import make_user_with_perms
+        from netbox_librenms_plugin.views.sync.modules import UpdateModuleInterfaceView
+
+        device = make_device("update-interface-redirect-invalid")
+        user = make_user_with_perms(
+            "update-interface-redirect-invalid",
+            [("view", Device), ("view", Module), ("change", Interface)],
+        )
+        request = self._request(user, {"ent_index": "77"})
+        view = UpdateModuleInterfaceView()
+        view._librenms_api = SimpleNamespace(server_key="prod")
+
+        response = _post(view, request, pk=device.pk)
+
+        assert response.status_code == 204
+        assert "server_key=prod" in response["HX-Redirect"]
+
+    def test_success_preserves_fallback_server_key(self):
+        from types import SimpleNamespace
+
+        from dcim.models import Device, Interface, Module, ModuleBay, ModuleType
+
+        from netbox_librenms_plugin.tests.conftest import make_device
+        from netbox_librenms_plugin.tests.view_test_helpers import make_user_with_perms
+        from netbox_librenms_plugin.views.sync.modules import UpdateModuleInterfaceView
+
+        device = make_device("update-interface-redirect-success")
+        bay = ModuleBay.objects.create(device=device, name="Redirect Bay")
+        module_type = ModuleType.objects.create(
+            manufacturer=device.device_type.manufacturer,
+            model="Redirect Module",
+        )
+        module = Module.objects.create(
+            device=device,
+            module_bay=bay,
+            module_type=module_type,
+            status="active",
+        )
+        user = make_user_with_perms(
+            "update-interface-redirect-success",
+            [("view", Device), ("view", Module), ("change", Interface)],
+        )
+        request = self._request(user, {"module_id": str(module.pk), "ent_index": "77"})
+        view = UpdateModuleInterfaceView()
+        view._librenms_api = SimpleNamespace(server_key="prod")
+
+        response = _post(view, request, pk=device.pk)
+
+        assert response.status_code == 204
         assert "server_key=prod" in response["HX-Redirect"]

--- a/netbox_librenms_plugin/tests/test_sync_modules.py
+++ b/netbox_librenms_plugin/tests/test_sync_modules.py
@@ -6372,11 +6372,12 @@ class TestStandaloneAdoptionAcrossEveryComponentType:
         # This is the call CodeRabbit questioned for NetBox 4.4/4.5: exercise it for every type.
         expected_name = _module_template_adoption_name(template_attribute, template, module)
         assert expected_name, f"{template_attribute} resolved an empty adoption name"
-        # The token only resolves when the module argument reaches NetBox, so this is what proves
-        # the version-compatible call is right rather than merely self-consistent.
-        assert expected_name == f"{self.BAY_POSITION}-adopt-{component_model.__name__.lower()}-0", (
-            f"{template_attribute} did not resolve the module placeholder from the installed bay"
-        )
+        # These seven go through resolve_name(module), where the token resolves only once the
+        # module argument arrives. NetBox 4.4 module bays instantiate from the raw name instead.
+        if template_attribute != "modulebaytemplates":
+            assert expected_name == f"{self.BAY_POSITION}-adopt-{component_model.__name__.lower()}-0", (
+                f"{template_attribute} did not resolve the module placeholder from the installed bay"
+            )
 
         standalone = component_model.objects.create(**self._standalone_kwargs(component_model, device, expected_name))
 

--- a/netbox_librenms_plugin/tests/test_sync_modules.py
+++ b/netbox_librenms_plugin/tests/test_sync_modules.py
@@ -2801,6 +2801,57 @@ class TestModuleMutationScopes:
         module = Module.objects.get(device=device, module_bay=bay)
         assert Interface.objects.filter(device=device, module=module, name="Te1/1/1").exists()
 
+    def test_install_authorizes_dependent_component_templates_without_instantiating_them(self):
+        from types import SimpleNamespace
+
+        from dcim.models import (
+            Module,
+            ModuleBay,
+            ModuleType,
+            PowerOutlet,
+            PowerOutletTemplate,
+            PowerPort,
+            PowerPortTemplate,
+        )
+
+        from netbox_librenms_plugin.tests.conftest import make_device
+        from netbox_librenms_plugin.tests.view_test_helpers import make_request
+        from netbox_librenms_plugin.views.sync.modules import InstallModuleView
+
+        device = make_device("module-dependent-component-template")
+        bay = ModuleBay.objects.create(device=device, name="Dependent Component Bay")
+        module_type = ModuleType.objects.create(
+            manufacturer=device.device_type.manufacturer,
+            model="Dependent Component Type",
+        )
+        power_port_template = PowerPortTemplate.objects.create(module_type=module_type, name="Power In")
+        PowerOutletTemplate.objects.create(
+            module_type=module_type,
+            name="Power Out",
+            power_port=power_port_template,
+        )
+        request = make_request(
+            "post",
+            {
+                "module_bay_id": str(bay.pk),
+                "module_type_id": str(module_type.pk),
+                "server_key": "default",
+            },
+        )
+        view = InstallModuleView()
+        view._librenms_api = SimpleNamespace(server_key="default")
+
+        _post(view, request, pk=device.pk)
+
+        module = Module.objects.get(device=device, module_bay=bay)
+        power_port = PowerPort.objects.get(device=device, module=module, name="Power In")
+        assert PowerOutlet.objects.filter(
+            device=device,
+            module=module,
+            name="Power Out",
+            power_port=power_port,
+        ).exists()
+
     def test_install_does_not_adopt_a_module_bay_without_change_permission(self):
         from types import SimpleNamespace
 

--- a/netbox_librenms_plugin/tests/test_sync_modules.py
+++ b/netbox_librenms_plugin/tests/test_sync_modules.py
@@ -2603,6 +2603,58 @@ class TestModuleMutationScopes:
         assert hidden.module_id is None
         assert not Module.objects.filter(device=device, module_bay=bay).exists()
 
+    def test_vc_install_does_not_adopt_a_raw_name_outside_change_grant(self):
+        from types import SimpleNamespace
+
+        from dcim.models import Device, Interface, InterfaceTemplate, Module, ModuleBay, ModuleType
+
+        from netbox_librenms_plugin.tests.conftest import make_interface, make_virtual_chassis_members
+        from netbox_librenms_plugin.tests.view_test_helpers import grant, make_request, make_user_with_perms
+        from netbox_librenms_plugin.views.sync.modules import InstallModuleView
+
+        _vc, (_page, device) = make_virtual_chassis_members("module-vc-adoption-scope")
+        bay = ModuleBay.objects.create(device=device, name="VC Adoption Scope Bay")
+        module_type = ModuleType.objects.create(
+            manufacturer=device.device_type.manufacturer,
+            model="VC Adoption Scope Type",
+        )
+        InterfaceTemplate.objects.create(
+            module_type=module_type,
+            name="TenGigabitEthernet1/1/1",
+            type="10gbase-x-sfpp",
+        )
+        hidden = make_interface(device, "TenGigabitEthernet1/1/1", iface_type="10gbase-x-sfpp")
+        allowed = make_interface(device, "TenGigabitEthernet2/1/2", iface_type="10gbase-x-sfpp")
+        user = make_user_with_perms(
+            "module-vc-adoption-scope",
+            [
+                ("view", Device),
+                ("view", ModuleBay),
+                ("view", ModuleType),
+                ("add", Module),
+                ("add", Interface),
+                ("delete", Interface),
+            ],
+        )
+        user = grant(user, "change", Interface, constraints={"pk": allowed.pk})
+        request = make_request(
+            "post",
+            {
+                "module_bay_id": str(bay.pk),
+                "module_type_id": str(module_type.pk),
+                "server_key": "default",
+            },
+            user=user,
+        )
+        view = InstallModuleView()
+        view._librenms_api = SimpleNamespace(server_key="default")
+
+        _post(view, request, pk=device.pk)
+
+        hidden.refresh_from_db()
+        assert hidden.module_id is None
+        assert not Module.objects.filter(device=device, module_bay=bay).exists()
+
     @pytest.mark.parametrize("excluded_action", ["change_conflict", "delete_generated"])
     def test_vc_normalization_does_not_cross_interface_grants(self, excluded_action):
         from dcim.models import Interface

--- a/netbox_librenms_plugin/tests/test_sync_modules.py
+++ b/netbox_librenms_plugin/tests/test_sync_modules.py
@@ -2655,6 +2655,117 @@ class TestModuleMutationScopes:
         assert hidden.module_id is None
         assert not Module.objects.filter(device=device, module_bay=bay).exists()
 
+    def test_install_checks_the_interface_adopted_before_prediction_hooks(self):
+        from types import SimpleNamespace
+
+        from dcim.models import Device, Interface, InterfaceTemplate, Module, ModuleBay, ModuleType
+        from django.dispatch import receiver
+
+        from netbox_librenms_plugin.signals import predict_module_interface_names
+        from netbox_librenms_plugin.tests.conftest import make_device, make_interface
+        from netbox_librenms_plugin.tests.view_test_helpers import grant, make_request, make_user_with_perms
+        from netbox_librenms_plugin.views.sync.modules import InstallModuleView
+
+        device = make_device("module-predicted-adoption-scope")
+        bay = ModuleBay.objects.create(device=device, name="Predicted Adoption Scope Bay")
+        module_type = ModuleType.objects.create(
+            manufacturer=device.device_type.manufacturer,
+            model="Predicted Adoption Scope Type",
+        )
+        InterfaceTemplate.objects.create(
+            module_type=module_type,
+            name="Te1/1/1",
+            type="10gbase-x-sfpp",
+        )
+        hidden = make_interface(device, "Te1/1/1", iface_type="10gbase-x-sfpp")
+        allowed = make_interface(device, "Ethernet1/1/1", iface_type="10gbase-x-sfpp")
+        user = make_user_with_perms(
+            "module-predicted-adoption-scope",
+            [
+                ("view", Device),
+                ("view", ModuleBay),
+                ("view", ModuleType),
+                ("add", Module),
+                ("add", Interface),
+                ("delete", Interface),
+            ],
+        )
+        user = grant(user, "change", Interface, constraints={"pk": allowed.pk})
+        request = make_request(
+            "post",
+            {
+                "module_bay_id": str(bay.pk),
+                "module_type_id": str(module_type.pk),
+                "server_key": "default",
+            },
+            user=user,
+        )
+        view = InstallModuleView()
+        view._librenms_api = SimpleNamespace(server_key="default")
+
+        @receiver(predict_module_interface_names)
+        def predict_name(sender, device, module, names, **kwargs):
+            return ["Ethernet1/1/1"]
+
+        try:
+            _post(view, request, pk=device.pk)
+        finally:
+            predict_module_interface_names.disconnect(predict_name)
+
+        hidden.refresh_from_db()
+        assert hidden.module_id is None
+        assert not Module.objects.filter(device=device, module_bay=bay).exists()
+
+    def test_install_does_not_require_change_scope_for_a_new_template_interface(self):
+        from types import SimpleNamespace
+
+        from dcim.models import Device, Interface, InterfaceTemplate, Module, ModuleBay, ModuleType
+
+        from netbox_librenms_plugin.tests.conftest import make_device, make_interface
+        from netbox_librenms_plugin.tests.view_test_helpers import grant, make_request, make_user_with_perms
+        from netbox_librenms_plugin.views.sync.modules import InstallModuleView
+
+        device = make_device("module-created-interface-scope")
+        bay = ModuleBay.objects.create(device=device, name="Created Interface Scope Bay")
+        module_type = ModuleType.objects.create(
+            manufacturer=device.device_type.manufacturer,
+            model="Created Interface Scope Type",
+        )
+        InterfaceTemplate.objects.create(
+            module_type=module_type,
+            name="Te1/1/1",
+            type="10gbase-x-sfpp",
+        )
+        allowed = make_interface(device, "Te1/1/2", iface_type="10gbase-x-sfpp")
+        user = make_user_with_perms(
+            "module-created-interface-scope",
+            [
+                ("view", Device),
+                ("view", ModuleBay),
+                ("view", ModuleType),
+                ("add", Module),
+                ("add", Interface),
+                ("delete", Interface),
+            ],
+        )
+        user = grant(user, "change", Interface, constraints={"pk": allowed.pk})
+        request = make_request(
+            "post",
+            {
+                "module_bay_id": str(bay.pk),
+                "module_type_id": str(module_type.pk),
+                "server_key": "default",
+            },
+            user=user,
+        )
+        view = InstallModuleView()
+        view._librenms_api = SimpleNamespace(server_key="default")
+
+        _post(view, request, pk=device.pk)
+
+        module = Module.objects.get(device=device, module_bay=bay)
+        assert Interface.objects.filter(device=device, module=module, name="Te1/1/1").exists()
+
     @pytest.mark.parametrize("excluded_action", ["change_conflict", "delete_generated"])
     def test_vc_normalization_does_not_cross_interface_grants(self, excluded_action):
         from dcim.models import Interface

--- a/netbox_librenms_plugin/tests/test_sync_modules.py
+++ b/netbox_librenms_plugin/tests/test_sync_modules.py
@@ -40,9 +40,10 @@ def _run_install_single(device, item, index_map, module_types, **kwargs):
     """Run the shared installer against real NetBox models and querysets."""
     from dcim.models import Interface, ModuleBay
 
-    from netbox_librenms_plugin.views.sync.modules import InstallBranchView
+    from netbox_librenms_plugin.views.sync.modules import InstallBranchView, _module_component_specs
 
     allowed_type_ids = {module_type.pk for module_type in module_types.values()}
+    changeable_components = {model: model.objects.all() for _, _, model in _module_component_specs()}
     return InstallBranchView._install_single(
         device,
         item,
@@ -50,6 +51,7 @@ def _run_install_single(device, item, index_map, module_types, **kwargs):
         module_types,
         module_bays=ModuleBay.objects.all(),
         allowed_module_type_ids=allowed_type_ids,
+        changeable_components=changeable_components,
         changeable_interfaces=Interface.objects.all(),
         deletable_interfaces=Interface.objects.all(),
         **kwargs,
@@ -843,6 +845,35 @@ class TestMatchModuleBayExactFallback:
 class TestInstallSingleStatus:
     """_install_single returns the correct status dict in each path."""
 
+    def test_component_scope_tracks_netbox_module_adoption_models(self):
+        """Fail when a NetBox upgrade adds an adoption path that this scope does not cover."""
+        import ast
+        import inspect
+        import textwrap
+
+        from dcim.models import Module
+
+        from netbox_librenms_plugin.views.sync.modules import _module_component_specs
+
+        tree = ast.parse(textwrap.dedent(inspect.getsource(Module.save)))
+        component_loop = next(
+            node
+            for node in ast.walk(tree)
+            if isinstance(node, ast.For)
+            and isinstance(node.target, ast.Tuple)
+            and [element.id for element in node.target.elts if isinstance(element, ast.Name)]
+            == ["templates", "component_attribute", "component_model"]
+        )
+        netbox_specs = [
+            (entry.elts[0].value, entry.elts[1].value, entry.elts[2].id) for entry in component_loop.iter.elts
+        ]
+        scoped_specs = [
+            (template_attribute, component_attribute, component_model.__name__)
+            for template_attribute, component_attribute, component_model in _module_component_specs()
+        ]
+
+        assert scoped_specs == netbox_specs
+
     @pytest.mark.django_db
     def test_returns_installed_on_success(self):
         """A real Module is created in the matched bay and persisted (the create was faked before)."""
@@ -987,7 +1018,7 @@ class TestInstallSingleStatus:
 
     @pytest.mark.django_db
     def test_installed_name_includes_real_adoption_count(self):
-        from dcim.models import Interface, InterfaceTemplate, Module
+        from dcim.models import Interface, InterfaceTemplate, Module, ModuleBay, ModuleBayTemplate
 
         from netbox_librenms_plugin.tests.conftest import make_device, make_module_bay, make_module_type
         from netbox_librenms_plugin.views.sync.modules import InstallBranchView
@@ -996,7 +1027,9 @@ class TestInstallSingleStatus:
         bay = make_module_bay(device, "Slot 1")
         module_type = make_module_type("ADOPT-MODULE")
         InterfaceTemplate.objects.create(module_type=module_type, name="Te1/1/1", type="10gbase-x-sfpp")
-        standalone = Interface.objects.create(device=device, name="Te1/1/1", type="10gbase-x-sfpp")
+        ModuleBayTemplate.objects.create(module_type=module_type, name="Nested Bay")
+        standalone_interface = Interface.objects.create(device=device, name="Te1/1/1", type="10gbase-x-sfpp")
+        standalone_bay = ModuleBay.objects.create(device=device, name="Nested Bay")
         item = {
             "entPhysicalIndex": 10,
             "entPhysicalModelName": module_type.model,
@@ -1013,9 +1046,11 @@ class TestInstallSingleStatus:
             result = _run_install_single(device, item, {10: item}, {module_type.model: module_type})
 
         assert result["status"] == "installed"
-        assert result["adopted_interfaces"] == 1
-        standalone.refresh_from_db()
-        assert standalone.module_id == result["module_pk"]
+        assert result["adopted_components"] == 2
+        standalone_interface.refresh_from_db()
+        standalone_bay.refresh_from_db()
+        assert standalone_interface.module_id == result["module_pk"]
+        assert standalone_bay.module_id == result["module_pk"]
         assert Module.objects.filter(pk=result["module_pk"]).exists()
 
     @pytest.mark.django_db
@@ -2765,6 +2800,109 @@ class TestModuleMutationScopes:
 
         module = Module.objects.get(device=device, module_bay=bay)
         assert Interface.objects.filter(device=device, module=module, name="Te1/1/1").exists()
+
+    def test_install_does_not_adopt_a_module_bay_without_change_permission(self):
+        from types import SimpleNamespace
+
+        from dcim.models import Device, Interface, Module, ModuleBay, ModuleBayTemplate, ModuleType
+
+        from netbox_librenms_plugin.tests.conftest import make_device
+        from netbox_librenms_plugin.tests.view_test_helpers import make_request, make_user_with_perms
+        from netbox_librenms_plugin.views.sync.modules import InstallModuleView
+
+        device = make_device("module-bay-adoption-scope")
+        install_bay = ModuleBay.objects.create(device=device, name="Install Bay")
+        hidden = ModuleBay.objects.create(device=device, name="Nested Bay")
+        module_type = ModuleType.objects.create(
+            manufacturer=device.device_type.manufacturer,
+            model="Module Bay Adoption Scope Type",
+        )
+        ModuleBayTemplate.objects.create(module_type=module_type, name=hidden.name)
+        user = make_user_with_perms(
+            "module-bay-adoption-scope",
+            [
+                ("view", Device),
+                ("view", ModuleBay),
+                ("view", ModuleType),
+                ("add", Module),
+                ("add", Interface),
+                ("change", Interface),
+                ("delete", Interface),
+            ],
+        )
+        request = make_request(
+            "post",
+            {
+                "module_bay_id": str(install_bay.pk),
+                "module_type_id": str(module_type.pk),
+                "server_key": "default",
+            },
+            user=user,
+        )
+        view = InstallModuleView()
+        view._librenms_api = SimpleNamespace(server_key="default")
+
+        _post(view, request, pk=device.pk)
+
+        hidden.refresh_from_db()
+        assert hidden.module_id is None
+        assert not Module.objects.filter(device=device, module_bay=install_bay).exists()
+
+    def test_install_checks_interface_change_scope_before_adoption(self):
+        from types import SimpleNamespace
+
+        from dcim.models import Device, Interface, InterfaceTemplate, Module, ModuleBay, ModuleType
+
+        from netbox_librenms_plugin.tests.conftest import make_device, make_interface
+        from netbox_librenms_plugin.tests.view_test_helpers import grant, make_request, make_user_with_perms
+        from netbox_librenms_plugin.views.sync.modules import InstallModuleView
+
+        device = make_device("module-pre-adoption-scope")
+        bay = ModuleBay.objects.create(device=device, name="Pre-adoption Scope Bay")
+        module_type = ModuleType.objects.create(
+            manufacturer=device.device_type.manufacturer,
+            model="Pre-adoption Scope Type",
+        )
+        InterfaceTemplate.objects.create(
+            module_type=module_type,
+            name="Te1/1/1",
+            type="10gbase-x-sfpp",
+        )
+        hidden = make_interface(device, "Te1/1/1", iface_type="10gbase-x-sfpp")
+        user = make_user_with_perms(
+            "module-pre-adoption-scope",
+            [
+                ("view", Device),
+                ("view", ModuleBay),
+                ("view", ModuleType),
+                ("add", Module),
+                ("add", Interface),
+                ("delete", Interface),
+            ],
+        )
+        user = grant(
+            user,
+            "change",
+            Interface,
+            constraints={"module__module_type_id": module_type.pk},
+        )
+        request = make_request(
+            "post",
+            {
+                "module_bay_id": str(bay.pk),
+                "module_type_id": str(module_type.pk),
+                "server_key": "default",
+            },
+            user=user,
+        )
+        view = InstallModuleView()
+        view._librenms_api = SimpleNamespace(server_key="default")
+
+        _post(view, request, pk=device.pk)
+
+        hidden.refresh_from_db()
+        assert hidden.module_id is None
+        assert not Module.objects.filter(device=device, module_bay=bay).exists()
 
     @pytest.mark.parametrize("excluded_action", ["change_conflict", "delete_generated"])
     def test_vc_normalization_does_not_cross_interface_grants(self, excluded_action):

--- a/netbox_librenms_plugin/tests/test_sync_modules.py
+++ b/netbox_librenms_plugin/tests/test_sync_modules.py
@@ -6285,3 +6285,110 @@ class TestUpdateModuleInterfaceRedirectServerKey:
 
         assert response.status_code == 204
         assert "server_key=prod" in response["HX-Redirect"]
+
+
+class TestStandaloneAdoptionAcrossEveryComponentType:
+    """Every component NetBox can adopt must be authorized through the change-scoped queryset.
+
+    The adoption helper walks eight component specs, and each one resolves its template name
+    through ``_module_template_adoption_name``. Only interfaces and module bays were covered, so a
+    regression in any of the other six -- or in the version-dependent name resolution -- went
+    unnoticed. Drive all eight against the real ORM.
+    """
+
+    @staticmethod
+    def _module_with_one_template(spec, name):
+        """Build a real Device + ModuleType carrying exactly one template for *spec*."""
+        from dcim.models import Manufacturer, Module, ModuleBay, ModuleType
+
+        from netbox_librenms_plugin.tests.conftest import make_device
+
+        template_attribute, component_attribute, component_model = spec
+        device = make_device(f"adopt-{name}")
+        manufacturer = Manufacturer.objects.get_or_create(name="AdoptMfr", slug="adopt-mfr")[0]
+        module_type = ModuleType.objects.create(manufacturer=manufacturer, model=f"AdoptType-{name}")
+
+        template_model = getattr(ModuleType, template_attribute).rel.related_model
+        template_kwargs = {"module_type": module_type, "name": f"adopt-{name}-0"}
+        if template_model.__name__ == "FrontPortTemplate":
+            # This NetBox decouples the front-port TEMPLATE from a rear-port template: it carries
+            # only type/color/positions. The standalone FrontPort below still needs a rear port.
+            template_kwargs["type"] = "8p8c"
+        elif template_model.__name__ in ("RearPortTemplate", "InterfaceTemplate"):
+            template_kwargs["type"] = "8p8c" if "Port" in template_model.__name__ else "1000base-t"
+        template = template_model.objects.create(**template_kwargs)
+
+        bay = ModuleBay.objects.create(device=device, name=f"bay-{name}")
+        module = Module(device=device, module_bay=bay, module_type=module_type)
+        return device, module, template, component_attribute, component_model
+
+    @pytest.mark.django_db
+    @pytest.mark.parametrize("spec_index", range(8))
+    def test_a_standalone_component_is_authorized_for_adoption(self, spec_index):
+        """A standalone component matching the template name is locked and authorized."""
+        from netbox_librenms_plugin.views.sync.modules import (
+            _authorize_adoptable_module_components,
+            _module_component_specs,
+            _module_template_adoption_name,
+        )
+
+        spec = _module_component_specs()[spec_index]
+        template_attribute, _component_attribute, component_model = spec
+        device, module, template, component_attribute, component_model = self._module_with_one_template(
+            spec, component_model.__name__.lower()
+        )
+
+        # This is the call CodeRabbit questioned for NetBox 4.4/4.5: exercise it for every type.
+        expected_name = _module_template_adoption_name(template_attribute, template, module)
+        assert expected_name, f"{template_attribute} resolved an empty adoption name"
+
+        standalone_kwargs = {"device": device, "name": expected_name}
+        if component_model.__name__ == "Interface":
+            standalone_kwargs["type"] = "1000base-t"
+        elif component_model.__name__ in ("RearPort", "FrontPort"):
+            standalone_kwargs["type"] = "8p8c"
+        standalone = component_model.objects.create(**standalone_kwargs)
+
+        allowed = {model: model.objects.all() for _, _, model in _module_component_specs()}
+        expected = _authorize_adoptable_module_components(module, allowed)
+
+        assert expected.get(component_model) == {standalone.pk}, (
+            f"{component_model.__name__} standalone adoption was not authorized"
+        )
+
+    @pytest.mark.django_db
+    @pytest.mark.parametrize("spec_index", range(8))
+    def test_an_unauthorized_standalone_component_is_refused_by_name(self, spec_index):
+        """A component outside the change scope aborts the write and names the component."""
+        from netbox_librenms_plugin.views.sync.modules import (
+            _ModuleComponentAdoptionUnavailable,
+            _authorize_adoptable_module_components,
+            _module_component_specs,
+            _module_template_adoption_name,
+        )
+
+        spec = _module_component_specs()[spec_index]
+        template_attribute, _component_attribute, component_model = spec
+        device, module, template, component_attribute, component_model = self._module_with_one_template(
+            spec, f"deny-{component_model.__name__.lower()}"
+        )
+        expected_name = _module_template_adoption_name(template_attribute, template, module)
+
+        standalone_kwargs = {"device": device, "name": expected_name}
+        if component_model.__name__ == "Interface":
+            standalone_kwargs["type"] = "1000base-t"
+        elif component_model.__name__ in ("RearPort", "FrontPort"):
+            standalone_kwargs["type"] = "8p8c"
+        component_model.objects.create(**standalone_kwargs)
+
+        # Every model is in scope EXCEPT the one under test.
+        allowed = {
+            model: (model.objects.none() if model is component_model else model.objects.all())
+            for _, _, model in _module_component_specs()
+        }
+
+        with pytest.raises(_ModuleComponentAdoptionUnavailable) as exc:
+            _authorize_adoptable_module_components(module, allowed)
+        assert exc.value.component_label == component_model._meta.verbose_name, (
+            "the refusal must name the component the caller could not adopt"
+        )

--- a/netbox_librenms_plugin/tests/test_sync_view_mismatch.py
+++ b/netbox_librenms_plugin/tests/test_sync_view_mismatch.py
@@ -487,7 +487,7 @@ class TestVCLookupDelegation:
     has its own librenms_id."""
 
     @patch("netbox_librenms_plugin.views.base.librenms_sync_view.render")
-    @patch("netbox_librenms_plugin.views.base.librenms_sync_view.get_object_or_404")
+    @patch("netbox_librenms_plugin.views.base.librenms_sync_view.BaseLibreNMSSyncView.get_object")
     @patch("netbox_librenms_plugin.views.base.librenms_sync_view.get_librenms_sync_device")
     def test_vc_member_with_own_id_delegates_to_sync_device(self, mock_sync_device, mock_get_object, mock_render):
         """
@@ -530,7 +530,7 @@ class TestVCLookupDelegation:
         api.get_librenms_id.assert_called_once_with(member_b)
 
     @patch("netbox_librenms_plugin.views.base.librenms_sync_view.render")
-    @patch("netbox_librenms_plugin.views.base.librenms_sync_view.get_object_or_404")
+    @patch("netbox_librenms_plugin.views.base.librenms_sync_view.BaseLibreNMSSyncView.get_object")
     @patch("netbox_librenms_plugin.views.base.librenms_sync_view.get_librenms_sync_device")
     def test_non_vc_device_skips_sync_device_lookup(self, mock_sync_device, mock_get_object, mock_render):
         """

--- a/netbox_librenms_plugin/tests/test_sync_view_unresolved_vc.py
+++ b/netbox_librenms_plugin/tests/test_sync_view_unresolved_vc.py
@@ -18,8 +18,10 @@ import copy
 from unittest.mock import MagicMock, patch
 
 import pytest
+from dcim.models import Device
+
+from netbox_librenms_plugin.tests.view_test_helpers import make_user_with_perms
 from django.conf import settings
-from django.contrib.auth.models import AnonymousUser
 from django.test import RequestFactory, override_settings
 
 from netbox_librenms_plugin.tests.conftest import make_device
@@ -79,7 +81,9 @@ class TestUnresolvedServerKeyVCLeak:
         member.save()
 
         request = RequestFactory().get("/x/?server_key=ghost")  # non-blank, not configured -> unresolved
-        request.user = AnonymousUser()
+        # A real permitted user: the scoped lookup would 404 for AnonymousUser, and this
+        # test is about server-key resolution, not authorization.
+        request.user = make_user_with_perms("unresolved-vc-viewer", [("view", Device)])
         view = self._make_view(request)
 
         captured = {}

--- a/netbox_librenms_plugin/tests/test_utils.py
+++ b/netbox_librenms_plugin/tests/test_utils.py
@@ -893,6 +893,37 @@ class TestInterfaceNameField:
             "plugins.netbox_librenms_plugin.interface_name_field", "ifDescr", commit=True
         )
 
+    @pytest.mark.django_db
+    def test_persisting_the_preference_does_not_leak_to_other_users(self):
+        """One user's choice must stay that user's.
+
+        NetBox creates each UserConfig with the ``DEFAULT_USER_PREFERENCES`` dict itself (not a
+        copy) and ``UserConfig.set()`` writes in place, so a naive write turns this choice into
+        the process-wide default that every later-created user inherits.
+        """
+        from copy import deepcopy
+
+        from django.contrib.auth import get_user_model
+        from django.test import RequestFactory
+        from netbox.config import get_config
+
+        from netbox_librenms_plugin.utils import get_interface_name_field
+
+        user_model = get_user_model()
+        chooser = user_model.objects.create_user(username="pref-chooser")
+        defaults_before = deepcopy(get_config().DEFAULT_USER_PREFERENCES)
+        request = RequestFactory().get("/", {"interface_name_field": "ifDescr"})
+        request.user = chooser
+
+        assert get_interface_name_field(request) == "ifDescr"
+
+        pref_path = "plugins.netbox_librenms_plugin.interface_name_field"
+        stored = user_model.objects.get(pk=chooser.pk)
+        assert stored.config.get(pref_path) == "ifDescr"
+        assert get_config().DEFAULT_USER_PREFERENCES == defaults_before
+        later = user_model.objects.create_user(username="pref-later")
+        assert later.config.get(pref_path) is None
+
 
 # =============================================================================
 # TestSaveUserPrefView - 6 tests

--- a/netbox_librenms_plugin/tests/test_validation_template_server_key.py
+++ b/netbox_librenms_plugin/tests/test_validation_template_server_key.py
@@ -46,6 +46,17 @@ def _form_has_named_control(form_html, name):
     return next(_named_control_tags(form_html, name), None) is not None
 
 
+def _form_has_hidden_input(form_html, name):
+    for tag in _named_control_tags(form_html, name):
+        if tag.lstrip().lower().startswith("<input") and re.search(
+            r"(?:^|\s)type\s*=\s*(['\"])hidden\1(?=\s|/?>)",
+            tag,
+            re.IGNORECASE,
+        ):
+            return True
+    return False
+
+
 def test_form_actions_accepts_attributes_between_name_and_value():
     """An action input stays visible to the server-key scan when it gains another attribute."""
     form = '<input type="hidden" name="action" class="mapping-action" value="link">'
@@ -67,10 +78,17 @@ def test_form_named_control_ignores_data_attributes():
     assert not _form_has_named_control(form, "server_key")
 
 
+def test_server_key_matcher_requires_a_hidden_input():
+    """A submit button must not stand in for the server-scoping hidden input."""
+    form = '<button name="server_key" value="secondary">Submit</button>'
+
+    assert not _form_has_hidden_input(form, "server_key")
+
+
 def test_mapping_writing_conflict_forms_include_server_key():
     src = pathlib.Path(get_template(TEMPLATE).origin.name).read_text()
     partial = pathlib.Path(get_template("netbox_librenms_plugin/inc/_hidden_server_key.html").origin.name).read_text()
-    assert _form_has_named_control(partial, "server_key")
+    assert _form_has_hidden_input(partial, "server_key")
 
     forms = [f for f in re.findall(r"<form\b.*?</form>", src, re.DOTALL) if "device_conflict_action" in f]
 
@@ -80,6 +98,6 @@ def test_mapping_writing_conflict_forms_include_server_key():
     missing = [
         sorted(_form_actions(f))
         for f in mapping_forms
-        if not _form_has_named_control(f, "server_key") and not HIDDEN_SERVER_KEY_INCLUDE.search(f)
+        if not _form_has_hidden_input(f, "server_key") and not HIDDEN_SERVER_KEY_INCLUDE.search(f)
     ]
     assert not missing, f"mapping-writing forms missing a server_key hidden input: {missing}"

--- a/netbox_librenms_plugin/tests/test_view_wiring.py
+++ b/netbox_librenms_plugin/tests/test_view_wiring.py
@@ -454,17 +454,26 @@ class TestGatedViewsResolveThroughRestrictedQuerysets:
     defect kept reappearing after the primary lookups were scoped — on the module move/serial
     endpoints, the interface delete targets and the OOB interface reuse.
 
-    What counts is where the id came from. A bare name, ``int(...)`` or a subscript is a CLIENT id
-    and must be scoped. A re-lock keyed by an already-resolved object (``pk=device.pk``,
-    ``pk=donor.oob_ip_id``) is exempt: the scoping happened where that object was resolved, and
-    restricting the re-read would instead demand a permission the view's gate never required —
-    ``restrict()`` returns ``none()`` for a user who lacks the model-level grant, so a change-only
-    caller would silently lose rows out of a lock set and be told the object "no longer exists".
+    What counts is where the id came from, and a deliberate re-lock must SAY so: call
+    ``relock_scoped_row(Model, pk=donor.oob_ip_id)``. That is not a ``<Model>.objects`` chain, so it
+    never reaches this rule, and every call is greppable. Scoping happened where the source object
+    was resolved, and restricting the re-read would instead demand a permission the view's gate
+    never required: ``restrict()`` returns ``none()`` for a user who lacks the model-level grant, so
+    a change-only caller would silently lose rows out of a lock set and be told the object "no
+    longer exists".
 
-    Scope and limits: a raw lookup inherited from an ungated base class is NOT seen; bulk
-    ``pk__in=<collection>`` locks are not covered (each is built in-function from rows already
-    resolved); and a ``.filter(pk=...).exists()`` probe is exempt — it reads no object data and is how
-    ``_required_perms_for_object`` decides WHICH permission to demand, before any gate has run.
+    Until 2026-08 the rule instead exempted any ``pk=<expr>.<name>_id``. That read a SPELLING as
+    provenance: it silenced a legitimate re-lock keyed by a local, while waving through
+    ``Device.objects.get(pk=payload.device_id)`` on a request-derived object. Both directions were
+    wrong, so the heuristic is gone.
+
+    Scope and limits, stated because this rule is a lint and not a proof: a class gated only
+    through an INHERITED base is not seen (that is how the routed sync pages resolved any device by
+    pk; :class:`TestRoutedSyncPagesScopeTheirObject` now covers them behaviourally); module-level
+    helpers are not seen at all; a manager reached through an alias or ``_default_manager``, a
+    ``**kwargs``/``Q()`` lookup, or a natural-key lookup all pass; bulk ``pk__in=<collection>``
+    locks are not covered; and a ``.filter(pk=...).exists()`` probe is exempt because it reads no
+    object data and is how ``_required_perms_for_object`` decides WHICH permission to demand.
     """
 
     GATE_CALLS = frozenset(
@@ -572,11 +581,11 @@ class TestGatedViewsResolveThroughRestrictedQuerysets:
                 if sub in exempt:
                     continue
                 pk_kwargs = [kw for kw in sub.keywords if kw.arg in cls.PK_LOOKUP_KEYS]
-                # `pk=obj.pk` / `pk=obj.foo_id` is a re-lock, not a client id — see the docstring.
-                if not pk_kwargs or all(
-                    isinstance(kw.value, ast.Attribute) and (kw.value.attr == "pk" or kw.value.attr.endswith("_id"))
-                    for kw in pk_kwargs
-                ):
+                # A deliberate re-lock declares itself by calling relock_scoped_row, which is not a
+                # `<Model>.objects` chain and so never reaches here. The old exemption instead
+                # accepted any `pk=<expr>.<name>_id`, which a request-derived attribute satisfied
+                # by accident (`pk=payload.device_id`) — see test_the_scan_flags_a_tainted_attribute.
+                if not pk_kwargs:
                     continue
                 # A scoped queryset can also arrive as an ARGUMENT rather than the receiver:
                 # `Port.objects.filter(pk=..., device__in=self.restricted_queryset(Device))`
@@ -604,12 +613,18 @@ class TestGatedViewsResolveThroughRestrictedQuerysets:
             offenders |= cls._scan_tree(tree, str(path.relative_to(views_root)))
         return offenders
 
-    def test_no_gated_view_resolves_an_object_by_raw_pk(self):
-        """Every gated view resolves through restrict_object_or_404 / restricted_queryset, never a raw pk lookup."""
+    def test_no_lexically_gated_view_resolves_an_object_by_raw_pk(self):
+        """No class declaring a gate in its own body resolves an object by raw pk.
+
+        This is a lint over one spelling, NOT proof that every view is scoped: a class gated only
+        through an inherited base is invisible here (see TestRoutedSyncPagesScopeTheirObject, which
+        covers the routed pages behaviourally), and so are module-level helpers.
+        """
         offenders = sorted(self._scan())
         assert not offenders, (
-            "gated view(s) resolving an object by raw pk — a constrained grant clears the gate and "
-            f"then reaches objects outside it; use restrict_object_or_404: {offenders}"
+            "view(s) resolving an object by raw pk — a constrained grant clears the gate and then "
+            "reaches objects outside it; use restrict_object_or_404, or relock_scoped_row when the "
+            f"id came from an already-resolved object: {offenders}"
         )
 
     def test_the_scan_flags_a_raw_lookup(self):
@@ -623,6 +638,26 @@ class TestGatedViewsResolveThroughRestrictedQuerysets:
             "        return get_object_or_404(Device, pk=pk)\n"
         )
         assert self._scan_tree(ast.parse(source), "<fixture>"), "the scan no longer flags a raw pk lookup"
+
+    def test_the_scan_flags_a_tainted_attribute(self):
+        """Guard the guard: an `*_id` ATTRIBUTE is not proof of provenance.
+
+        The retired exemption accepted any ``pk=<expr>.<name>_id``, so a request-derived attribute
+        passed silently. Only relock_scoped_row marks a lookup as a deliberate re-lock now.
+        """
+        import ast
+
+        source = (
+            "class V:\n"
+            "    required_object_permissions = {'POST': []}\n"
+            "    def post(self, request):\n"
+            "        payload = json.loads(request.body)\n"
+            "        return Device.objects.get(pk=payload.device_id)\n"
+        )
+        assert self._scan_tree(ast.parse(source), "<fixture>"), (
+            "the scan exempts a client-derived `*_id` attribute again — provenance must come from "
+            "relock_scoped_row, not from how the expression is spelled"
+        )
 
     def test_the_scan_flags_a_view_gated_only_by_the_write_permission(self):
         """A view gated by require_write_permission alone reaches objects by raw pk just as easily."""
@@ -753,18 +788,30 @@ class TestGatedViewsResolveThroughRestrictedQuerysets:
         )
         assert self._scan_tree(ast.parse(source), "<fixture>"), "an unrelated scope call must not hide a raw lookup"
 
-    def test_the_scan_exempts_a_relock_of_an_already_resolved_object(self):
-        """Re-locking a row already resolved through a scoped queryset must not demand a new permission."""
+    def test_the_scan_exempts_a_relock_that_declares_itself(self):
+        """A re-lock routed through relock_scoped_row must not demand a new permission."""
         import ast
 
         source = (
             "class V:\n"
             "    required_object_permissions = {'POST': []}\n"
             "    def post(self, request, pk):\n"
-            "        a = Device.objects.select_for_update().get(pk=existing_device.pk)\n"
-            "        return IPAddress.objects.select_for_update().filter(pk=donor.oob_ip_id).first()\n"
+            "        a = self.relock_scoped_row(Device, pk=existing_device.pk)\n"
+            "        return relock_scoped_row(IPAddress, pk=donor.oob_ip_id)\n"
         )
         assert not self._scan_tree(ast.parse(source), "<fixture>")
+
+    def test_the_scan_still_flags_a_relock_that_does_not(self):
+        """The same re-lock spelled as a raw manager chain is reported: provenance must be declared."""
+        import ast
+
+        source = (
+            "class V:\n"
+            "    required_object_permissions = {'POST': []}\n"
+            "    def post(self, request, pk):\n"
+            "        return IPAddress.objects.select_for_update().filter(pk=donor.oob_ip_id).first()\n"
+        )
+        assert self._scan_tree(ast.parse(source), "<fixture>"), "use relock_scoped_row to declare a re-lock"
 
     def test_the_scan_exempts_an_exists_probe(self):
         """A .exists() probe reads no object data and picks WHICH permission to demand."""

--- a/netbox_librenms_plugin/tests/test_view_wiring.py
+++ b/netbox_librenms_plugin/tests/test_view_wiring.py
@@ -1463,7 +1463,7 @@ class TestGatedViewsRefuseOutOfScopeObjects:
 
     def test_module_replace_refuses_to_delete_the_target_outside_the_delete_grant(self):
         """Replace deletes its target, so change access alone must not authorize the operation."""
-        from dcim.models import Device, Interface, Module
+        from dcim.models import Device, Interface, Module, ModuleType
         from django.core.cache import cache
         from django.http import Http404
 
@@ -1487,6 +1487,7 @@ class TestGatedViewsRefuseOutOfScopeObjects:
             "scope-replace-target",
             [
                 (Device, "view", {"pk": device.pk}),
+                (ModuleType, "view", {"pk": module_type.pk}),
                 (Module, "add", None),
                 (Module, "change", {"pk": target.pk}),
                 (Module, "delete", {"pk": decoy.pk}),
@@ -1528,7 +1529,7 @@ class TestGatedViewsRefuseOutOfScopeObjects:
 
     def test_module_replace_fails_closed_on_a_hidden_serial_conflict(self):
         """An existing serial outside delete scope must block replacement, not become a duplicate."""
-        from dcim.models import Device, Interface, Module
+        from dcim.models import Device, Interface, Module, ModuleType
         from django.core.cache import cache
 
         from netbox_librenms_plugin.tests.conftest import make_device, make_module_bay, make_module_type
@@ -1554,6 +1555,7 @@ class TestGatedViewsRefuseOutOfScopeObjects:
             "scope-replace-conflict",
             [
                 (Device, "view", {"pk": device.pk}),
+                (ModuleType, "view", {"pk": module_type.pk}),
                 (Module, "add", None),
                 (Module, "change", {"pk": target.pk}),
                 (Module, "delete", {"pk": target.pk}),

--- a/netbox_librenms_plugin/tests/test_view_wiring.py
+++ b/netbox_librenms_plugin/tests/test_view_wiring.py
@@ -1976,6 +1976,7 @@ class TestRoutedSyncPagesScopeTheirObject:
 
     ROUTED_DEVICE_PAGES = (
         ("object_sync.devices", "DeviceInterfaceTableView"),
+        ("object_sync.devices", "DeviceCableTableView"),
         ("object_sync.devices", "DeviceIPAddressTableView"),
         ("object_sync.devices", "DeviceVLANTableView"),
         ("object_sync.devices", "DeviceModuleTableView"),

--- a/netbox_librenms_plugin/tests/test_view_wiring.py
+++ b/netbox_librenms_plugin/tests/test_view_wiring.py
@@ -1913,3 +1913,56 @@ class TestCacheKeysAreServerScoped:
             assert params[-1] == "server_key", f"{helper} no longer takes server_key last: {params}"
             # params includes self, so the positional count to reach server_key is len(params) - 1.
             assert len(params) - 1 == position, f"{helper} arity changed — update HELPERS: {params}"
+
+
+class TestRoutedSyncPagesScopeTheirObject:
+    """A routed sync page must not resolve an object the caller's grant excludes.
+
+    ``LibreNMSPermissionMixin`` extends Django's ``PermissionRequiredMixin``, which only checks the
+    model-level plugin permission and never evaluates NetBox object-permission constraints. The base
+    table views then resolve the URL pk with a raw ``get_object_or_404``, so a CONSTRAINED
+    ``dcim.view_device`` grant never narrows the lookup and the page renders any device by pk.
+
+    The static scan in :class:`TestGatedViewsResolveThroughRestrictedQuerysets` cannot see this: it
+    only considers classes that declare a gate lexically, and these classes declare none.
+    """
+
+    ROUTED_DEVICE_PAGES = (
+        ("object_sync.devices", "DeviceInterfaceTableView"),
+        ("object_sync.devices", "DeviceIPAddressTableView"),
+        ("object_sync.devices", "DeviceVLANTableView"),
+        ("object_sync.devices", "DeviceModuleTableView"),
+    )
+
+    @pytest.mark.django_db
+    @pytest.mark.parametrize("module_path,class_name", ROUTED_DEVICE_PAGES)
+    def test_a_constrained_grant_cannot_reach_a_hidden_device(self, module_path, class_name):
+        """A user granted view_device only for device A must not resolve device B."""
+        import importlib
+
+        from dcim.models import Device
+        from django.http import Http404
+
+        from netbox_librenms_plugin.tests.conftest import make_device
+        from netbox_librenms_plugin.tests.view_test_helpers import (
+            make_request,
+            make_user_with_perms,
+            make_view,
+        )
+
+        allowed = make_device(f"scoped-allowed-{class_name.lower()}")
+        hidden = make_device(f"scoped-hidden-{class_name.lower()}")
+        user = make_user_with_perms(
+            f"scoped-viewer-{class_name.lower()}",
+            [("view", Device)],
+            constraints={"name": allowed.name},
+        )
+        request = make_request("get", user=user, path=f"/plugins/librenms/devices/{hidden.pk}/sync/")
+        view_class = getattr(importlib.import_module(f"netbox_librenms_plugin.views.{module_path}"), class_name)
+        view = make_view(view_class, request)
+
+        # Sanity: the grant really is constrained — the allowed device stays reachable.
+        assert view.get_object(allowed.pk).pk == allowed.pk
+
+        with pytest.raises(Http404):
+            view.get_object(hidden.pk)

--- a/netbox_librenms_plugin/tests/test_vlan_sync_concurrency.py
+++ b/netbox_librenms_plugin/tests/test_vlan_sync_concurrency.py
@@ -1,7 +1,11 @@
-"""Concurrency tests for global VLAN synchronization."""
+"""Concurrency tests for VLAN synchronization.
+
+Global VIDs are serialized by an advisory lock. A grouped VLAN has no such lock, so its row is
+protected only by the re-lock the sync takes between the change-scope check and the save.
+"""
 
 from concurrent.futures import ThreadPoolExecutor
-from threading import Barrier, BrokenBarrierError
+from threading import Barrier, BrokenBarrierError, Event
 
 import pytest
 from django.apps import apps
@@ -10,7 +14,7 @@ from django.core.cache import cache
 from django.db import close_old_connections, connection
 
 from netbox_librenms_plugin.tests.conftest import make_device
-from netbox_librenms_plugin.tests.view_test_helpers import make_request
+from netbox_librenms_plugin.tests.view_test_helpers import make_request, make_user_with_perms, messages_on, post
 
 
 class _GlobalVLANLookupBarrier:
@@ -94,3 +98,131 @@ def test_concurrent_global_vlan_sync_creates_one_vlan():
 
     assert all(wrapper.lookup_seen for wrapper in lookup_wrappers)
     assert VLAN.objects.filter(vid=321, group__isnull=True).count() == 1
+
+
+def _drive_grouped_sync(device, user, group, vid, librenms_name):
+    """POST one grouped VID into the real view and return the recorded messages."""
+    from netbox_librenms_plugin.views.sync.vlans import SyncVLANsView
+
+    request = make_request(
+        data={
+            "action": "create_vlans",
+            "select": [str(vid)],
+            f"vlan_group_{vid}": str(group.pk),
+            "server_key": "default",
+        },
+        user=user,
+        path="/sync/vlans/",
+    )
+    view = SyncVLANsView()
+    cache.set(
+        view.get_cache_key(device, "vlans", "default"),
+        [{"vlan_vlan": vid, "vlan_name": librenms_name}],
+        timeout=60,
+    )
+    post(view, request, object_type="device", object_id=device.pk)
+    return messages_on(request)
+
+
+@pytest.mark.django_db
+def test_grouped_vlan_row_is_locked_before_the_rename():
+    """The resolved VLAN row must be locked, since no advisory lock covers a grouped VID.
+
+    Asserted on the emitted SQL rather than on a patched manager: a mock records whichever call
+    the code happens to make, so it stays green while the row is read unlocked.
+    """
+    from django.db import transaction
+    from django.test.utils import CaptureQueriesContext
+    from ipam.models import VLAN, VLANGroup
+
+    device = make_device("vlan-lock-sql")
+    group = VLANGroup.objects.create(name="Lock-SQL", slug="lock-sql")
+    vlan = VLAN.objects.create(vid=41, group=group, name="old-name", status="active")
+    user = make_user_with_perms(
+        "vlan-lock-sql-user",
+        [("view", type(device)), ("view", VLANGroup), ("add", VLAN), ("change", VLAN)],
+    )
+
+    with transaction.atomic(), CaptureQueriesContext(connection) as captured:
+        _drive_grouped_sync(device, user, group, vid=41, librenms_name="librenms-name")
+
+    locking = [
+        q["sql"] for q in captured.captured_queries if "FOR UPDATE" in q["sql"].upper() and "ipam_vlan" in q["sql"]
+    ]
+    assert locking, "the resolved VLAN row was never locked"
+    vlan.refresh_from_db()
+    assert vlan.name == "librenms-name"
+
+
+class _ScopedVLANReadGate:
+    """Hold the sync between its scoped VLAN read and whatever it does next.
+
+    Both the locked and the unlocked path run this pk read, so the gate stops the sync at the same
+    point either way and neither can win the race by accident.
+    """
+
+    def __init__(self, read_done, resume):
+        self.read_done = read_done
+        self.resume = resume
+        self.seen = False
+
+    def __call__(self, execute, sql, params, many, context):
+        result = execute(sql, params, many, context)
+        if (
+            not self.seen
+            and sql.lstrip().upper().startswith("SELECT")
+            and 'FROM "ipam_vlan"' in sql
+            and '"ipam_vlan"."id" =' in sql
+        ):
+            self.seen = True
+            self.read_done.set()
+            assert self.resume.wait(10), "test never released the VLAN sync"
+        return result
+
+
+@pytest.mark.django_db(
+    transaction=True,
+    # Explicit available apps make Django use cascade-aware transaction cleanup.
+    # This is required when another installed plugin has M2M tables outside the default flush list.
+    available_apps=[app.name for app in apps.get_app_configs()],
+)
+def test_grouped_vlan_deleted_after_the_scope_check_is_skipped_not_crashed():
+    """A grouped VLAN deleted between the scope check and the save must be skipped.
+
+    Without the re-lock the sync renames a row it read unlocked, and ``save(update_fields=...)``
+    raises "did not affect any rows" once that row is gone — a 500 for the operator.
+    """
+    from ipam.models import VLAN, VLANGroup
+
+    device = make_device("vlan-relock-delete")
+    group = VLANGroup.objects.create(name="Relock-Delete", slug="relock-delete")
+    vlan = VLAN.objects.create(vid=42, group=group, name="old-name", status="active")
+    user = make_user_with_perms(
+        "vlan-relock-delete-user",
+        [("view", type(device)), ("view", VLANGroup), ("add", VLAN), ("change", VLAN)],
+    )
+
+    read_done, resume = Event(), Event()
+
+    def sync_as_caller():
+        close_old_connections()
+        try:
+            thread_user = get_user_model().objects.get(pk=user.pk)
+            with connection.execute_wrapper(_ScopedVLANReadGate(read_done, resume)):
+                return _drive_grouped_sync(device, thread_user, group, vid=42, librenms_name="librenms-name")
+        finally:
+            close_old_connections()
+
+    with ThreadPoolExecutor(max_workers=1) as executor:
+        syncing = executor.submit(sync_as_caller)
+        try:
+            assert read_done.wait(10), "the VLAN sync never reached its scoped read"
+            VLAN.objects.filter(pk=vlan.pk).delete()
+        finally:
+            resume.set()
+        recorded = syncing.result(timeout=20)
+
+    joined = " || ".join(text for _level, text in recorded)
+    assert "concurrent VLAN change" in joined, joined
+    assert not any(level == "success" for level, _text in recorded), joined
+    assert not VLAN.objects.filter(pk=vlan.pk).exists()

--- a/netbox_librenms_plugin/tests/test_vlan_sync_concurrency.py
+++ b/netbox_librenms_plugin/tests/test_vlan_sync_concurrency.py
@@ -23,6 +23,36 @@ from netbox_librenms_plugin.tests.view_test_helpers import (
 )
 
 
+class _CapturedQueries:
+    """Expose synthetic SQL through the CaptureQueriesContext contract."""
+
+    def __init__(self, *statements):
+        self.captured_queries = [{"sql": statement} for statement in statements]
+
+
+def test_lock_order_assertion_ignores_sibling_table_names():
+    """A lock on ipam_vlangroup must not satisfy the ipam_vlan assertion."""
+    captured = _CapturedQueries(
+        'SELECT "ipam_vlangroup"."id" FROM "ipam_vlangroup" FOR UPDATE',
+        'UPDATE "ipam_vlan" SET "name" = \'new\' WHERE "ipam_vlan"."id" = 1',
+    )
+
+    with pytest.raises(AssertionError, match="ipam_vlan was never locked"):
+        assert_locked_before_update(captured, "ipam_vlan")
+
+
+def test_lock_order_assertion_requires_one_exact_update_pair():
+    """One early lock must not hide a later unpaired update in the same capture."""
+    captured = _CapturedQueries(
+        'SELECT "ipam_vlan"."id" FROM "ipam_vlan" FOR UPDATE',
+        'UPDATE "ipam_vlan" SET "name" = \'one\' WHERE "ipam_vlan"."id" = 1',
+        'UPDATE "ipam_vlan" SET "name" = \'two\' WHERE "ipam_vlan"."id" = 2',
+    )
+
+    with pytest.raises(AssertionError, match="exactly one lock/update pair"):
+        assert_locked_before_update(captured, "ipam_vlan")
+
+
 class _GlobalVLANLookupBarrier:
     """Pause both workers after their first global VLAN lookup completes."""
 
@@ -220,6 +250,8 @@ def test_grouped_vlan_deleted_after_the_scope_check_is_skipped_not_crashed():
         syncing = executor.submit(sync_as_caller)
         try:
             assert read_done.wait(10), "the VLAN sync never reached its scoped read"
+            with connection.cursor() as cursor:
+                cursor.execute("SET lock_timeout = '5s'")
             VLAN.objects.filter(pk=vlan.pk).delete()
         finally:
             resume.set()

--- a/netbox_librenms_plugin/tests/test_vlan_sync_concurrency.py
+++ b/netbox_librenms_plugin/tests/test_vlan_sync_concurrency.py
@@ -14,7 +14,13 @@ from django.core.cache import cache
 from django.db import close_old_connections, connection
 
 from netbox_librenms_plugin.tests.conftest import make_device
-from netbox_librenms_plugin.tests.view_test_helpers import make_request, make_user_with_perms, messages_on, post
+from netbox_librenms_plugin.tests.view_test_helpers import (
+    assert_locked_before_update,
+    make_request,
+    make_user_with_perms,
+    messages_on,
+    post,
+)
 
 
 class _GlobalVLANLookupBarrier:
@@ -146,10 +152,7 @@ def test_grouped_vlan_row_is_locked_before_the_rename():
     with transaction.atomic(), CaptureQueriesContext(connection) as captured:
         _drive_grouped_sync(device, user, group, vid=41, librenms_name="librenms-name")
 
-    locking = [
-        q["sql"] for q in captured.captured_queries if "FOR UPDATE" in q["sql"].upper() and "ipam_vlan" in q["sql"]
-    ]
-    assert locking, "the resolved VLAN row was never locked"
+    assert_locked_before_update(captured, "ipam_vlan")
     vlan.refresh_from_db()
     assert vlan.name == "librenms-name"
 

--- a/netbox_librenms_plugin/tests/view_test_helpers.py
+++ b/netbox_librenms_plugin/tests/view_test_helpers.py
@@ -190,13 +190,15 @@ def assert_locked_before_update(captured, table):
         table: Database table name, for example ``"ipam_ipaddress"``.
     """
     statements = [q["sql"] for q in captured.captured_queries]
-    locks = [i for i, sql in enumerate(statements) if table in sql.lower() and "for update" in sql.lower()]
-    updates = [
-        i for i, sql in enumerate(statements) if sql.lstrip().upper().startswith("UPDATE") and table in sql.lower()
-    ]
+    quoted_table = f'"{table.lower()}"'
+    locks = [i for i, sql in enumerate(statements) if quoted_table in sql.lower() and "for update" in sql.lower()]
+    updates = [i for i, sql in enumerate(statements) if sql.lower().lstrip().startswith(f"update {quoted_table}")]
     assert locks, f"{table} was never locked with SELECT ... FOR UPDATE"
     assert updates, f"{table} was never updated, so the lock ordering is untested"
-    assert min(locks) < min(updates), f"{table} was updated before it was locked: locks={locks} updates={updates}"
+    assert len(locks) == len(updates) == 1, (
+        f"{table} must have exactly one lock/update pair: locks={locks} updates={updates}"
+    )
+    assert locks[0] < updates[0], f"{table} was updated before it was locked: locks={locks} updates={updates}"
 
 
 # =============================================================================

--- a/netbox_librenms_plugin/tests/view_test_helpers.py
+++ b/netbox_librenms_plugin/tests/view_test_helpers.py
@@ -179,6 +179,26 @@ def missing_pk(model, offset=1000):
     return (highest_pk or 0) + offset
 
 
+def assert_locked_before_update(captured, table):
+    """Assert *table* was locked with ``SELECT ... FOR UPDATE`` before it was updated.
+
+    Asserting only that a lock exists passes even when the lock runs after the write, which is
+    the ordering the lock is there to guarantee.
+
+    Args:
+        captured: A ``CaptureQueriesContext`` that wrapped the code under test.
+        table: Database table name, for example ``"ipam_ipaddress"``.
+    """
+    statements = [q["sql"] for q in captured.captured_queries]
+    locks = [i for i, sql in enumerate(statements) if table in sql.lower() and "for update" in sql.lower()]
+    updates = [
+        i for i, sql in enumerate(statements) if sql.lstrip().upper().startswith("UPDATE") and table in sql.lower()
+    ]
+    assert locks, f"{table} was never locked with SELECT ... FOR UPDATE"
+    assert updates, f"{table} was never updated, so the lock ordering is untested"
+    assert min(locks) < min(updates), f"{table} was updated before it was locked: locks={locks} updates={updates}"
+
+
 # =============================================================================
 # Real views
 # =============================================================================

--- a/netbox_librenms_plugin/utils.py
+++ b/netbox_librenms_plugin/utils.py
@@ -291,8 +291,8 @@ def rewrite_interface_name_for_vc_member(
     return f"{match.group('prefix')}{vc_position}{match.group('suffix')}"
 
 
-def get_module_template_interface_names(device: Device, module, *, rewrite_for_vc=True) -> list[str]:
-    """Return unique instantiated interface-template names, optionally rewritten for VC members."""
+def get_module_template_interface_names(device: Device, module) -> list[str]:
+    """Return unique instantiated interface-template names, rewritten for VC members when needed."""
     if device is None:
         return []
 
@@ -303,7 +303,7 @@ def get_module_template_interface_names(device: Device, module, *, rewrite_for_v
     vc_position = getattr(device, "vc_position", None)
     vc_id = getattr(device, "virtual_chassis_id", None)
     member_positions = None
-    if rewrite_for_vc and isinstance(vc_position, int) and vc_position > 0 and isinstance(vc_id, int):
+    if isinstance(vc_position, int) and vc_position > 0 and isinstance(vc_id, int):
         member_positions = get_vc_member_positions(device)
 
     template_names = []

--- a/netbox_librenms_plugin/utils.py
+++ b/netbox_librenms_plugin/utils.py
@@ -1,6 +1,7 @@
 import logging
 import re
 import threading
+from copy import deepcopy
 from typing import Optional
 
 import netaddr
@@ -677,10 +678,20 @@ def get_user_pref(request, path, default=None):
 
 
 def save_user_pref(request, path, value):
-    """Save a user preference value via request.user.config."""
+    """
+    Save a user preference value via request.user.config.
+
+    NetBox seeds a new UserConfig with ``settings.DEFAULT_USER_PREFERENCES`` **by reference**
+    (users/signals.py) and ``UserConfig.set()`` edits ``data`` in place, so writing straight
+    through would mutate that process-wide dict: this user's choice would then become the
+    default every later-created user inherits, and the fallback every preference-less user
+    reads. Copy the row's data first so the write stays with this user.
+    """
     if hasattr(request, "user") and hasattr(request.user, "config"):
+        user_config = request.user.config
+        user_config.data = deepcopy(user_config.data)
         try:
-            request.user.config.set(path, value, commit=True)
+            user_config.set(path, value, commit=True)
         except (TypeError, ValueError):
             pass
 

--- a/netbox_librenms_plugin/utils.py
+++ b/netbox_librenms_plugin/utils.py
@@ -291,8 +291,8 @@ def rewrite_interface_name_for_vc_member(
     return f"{match.group('prefix')}{vc_position}{match.group('suffix')}"
 
 
-def get_module_template_interface_names(device: Device, module) -> list[str]:
-    """Return unique instantiated interface-template names, rewritten for VC members when needed."""
+def get_module_template_interface_names(device: Device, module, *, rewrite_for_vc=True) -> list[str]:
+    """Return unique instantiated interface-template names, optionally rewritten for VC members."""
     if device is None:
         return []
 
@@ -303,7 +303,7 @@ def get_module_template_interface_names(device: Device, module) -> list[str]:
     vc_position = getattr(device, "vc_position", None)
     vc_id = getattr(device, "virtual_chassis_id", None)
     member_positions = None
-    if isinstance(vc_position, int) and vc_position > 0 and isinstance(vc_id, int):
+    if rewrite_for_vc and isinstance(vc_position, int) and vc_position > 0 and isinstance(vc_id, int):
         member_positions = get_vc_member_positions(device)
 
     template_names = []

--- a/netbox_librenms_plugin/views/base/cables_view.py
+++ b/netbox_librenms_plugin/views/base/cables_view.py
@@ -8,7 +8,6 @@ from django.core.exceptions import MultipleObjectsReturned
 from django.db.models import Q
 from django.http import JsonResponse
 from django.middleware.csrf import get_token
-from django.shortcuts import get_object_or_404
 from django.urls import reverse
 from django.utils import timezone
 from django.utils.html import escape
@@ -159,7 +158,7 @@ _RAW_LINK_KEYS = frozenset(
 )
 
 
-class BaseCableTableView(LibreNMSPermissionMixin, LibreNMSAPIMixin, CacheMixin, View):
+class BaseCableTableView(LibreNMSPermissionMixin, LibreNMSAPIMixin, NetBoxObjectPermissionMixin, CacheMixin, View):
     """
     Base view for synchronizing cable information from LibreNMS.
     """
@@ -169,7 +168,7 @@ class BaseCableTableView(LibreNMSPermissionMixin, LibreNMSAPIMixin, CacheMixin, 
 
     def get_object(self, pk):
         """Retrieve the object (Device or VirtualMachine)."""
-        return get_object_or_404(self.model, pk=pk)
+        return self.restrict_object_or_404(self.model, pk=pk)
 
     def get_ip_address(self, obj):
         """Get the primary IP address for the object."""
@@ -811,7 +810,7 @@ class BaseCableTableView(LibreNMSPermissionMixin, LibreNMSAPIMixin, CacheMixin, 
         return self.render_sync_partial(request, obj, server_key, {"cable_sync": context})
 
 
-class SingleCableVerifyView(NetBoxObjectPermissionMixin, BaseCableTableView):
+class SingleCableVerifyView(BaseCableTableView):
     """
     View to verify a single cable link between two devices.
     """

--- a/netbox_librenms_plugin/views/base/interfaces_view.py
+++ b/netbox_librenms_plugin/views/base/interfaces_view.py
@@ -2,7 +2,6 @@ import logging
 
 from django.contrib import messages
 from django.core.cache import cache
-from django.shortcuts import get_object_or_404
 from django.utils import timezone
 from django.views import View
 
@@ -21,6 +20,7 @@ from netbox_librenms_plugin.views.mixins import (
     CacheMixin,
     LibreNMSAPIMixin,
     LibreNMSPermissionMixin,
+    NetBoxObjectPermissionMixin,
     VlanAssignmentMixin,
     redirect_with_server_key,
 )
@@ -28,7 +28,9 @@ from netbox_librenms_plugin.views.mixins import (
 logger = logging.getLogger(__name__)
 
 
-class BaseInterfaceTableView(VlanAssignmentMixin, LibreNMSAPIMixin, LibreNMSPermissionMixin, CacheMixin, View):
+class BaseInterfaceTableView(
+    VlanAssignmentMixin, LibreNMSAPIMixin, LibreNMSPermissionMixin, NetBoxObjectPermissionMixin, CacheMixin, View
+):
     """
     Base view for fetching interface data from LibreNMS and generating table data.
     Includes VLAN enrichment for interface VLAN sync functionality.
@@ -39,8 +41,9 @@ class BaseInterfaceTableView(VlanAssignmentMixin, LibreNMSAPIMixin, LibreNMSPerm
     interface_name_field = None
 
     def get_object(self, pk):
-        """Retrieve the object (Device or VirtualMachine)."""
-        return get_object_or_404(self.model, pk=pk)
+        """Retrieve the object (Device or VirtualMachine) the user may view."""
+        # The plugin gate is model-level only, so scope the lookup or any pk is reachable.
+        return self.restrict_object_or_404(self.model, pk=pk)
 
     def get_ip_address(self, obj):
         """Get the primary IP address for the object."""

--- a/netbox_librenms_plugin/views/base/ip_addresses_view.py
+++ b/netbox_librenms_plugin/views/base/ip_addresses_view.py
@@ -6,7 +6,6 @@ from dcim.models import Device
 from django.contrib import messages
 from django.core.cache import cache
 from django.http import Http404, JsonResponse
-from django.shortcuts import get_object_or_404
 from django.utils import timezone
 from django.views import View
 from ipam.models import VRF, IPAddress
@@ -31,7 +30,7 @@ from netbox_librenms_plugin.views.mixins import (
 logger = logging.getLogger(__name__)
 
 
-class BaseIPAddressTableView(LibreNMSPermissionMixin, LibreNMSAPIMixin, CacheMixin, View):
+class BaseIPAddressTableView(LibreNMSPermissionMixin, LibreNMSAPIMixin, NetBoxObjectPermissionMixin, CacheMixin, View):
     """
     Base view for synchronizing IP address information from LibreNMS.
     """
@@ -40,7 +39,7 @@ class BaseIPAddressTableView(LibreNMSPermissionMixin, LibreNMSAPIMixin, CacheMix
     interface_name_field = None
 
     def get_object(self, pk):
-        return get_object_or_404(self.model, pk=pk)
+        return self.restrict_object_or_404(self.model, pk=pk)
 
     def get_ip_addresses(self, obj):
         """Fetch IP address data from LibreNMS for the given object."""

--- a/netbox_librenms_plugin/views/base/librenms_sync_view.py
+++ b/netbox_librenms_plugin/views/base/librenms_sync_view.py
@@ -37,9 +37,14 @@ class BaseLibreNMSSyncView(
     # None until get() runs (e.g. a direct get_context_data() call), then active_server_key is used.
     _scoped_render_server_key = None
 
+    def get_object(self, pk):
+        """Retrieve the object the user may view (same seam as the base table views)."""
+        # The plugin gate is model-level only, so scope the lookup or any pk is reachable.
+        return self.restrict_object_or_404(self.model, pk=pk)
+
     def get(self, request, pk, context=None):
         """Handle GET request for the LibreNMS sync view."""
-        obj = self.restrict_object_or_404(self.model, pk=pk)
+        obj = self.get_object(pk)
 
         # Scope the page header (device info, VC inventory serials, active-server highlight) to the
         # same ?server_key the embedded tabs rebind to. Without this the orchestrator reads the

--- a/netbox_librenms_plugin/views/base/librenms_sync_view.py
+++ b/netbox_librenms_plugin/views/base/librenms_sync_view.py
@@ -2,7 +2,7 @@ import re
 
 from django.conf import settings as django_settings
 from django.contrib import messages
-from django.shortcuts import get_object_or_404, render
+from django.shortcuts import render
 from netbox.views import generic
 
 from netbox_librenms_plugin.forms import AddToLIbreSNMPV1V2, AddToLIbreSNMPV3
@@ -19,10 +19,12 @@ from netbox_librenms_plugin.utils import (
     resolve_naming_preferences,
     resolve_server_mapping_display_id,
 )
-from netbox_librenms_plugin.views.mixins import LibreNMSAPIMixin, LibreNMSPermissionMixin
+from netbox_librenms_plugin.views.mixins import LibreNMSAPIMixin, LibreNMSPermissionMixin, NetBoxObjectPermissionMixin
 
 
-class BaseLibreNMSSyncView(LibreNMSPermissionMixin, LibreNMSAPIMixin, generic.ObjectListView):
+class BaseLibreNMSSyncView(
+    LibreNMSPermissionMixin, LibreNMSAPIMixin, NetBoxObjectPermissionMixin, generic.ObjectListView
+):
     """
     Base view for LibreNMS sync information.
     """
@@ -37,7 +39,7 @@ class BaseLibreNMSSyncView(LibreNMSPermissionMixin, LibreNMSAPIMixin, generic.Ob
 
     def get(self, request, pk, context=None):
         """Handle GET request for the LibreNMS sync view."""
-        obj = get_object_or_404(self.model, pk=pk)
+        obj = self.restrict_object_or_404(self.model, pk=pk)
 
         # Scope the page header (device info, VC inventory serials, active-server highlight) to the
         # same ?server_key the embedded tabs rebind to. Without this the orchestrator reads the

--- a/netbox_librenms_plugin/views/base/modules_view.py
+++ b/netbox_librenms_plugin/views/base/modules_view.py
@@ -3,7 +3,6 @@ import re
 
 from django.contrib import messages
 from django.core.cache import cache
-from django.shortcuts import get_object_or_404
 from django.utils import timezone
 from django.views import View
 
@@ -22,6 +21,7 @@ from netbox_librenms_plugin.views.mixins import (
     CacheMixin,
     LibreNMSAPIMixin,
     LibreNMSPermissionMixin,
+    NetBoxObjectPermissionMixin,
 )
 
 logger = logging.getLogger(__name__)
@@ -193,7 +193,7 @@ def _check_ignore_rules(
     return None
 
 
-class BaseModuleTableView(LibreNMSPermissionMixin, LibreNMSAPIMixin, CacheMixin, View):
+class BaseModuleTableView(LibreNMSPermissionMixin, LibreNMSAPIMixin, NetBoxObjectPermissionMixin, CacheMixin, View):
     """
     Base view for synchronizing module/inventory data from LibreNMS.
     Fetches inventory, matches against NetBox module bays and module types,
@@ -205,7 +205,7 @@ class BaseModuleTableView(LibreNMSPermissionMixin, LibreNMSAPIMixin, CacheMixin,
 
     def get_object(self, pk):
         """Retrieve the object (Device)."""
-        return get_object_or_404(self.model, pk=pk)
+        return self.restrict_object_or_404(self.model, pk=pk)
 
     def get_table(self, data, obj):
         """Returns the table class. Subclasses should override."""

--- a/netbox_librenms_plugin/views/base/vlan_table_view.py
+++ b/netbox_librenms_plugin/views/base/vlan_table_view.py
@@ -1,6 +1,5 @@
 from django.contrib import messages
 from django.core.cache import cache
-from django.shortcuts import get_object_or_404
 from django.utils import timezone
 from django.views import View
 
@@ -15,6 +14,7 @@ from netbox_librenms_plugin.views.mixins import (
     CacheMixin,
     LibreNMSAPIMixin,
     LibreNMSPermissionMixin,
+    NetBoxObjectPermissionMixin,
     VlanAssignmentMixin,
 )
 
@@ -23,7 +23,9 @@ from netbox_librenms_plugin.views.mixins import (
 _SERVER_KEY_UNSET = object()
 
 
-class BaseVLANTableView(VlanAssignmentMixin, LibreNMSAPIMixin, LibreNMSPermissionMixin, CacheMixin, View):
+class BaseVLANTableView(
+    VlanAssignmentMixin, LibreNMSAPIMixin, LibreNMSPermissionMixin, NetBoxObjectPermissionMixin, CacheMixin, View
+):
     """
     Base view for VLAN synchronization table.
     Fetches LibreNMS VLAN data and compares with NetBox.
@@ -34,7 +36,7 @@ class BaseVLANTableView(VlanAssignmentMixin, LibreNMSAPIMixin, LibreNMSPermissio
 
     def get_object(self, pk):
         """Retrieve the object (Device or VirtualMachine)."""
-        return get_object_or_404(self.model, pk=pk)
+        return self.restrict_object_or_404(self.model, pk=pk)
 
     def post(self, request, pk):
         """Handle POST request to fetch and cache LibreNMS VLAN data."""

--- a/netbox_librenms_plugin/views/imports/actions.py
+++ b/netbox_librenms_plugin/views/imports/actions.py
@@ -3609,10 +3609,10 @@ class MergeNetBoxDevicesView(
                     from dcim.models import Interface
                     from ipam.models import IPAddress
 
-                    locked_oob_ip = IPAddress.objects.select_for_update().filter(pk=donor.oob_ip_id).first()
+                    locked_oob_ip = self.relock_scoped_row(IPAddress, pk=donor.oob_ip_id)
                     oob_assigned = locked_oob_ip.assigned_object if locked_oob_ip is not None else None
                     if isinstance(oob_assigned, Interface):
-                        locked_iface = Interface.objects.select_for_update().filter(pk=oob_assigned.pk).first()
+                        locked_iface = self.relock_scoped_row(Interface, pk=oob_assigned.pk)
                         if locked_iface is not None and locked_iface.device_id == winner.pk:
                             # Refresh the cached GenericForeignKey on locked_oob_ip to the freshly
                             # locked interface: set_device_ip_fk() re-reads locked_oob_ip.assigned_object

--- a/netbox_librenms_plugin/views/imports/actions.py
+++ b/netbox_librenms_plugin/views/imports/actions.py
@@ -2848,6 +2848,14 @@ class AddAsOOBView(
                             "invalid (too long or contains unsupported characters).",
                         )
                     )
+                elif iface_reason == "name_out_of_scope":
+                    deferred_messages.append(
+                        (
+                            messages.WARNING,
+                            f"OOB linked, but OOB IP {oob_ip_str} not set — an interface with that name "
+                            "already exists on the device and is outside your view scope.",
+                        )
+                    )
                 elif oob_iface is None:
                     deferred_messages.append(
                         (
@@ -3080,8 +3088,9 @@ class AddAsOOBView(
         Returns:
             tuple: ``(interface, None)`` on success, ``(None, None)`` when no
                 selection was made, ``(None, "permission_add")`` when creating is
-                required but the user lacks Interface ``add``, or
-                ``(None, "invalid_name")`` for a malformed new name.
+                required but the user lacks Interface ``add``, ``(None, "invalid_name")``
+                for a malformed new name, or ``(None, "name_out_of_scope")`` when the
+                requested name belongs to an interface outside the caller's view scope.
         """
         from django.core.exceptions import ValidationError
         from dcim.models import Interface
@@ -3109,7 +3118,7 @@ class AddAsOOBView(
             # The name may still be taken by a row outside that scope; refuse rather than race the
             # create below into an IntegrityError. `.exists()` reads no row data and takes no lock.
             if Interface.objects.filter(device=device, name=name).exists():
-                return None, None
+                return None, "name_out_of_scope"
             if not request.user.has_perm(get_permission_for_model(Interface, "add")):
                 return None, "permission_add"
             # Nested savepoint: catching IntegrityError without one would poison the outer
@@ -3136,7 +3145,9 @@ class AddAsOOBView(
                     .filter(device=device, name=name)
                     .first()
                 )
-                return (existing, None) if existing is not None else (None, None)
+                # The winner of the race can sit outside the caller's view scope, which is the
+                # same refusal as the pre-create check above.
+                return (existing, None) if existing is not None else (None, "name_out_of_scope")
         if iface_id:
             try:
                 # Lock the reused row too (same orphan-on-concurrent-delete reasoning).

--- a/netbox_librenms_plugin/views/imports/actions.py
+++ b/netbox_librenms_plugin/views/imports/actions.py
@@ -3072,7 +3072,12 @@ class AddAsOOBView(
                 # Lock the row we hand back: the OOB-IP assignment is generic-relational,
                 # not FK-protected, so a concurrent delete before the IP save would orphan
                 # oob_ip on a missing interface. select_for_update blocks that delete.
-                existing = Interface.objects.select_for_update().filter(device=device, name=name).first()
+                existing = (
+                    Interface.objects.restrict(request.user, "view")
+                    .select_for_update(of=("self",))
+                    .filter(device=device, name=name)
+                    .first()
+                )
                 return (existing, None) if existing is not None else (None, None)
         if iface_id:
             try:

--- a/netbox_librenms_plugin/views/imports/actions.py
+++ b/netbox_librenms_plugin/views/imports/actions.py
@@ -33,6 +33,7 @@ from netbox_librenms_plugin.import_utils import (
     get_librenms_device_by_id,
     get_virtual_chassis_data,
     required_import_permissions,
+    scope_bulk_collisions,
     update_vc_member_suggested_names,
     validate_device_for_import,
 )
@@ -893,7 +894,7 @@ class BulkImportConfirmView(LibreNMSPermissionMixin, LibreNMSAPIMixin, View):
             "vc_detection_enabled": vc_detection_enabled,
         }
 
-        collisions = detect_bulk_collisions(devices)
+        collisions = scope_bulk_collisions(detect_bulk_collisions(devices), request.user)
         if collisions:
             # Render at 200 (not 4xx): this is an interstitial modal swapped
             # into #htmx-modal-content, exactly like the confirm step. A non-2xx
@@ -1175,6 +1176,7 @@ class BulkImportDevicesView(LibreNMSPermissionMixin, LibreNMSAPIMixin, View):
                 # would run the serial/IP matching bulk_import_vms skips and could fabricate a
                 # collision that blocks a valid batch.
                 vm_device_ids=vm_imports,
+                user=request.user,
             )
             outcome = classify_bulk_precheck(collisions, unresolved, device_ids_to_import, vm_imports)
             if outcome.blocked:

--- a/netbox_librenms_plugin/views/imports/actions.py
+++ b/netbox_librenms_plugin/views/imports/actions.py
@@ -3053,7 +3053,9 @@ class AddAsOOBView(
             # stall concurrent work on it. Lock only within the caller's view scope.
             existing = (
                 Interface.objects.restrict(request.user, "view")
-                .select_for_update()
+                # of=("self",): restrict() joins the permission tables, and a bare
+                # select_for_update() would try to lock those joined rows too.
+                .select_for_update(of=("self",))
                 .filter(device=device, name=name)
                 .first()
             )

--- a/netbox_librenms_plugin/views/imports/actions.py
+++ b/netbox_librenms_plugin/views/imports/actions.py
@@ -245,6 +245,36 @@ def _mapping_change_is_allowed(view, model, pk) -> bool:
     return view.restricted_queryset(model, "change").filter(pk=pk).exists()
 
 
+def _oob_ip_is_reassignable(candidate, interface) -> bool:
+    """
+    Return whether *candidate* may be re-homed to *interface* without taking another device's IP.
+
+    Shared by the pre-lock refusal and the post-lock re-verify so the two readings cannot drift.
+
+    Args:
+        candidate: The existing IPAddress row matching the requested host address.
+        interface: The interface the caller wants the address assigned to.
+
+    Returns:
+        bool: True when the row is free or already on this device, and no other device
+            references it through primary_ip4/primary_ip6/oob_ip.
+    """
+    from dcim.models import Device
+    from django.db.models import Q
+
+    assigned = candidate.assigned_object
+    if not (assigned is None or getattr(assigned, "device_id", None) == interface.device_id):
+        return False
+    # An unassigned row can still be ANOTHER device's primary_ip4/primary_ip6/oob_ip — a direct
+    # Device FK, separate from assigned_object and UNIQUE per address. Claiming it would trip that
+    # constraint and roll the whole attach back with an opaque IntegrityError.
+    return not (
+        Device.objects.filter(Q(primary_ip4=candidate) | Q(primary_ip6=candidate) | Q(oob_ip=candidate))
+        .exclude(pk=interface.device_id)
+        .exists()
+    )
+
+
 def _acquire_serial_assignment_lock(serial: str) -> None:
     """
     Serialize serial-assignment guards on the serial value (transaction-scoped advisory lock).
@@ -2140,14 +2170,29 @@ class AddDeviceTypeMappingView(
                 # created duplicate rather than mutating an arbitrary row. Key on the
                 # NORMALISED hardware string (mapping_hardware) so the lock matches
                 # the existing_mapping lookup and create() below.
-                locked_rows = list(
-                    DeviceTypeMapping.objects.select_for_update().filter(librenms_hardware__iexact=mapping_hardware)[:2]
+                # Scope BEFORE locking: locking first lets a caller hold a row it cannot even see
+                # and stall concurrent work on it. The duplicate check still has to see every
+                # row, so it reads unlocked and by pk only.
+                present_pks = list(
+                    DeviceTypeMapping.objects.filter(librenms_hardware__iexact=mapping_hardware).values_list(
+                        "pk", flat=True
+                    )[:2]
                 )
-                if len(locked_rows) > 1:
+                if len(present_pks) > 1:
                     return _htmx_error_response(
                         "Multiple mappings exist for this hardware string. Remove duplicates before updating."
                     )
-                locked = locked_rows[0] if locked_rows else None
+                locked = None
+                if present_pks:
+                    locked = (
+                        self.restricted_queryset(DeviceTypeMapping, "change")
+                        .select_for_update(of=("self",))
+                        .filter(pk=present_pks[0])
+                        .first()
+                    )
+                    # A row appeared (or left this caller's scope) after the upfront check.
+                    if locked is None:
+                        return _htmx_error_response("Existing mapping is no longer available.")
                 if locked and not existing_mapping:
                     # A concurrent request created the mapping after our upfront read.
                     # Only escalate to change permission if we would actually mutate the row;
@@ -3146,37 +3191,40 @@ class AddAsOOBView(
         # Scope to the global table (vrf__isnull): the create path below makes a global
         # /32, and a same-host address inside a tenant VRF is a DIFFERENT address
         # (overlapping RFC1918 space) — re-homing it would hijack that VRF's IPAM record.
-        candidates = list(IPAddress.objects.select_for_update().filter(address__net_host=ip_str, vrf__isnull=True)[:2])
-        if len(candidates) > 1:
+        # Scope BEFORE locking: locking first lets a caller hold a row it cannot even see and
+        # stall concurrent work on it. The ambiguity check still has to see every row, so it
+        # reads unlocked and by pk only, then the lock is taken inside the caller's change scope.
+        host_rows = list(IPAddress.objects.filter(address__net_host=ip_str, vrf__isnull=True)[:2])
+        if len(host_rows) > 1:
             return None, "conflict"
-        existing = candidates[0] if candidates else None
-        if existing is not None:
-            assigned = existing.assigned_object
-            owned = assigned is None or getattr(assigned, "device_id", None) == interface.device_id
-            # A row that isn't on any interface (assigned_object is None) can still be ANOTHER
-            # device's primary_ip4/primary_ip6/oob_ip — a direct Device FK, separate from
-            # assigned_object and UNIQUE per address. Claiming it as this device's oob_ip would
-            # trip that constraint and roll the whole attach back with an opaque IntegrityError,
-            # so treat it as a conflict the user can resolve rather than a re-homeable row.
-            if owned:
-                from dcim.models import Device
-                from django.db.models import Q
-
-                if (
-                    Device.objects.filter(Q(primary_ip4=existing) | Q(primary_ip6=existing) | Q(oob_ip=existing))
-                    .exclude(pk=interface.device_id)
-                    .exists()
-                ):
-                    owned = False
-            if not owned:
+        existing = None
+        if host_rows:
+            # Ownership belongs to the data, not the caller, so judge it before taking any lock:
+            # a row owned elsewhere is refused without ever being pinned.
+            if not _oob_ip_is_reassignable(host_rows[0], interface):
                 return None, "conflict"
-            if assigned != interface:
-                # Re-homing an existing IP is a 'change'. The add-vs-change permission
-                # decision can only be made from the locked row: the unlocked pre-flight
-                # in _missing_oob_ip_permissions can race a concurrent create and wave
-                # through an 'add'-only user, so verify 'change' here before saving.
-                if not IPAddress.objects.restrict(request.user, "change").filter(pk=existing.pk).exists():
-                    return None, "permission_change"
+            existing = (
+                IPAddress.objects.restrict(request.user, "change")
+                # of=("self",): restrict() joins the permission tables, and a bare
+                # select_for_update() would try to lock those joined rows too.
+                .select_for_update(of=("self",))
+                .filter(pk=host_rows[0].pk)
+                .first()
+            )
+            # The row was there a moment ago, so a miss means the caller's change grant does not
+            # cover it (or it was deleted in the race). Refuse either way rather than lock it.
+            if existing is None:
+                return None, "permission_change"
+        if existing is not None:
+            # Re-verify from the locked row: the pre-check above read it unlocked, so a concurrent
+            # attach could have claimed it in between.
+            if not _oob_ip_is_reassignable(existing, interface):
+                return None, "conflict"
+            if existing.assigned_object != interface:
+                # Re-homing an existing IP is a 'change'. The lock above already ran through the
+                # caller's change scope, so reaching here means the grant covers this row: the
+                # unlocked pre-flight in _missing_oob_ip_permissions can race a concurrent create
+                # and wave through an 'add'-only user, and the scoped lock is what catches that.
                 existing.assigned_object = interface
                 existing.save()
             return existing, None
@@ -3825,14 +3873,27 @@ class AddPlatformMappingView(
                 # lock absent rows, so the create branch handles IntegrityError.
                 # Materialise the locked rows in one query — count() would drop
                 # the FOR UPDATE clause, leaving the rows unlocked.
-                locked_rows = list(
-                    PlatformMapping.objects.select_for_update().filter(librenms_os__iexact=librenms_os)[:2]
+                # Scope BEFORE locking: locking first lets a caller hold a row it cannot even see
+                # and stall concurrent work on it. The duplicate check still has to see every
+                # row, so it reads unlocked and by pk only.
+                present_pks = list(
+                    PlatformMapping.objects.filter(librenms_os__iexact=librenms_os).values_list("pk", flat=True)[:2]
                 )
-                if len(locked_rows) > 1:
+                if len(present_pks) > 1:
                     return _htmx_error_response(
                         "Multiple mappings exist for this OS string. Remove duplicates before updating."
                     )
-                locked = locked_rows[0] if locked_rows else None
+                locked = None
+                if present_pks:
+                    locked = (
+                        self.restricted_queryset(PlatformMapping, "change")
+                        .select_for_update(of=("self",))
+                        .filter(pk=present_pks[0])
+                        .first()
+                    )
+                    # A row appeared (or left this caller's scope) after the upfront check.
+                    if locked is None:
+                        return _htmx_error_response("Existing mapping is no longer available.")
                 if locked and not existing_mapping:
                     # Concurrent request created the mapping after our upfront read.
                     # Only escalate to change permission if we would actually mutate.

--- a/netbox_librenms_plugin/views/imports/actions.py
+++ b/netbox_librenms_plugin/views/imports/actions.py
@@ -3049,10 +3049,19 @@ class AddAsOOBView(
                 return None, None
             # Lock the candidate so a concurrent create/delete can't flip add-vs-reuse
             # between this check and the create below.
-            existing = Interface.objects.select_for_update().filter(device=device, name=name).first()
+            # Scope BEFORE locking: locking first lets a caller hold a row it cannot even see and
+            # stall concurrent work on it. Lock only within the caller's view scope.
+            existing = (
+                Interface.objects.restrict(request.user, "view")
+                .select_for_update()
+                .filter(device=device, name=name)
+                .first()
+            )
             if existing is not None:
-                if Interface.objects.restrict(request.user, "view").filter(pk=existing.pk).exists():
-                    return existing, None
+                return existing, None
+            # The name may still be taken by a row outside that scope; refuse rather than race the
+            # create below into an IntegrityError. `.exists()` reads no row data and takes no lock.
+            if Interface.objects.filter(device=device, name=name).exists():
                 return None, None
             if not request.user.has_perm(get_permission_for_model(Interface, "add")):
                 return None, "permission_add"

--- a/netbox_librenms_plugin/views/imports/actions.py
+++ b/netbox_librenms_plugin/views/imports/actions.py
@@ -239,6 +239,11 @@ def _rebind_or_htmx_error(view, request) -> HttpResponse | None:
     return None
 
 
+def _mapping_change_is_allowed(view, model, pk) -> bool:
+    """Return whether the current user may change the resolved mapping row."""
+    return view.restricted_queryset(model, "change").filter(pk=pk).exists()
+
+
 def _acquire_serial_assignment_lock(serial: str) -> None:
     """
     Serialize serial-assignment guards on the serial value (transaction-scoped advisory lock).
@@ -2116,6 +2121,8 @@ class AddDeviceTypeMappingView(
             self.required_object_permissions = {"POST": [("view", DeviceType), ("add", DeviceTypeMapping)]}
         if error := self.require_object_permissions("POST"):
             return error
+        if existing_mapping and not _mapping_change_is_allowed(self, DeviceTypeMapping, existing_mapping.pk):
+            return _htmx_error_response("Existing mapping is no longer available.")
 
         try:
             device_type = self.restricted_queryset(DeviceType).get(pk=device_type_id)
@@ -2158,6 +2165,8 @@ class AddDeviceTypeMappingView(
                         return error
                 if locked:
                     if locked.netbox_device_type_id != device_type_id:
+                        if not _mapping_change_is_allowed(self, DeviceTypeMapping, locked.pk):
+                            return _htmx_error_response("Existing mapping is no longer available.")
                         locked.netbox_device_type = device_type
                         locked.full_clean()
                         locked.save()
@@ -3040,7 +3049,9 @@ class AddAsOOBView(
             # between this check and the create below.
             existing = Interface.objects.select_for_update().filter(device=device, name=name).first()
             if existing is not None:
-                return existing, None
+                if Interface.objects.restrict(request.user, "view").filter(pk=existing.pk).exists():
+                    return existing, None
+                return None, None
             if not request.user.has_perm(get_permission_for_model(Interface, "add")):
                 return None, "permission_add"
             # Nested savepoint: catching IntegrityError without one would poison the outer
@@ -3146,7 +3157,7 @@ class AddAsOOBView(
                 # decision can only be made from the locked row: the unlocked pre-flight
                 # in _missing_oob_ip_permissions can race a concurrent create and wave
                 # through an 'add'-only user, so verify 'change' here before saving.
-                if not request.user.has_perm(get_permission_for_model(IPAddress, "change")):
+                if not IPAddress.objects.restrict(request.user, "change").filter(pk=existing.pk).exists():
                     return None, "permission_change"
                 existing.assigned_object = interface
                 existing.save()
@@ -3781,6 +3792,8 @@ class AddPlatformMappingView(
         }
         if error := self.require_object_permissions("POST"):
             return error
+        if existing_mapping and not _mapping_change_is_allowed(self, PlatformMapping, existing_mapping.pk):
+            return _htmx_error_response("Existing mapping is no longer available.")
 
         try:
             platform = self.restricted_queryset(Platform).get(pk=platform_id)
@@ -3817,6 +3830,8 @@ class AddPlatformMappingView(
                         return error
                 if locked:
                     if locked.netbox_platform_id != platform_id:
+                        if not _mapping_change_is_allowed(self, PlatformMapping, locked.pk):
+                            return _htmx_error_response("Existing mapping is no longer available.")
                         locked.netbox_platform = platform
                         locked.full_clean()
                         locked.save()

--- a/netbox_librenms_plugin/views/mixins.py
+++ b/netbox_librenms_plugin/views/mixins.py
@@ -265,7 +265,10 @@ def relock_scoped_row(model, **lookup):
     Returns:
         The locked instance, or None when the row is gone.
     """
-    return model.objects.select_for_update().filter(**lookup).first()
+    # order_by() drops the model ordering, which can traverse a nullable FK (VLAN orders by
+    # site/group): PostgreSQL refuses FOR UPDATE over the nullable side of the resulting outer
+    # join. first() then orders by pk, which joins nothing.
+    return model.objects.select_for_update().filter(**lookup).order_by().first()
 
 
 class NetBoxObjectPermissionMixin:

--- a/netbox_librenms_plugin/views/mixins.py
+++ b/netbox_librenms_plugin/views/mixins.py
@@ -244,6 +244,30 @@ class LibreNMSWritePermissionMixin(LibreNMSPermissionMixin):
     permission_required = PERM_CHANGE_PLUGIN
 
 
+def relock_scoped_row(model, **lookup):
+    """
+    Re-lock a row whose id came from an ALREADY-RESOLVED object: the single audited exception.
+
+    Scoping happened where that object was resolved. Restricting the re-read instead would demand a
+    permission the caller's gate never required: ``restrict()`` returns ``none()`` for a user
+    without the model-level grant, so a change-only caller would silently lose rows out of a lock
+    set and be told the object "no longer exists".
+
+    Every call asserts that *lookup* was derived from an object the request already resolved through
+    ``restricted_queryset``. Never pass a client-supplied id. One named chokepoint keeps these
+    greppable and lets the raw-pk scan drop its spelling heuristic, which any request-derived
+    ``*_id`` attribute satisfied by accident.
+
+    Args:
+        model: The model whose row to lock.
+        **lookup: Lookup kwargs identifying the row (e.g. ``pk=donor.oob_ip_id``).
+
+    Returns:
+        The locked instance, or None when the row is gone.
+    """
+    return model.objects.select_for_update().filter(**lookup).first()
+
+
 class NetBoxObjectPermissionMixin:
     """
     Mixin for views requiring specific NetBox object permissions.
@@ -365,6 +389,10 @@ class NetBoxObjectPermissionMixin:
         if select_related:
             queryset = queryset.select_related(*select_related)
         return get_object_or_404(queryset, **kwargs)
+
+    def relock_scoped_row(self, model, **lookup):
+        """Re-lock a row derived from an already-resolved object. See :func:`relock_scoped_row`."""
+        return relock_scoped_row(model, **lookup)
 
     def require_all_permissions(self, method="POST"):
         """

--- a/netbox_librenms_plugin/views/sync/device_fields.py
+++ b/netbox_librenms_plugin/views/sync/device_fields.py
@@ -403,6 +403,8 @@ class CreateAndAssignPlatformView(LibreNMSPermissionMixin, NetBoxObjectPermissio
         required = [("change", Device)]
         if existing_platform is None:
             required.append(("add", Platform))
+        else:
+            required.append(("view", Platform))
         # The manufacturer is optional, but when one IS posted it is resolved by client-supplied
         # id through a restricted queryset — so state that read in the gate.
         if (request.POST.get("manufacturer") or "").strip():
@@ -418,6 +420,16 @@ class CreateAndAssignPlatformView(LibreNMSPermissionMixin, NetBoxObjectPermissio
         # Check both plugin write and NetBox object permissions
         if error := self.require_all_permissions("POST"):
             return error
+
+        if existing_platform is not None:
+            existing_platform = self.restricted_queryset(Platform).filter(pk=existing_platform.pk).first()
+            if existing_platform is None:
+                messages.error(request, "Selected platform is not available.")
+                return self._sync_redirect(
+                    request,
+                    pk,
+                    getattr(getattr(self, "_librenms_api", None), "server_key", None),
+                )
 
         device = self.restrict_object_or_404(Device, "change", pk=pk)
 
@@ -483,8 +495,8 @@ class CreateAndAssignPlatformView(LibreNMSPermissionMixin, NetBoxObjectPermissio
                     # check and our save. Reuse the winner (the goal is reuse-or-create)
                     # instead of failing the whole assign; only abort if the re-query
                     # finds nothing (the IntegrityError was for some other reason).
-                    platform = Platform.objects.filter(name__iexact=platform_name).first()
-                    if platform is None:
+                    winner = Platform.objects.filter(name__iexact=platform_name).first()
+                    if winner is None:
                         transaction.set_rollback(True)
                         logger.exception(
                             "IntegrityError creating platform '%s' for device pk=%s",
@@ -495,6 +507,13 @@ class CreateAndAssignPlatformView(LibreNMSPermissionMixin, NetBoxObjectPermissio
                             request,
                             f"Platform '{platform_name}' could not be created: {e}",
                         )
+                        return self._sync_redirect(
+                            request, pk, getattr(getattr(self, "_librenms_api", None), "server_key", None)
+                        )
+                    platform = self.restricted_queryset(Platform).filter(pk=winner.pk).first()
+                    if platform is None:
+                        transaction.set_rollback(True)
+                        messages.error(request, "Selected platform is not available.")
                         return self._sync_redirect(
                             request, pk, getattr(getattr(self, "_librenms_api", None), "server_key", None)
                         )

--- a/netbox_librenms_plugin/views/sync/interfaces.py
+++ b/netbox_librenms_plugin/views/sync/interfaces.py
@@ -180,18 +180,54 @@ class SyncInterfacesView(
     ):
         """Create or update NetBox interfaces from LibreNMS port data."""
         with transaction.atomic():
-            for port in ports_data:
-                # OOB-controller rows are merged into the host's interface list only for context
-                # (shared-LOM detection) and are never routed to a real target device by
-                # sync_interface(). They must not sync onto the host — and skipping them prevents
-                # a main/OOB interface-name collision (both "eth0") from double-processing one
-                # selection and overwriting the host interface with the OOB row's port_id/attrs.
-                if port.get("_source") == "oob":
-                    continue
-                port_name = port.get(interface_name_field)
+            if isinstance(obj, Device):
+                locked_targets = self._lock_selected_device_targets(
+                    obj,
+                    selected_interfaces,
+                    ports_data,
+                    interface_name_field,
+                )
+                obj = locked_targets.get(obj.pk)
+                if obj is None:
+                    for interface_name in selected_interfaces:
+                        self._record_skipped_conflict(interface_name, "selected target unavailable")
+                    return
+                self._locked_target_devices = locked_targets
 
-                if port_name in selected_interfaces:
-                    self.sync_interface(obj, port, exclude_columns, interface_name_field)
+            try:
+                for port in ports_data:
+                    # OOB-controller rows are merged into the host's interface list only for context
+                    # (shared-LOM detection) and are never routed to a real target device by
+                    # sync_interface(). They must not sync onto the host — and skipping them prevents
+                    # a main/OOB interface-name collision (both "eth0") from double-processing one
+                    # selection and overwriting the host interface with the OOB row's port_id/attrs.
+                    if port.get("_source") == "oob":
+                        continue
+                    port_name = port.get(interface_name_field)
+
+                    if port_name in selected_interfaces:
+                        self.sync_interface(obj, port, exclude_columns, interface_name_field)
+            finally:
+                self.__dict__.pop("_locked_target_devices", None)
+
+    def _lock_selected_device_targets(self, obj, selected_interfaces, ports_data, interface_name_field):
+        """Lock the page device and selected VC targets for the sync transaction."""
+        target_ids = {obj.pk}
+        for port in ports_data:
+            if port.get("_source") == "oob":
+                continue
+            interface_name = port.get(interface_name_field)
+            if interface_name not in selected_interfaces:
+                continue
+            selected_id = self.request.POST.get(f"device_selection_{interface_name}")
+            if selected_id:
+                try:
+                    target_ids.add(int(selected_id))
+                except (TypeError, ValueError):
+                    continue
+
+        queryset = self.restricted_queryset(Device).select_for_update(of=("self",))
+        return {device.pk: device for device in queryset.filter(pk__in=target_ids).order_by("pk")}
 
     def sync_interface(self, obj, librenms_interface, exclude_columns, interface_name_field):
         """Create or update a single NetBox interface from LibreNMS data."""
@@ -205,17 +241,19 @@ class SyncInterfacesView(
 
             if selected_device_id:
                 try:
-                    target_device = self.restricted_queryset(Device).get(id=selected_device_id)
-                    # Validate the target is the current device or a VC member
-                    if hasattr(obj, "virtual_chassis") and obj.virtual_chassis:
-                        valid_ids = set(obj.virtual_chassis.members.values_list("id", flat=True))
-                        if target_device.id not in valid_ids:
-                            self._record_skipped_conflict(interface_name, "selected target unavailable")
-                            return
-                    elif target_device.id != obj.id:
+                    locked_targets = getattr(self, "_locked_target_devices", None)
+                    if locked_targets is None:
+                        target_device = self.restricted_queryset(Device).get(id=selected_device_id)
+                    else:
+                        target_device = locked_targets[int(selected_device_id)]
+                    # Both rows are current and locked in the HTTP sync path. Re-check that the
+                    # selected device is the page device or remains in the same virtual chassis.
+                    if target_device.id != obj.id and (
+                        obj.virtual_chassis_id is None or target_device.virtual_chassis_id != obj.virtual_chassis_id
+                    ):
                         self._record_skipped_conflict(interface_name, "selected target unavailable")
                         return
-                except (Device.DoesNotExist, ValueError, TypeError):
+                except (Device.DoesNotExist, KeyError, ValueError, TypeError):
                     # The user explicitly selected a target. If it is stale or outside the
                     # caller's grant, do not silently sync the row onto the page device.
                     self._record_skipped_conflict(interface_name, "selected target unavailable")

--- a/netbox_librenms_plugin/views/sync/interfaces.py
+++ b/netbox_librenms_plugin/views/sync/interfaces.py
@@ -303,6 +303,7 @@ class SyncInterfacesView(
 
     def _resolve_device_interface(self, target_device, interface_name, port_id, server_key):
         """Resolve a device interface using port_id first, then safe name fallback."""
+        changeable = self.restricted_queryset(Interface, "change")
         if port_id:
             try:
                 by_id = find_by_librenms_id(Interface, port_id, server_key)
@@ -312,6 +313,8 @@ class SyncInterfacesView(
                 logger.warning("Skipping interface row — port_id %s is ambiguous (multiple matches).", port_id)
                 return None
             if by_id is not None:
+                if not changeable.filter(pk=by_id.pk).exists():
+                    return None
                 if by_id.device_id == target_device.id:
                     return by_id
                 # The port_id resolves to an interface on a DIFFERENT device (a stale or
@@ -324,13 +327,14 @@ class SyncInterfacesView(
                 # interface (its existing_owner guard), so the foreign binding stays intact.
                 existing_by_name = Interface.objects.filter(device=target_device, name=interface_name).first()
                 if existing_by_name:
-                    return existing_by_name
+                    return existing_by_name if changeable.filter(pk=existing_by_name.pk).exists() else None
                 return None
-        interface, _ = Interface.objects.get_or_create(device=target_device, name=interface_name)
-        return interface
+        interface, created = Interface.objects.get_or_create(device=target_device, name=interface_name)
+        return interface if created or changeable.filter(pk=interface.pk).exists() else None
 
     def _resolve_vm_interface(self, vm, interface_name, port_id, server_key):
         """Resolve a VM interface using port_id first, then safe name fallback."""
+        changeable = self.restricted_queryset(VMInterface, "change")
         if port_id:
             try:
                 by_id = find_by_librenms_id(VMInterface, port_id, server_key)
@@ -338,6 +342,8 @@ class SyncInterfacesView(
                 logger.warning("Skipping VM interface row — port_id %s is ambiguous (multiple matches).", port_id)
                 return None
             if by_id is not None:
+                if not changeable.filter(pk=by_id.pk).exists():
+                    return None
                 if by_id.virtual_machine_id == vm.id:
                     return by_id
                 # The port_id resolves to an interface on a DIFFERENT VM (a stale or duplicate
@@ -348,10 +354,10 @@ class SyncInterfacesView(
                 # reassign the port_id off the other interface (its existing_owner guard).
                 existing_by_name = VMInterface.objects.filter(virtual_machine=vm, name=interface_name).first()
                 if existing_by_name:
-                    return existing_by_name
+                    return existing_by_name if changeable.filter(pk=existing_by_name.pk).exists() else None
                 return None
-        interface, _ = VMInterface.objects.get_or_create(virtual_machine=vm, name=interface_name)
-        return interface
+        interface, created = VMInterface.objects.get_or_create(virtual_machine=vm, name=interface_name)
+        return interface if created or changeable.filter(pk=interface.pk).exists() else None
 
     def get_netbox_interface_type(self, librenms_interface):
         """Return the NetBox interface type mapped from LibreNMS type and speed."""

--- a/netbox_librenms_plugin/views/sync/ip_addresses.py
+++ b/netbox_librenms_plugin/views/sync/ip_addresses.py
@@ -422,6 +422,14 @@ class SyncIPAddressesView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixin, 
                             raise ValueError(
                                 "Existing IP address is no longer available or you do not have permission to change it."
                             )
+                        # The scope check does not lock, so a concurrent assignment or VRF change
+                        # could commit between it and the save below and be overwritten. Re-read
+                        # the authorized row under a lock and decide from that.
+                        existing_ip = self.relock_scoped_row(IPAddress, pk=existing_ip.pk)
+                        if existing_ip is None:
+                            raise ValueError(
+                                "Existing IP address is no longer available or you do not have permission to change it."
+                            )
                         if existing_ip.assigned_object != interface or existing_ip.vrf != vrf:
                             existing_ip.assigned_object = interface
                             existing_ip.vrf = vrf

--- a/netbox_librenms_plugin/views/sync/ip_addresses.py
+++ b/netbox_librenms_plugin/views/sync/ip_addresses.py
@@ -67,6 +67,8 @@ class SyncIPAddressesView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixin, 
             ("view", interface_model),
             *type(self).required_object_permissions["POST"],
         ]
+        if resolve_set_primary_ip(self.request):
+            perms.append(("change", owner_model))
         # A per-row VRF is resolved by client-supplied id through a restricted queryset. Only
         # demand its view permission when one is actually posted, so the common no-VRF sync
         # is not gated on a permission it never uses.
@@ -98,12 +100,12 @@ class SyncIPAddressesView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixin, 
             return None
         return cached_data.get("ip_addresses", [])
 
-    def get_object(self, object_type, pk):
+    def get_object(self, object_type, pk, action="view"):
         """Return the Device or VirtualMachine instance for the given type and pk (object-scoped)."""
         if object_type == "device":
-            return self.restrict_object_or_404(Device, pk=pk)
+            return self.restrict_object_or_404(Device, action, pk=pk)
         if object_type == "virtualmachine":
-            return self.restrict_object_or_404(VirtualMachine, pk=pk)
+            return self.restrict_object_or_404(VirtualMachine, action, pk=pk)
         raise Http404("Invalid object type.")
 
     def get_ip_tab_url(self, obj):
@@ -141,7 +143,8 @@ class SyncIPAddressesView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixin, 
         if error := self.require_all_permissions("POST"):
             return error
 
-        obj = self.get_object(object_type, pk)
+        owner_action = "change" if resolve_set_primary_ip(request) else "view"
+        obj = self.get_object(object_type, pk, owner_action)
 
         # Rebind the cached API client to the POSTed server so live lookups (e.g. the
         # management-IP fetch for Set-Primary-IP) hit the same LibreNMS instance the cached
@@ -415,6 +418,10 @@ class SyncIPAddressesView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixin, 
                     existing_ip = IPAddress.objects.filter(address=ip_with_mask, vrf=vrf).first()
 
                     if existing_ip:
+                        if not self.restricted_queryset(IPAddress, "change").filter(pk=existing_ip.pk).exists():
+                            raise ValueError(
+                                "Existing IP address is no longer available or you do not have permission to change it."
+                            )
                         if existing_ip.assigned_object != interface or existing_ip.vrf != vrf:
                             existing_ip.assigned_object = interface
                             existing_ip.vrf = vrf

--- a/netbox_librenms_plugin/views/sync/ip_addresses.py
+++ b/netbox_librenms_plugin/views/sync/ip_addresses.py
@@ -404,7 +404,7 @@ class SyncIPAddressesView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixin, 
                         # Lock obj's row BEFORE the address write, so this path takes the same
                         # Device -> IPAddress lock order as the migrate move views. The reverse
                         # order closes a deadlock cycle with a concurrent donor move.
-                        if type(obj).objects.select_for_update().filter(pk=obj.pk).first() is None:
+                        if self.relock_scoped_row(type(obj), pk=obj.pk) is None:
                             raise type(obj).DoesNotExist(f"{type(obj).__name__} {obj.pk} no longer exists")
                         # Re-read the primary_ip ids from the locked row. A stale in-memory value
                         # would make _set_primary_ip skip a set it must perform.

--- a/netbox_librenms_plugin/views/sync/migrate.py
+++ b/netbox_librenms_plugin/views/sync/migrate.py
@@ -38,6 +38,7 @@ from netbox_librenms_plugin.views.mixins import (
     LibreNMSAPIMixin,
     LibreNMSPermissionMixin,
     NetBoxObjectPermissionMixin,
+    relock_scoped_row,
     resolve_configured_server_key,
     validated_referer,
 )
@@ -293,7 +294,7 @@ def _reconcile_donor_device_ip_fks(donor, winner):
         # could flip device_id between this check and winner.save(). Lock the owning Interface
         # and re-read device_id from the locked row so the winner can't end up owning an address
         # that has since moved away.
-        locked_iface = Interface.objects.select_for_update().filter(pk=assigned.pk).first()
+        locked_iface = relock_scoped_row(Interface, pk=assigned.pk)
         if locked_iface is None or locked_iface.device_id != winner.pk:
             continue
         # Refresh the cached GenericForeignKey on `ip` to the freshly locked interface:
@@ -789,7 +790,7 @@ class MoveIPAddressToWinnerView(_BaseMoveToWinnerView):
             # Lock the donor interface row too and re-read it: its name is used
             # below to find the winner-side interface, so a concurrent rename
             # would otherwise send the IP to the wrong interface (TOCTOU).
-            assigned = Interface.objects.select_for_update().filter(pk=assigned.pk, device=donor).first()
+            assigned = self.relock_scoped_row(Interface, pk=assigned.pk, device=donor)
             if assigned is None:
                 return self._fail(request, "IP is no longer assigned to the donor interface.", status=409)
             # Re-fetch the winner interface under the lock to close the TOCTOU window.
@@ -886,7 +887,7 @@ class TransferDeviceIPView(_BaseMoveToWinnerView):
             # device FKs are locked but the address is not, so a concurrent reassignment
             # could otherwise change assigned_object between this check and the FK update,
             # leaving winner.primary_ip*/oob_ip pointing at an address it no longer owns.
-            donor_ip = IPAddress.objects.select_for_update().filter(pk=donor_ip.pk).first()
+            donor_ip = self.relock_scoped_row(IPAddress, pk=donor_ip.pk)
             if donor_ip is None:
                 return self._fail(request, f"Donor's {human} no longer exists.", status=410)
             if getattr(winner, field, None) is not None:
@@ -912,7 +913,7 @@ class TransferDeviceIPView(_BaseMoveToWinnerView):
             # check validate the wrong row. A non-Interface assignment fails closed (None).
             if isinstance(assigned, Interface):
                 # Lock the owning interface row (this transfer is device-scoped).
-                assigned = Interface.objects.select_for_update().filter(pk=assigned.pk).first()
+                assigned = self.relock_scoped_row(Interface, pk=assigned.pk)
                 if assigned is not None:
                     # Freshen the cached GFK to the locked row: set_device_ip_fk() re-reads
                     # donor_ip.assigned_object for its ownership check, and the pre-lock snapshot

--- a/netbox_librenms_plugin/views/sync/modules.py
+++ b/netbox_librenms_plugin/views/sync/modules.py
@@ -167,8 +167,8 @@ class _SerialConflictUnavailable(Exception):
         self.serial = serial
 
 
-class _InterfaceAdoptionUnavailable(Exception):
-    """Abort a module write that adopted an interface outside the caller's change scope."""
+class _ModuleComponentAdoptionUnavailable(Exception):
+    """Abort a module write that adopted a component outside the caller's change scope."""
 
 
 def _get_sync_device_for_inventory(device, server_key):
@@ -251,35 +251,102 @@ def _select_module_interface_by_coordinates(device, module_interfaces, item):
     return scored[0][2]
 
 
-def _save_module_with_scoped_interface_adoption(module, interfaces):
-    """Save a module and verify every interface that NetBox adopted."""
-    from dcim.models import Interface
+def _module_component_specs():
+    """Return the template, device relation, and model used by NetBox module replication."""
+    from dcim.models import (
+        ConsolePort,
+        ConsoleServerPort,
+        FrontPort,
+        Interface,
+        ModuleBay,
+        PowerOutlet,
+        PowerPort,
+        RearPort,
+    )
+
+    return (
+        ("consoleporttemplates", "consoleports", ConsolePort),
+        ("consoleserverporttemplates", "consoleserverports", ConsoleServerPort),
+        ("interfacetemplates", "interfaces", Interface),
+        ("powerporttemplates", "powerports", PowerPort),
+        ("poweroutlettemplates", "poweroutlets", PowerOutlet),
+        ("rearporttemplates", "rearports", RearPort),
+        ("frontporttemplates", "frontports", FrontPort),
+        ("modulebaytemplates", "modulebays", ModuleBay),
+    )
+
+
+def _restricted_module_component_querysets(view):
+    """Return change-scoped querysets for every component NetBox can adopt."""
+    return {model: view.restricted_queryset(model, "change") for _, _, model in _module_component_specs()}
+
+
+def _authorize_adoptable_module_components(module, component_querysets):
+    """Lock and authorize the exact standalone components NetBox can adopt."""
+    expected_ids = {}
+
+    for template_attribute, component_attribute, component_model in _module_component_specs():
+        names = [
+            template.instantiate(device=module.device, module=module).name
+            for template in getattr(module.module_type, template_attribute).all()
+        ]
+        if not names:
+            continue
+
+        candidates = list(
+            getattr(module.device, component_attribute)
+            .select_for_update(of=("self",))
+            .filter(module__isnull=True, name__in=names)
+        )
+        candidates_by_name = {candidate.name: candidate for candidate in candidates}
+        candidate_ids = {candidates_by_name[name].pk for name in names if name in candidates_by_name}
+        if not candidate_ids:
+            continue
+
+        allowed = component_querysets.get(component_model)
+        if allowed is None or allowed.filter(pk__in=candidate_ids).count() != len(candidate_ids):
+            raise _ModuleComponentAdoptionUnavailable
+        expected_ids[component_model] = candidate_ids
+
+    return expected_ids
+
+
+def _save_module_with_scoped_component_adoption(module, component_querysets):
+    """Save a module after authorizing and locking every component NetBox can adopt."""
     from django.db.models.signals import post_save
 
-    created_ids = set()
-    adopted_ids = set()
+    component_models = tuple(spec[2] for spec in _module_component_specs())
+    created_ids = {model: set() for model in component_models}
+    adopted_ids = {model: set() for model in component_models}
 
-    def capture_interface_save(sender, instance, created, **kwargs):
+    def capture_component_save(sender, instance, created, **kwargs):
         if instance.module_id != module.pk:
             return
         if created:
-            created_ids.add(instance.pk)
+            created_ids[sender].add(instance.pk)
         else:
-            adopted_ids.add(instance.pk)
+            adopted_ids[sender].add(instance.pk)
 
     with transaction.atomic():
+        expected_ids = _authorize_adoptable_module_components(module, component_querysets)
         module._adopt_components = True
         module.full_clean()
-        post_save.connect(capture_interface_save, sender=Interface, weak=False)
+        for component_model in component_models:
+            post_save.connect(capture_component_save, sender=component_model, weak=False)
         try:
             module.save()
         finally:
-            post_save.disconnect(capture_interface_save, sender=Interface)
+            for component_model in component_models:
+                post_save.disconnect(capture_component_save, sender=component_model)
 
-        adopted_ids.difference_update(created_ids)
-        if interfaces.filter(pk__in=adopted_ids).count() != len(adopted_ids):
-            raise _InterfaceAdoptionUnavailable
-    return len(adopted_ids)
+        actual_ids = {}
+        for component_model in component_models:
+            ids = adopted_ids[component_model] - created_ids[component_model]
+            if ids:
+                actual_ids[component_model] = ids
+        if actual_ids != expected_ids:
+            raise _ModuleComponentAdoptionUnavailable
+    return sum(len(ids) for ids in actual_ids.values())
 
 
 def _adopt_existing_template_interfaces(device, module, interfaces):
@@ -624,7 +691,8 @@ class InstallModuleView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixin, Li
         )
         if invalid_selected_device:
             _warn_invalid_selected_device(request)
-        changeable_interfaces = self.restricted_queryset(Interface, "change")
+        changeable_components = _restricted_module_component_querysets(self)
+        changeable_interfaces = changeable_components[Interface]
         deletable_interfaces = self.restricted_queryset(Interface, "delete")
         # Validate the posted server_key against configured servers, else fall back to the active
         # client server (resolve_posted_server_key). A blank key (e.g. a fallback render where
@@ -672,7 +740,7 @@ class InstallModuleView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixin, Li
                     serial=serial,
                     status="active",
                 )
-                adopted_interfaces = _save_module_with_scoped_interface_adoption(module, changeable_interfaces)
+                adopted_components = _save_module_with_scoped_component_adoption(module, changeable_components)
                 vc_adjustments = _normalize_module_interface_names_for_vc_member(
                     target_device,
                     module,
@@ -699,11 +767,11 @@ class InstallModuleView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixin, Li
             messages.success(
                 request, f"Installed {module_type.model} in {locked_bay.name} (serial: {serial or 'N/A'})."
             )
-            if adopted_interfaces:
+            if adopted_components:
                 messages.warning(
                     request,
                     "Module sync authority applied: adopted "
-                    f"{adopted_interfaces} existing standalone interface(s) into the module.",
+                    f"{adopted_components} existing standalone component(s) into the module.",
                 )
             vc_summary = _format_vc_adjustment_summary(vc_adjustments)
             if vc_summary:
@@ -728,8 +796,8 @@ class InstallModuleView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixin, Li
                     "Installed module, but interface binding was skipped: "
                     f"{bind_result.get('reason', 'unknown reason')}",
                 )
-        except _InterfaceAdoptionUnavailable:
-            messages.error(request, "A matching interface is not available for module adoption.")
+        except _ModuleComponentAdoptionUnavailable:
+            messages.error(request, "A matching component is not available for module adoption.")
         except (ValidationError, IntegrityError) as e:
             messages.error(request, f"Failed to install module: {e}")
 
@@ -765,7 +833,8 @@ class InstallBranchView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixin, Li
         if invalid_selected_device:
             _warn_invalid_selected_device(request)
         module_bays = self.restricted_queryset(ModuleBay)
-        changeable_interfaces = self.restricted_queryset(Interface, "change")
+        changeable_components = _restricted_module_component_querysets(self)
+        changeable_interfaces = changeable_components[Interface]
         deletable_interfaces = self.restricted_queryset(Interface, "delete")
         parent_index = request.POST.get("parent_index")
         server_key = self.resolve_posted_server_key(request.POST)
@@ -842,6 +911,7 @@ class InstallBranchView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixin, Li
                         norm_rules_bay=norm_rules_bay,
                         module_bays=module_bays,
                         allowed_module_type_ids=allowed_module_type_ids,
+                        changeable_components=changeable_components,
                         changeable_interfaces=changeable_interfaces,
                         deletable_interfaces=deletable_interfaces,
                     )
@@ -961,6 +1031,7 @@ class InstallBranchView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixin, Li
         *,
         module_bays,
         allowed_module_type_ids,
+        changeable_components,
         changeable_interfaces,
         deletable_interfaces,
         exact_mappings=None,
@@ -1052,18 +1123,18 @@ class InstallBranchView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixin, Li
                     serial=serial,
                     status="active",
                 )
-                adopted_interfaces = _save_module_with_scoped_interface_adoption(module, changeable_interfaces)
+                adopted_components = _save_module_with_scoped_component_adoption(module, changeable_components)
                 vc_adjustments = _normalize_module_interface_names_for_vc_member(
                     device,
                     module,
                     changeable_interfaces,
                     deletable_interfaces,
                 )
-        except _InterfaceAdoptionUnavailable:
+        except _ModuleComponentAdoptionUnavailable:
             return {
                 "status": "skipped",
                 "name": name,
-                "reason": "a matching interface is not available for module adoption",
+                "reason": "a matching component is not available for module adoption",
             }
         except (ValidationError, IntegrityError) as e:
             error_msg = str(e)
@@ -1076,8 +1147,8 @@ class InstallBranchView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixin, Li
             return {"status": "failed", "name": name, "reason": error_msg}
 
         name = f"{matched_type.model} → {matched_bay.name}"
-        if adopted_interfaces:
-            name += f" (adopted {adopted_interfaces} existing interface(s))"
+        if adopted_components:
+            name += f" (adopted {adopted_components} existing component(s))"
         vc_summary = _format_vc_adjustment_summary(vc_adjustments)
         if vc_summary:
             name += f" (vc normalize: {vc_summary})"
@@ -1086,7 +1157,7 @@ class InstallBranchView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixin, Li
             "status": "installed",
             "name": name,
             "module_pk": module.pk,
-            "adopted_interfaces": adopted_interfaces,
+            "adopted_components": adopted_components,
             "vc_adjustments": vc_adjustments,
         }
 
@@ -1340,7 +1411,8 @@ class InstallSelectedView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixin, 
 
         page_device = self.restrict_object_or_404(Device, pk=pk)
         module_bays = self.restricted_queryset(ModuleBay)
-        changeable_interfaces = self.restricted_queryset(Interface, "change")
+        changeable_components = _restricted_module_component_querysets(self)
+        changeable_interfaces = changeable_components[Interface]
         deletable_interfaces = self.restricted_queryset(Interface, "delete")
         server_key = self.resolve_posted_server_key(request.POST)
         sync_url = reverse("plugins:netbox_librenms_plugin:device_librenms_sync", kwargs={"pk": pk})
@@ -1435,6 +1507,7 @@ class InstallSelectedView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixin, 
                         norm_rules_bay=norm_rules_bay,
                         module_bays=module_bays,
                         allowed_module_type_ids=allowed_module_type_ids,
+                        changeable_components=changeable_components,
                         changeable_interfaces=changeable_interfaces,
                         deletable_interfaces=deletable_interfaces,
                     )
@@ -1870,7 +1943,8 @@ class ReplaceModuleView(LibreNMSPermissionMixin, LibreNMSAPIMixin, NetBoxObjectP
         )
         if invalid_selected_device:
             _warn_invalid_selected_device(request)
-        changeable_interfaces = self.restricted_queryset(Interface, "change")
+        changeable_components = _restricted_module_component_querysets(self)
+        changeable_interfaces = changeable_components[Interface]
         deletable_interfaces = self.restricted_queryset(Interface, "delete")
         server_key = self.resolve_posted_server_key(request.POST)
         sync_url = reverse("plugins:netbox_librenms_plugin:device_librenms_sync", kwargs={"pk": pk})
@@ -1927,7 +2001,7 @@ class ReplaceModuleView(LibreNMSPermissionMixin, LibreNMSAPIMixin, NetBoxObjectP
         try:
             conflict_removed_msg = None
             bind_result = None
-            adopted_interfaces = 0
+            adopted_components = 0
             vc_adjustments = {"renamed": 0, "adopted": 0, "removed": 0, "skipped": 0}
             with transaction.atomic():
                 # Re-fetch with row lock to prevent concurrent modifications
@@ -1995,9 +2069,9 @@ class ReplaceModuleView(LibreNMSPermissionMixin, LibreNMSAPIMixin, NetBoxObjectP
                 installed_module.delete()
 
                 # Install fresh module from LibreNMS data
-                adopted_interfaces = _save_module_with_scoped_interface_adoption(
+                adopted_components = _save_module_with_scoped_component_adoption(
                     new_module,
-                    changeable_interfaces,
+                    changeable_components,
                 )
                 vc_adjustments = _normalize_module_interface_names_for_vc_member(
                     target_device,
@@ -2029,11 +2103,11 @@ class ReplaceModuleView(LibreNMSPermissionMixin, LibreNMSAPIMixin, NetBoxObjectP
                 + (f" (serial: {serial})" if serial else "")
                 + ".",
             )
-            if adopted_interfaces:
+            if adopted_components:
                 messages.warning(
                     request,
                     "Module sync authority applied: adopted "
-                    f"{adopted_interfaces} existing standalone interface(s) into the module.",
+                    f"{adopted_components} existing standalone component(s) into the module.",
                 )
             vc_summary = _format_vc_adjustment_summary(vc_adjustments)
             if vc_summary:
@@ -2052,8 +2126,8 @@ class ReplaceModuleView(LibreNMSPermissionMixin, LibreNMSAPIMixin, NetBoxObjectP
                     "Replaced module, but interface binding was skipped: "
                     f"{bind_result.get('reason', 'unknown reason')}",
                 )
-        except _InterfaceAdoptionUnavailable:
-            messages.error(request, "A matching interface is not available for module adoption.")
+        except _ModuleComponentAdoptionUnavailable:
+            messages.error(request, "A matching component is not available for module adoption.")
         except _SerialConflictAmbiguous as exc:
             messages.error(
                 request,

--- a/netbox_librenms_plugin/views/sync/modules.py
+++ b/netbox_librenms_plugin/views/sync/modules.py
@@ -167,6 +167,10 @@ class _SerialConflictUnavailable(Exception):
         self.serial = serial
 
 
+class _InterfaceAdoptionUnavailable(Exception):
+    """Abort a module write that adopted an interface outside the caller's change scope."""
+
+
 def _get_sync_device_for_inventory(device, server_key):
     """Return the VC sync device used for module inventory cache keys."""
     return get_librenms_sync_device(device, server_key=server_key) or device
@@ -247,21 +251,35 @@ def _select_module_interface_by_coordinates(device, module_interfaces, item):
     return scored[0][2]
 
 
-def _count_adoptable_interfaces(device, module, interfaces):
-    """Count adoptable interfaces, or return None if the change scope excludes one."""
+def _save_module_with_scoped_interface_adoption(module, interfaces):
+    """Save a module and verify every interface that NetBox adopted."""
     from dcim.models import Interface
+    from django.db.models.signals import post_save
 
-    # NetBox adopts standalone components during Module.save() before this plugin rewrites
-    # interface names for a VC member. Check the raw instantiated names that NetBox will use.
-    template_names = get_module_template_interface_names(device, module, rewrite_for_vc=False)
-    if not template_names:
-        return 0
+    created_ids = set()
+    adopted_ids = set()
 
-    candidates = Interface.objects.filter(device=device, module__isnull=True, name__in=template_names)
-    candidate_count = candidates.count()
-    if interfaces.filter(pk__in=candidates.values("pk")).count() != candidate_count:
-        return None
-    return candidate_count
+    def capture_interface_save(sender, instance, created, **kwargs):
+        if instance.module_id != module.pk:
+            return
+        if created:
+            created_ids.add(instance.pk)
+        else:
+            adopted_ids.add(instance.pk)
+
+    with transaction.atomic():
+        module._adopt_components = True
+        module.full_clean()
+        post_save.connect(capture_interface_save, sender=Interface, weak=False)
+        try:
+            module.save()
+        finally:
+            post_save.disconnect(capture_interface_save, sender=Interface)
+
+        adopted_ids.difference_update(created_ids)
+        if interfaces.filter(pk__in=adopted_ids).count() != len(adopted_ids):
+            raise _InterfaceAdoptionUnavailable
+    return len(adopted_ids)
 
 
 def _adopt_existing_template_interfaces(device, module, interfaces):
@@ -654,17 +672,7 @@ class InstallModuleView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixin, Li
                     serial=serial,
                     status="active",
                 )
-                adopted_interfaces = _count_adoptable_interfaces(
-                    target_device,
-                    module,
-                    changeable_interfaces,
-                )
-                if adopted_interfaces is None:
-                    messages.error(request, "A matching interface is not available for module adoption.")
-                    return _modules_redirect_response(request, sync_url, server_key)
-                module._adopt_components = True
-                module.full_clean()
-                module.save()
+                adopted_interfaces = _save_module_with_scoped_interface_adoption(module, changeable_interfaces)
                 vc_adjustments = _normalize_module_interface_names_for_vc_member(
                     target_device,
                     module,
@@ -720,6 +728,8 @@ class InstallModuleView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixin, Li
                     "Installed module, but interface binding was skipped: "
                     f"{bind_result.get('reason', 'unknown reason')}",
                 )
+        except _InterfaceAdoptionUnavailable:
+            messages.error(request, "A matching interface is not available for module adoption.")
         except (ValidationError, IntegrityError) as e:
             messages.error(request, f"Failed to install module: {e}")
 
@@ -1042,22 +1052,19 @@ class InstallBranchView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixin, Li
                     serial=serial,
                     status="active",
                 )
-                adopted_interfaces = _count_adoptable_interfaces(device, module, changeable_interfaces)
-                if adopted_interfaces is None:
-                    return {
-                        "status": "skipped",
-                        "name": name,
-                        "reason": "a matching interface is not available for module adoption",
-                    }
-                module._adopt_components = True
-                module.full_clean()
-                module.save()
+                adopted_interfaces = _save_module_with_scoped_interface_adoption(module, changeable_interfaces)
                 vc_adjustments = _normalize_module_interface_names_for_vc_member(
                     device,
                     module,
                     changeable_interfaces,
                     deletable_interfaces,
                 )
+        except _InterfaceAdoptionUnavailable:
+            return {
+                "status": "skipped",
+                "name": name,
+                "reason": "a matching interface is not available for module adoption",
+            }
         except (ValidationError, IntegrityError) as e:
             error_msg = str(e)
             if "dcim_interface_unique_device_name" in error_msg:
@@ -1950,15 +1957,6 @@ class ReplaceModuleView(LibreNMSPermissionMixin, LibreNMSAPIMixin, NetBoxObjectP
                     serial=serial,
                     status="active",
                 )
-                adopted_interfaces = _count_adoptable_interfaces(
-                    target_device,
-                    new_module,
-                    changeable_interfaces,
-                )
-                if adopted_interfaces is None:
-                    messages.error(request, "A matching interface is not available for module adoption.")
-                    return _modules_redirect_response(request, sync_url, server_key)
-
                 # Re-derive any serial conflict from the database INSIDE the locked
                 # transaction (and lock those rows too) — checking before the lock
                 # opens a TOCTOU window where a concurrent request could change a
@@ -1997,9 +1995,10 @@ class ReplaceModuleView(LibreNMSPermissionMixin, LibreNMSAPIMixin, NetBoxObjectP
                 installed_module.delete()
 
                 # Install fresh module from LibreNMS data
-                new_module._adopt_components = True
-                new_module.full_clean()
-                new_module.save()
+                adopted_interfaces = _save_module_with_scoped_interface_adoption(
+                    new_module,
+                    changeable_interfaces,
+                )
                 vc_adjustments = _normalize_module_interface_names_for_vc_member(
                     target_device,
                     new_module,
@@ -2053,6 +2052,8 @@ class ReplaceModuleView(LibreNMSPermissionMixin, LibreNMSAPIMixin, NetBoxObjectP
                     "Replaced module, but interface binding was skipped: "
                     f"{bind_result.get('reason', 'unknown reason')}",
                 )
+        except _InterfaceAdoptionUnavailable:
+            messages.error(request, "A matching interface is not available for module adoption.")
         except _SerialConflictAmbiguous as exc:
             messages.error(
                 request,

--- a/netbox_librenms_plugin/views/sync/modules.py
+++ b/netbox_librenms_plugin/views/sync/modules.py
@@ -251,7 +251,9 @@ def _count_adoptable_interfaces(device, module, interfaces):
     """Count adoptable interfaces, or return None if the change scope excludes one."""
     from dcim.models import Interface
 
-    template_names = get_module_template_interface_names(device, module)
+    # NetBox adopts standalone components during Module.save() before this plugin rewrites
+    # interface names for a VC member. Check the raw instantiated names that NetBox will use.
+    template_names = get_module_template_interface_names(device, module, rewrite_for_vc=False)
     if not template_names:
         return 0
 

--- a/netbox_librenms_plugin/views/sync/modules.py
+++ b/netbox_librenms_plugin/views/sync/modules.py
@@ -168,7 +168,20 @@ class _SerialConflictUnavailable(Exception):
 
 
 class _ModuleComponentAdoptionUnavailable(Exception):
-    """Abort a module write that adopted a component outside the caller's change scope."""
+    """
+    Abort a module write that adopted a component outside the caller's change scope.
+
+    Carries the component so the operator is told WHICH of the eight adoptable types they lack
+    ``change`` on; without it all three handlers emitted the same untraceable sentence.
+
+    Args:
+        component_model: The component model that could not be adopted, when known.
+    """
+
+    def __init__(self, component_model=None):
+        self.component_model = component_model
+        self.component_label = str(component_model._meta.verbose_name) if component_model is not None else "component"
+        super().__init__(f"{self.component_label} is not available for module adoption")
 
 
 def _get_sync_device_for_inventory(device, server_key):
@@ -316,7 +329,7 @@ def _authorize_adoptable_module_components(module, component_querysets):
 
         allowed = component_querysets.get(component_model)
         if allowed is None or allowed.filter(pk__in=candidate_ids).count() != len(candidate_ids):
-            raise _ModuleComponentAdoptionUnavailable
+            raise _ModuleComponentAdoptionUnavailable(component_model)
         expected_ids[component_model] = candidate_ids
 
     return expected_ids
@@ -355,7 +368,11 @@ def _save_module_with_expected_component_adoption(module, expected_ids):
             if ids:
                 actual_ids[component_model] = ids
         if actual_ids != expected_ids:
-            raise _ModuleComponentAdoptionUnavailable
+            diverged = next(
+                (m for m in component_models if actual_ids.get(m) != expected_ids.get(m)),
+                None,
+            )
+            raise _ModuleComponentAdoptionUnavailable(diverged)
     return sum(len(ids) for ids in actual_ids.values())
 
 
@@ -813,8 +830,8 @@ class InstallModuleView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixin, Li
                     "Installed module, but interface binding was skipped: "
                     f"{bind_result.get('reason', 'unknown reason')}",
                 )
-        except _ModuleComponentAdoptionUnavailable:
-            messages.error(request, "A matching component is not available for module adoption.")
+        except _ModuleComponentAdoptionUnavailable as exc:
+            messages.error(request, f"A matching {exc.component_label} is not available for module adoption.")
         except (ValidationError, IntegrityError) as e:
             messages.error(request, f"Failed to install module: {e}")
 
@@ -1147,11 +1164,11 @@ class InstallBranchView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixin, Li
                     changeable_interfaces,
                     deletable_interfaces,
                 )
-        except _ModuleComponentAdoptionUnavailable:
+        except _ModuleComponentAdoptionUnavailable as exc:
             return {
                 "status": "skipped",
                 "name": name,
-                "reason": "a matching component is not available for module adoption",
+                "reason": f"a matching {exc.component_label} is not available for module adoption",
             }
         except (ValidationError, IntegrityError) as e:
             error_msg = str(e)
@@ -2147,8 +2164,8 @@ class ReplaceModuleView(LibreNMSPermissionMixin, LibreNMSAPIMixin, NetBoxObjectP
                     "Replaced module, but interface binding was skipped: "
                     f"{bind_result.get('reason', 'unknown reason')}",
                 )
-        except _ModuleComponentAdoptionUnavailable:
-            messages.error(request, "A matching component is not available for module adoption.")
+        except _ModuleComponentAdoptionUnavailable as exc:
+            messages.error(request, f"A matching {exc.component_label} is not available for module adoption.")
         except _SerialConflictAmbiguous as exc:
             messages.error(
                 request,

--- a/netbox_librenms_plugin/views/sync/modules.py
+++ b/netbox_librenms_plugin/views/sync/modules.py
@@ -281,13 +281,24 @@ def _restricted_module_component_querysets(view):
     return {model: view.restricted_queryset(model, "change") for _, _, model in _module_component_specs()}
 
 
+def _module_template_adoption_name(template_attribute, template, module):
+    """Return the exact name that the running NetBox version uses for adoption."""
+    if template_attribute == "modulebaytemplates":
+        # NetBox 4.4.0 through 4.4.7 instantiate module-bay names without resolving
+        # placeholders. This template has no dependent lookup, so it is safe before save.
+        return template.instantiate(device=module.device, module=module).name
+    # NetBox 4.4 and 4.5 accept only the module argument. Newer releases also
+    # resolve the device through module.device, so the compatible call is exact.
+    return template.resolve_name(module)
+
+
 def _authorize_adoptable_module_components(module, component_querysets):
     """Lock and authorize the exact standalone components NetBox can adopt."""
     expected_ids = {}
 
     for template_attribute, component_attribute, component_model in _module_component_specs():
         names = [
-            template.resolve_name(device=module.device, module=module)
+            _module_template_adoption_name(template_attribute, template, module)
             for template in getattr(module.module_type, template_attribute).all()
         ]
         if not names:

--- a/netbox_librenms_plugin/views/sync/modules.py
+++ b/netbox_librenms_plugin/views/sync/modules.py
@@ -113,7 +113,7 @@ def _report_install_results(request, installed, skipped, failed):
         messages.warning(request, f"Failed {len(failed)}: {'; '.join(failed)}")
 
 
-def _resolve_target_device_with_validation(page_device, selected_device_id):
+def _resolve_target_device_with_validation(page_device, selected_device_id, devices):
     """Resolve a target device and indicate whether selection input was invalid."""
     if not selected_device_id:
         return page_device, False
@@ -129,15 +129,15 @@ def _resolve_target_device_with_validation(page_device, selected_device_id):
     if not getattr(page_device, "virtual_chassis", None):
         return page_device, True
 
-    member = page_device.virtual_chassis.members.filter(pk=selected_device_id).first()
+    member = devices.filter(pk=selected_device_id, virtual_chassis=page_device.virtual_chassis).first()
     if member is None:
         return page_device, True
     return member, False
 
 
-def _resolve_target_device(page_device, selected_device_id):
+def _resolve_target_device(page_device, selected_device_id, devices):
     """Resolve and validate a target device from row-level VC selection."""
-    target_device, _ = _resolve_target_device_with_validation(page_device, selected_device_id)
+    target_device, _ = _resolve_target_device_with_validation(page_device, selected_device_id, devices)
     return target_device
 
 
@@ -247,21 +247,23 @@ def _select_module_interface_by_coordinates(device, module_interfaces, item):
     return scored[0][2]
 
 
-def _count_adoptable_interfaces(device, module):
-    """Count standalone interfaces that would be adopted during module install."""
+def _count_adoptable_interfaces(device, module, interfaces):
+    """Count adoptable interfaces, or return None if the change scope excludes one."""
     from dcim.models import Interface
 
     template_names = get_module_template_interface_names(device, module)
     if not template_names:
         return 0
 
-    return Interface.objects.filter(device=device, module__isnull=True, name__in=template_names).count()
+    candidates = Interface.objects.filter(device=device, module__isnull=True, name__in=template_names)
+    candidate_count = candidates.count()
+    if interfaces.filter(pk__in=candidates.values("pk")).count() != candidate_count:
+        return None
+    return candidate_count
 
 
-def _adopt_existing_template_interfaces(device, module):
+def _adopt_existing_template_interfaces(device, module, interfaces):
     """Adopt existing standalone interfaces into an already-installed module by template name."""
-    from dcim.models import Interface
-
     template_names = get_module_template_interface_names(device, module)
     if not template_names:
         return {
@@ -269,8 +271,8 @@ def _adopt_existing_template_interfaces(device, module):
             "reason": "this module type has no interface templates to match against",
         }
 
-    interfaces = list(Interface.objects.filter(device=device, module__isnull=True, name__in=template_names))
-    if not interfaces:
+    adoptable = list(interfaces.filter(device=device, module__isnull=True, name__in=template_names))
+    if not adoptable:
         return {
             "status": "skipped",
             "reason": "no matching standalone interfaces found for this module's interface templates",
@@ -278,7 +280,7 @@ def _adopt_existing_template_interfaces(device, module):
 
     adopted_names = []
     with transaction.atomic():
-        for interface in interfaces:
+        for interface in adoptable:
             interface.module = module
             interface.save(update_fields=["module"])
             adopted_names.append(interface.name)
@@ -340,7 +342,12 @@ def _rewrite_interface_name_for_vc_member(interface_name, vc_position, member_po
     )
 
 
-def _normalize_module_interface_names_for_vc_member(device, module):
+def _normalize_module_interface_names_for_vc_member(
+    device,
+    module,
+    changeable_interfaces,
+    deletable_interfaces,
+):
     """
     Normalize module interface names to the selected VC member position.
 
@@ -368,6 +375,9 @@ def _normalize_module_interface_names_for_vc_member(device, module):
     module_interfaces = list(Interface.objects.filter(device=device, module=module).order_by("pk"))
 
     for interface in module_interfaces:
+        if not changeable_interfaces.filter(pk=interface.pk).exists():
+            result["skipped"] += 1
+            continue
         desired_name = _rewrite_interface_name_for_vc_member(
             interface.name,
             vc_position,
@@ -379,6 +389,12 @@ def _normalize_module_interface_names_for_vc_member(device, module):
         conflict = Interface.objects.filter(device=device, name=desired_name).exclude(pk=interface.pk).first()
         if conflict is not None:
             if getattr(conflict, "module_id", None) is None:
+                if not changeable_interfaces.filter(pk=conflict.pk).exists():
+                    result["skipped"] += 1
+                    continue
+                if not deletable_interfaces.filter(pk=interface.pk).exists():
+                    result["skipped"] += 1
+                    continue
                 conflict.module = module
                 conflict.save(update_fields=["module"])
                 result["adopted"] += 1
@@ -420,7 +436,7 @@ def _format_vc_adjustment_summary(adjustments):
     return ", ".join(parts)
 
 
-def _bind_interface_librenms_id(device, item, module_pk, server_key):
+def _bind_interface_librenms_id(device, item, module_pk, server_key, interfaces):
     """
     Bind LibreNMS ``port_id`` to the best matching NetBox interface.
 
@@ -444,6 +460,11 @@ def _bind_interface_librenms_id(device, item, module_pk, server_key):
                 "not reassigning. Resolve the duplicate librenms_id first."
             ),
         }
+    if existing_owner is not None and not interfaces.filter(pk=existing_owner.pk).exists():
+        return {
+            "status": "skipped",
+            "reason": f"matching interface is not available for port_id {port_id}",
+        }
     if existing_owner is not None and existing_owner.device_id != device.pk:
         return {
             "status": "conflict",
@@ -455,10 +476,10 @@ def _bind_interface_librenms_id(device, item, module_pk, server_key):
 
     candidate = existing_owner
     if candidate is None and interface_names:
-        candidate = Interface.objects.filter(device=device, name__in=interface_names).first()
+        candidate = interfaces.filter(device=device, name__in=interface_names).first()
 
     if candidate is None and module_pk:
-        module_interfaces = Interface.objects.filter(device=device, module_id=module_pk)
+        module_interfaces = interfaces.filter(device=device, module_id=module_pk)
         if interface_names:
             candidate = module_interfaces.filter(name__in=interface_names).first()
         if candidate is None:
@@ -577,10 +598,14 @@ class InstallModuleView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixin, Li
 
         page_device = self.restrict_object_or_404(Device, pk=pk)
         target_device, invalid_selected_device = _resolve_target_device_with_validation(
-            page_device, request.POST.get("selected_device_id")
+            page_device,
+            request.POST.get("selected_device_id"),
+            self.restricted_queryset(Device),
         )
         if invalid_selected_device:
             _warn_invalid_selected_device(request)
+        changeable_interfaces = self.restricted_queryset(Interface, "change")
+        deletable_interfaces = self.restricted_queryset(Interface, "delete")
         # Validate the posted server_key against configured servers, else fall back to the active
         # client server (resolve_posted_server_key). A blank key (e.g. a fallback render where
         # module_sync.server_key is empty) OR a forged/unconfigured one must degrade rather than scope
@@ -627,16 +652,34 @@ class InstallModuleView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixin, Li
                     serial=serial,
                     status="active",
                 )
-                adopted_interfaces = _count_adoptable_interfaces(target_device, module)
+                adopted_interfaces = _count_adoptable_interfaces(
+                    target_device,
+                    module,
+                    changeable_interfaces,
+                )
+                if adopted_interfaces is None:
+                    messages.error(request, "A matching interface is not available for module adoption.")
+                    return _modules_redirect_response(request, sync_url, server_key)
                 module._adopt_components = True
                 module.full_clean()
                 module.save()
-                vc_adjustments = _normalize_module_interface_names_for_vc_member(target_device, module)
+                vc_adjustments = _normalize_module_interface_names_for_vc_member(
+                    target_device,
+                    module,
+                    changeable_interfaces,
+                    deletable_interfaces,
+                )
 
             bind_result = None
             if bind_item and server_key:
                 try:
-                    bind_result = _bind_interface_librenms_id(target_device, bind_item, module.pk, server_key)
+                    bind_result = _bind_interface_librenms_id(
+                        target_device,
+                        bind_item,
+                        module.pk,
+                        server_key,
+                        changeable_interfaces,
+                    )
                 except Exception:
                     bind_result = {
                         "status": "failed",
@@ -690,6 +733,8 @@ class InstallBranchView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixin, Li
         self.required_object_permissions = {
             "POST": [
                 ("view", Device),
+                ("view", ModuleBay),
+                ("view", ModuleType),
                 ("add", Module),
                 ("add", Interface),
                 ("change", Interface),
@@ -701,10 +746,15 @@ class InstallBranchView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixin, Li
 
         page_device = self.restrict_object_or_404(Device, pk=pk)
         target_device, invalid_selected_device = _resolve_target_device_with_validation(
-            page_device, request.POST.get("selected_device_id")
+            page_device,
+            request.POST.get("selected_device_id"),
+            self.restricted_queryset(Device),
         )
         if invalid_selected_device:
             _warn_invalid_selected_device(request)
+        module_bays = self.restricted_queryset(ModuleBay)
+        changeable_interfaces = self.restricted_queryset(Interface, "change")
+        deletable_interfaces = self.restricted_queryset(Interface, "delete")
         parent_index = request.POST.get("parent_index")
         server_key = self.resolve_posted_server_key(request.POST)
         sync_url = reverse("plugins:netbox_librenms_plugin:device_librenms_sync", kwargs={"pk": pk})
@@ -742,6 +792,7 @@ class InstallBranchView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixin, Li
 
         # Load module types (with mappings)
         module_types = get_module_types_indexed()
+        allowed_module_type_ids = set(self.restricted_queryset(ModuleType).values_list("pk", flat=True))
 
         # Preload all ModuleBayMappings once to avoid N+1 per-item queries.
         # Filter by device manufacturer so vendor-scoped mappings only apply to
@@ -773,13 +824,14 @@ class InstallBranchView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixin, Li
                         item,
                         index_map,
                         module_types,
-                        ModuleBay,
-                        ModuleType,
-                        Module,
                         exact_mappings=exact_mappings,
                         regex_mappings=regex_mappings,
                         manufacturer_id=mfr_id,
                         norm_rules_bay=norm_rules_bay,
+                        module_bays=module_bays,
+                        allowed_module_type_ids=allowed_module_type_ids,
+                        changeable_interfaces=changeable_interfaces,
+                        deletable_interfaces=deletable_interfaces,
                     )
                     should_bind = _should_attempt_bind_for_result(result)
                     if result["status"] == "installed":
@@ -795,6 +847,7 @@ class InstallBranchView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixin, Li
                             item,
                             result.get("module_pk"),
                             server_key,
+                            changeable_interfaces,
                         )
                         if bind_result and bind_result["status"] != "bound":
                             skipped.append(f"{result['name']}: {bind_result['reason']}")
@@ -893,9 +946,11 @@ class InstallBranchView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixin, Li
         item,
         index_map,
         module_types,
-        ModuleBay,
-        ModuleType,
-        Module,
+        *,
+        module_bays,
+        allowed_module_type_ids,
+        changeable_interfaces,
+        deletable_interfaces,
         exact_mappings=None,
         regex_mappings=None,
         manufacturer_id=None,
@@ -907,6 +962,8 @@ class InstallBranchView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixin, Li
         Re-fetches module bays each time since parent installs create new ones.
         Scopes bay lookup to the correct parent module to handle duplicate bay names.
         """
+        from dcim.models import Module
+
         from netbox_librenms_plugin.utils import resolve_module_type
 
         model_name = (item.get("entPhysicalModelName") or "").strip()
@@ -927,9 +984,11 @@ class InstallBranchView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixin, Li
         matched_type = resolve_module_type(model_name, module_types, manufacturer=manufacturer)
         if not matched_type:
             return {"status": "skipped", "name": name, "reason": "no matching type"}
+        if matched_type.pk not in allowed_module_type_ids:
+            return {"status": "skipped", "name": name, "reason": "no matching type"}
 
         # Re-fetch module bays (parent install creates new child bays)
-        bays = ModuleBay.objects.filter(device=device).select_related("installed_module__module_type")
+        bays = module_bays.filter(device=device).select_related("installed_module__module_type")
 
         # Use preloaded mappings if provided, otherwise load from DB
         if exact_mappings is None or regex_mappings is None:
@@ -962,7 +1021,7 @@ class InstallBranchView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixin, Li
         try:
             with transaction.atomic():  # savepoint: failure here won't abort parent tx
                 locked_bay = (
-                    ModuleBay.objects.select_for_update(of=("self",))
+                    module_bays.select_for_update(of=("self",))
                     .select_related("installed_module")
                     .get(pk=matched_bay.pk)
                 )
@@ -981,11 +1040,22 @@ class InstallBranchView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixin, Li
                     serial=serial,
                     status="active",
                 )
-                adopted_interfaces = _count_adoptable_interfaces(device, module)
+                adopted_interfaces = _count_adoptable_interfaces(device, module, changeable_interfaces)
+                if adopted_interfaces is None:
+                    return {
+                        "status": "skipped",
+                        "name": name,
+                        "reason": "a matching interface is not available for module adoption",
+                    }
                 module._adopt_components = True
                 module.full_clean()
                 module.save()
-                vc_adjustments = _normalize_module_interface_names_for_vc_member(device, module)
+                vc_adjustments = _normalize_module_interface_names_for_vc_member(
+                    device,
+                    module,
+                    changeable_interfaces,
+                    deletable_interfaces,
+                )
         except (ValidationError, IntegrityError) as e:
             error_msg = str(e)
             if "dcim_interface_unique_device_name" in error_msg:
@@ -1248,6 +1318,8 @@ class InstallSelectedView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixin, 
         self.required_object_permissions = {
             "POST": [
                 ("view", Device),
+                ("view", ModuleBay),
+                ("view", ModuleType),
                 ("add", Module),
                 ("add", Interface),
                 ("change", Interface),
@@ -1258,6 +1330,9 @@ class InstallSelectedView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixin, 
             return error
 
         page_device = self.restrict_object_or_404(Device, pk=pk)
+        module_bays = self.restricted_queryset(ModuleBay)
+        changeable_interfaces = self.restricted_queryset(Interface, "change")
+        deletable_interfaces = self.restricted_queryset(Interface, "delete")
         server_key = self.resolve_posted_server_key(request.POST)
         sync_url = reverse("plugins:netbox_librenms_plugin:device_librenms_sync", kwargs={"pk": pk})
 
@@ -1301,6 +1376,7 @@ class InstallSelectedView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixin, 
         from netbox_librenms_plugin.views.base.modules_view import BaseModuleTableView
 
         module_types = get_module_types_indexed()
+        allowed_module_type_ids = set(self.restricted_queryset(ModuleType).values_list("pk", flat=True))
         all_exact, all_regex = load_bay_mappings()
 
         # Preload module_bay normalization rules once so _match_bay considers the
@@ -1318,7 +1394,9 @@ class InstallSelectedView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixin, 
                     ent_index = item.get("entPhysicalIndex")
                     selected_device_id = request.POST.get(f"device_selection_{ent_index}")
                     target_device, invalid_selected_device = _resolve_target_device_with_validation(
-                        page_device, selected_device_id
+                        page_device,
+                        selected_device_id,
+                        self.restricted_queryset(Device),
                     )
                     if invalid_selected_device:
                         invalid_selection_seen = True
@@ -1342,13 +1420,14 @@ class InstallSelectedView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixin, 
                         item,
                         index_map,
                         module_types,
-                        ModuleBay,
-                        ModuleType,
-                        Module,
                         exact_mappings=exact_mappings,
                         regex_mappings=regex_mappings,
                         manufacturer_id=mfr_id,
                         norm_rules_bay=norm_rules_bay,
+                        module_bays=module_bays,
+                        allowed_module_type_ids=allowed_module_type_ids,
+                        changeable_interfaces=changeable_interfaces,
+                        deletable_interfaces=deletable_interfaces,
                     )
                     should_bind = _should_attempt_bind_for_result(result)
                     if result["status"] == "installed":
@@ -1364,6 +1443,7 @@ class InstallSelectedView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixin, 
                             item,
                             result.get("module_pk"),
                             server_key,
+                            changeable_interfaces,
                         )
                         if bind_result and bind_result["status"] != "bound":
                             skipped.append(f"{result['name']}: {bind_result['reason']}")
@@ -1390,7 +1470,9 @@ class UpdateModuleSerialView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixi
 
         page_device = self.restrict_object_or_404(Device, pk=pk)
         target_device, invalid_selected_device = _resolve_target_device_with_validation(
-            page_device, request.POST.get("selected_device_id")
+            page_device,
+            request.POST.get("selected_device_id"),
+            self.restricted_queryset(Device),
         )
         if invalid_selected_device:
             _warn_invalid_selected_device(request)
@@ -1442,26 +1524,30 @@ class UpdateModuleInterfaceView(
         if error := self.require_all_permissions("POST"):
             return error
 
-        page_device = self.restrict_object_or_404(Device, pk=pk)
-        target_device, invalid_selected_device = _resolve_target_device_with_validation(
-            page_device, request.POST.get("selected_device_id")
-        )
-        if invalid_selected_device:
-            _warn_invalid_selected_device(request)
-        # Validate the posted server_key against configured servers, else fall back to the active
-        # client server (mirrors InstallModuleView via resolve_posted_server_key). A blank key (stale
-        # tab / fallback render) OR a forged/unconfigured one degrades to the active server rather than
-        # scoping under a bogus namespace. Without a usable key the port-bind is skipped AND the
-        # adopt/merge runs without a server scope, so the raw twin's LibreNMS binding can't transfer.
+        # Resolve redirect context and validate the row identifier before any target or cache lookup.
         server_key = self.resolve_posted_server_key(request.POST)
-        bind_item = _resolve_single_install_binding_item(request, target_device, server_key, self.get_cache_key)
         sync_url = reverse("plugins:netbox_librenms_plugin:device_librenms_sync", kwargs={"pk": pk})
-
         try:
             module_id = int(request.POST.get("module_id"))
         except (TypeError, ValueError):
             messages.error(request, "Missing or invalid module ID.")
             return _modules_redirect_response(request, sync_url, server_key)
+
+        page_device = self.restrict_object_or_404(Device, pk=pk)
+        target_device, invalid_selected_device = _resolve_target_device_with_validation(
+            page_device,
+            request.POST.get("selected_device_id"),
+            self.restricted_queryset(Device),
+        )
+        if invalid_selected_device:
+            _warn_invalid_selected_device(request)
+        changeable_interfaces = self.restricted_queryset(Interface, "change")
+        # Validate the posted server_key against configured servers, else fall back to the active
+        # client server (mirrors InstallModuleView via resolve_posted_server_key). A blank key (stale
+        # tab / fallback render) OR a forged/unconfigured one degrades to the active server rather than
+        # scoping under a bogus namespace. Without a usable key the port-bind is skipped AND the
+        # adopt/merge runs without a server scope, so the raw twin's LibreNMS binding can't transfer.
+        bind_item = _resolve_single_install_binding_item(request, target_device, server_key, self.get_cache_key)
 
         module = self.restrict_object_or_404(Module, "view", pk=module_id, device=target_device)
 
@@ -1475,7 +1561,13 @@ class UpdateModuleInterfaceView(
         primary_bind_attempted = bool(bind_item and server_key)
         try:
             if primary_bind_attempted:
-                bind_result = _bind_interface_librenms_id(target_device, bind_item, module.pk, server_key)
+                bind_result = _bind_interface_librenms_id(
+                    target_device,
+                    bind_item,
+                    module.pk,
+                    server_key,
+                    changeable_interfaces,
+                )
         except Exception:
             logger.exception(
                 "Unexpected error binding interface to module (device %s, module %s)",
@@ -1503,7 +1595,11 @@ class UpdateModuleInterfaceView(
                 }
             elif bind_result is None or bind_result.get("status") == "bound":
                 try:
-                    adopt_result = _adopt_existing_template_interfaces(target_device, module)
+                    adopt_result = _adopt_existing_template_interfaces(
+                        target_device,
+                        module,
+                        changeable_interfaces,
+                    )
                 except Exception:
                     logger.exception(
                         "Unexpected error adopting standalone template interfaces (device %s, module %s)",
@@ -1575,7 +1671,9 @@ class ModuleMismatchPreviewView(
 
         page_device = self.restrict_object_or_404(Device, pk=pk)
         target_device, invalid_selected_device = _resolve_target_device_with_validation(
-            page_device, request.GET.get("selected_device_id")
+            page_device,
+            request.GET.get("selected_device_id"),
+            self.restricted_queryset(Device),
         )
         if invalid_selected_device:
             _warn_invalid_selected_device(request)
@@ -1691,17 +1789,19 @@ class VCNormalizationReportView(LibreNMSPermissionMixin, NetBoxObjectPermissionM
         if error := self.require_object_permissions("GET"):
             return error
 
-        page_device = self.restrict_object_or_404(Device, pk=pk)
-        target_device, invalid_selected_device = _resolve_target_device_with_validation(
-            page_device, request.GET.get("selected_device_id")
-        )
-        if invalid_selected_device:
-            _warn_invalid_selected_device(request)
-
         try:
             module_id = int(request.GET.get("module_id"))
         except (TypeError, ValueError):
             return HttpResponse("Missing or invalid module_id.", status=400)
+
+        page_device = self.restrict_object_or_404(Device, pk=pk)
+        target_device, invalid_selected_device = _resolve_target_device_with_validation(
+            page_device,
+            request.GET.get("selected_device_id"),
+            self.restricted_queryset(Device),
+        )
+        if invalid_selected_device:
+            _warn_invalid_selected_device(request)
 
         module = self.restrict_object_or_404(
             Module,
@@ -1741,6 +1841,7 @@ class ReplaceModuleView(LibreNMSPermissionMixin, LibreNMSAPIMixin, NetBoxObjectP
         self.required_object_permissions = {
             "POST": [
                 ("view", Device),
+                ("view", ModuleType),
                 ("add", Module),
                 ("change", Module),
                 ("delete", Module),
@@ -1754,10 +1855,14 @@ class ReplaceModuleView(LibreNMSPermissionMixin, LibreNMSAPIMixin, NetBoxObjectP
 
         page_device = self.restrict_object_or_404(Device, pk=pk)
         target_device, invalid_selected_device = _resolve_target_device_with_validation(
-            page_device, request.POST.get("selected_device_id")
+            page_device,
+            request.POST.get("selected_device_id"),
+            self.restricted_queryset(Device),
         )
         if invalid_selected_device:
             _warn_invalid_selected_device(request)
+        changeable_interfaces = self.restricted_queryset(Interface, "change")
+        deletable_interfaces = self.restricted_queryset(Interface, "delete")
         server_key = self.resolve_posted_server_key(request.POST)
         sync_url = reverse("plugins:netbox_librenms_plugin:device_librenms_sync", kwargs={"pk": pk})
 
@@ -1806,6 +1911,9 @@ class ReplaceModuleView(LibreNMSPermissionMixin, LibreNMSAPIMixin, NetBoxObjectP
         if not matched_type:
             messages.error(request, f"No matching module type found for '{model_name}'.")
             return _modules_redirect_response(request, sync_url, server_key)
+        if not self.restricted_queryset(ModuleType).filter(pk=matched_type.pk).exists():
+            messages.error(request, f"No matching module type found for '{model_name}'.")
+            return _modules_redirect_response(request, sync_url, server_key)
 
         try:
             conflict_removed_msg = None
@@ -1833,6 +1941,21 @@ class ReplaceModuleView(LibreNMSPermissionMixin, LibreNMSAPIMixin, NetBoxObjectP
                 target_bay = installed_module.module_bay
                 old_type_name = installed_module.module_type.model
                 old_bay_name = target_bay.name
+                new_module = Module(
+                    device=target_device,
+                    module_bay=target_bay,
+                    module_type=matched_type,
+                    serial=serial,
+                    status="active",
+                )
+                adopted_interfaces = _count_adoptable_interfaces(
+                    target_device,
+                    new_module,
+                    changeable_interfaces,
+                )
+                if adopted_interfaces is None:
+                    messages.error(request, "A matching interface is not available for module adoption.")
+                    return _modules_redirect_response(request, sync_url, server_key)
 
                 # Re-derive any serial conflict from the database INSIDE the locked
                 # transaction (and lock those rows too) — checking before the lock
@@ -1872,22 +1995,25 @@ class ReplaceModuleView(LibreNMSPermissionMixin, LibreNMSAPIMixin, NetBoxObjectP
                 installed_module.delete()
 
                 # Install fresh module from LibreNMS data
-                new_module = Module(
-                    device=target_device,
-                    module_bay=target_bay,
-                    module_type=matched_type,
-                    serial=serial,
-                    status="active",
-                )
-                adopted_interfaces = _count_adoptable_interfaces(target_device, new_module)
                 new_module._adopt_components = True
                 new_module.full_clean()
                 new_module.save()
-                vc_adjustments = _normalize_module_interface_names_for_vc_member(target_device, new_module)
+                vc_adjustments = _normalize_module_interface_names_for_vc_member(
+                    target_device,
+                    new_module,
+                    changeable_interfaces,
+                    deletable_interfaces,
+                )
 
             if server_key:
                 try:
-                    bind_result = _bind_interface_librenms_id(target_device, librenms_item, new_module.pk, server_key)
+                    bind_result = _bind_interface_librenms_id(
+                        target_device,
+                        librenms_item,
+                        new_module.pk,
+                        server_key,
+                        changeable_interfaces,
+                    )
                 except Exception:
                     bind_result = {
                         "status": "failed",
@@ -1976,7 +2102,9 @@ class MoveModuleView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixin, View)
 
         page_device = self.restrict_object_or_404(Device, pk=pk)
         target_device, invalid_selected_device = _resolve_target_device_with_validation(
-            page_device, request.POST.get("selected_device_id")
+            page_device,
+            request.POST.get("selected_device_id"),
+            self.restricted_queryset(Device),
         )
         if invalid_selected_device:
             _warn_invalid_selected_device(request)

--- a/netbox_librenms_plugin/views/sync/modules.py
+++ b/netbox_librenms_plugin/views/sync/modules.py
@@ -287,7 +287,7 @@ def _authorize_adoptable_module_components(module, component_querysets):
 
     for template_attribute, component_attribute, component_model in _module_component_specs():
         names = [
-            template.instantiate(device=module.device, module=module).name
+            template.resolve_name(device=module.device, module=module)
             for template in getattr(module.module_type, template_attribute).all()
         ]
         if not names:
@@ -311,8 +311,8 @@ def _authorize_adoptable_module_components(module, component_querysets):
     return expected_ids
 
 
-def _save_module_with_scoped_component_adoption(module, component_querysets):
-    """Save a module after authorizing and locking every component NetBox can adopt."""
+def _save_module_with_expected_component_adoption(module, expected_ids):
+    """Save a module and verify that NetBox adopted only the expected components."""
     from django.db.models.signals import post_save
 
     component_models = tuple(spec[2] for spec in _module_component_specs())
@@ -328,7 +328,6 @@ def _save_module_with_scoped_component_adoption(module, component_querysets):
             adopted_ids[sender].add(instance.pk)
 
     with transaction.atomic():
-        expected_ids = _authorize_adoptable_module_components(module, component_querysets)
         module._adopt_components = True
         module.full_clean()
         for component_model in component_models:
@@ -347,6 +346,13 @@ def _save_module_with_scoped_component_adoption(module, component_querysets):
         if actual_ids != expected_ids:
             raise _ModuleComponentAdoptionUnavailable
     return sum(len(ids) for ids in actual_ids.values())
+
+
+def _save_module_with_scoped_component_adoption(module, component_querysets):
+    """Authorize, lock, and save every component NetBox can adopt."""
+    with transaction.atomic():
+        expected_ids = _authorize_adoptable_module_components(module, component_querysets)
+        return _save_module_with_expected_component_adoption(module, expected_ids)
 
 
 def _adopt_existing_template_interfaces(device, module, interfaces):
@@ -2031,6 +2037,10 @@ class ReplaceModuleView(LibreNMSPermissionMixin, LibreNMSAPIMixin, NetBoxObjectP
                     serial=serial,
                     status="active",
                 )
+                expected_component_ids = _authorize_adoptable_module_components(
+                    new_module,
+                    changeable_components,
+                )
                 # Re-derive any serial conflict from the database INSIDE the locked
                 # transaction (and lock those rows too) — checking before the lock
                 # opens a TOCTOU window where a concurrent request could change a
@@ -2069,9 +2079,9 @@ class ReplaceModuleView(LibreNMSPermissionMixin, LibreNMSAPIMixin, NetBoxObjectP
                 installed_module.delete()
 
                 # Install fresh module from LibreNMS data
-                adopted_components = _save_module_with_scoped_component_adoption(
+                adopted_components = _save_module_with_expected_component_adoption(
                     new_module,
-                    changeable_components,
+                    expected_component_ids,
                 )
                 vc_adjustments = _normalize_module_interface_names_for_vc_member(
                     target_device,

--- a/netbox_librenms_plugin/views/sync/vlans.py
+++ b/netbox_librenms_plugin/views/sync/vlans.py
@@ -126,6 +126,7 @@ class SyncVLANsView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixin, LibreN
         permission_skipped_count = 0
         ambiguous_count = 0
         concurrent_change_count = 0
+        invalid_vid_count = 0
         invalid_name_count = 0
         changeable_vlans = self.restricted_queryset(VLAN, "change")
 
@@ -176,6 +177,12 @@ class SyncVLANsView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixin, LibreN
                         continue
 
                 librenms_name = vlan_data.get("vlan_name", f"VLAN {vid}")
+                try:
+                    VLAN._meta.get_field("vid").clean(vid, None)
+                except ValidationError:
+                    messages.error(request, f"VLAN {vid}: the LibreNMS VID is invalid; skipped.")
+                    invalid_vid_count += 1
+                    continue
                 try:
                     VLAN._meta.get_field("name").clean(librenms_name, None)
                 except ValidationError:
@@ -268,6 +275,8 @@ class SyncVLANsView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixin, LibreN
             skip_reasons.append(f"{ambiguous_count} skipped (VLAN match ambiguous)")
         if concurrent_change_count > 0:
             skip_reasons.append(f"{concurrent_change_count} skipped (concurrent VLAN change)")
+        if invalid_vid_count > 0:
+            skip_reasons.append(f"{invalid_vid_count} skipped (invalid VLAN VID)")
         if invalid_name_count > 0:
             skip_reasons.append(f"{invalid_name_count} skipped (invalid VLAN name)")
 

--- a/netbox_librenms_plugin/views/sync/vlans.py
+++ b/netbox_librenms_plugin/views/sync/vlans.py
@@ -141,7 +141,7 @@ class SyncVLANsView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixin, LibreN
                     vid = int(vid_str)
                 except ValueError:
                     continue
-                if vid_str in librenms_vlans and not request.POST.get(f"vlan_group_{vid}", ""):
+                if str(vid) in librenms_vlans and not request.POST.get(f"vlan_group_{vid}", ""):
                     global_vids.append(vid)
             _acquire_global_vlan_locks(global_vids)
 
@@ -151,7 +151,7 @@ class SyncVLANsView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixin, LibreN
                 except ValueError:
                     continue
 
-                vlan_data = librenms_vlans.get(vid_str)
+                vlan_data = librenms_vlans.get(str(vid))
                 if not vlan_data:
                     continue
 

--- a/netbox_librenms_plugin/views/sync/vlans.py
+++ b/netbox_librenms_plugin/views/sync/vlans.py
@@ -245,6 +245,17 @@ class SyncVLANsView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixin, LibreN
                         permission_skipped_count += 1
                         continue
 
+                    # The advisory lock above covers global VIDs only, so a grouped row is still
+                    # unprotected between this scope check and the save below.
+                    vlan = self.relock_scoped_row(VLAN, pk=vlan.pk)
+                    if vlan is None:
+                        messages.error(
+                            request,
+                            f"VLAN {vid}: the VLAN could not be resolved after a concurrent change; skipped.",
+                        )
+                        concurrent_change_count += 1
+                        continue
+
                 if created:
                     created_count += 1
                 elif vlan.name != librenms_name:


### PR DESCRIPTION
## Summary

Makes each protected view find objects through a queryset that applies the user permissions.

## Motivation / Problem

Bug: A limited NetBox permission could pass the first check. The view could then use a raw ID lookup to read or change an object outside that permission.

## Scope of Change

- Sync/Import logic
- NetBox models / ORM
- Tests

## How Was This Tested?

- Unit tests: yes.  The permission tests use the real view, database, user, limited `ObjectPermission`, and NetBox `restrict()` behavior. Each test failed before the fix and passed after it.
- Manual testing: no.

## Risk Assessment

- Existing users: Users with limited permissions can no longer access objects outside those permissions. These requests now return 404 or omit the restricted row. Other users are not affected.
- Unintended imports or updates: no. Device selection does not change.

## Backwards Compatibility

There are no breaking changes for authorized use. The fix stops access that should not have been allowed.

## Other Notes

- This PR changes 41 lookups in eight view modules. Two static checks prevent new raw ID lookups in protected views and cache keys without `server_key` plus three more view modules (bulk-import actions, location sync, legacy-ID migration), plus the secondary lookups and the delete targets that take an ID from the client after additional review.
- Derived targets. An interface, an IP address, or a module component that the sync finds by name or by relationship is now checked against a `change`-scoped queryset before it is written, and locked so a concurrent request cannot change it after the check.
- Module adoption. NetBox adopts standalone components when it installs a module. Each adoptable component is now locked and authorized first, in the replace path too, before the old module is deleted. The adoption name is resolved the way the running NetBox version resolves it.
- A posted selection that fails its restricted lookup (a VRF, an interface, a VLAN) now reports the error. It does not continue with no selection and does not fall back to another object.
- Two more static checks, four in total: a posted selection must not fail open, and a restricted row lock must use `select_for_update(of=("self",))` so it does not lock the permission join.
- The tests for these views now run against real objects, a real database, and a real permission gate instead of ORM mocks.

