### PR TITLE
ci: make Ruff lint/format version-independent

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,8 +52,12 @@ addopts = "-v --tb=short"
 
 [tool.ruff]
 line-length = 120
+# Python only (skip Ruff Markdown formatting).
+extend-exclude = ["*.md"]
 
 [tool.ruff.lint]
+# Explicit defaults; stable across Ruff versions.
+select = ["E4", "E7", "E9", "F"]
 # Follow NetBox conventions - ignore certain rules
 ignore = [
     "E501",  # Line too long (strongly encouraged but not enforced)


### PR DESCRIPTION
## Summary

Ports the ruff configuration fix from `develop` (commit `1cc3aace`) to `master`.

The `Lint and Format` CI job installs ruff unpinned (`pip install ruff`). Ruff 0.16.0 broadened its default lint rule set and began formatting Markdown, so CI started failing on unrelated, pre-existing code on any PR targeting `master` (e.g. the Dependabot PR #329).

This fixes the root cause instead of pinning the ruff version:

- `select = ["E4", "E7", "E9", "F"]` — declares the lint rule set explicitly so results are stable across ruff versions.
- `extend-exclude = ["*.md"]` — keeps the formatter to Python only.

Verified locally: both `ruff check .` and `ruff format --check .` pass.

## Context

This change already exists on `develop` but had not been merged to `master`, which is why PRs targeting `master` show a red `Lint and Format` check despite the code being clean.
