### PR TITLE
Fix generic view object permissions

### DIFF
--- a/docs/usage_tips/permissions.md
+++ b/docs/usage_tips/permissions.md
@@ -22,7 +22,7 @@ A user needs both tiers of permissions to complete an action. For example, to vi
 1. **Tier 1: Plugin permission**: User needs View AND Change permission on **LibreNMS Settings**
 
     - View: allows access to the plugin pages and pulling data from LibreNMS.
-    - Change: allows performing actions that modify Netbox or Librenms data
+    - Change: together with View, allows performing actions that modify NetBox or LibreNMS data
 
 The Plugin also enforces Netbox object permissions so the following permission would also be required:
 
@@ -53,14 +53,15 @@ To grant a user or group access to the plugin:
 
 NetBox object permissions are created similarly but for different object types (DCIM, IPAM, VIRTUALIZATION, etc.).
 
-### Interface Type Mapping Permissions
+### Mapping & Rule Permissions
 
-The Interface Type Mapping feature uses its own object permissions in addition to the plugin permissions. To manage interface mappings, users need:
+Each mapping and rule feature uses its own object permissions in addition to the plugin permissions. To manage a mapping or rule, users need:
 
 - **Plugin permission**: View permission on LibreNMS Settings (to access the page)
-- **Object permissions**: `netbox_librenms_plugin.add_interfacetypemapping`, `netbox_librenms_plugin.change_interfacetypemapping`, or `netbox_librenms_plugin.delete_interfacetypemapping` as needed
+- **Plugin write permission**: Change permission on LibreNMS Settings, in addition to View, for create, edit, delete, bulk import, and bulk delete actions
+- **Object permissions**: the matching `netbox_librenms_plugin.add_*`, `change_*`, `delete_*`, or `view_*` permission as needed
 
-These permissions are enforced automatically by NetBox's generic views.
+NetBox's generic views enforce both the plugin gate and the mapping/rule model permission. Where an object permission is constrained, NetBox also filters the queryset so a user can see and act on only the permitted records.
 
 
 ## Example Scenarios
@@ -89,13 +90,13 @@ Plugins permissions use the **LibreNMS Settings** model permissions:
 | Permission | NetBox UI Selection | Grants |
 |------------|---------------------|--------|
 | `view_librenmssettings` | LibreNMS Settings → ☑ Can view | Access all plugin pages, view LibreNMS data |
-| `change_librenmssettings` | LibreNMS Settings → ☑ Can change | Import devices, sync data, save settings |
+| `change_librenmssettings` | LibreNMS Settings → ☑ Can change | Together with View: import devices, sync data, save settings, and manage plugin mapping/rule records |
 
-Users without View permission won't see the LibreNMS menu or the LibreNMS Sync tab. Users with **View** but not **Change** can browse all plugin pages but cannot perform import or sync actions that modify Netbox data and Librenms data like Locations and Adding devices.
+Users without View permission won't see the LibreNMS menu or the LibreNMS Sync tab. Users with **View** but not **Change** can use read-only plugin features, subject to the applicable NetBox object permissions, but cannot perform actions that modify NetBox or LibreNMS data.
 
 ### Tier 2: NetBox Object Permissions
 
-When the plugin creates or modifies NetBox objects (devices, interfaces, cables, IP addresses, VLANs), NetBox enforces its standard object permissions. The plugin checks these permissions and will block operations if the user lacks the required access.
+When the plugin lists, reads, creates, or modifies NetBox objects (including devices, interfaces, cables, IP addresses, VLANs, virtual machines, and plugin mapping/rule records), NetBox enforces its standard object permissions. The plugin checks these permissions and will block operations if the user lacks the required access. Object permission constraints also limit the NetBox objects returned by plugin pages.
 
 | Plugin Action | Required Object Permissions |
 |---------------|----------------------------|
@@ -125,6 +126,12 @@ To control access to these pages, the plugin uses the **LibreNMS Settings** mode
 - **Single permission per access level** — One "View" permission for read access, one "Change" permission for write access
 
 While using a settings model for access control may seem unconventional, it provides a simple and maintainable way to gate plugin access without introducing custom permission infrastructure.
+
+### Cached LibreNMS Data and NetBox Objects
+
+LibreNMS API responses and validation data are cached plugin data rather than NetBox database models, so NetBox cannot apply queryset-based object permissions directly to those cache entries. The LibreNMS Settings permissions therefore gate access to the integration and its cached data.
+
+When a page also reads or presents NetBox objects, both permission tiers apply. For example, the import page requires plugin View and `dcim.view_device`; Device and VM status pages require plugin View plus `dcim.view_device` or `virtualization.view_virtualmachine`. This preserves the integration gate without allowing a cached-data feature to bypass the user's NetBox object scope.
 
 
 ## Special note: Background Jobs and Superuser Access

--- a/netbox_librenms_plugin/static/netbox_librenms_plugin/js/librenms_sync.js
+++ b/netbox_librenms_plugin/static/netbox_librenms_plugin/js/librenms_sync.js
@@ -155,6 +155,54 @@ function fetchErrorMessage(response) {
 }
 
 /**
+ * Show an error in NetBox's standard Django-message toast area.
+ *
+ * @param {string} message
+ */
+function showErrorToast(message) {
+    const container = document.getElementById('django-messages');
+    const text = String(message || 'Server error').trim();
+
+    if (!container) {
+        console.error('LibreNMS plugin error:', text);
+        return;
+    }
+
+    const toast = document.createElement('div');
+    toast.className = 'toast toast-dark border-0 shadow-sm';
+    toast.setAttribute('role', 'alert');
+    toast.setAttribute('aria-live', 'assertive');
+    toast.setAttribute('aria-atomic', 'true');
+    toast.setAttribute('data-bs-delay', '12000');
+
+    const header = document.createElement('div');
+    header.className = 'toast-header text-bg-danger';
+    const icon = document.createElement('i');
+    icon.className = 'mdi mdi-alert-circle me-1';
+    header.appendChild(icon);
+    header.appendChild(document.createTextNode(' Error'));
+    const closeButton = document.createElement('button');
+    closeButton.type = 'button';
+    closeButton.className = 'btn-close me-0 m-auto';
+    closeButton.setAttribute('data-bs-dismiss', 'toast');
+    closeButton.setAttribute('aria-label', 'Close');
+    header.appendChild(closeButton);
+
+    const body = document.createElement('div');
+    body.className = 'toast-body';
+    body.textContent = text;
+
+    toast.appendChild(header);
+    toast.appendChild(body);
+    container.appendChild(toast);
+    // NetBox bundles Bootstrap as an ES module, so `window.bootstrap` is not
+    // available to plugin scripts. Display the standard toast markup directly.
+    toast.classList.add('show');
+    closeButton.addEventListener('click', () => toast.remove());
+    window.setTimeout(() => toast.remove(), 12000);
+}
+
+/**
  * Extract device/VM ID and type from current URL pathname.
  * Supports multiple URL patterns:
  * - /dcim/devices/{id}/
@@ -1997,11 +2045,14 @@ function deleteSelectedInterfaces(selectedCheckboxes) {
                     window.location.reload();
                 }
             } else {
-                alert('Error: ' + (data.error || 'Unknown error occurred'));
+                const message = data.error || 'Unknown error occurred';
+                console.error('Error deleting interfaces:', message);
+                showErrorToast(message);
             }
         })
         .catch(error => {
-            alert('Error deleting interfaces: ' + error.message);
+            console.error('Error deleting interfaces:', error);
+            showErrorToast('Error deleting interfaces: ' + error.message);
         })
         .finally(() => {
             // Restore button state

--- a/netbox_librenms_plugin/tests/test_coverage_sync_views3.py
+++ b/netbox_librenms_plugin/tests/test_coverage_sync_views3.py
@@ -404,6 +404,7 @@ class TestDeleteNetBoxInterfacesPost:
         response = _post(_make_dv(req), req, object_type="device", object_id=dev.pk)
 
         assert response.status_code == 403
+        assert self._payload(response)["error"] == "Missing permissions: dcim.delete_interface"
         assert Interface.objects.filter(pk=iface.pk).exists()
 
     def test_invalid_object_type_raises_http404(self):

--- a/netbox_librenms_plugin/tests/test_permissions.py
+++ b/netbox_librenms_plugin/tests/test_permissions.py
@@ -137,6 +137,36 @@ class TestLibreNMSPermissionMixin:
         assert content["error"] == "Custom denied message"
 
 
+class TestLibreNMSGenericPermissionMixins:
+    """Generic view mixins must supplement NetBox permissions without replacing them."""
+
+    def test_read_mixin_requires_plugin_view_permission(self):
+        from netbox_librenms_plugin.constants import PERM_VIEW_PLUGIN
+        from netbox_librenms_plugin.views.mixins import LibreNMSGenericPermissionMixin
+
+        assert LibreNMSGenericPermissionMixin.additional_permissions == (PERM_VIEW_PLUGIN,)
+
+    def test_write_mixin_requires_plugin_view_and_change_permissions(self):
+        from netbox_librenms_plugin.constants import PERM_CHANGE_PLUGIN, PERM_VIEW_PLUGIN
+        from netbox_librenms_plugin.views.mixins import LibreNMSGenericWritePermissionMixin
+
+        assert LibreNMSGenericWritePermissionMixin.additional_permissions == (
+            PERM_VIEW_PLUGIN,
+            PERM_CHANGE_PLUGIN,
+        )
+
+    def test_generic_mixins_do_not_inherit_django_permission_required_mixin(self):
+        from django.contrib.auth.mixins import PermissionRequiredMixin
+
+        from netbox_librenms_plugin.views.mixins import (
+            LibreNMSGenericPermissionMixin,
+            LibreNMSGenericWritePermissionMixin,
+        )
+
+        assert PermissionRequiredMixin not in LibreNMSGenericPermissionMixin.__mro__
+        assert PermissionRequiredMixin not in LibreNMSGenericWritePermissionMixin.__mro__
+
+
 class TestAPIPermissions:
     """Tests for API permission class."""
 

--- a/netbox_librenms_plugin/tests/test_platform_mapping.py
+++ b/netbox_librenms_plugin/tests/test_platform_mapping.py
@@ -462,6 +462,7 @@ class TestBulkExportYAMLView:
 
         mock_qs = MagicMock()
         mock_qs.filter.return_value.order_by.return_value = [mock_mapping, mock_mapping]
+        mock_qs.model.objects.restrict.return_value = mock_qs
         view.queryset = mock_qs
 
         with patch.object(view, "require_object_permissions", return_value=None):
@@ -481,6 +482,7 @@ class TestBulkExportYAMLView:
 
         mock_qs = MagicMock()
         mock_qs.filter.return_value.order_by.return_value = [mock_mapping]
+        mock_qs.model.objects.restrict.return_value = mock_qs
         view.queryset = mock_qs
 
         with patch.object(view, "require_object_permissions", return_value=None):
@@ -497,6 +499,7 @@ class TestBulkExportYAMLView:
         request = self._make_request(["3", "7"])
 
         mock_qs = MagicMock()
+        mock_qs.model.objects.restrict.return_value = mock_qs
         view.queryset = mock_qs
 
         with patch.object(view, "require_object_permissions", return_value=None):

--- a/netbox_librenms_plugin/tests/test_platform_mapping.py
+++ b/netbox_librenms_plugin/tests/test_platform_mapping.py
@@ -461,14 +461,17 @@ class TestBulkExportYAMLView:
         mock_mapping.to_yaml.return_value = "librenms_hardware: Cisco 4321\n"
 
         mock_qs = MagicMock()
-        mock_qs.filter.return_value.order_by.return_value = [mock_mapping, mock_mapping]
-        mock_qs.model.objects.restrict.return_value = mock_qs
+        restricted_qs = MagicMock()
+        restricted_qs.filter.return_value.order_by.return_value = [mock_mapping, mock_mapping]
+        mock_qs.model.objects.restrict.return_value = restricted_qs
         view.queryset = mock_qs
 
         with patch.object(view, "require_object_permissions", return_value=None):
             response = view.post(request)
 
         assert "text/yaml" in response.get("Content-Type", "")
+        mock_qs.model.objects.restrict.assert_called_once_with(request.user, "view")
+        restricted_qs.filter.assert_called_once_with(pk__in=[1, 2])
 
     def test_returns_yaml_for_selected_pks(self):
         """Response body contains YAML from selected objects."""
@@ -481,8 +484,9 @@ class TestBulkExportYAMLView:
         mock_mapping.to_yaml.return_value = "librenms_hardware: Cisco 4321\n"
 
         mock_qs = MagicMock()
-        mock_qs.filter.return_value.order_by.return_value = [mock_mapping]
-        mock_qs.model.objects.restrict.return_value = mock_qs
+        restricted_qs = MagicMock()
+        restricted_qs.filter.return_value.order_by.return_value = [mock_mapping]
+        mock_qs.model.objects.restrict.return_value = restricted_qs
         view.queryset = mock_qs
 
         with patch.object(view, "require_object_permissions", return_value=None):
@@ -490,23 +494,28 @@ class TestBulkExportYAMLView:
 
         content = response.content.decode()
         assert "Cisco 4321" in content
+        mock_qs.model.objects.restrict.assert_called_once_with(request.user, "view")
+        restricted_qs.filter.assert_called_once_with(pk__in=[1])
 
     def test_filters_by_selected_pks(self):
-        """View filters queryset by the selected PKs from POST data."""
+        """View filters the user-restricted queryset by the selected PKs from POST data."""
         from netbox_librenms_plugin.views.mapping_views import DeviceTypeMappingBulkExportYAMLView
 
         view = DeviceTypeMappingBulkExportYAMLView.__new__(DeviceTypeMappingBulkExportYAMLView)
         request = self._make_request(["3", "7"])
 
         mock_qs = MagicMock()
-        mock_qs.model.objects.restrict.return_value = mock_qs
+        restricted_qs = MagicMock()
+        mock_qs.model.objects.restrict.return_value = restricted_qs
         view.queryset = mock_qs
 
         with patch.object(view, "require_object_permissions", return_value=None):
             view.post(request)
 
-        mock_qs.filter.assert_called_once_with(pk__in=[3, 7])
-        mock_qs.filter.return_value.order_by.assert_called_once_with("pk")
+        mock_qs.model.objects.restrict.assert_called_once_with(request.user, "view")
+        mock_qs.filter.assert_not_called()
+        restricted_qs.filter.assert_called_once_with(pk__in=[3, 7])
+        restricted_qs.filter.return_value.order_by.assert_called_once_with("pk")
 
     def test_returns_200_with_empty_selection(self):
         """Response is 400 when no PKs are selected."""

--- a/netbox_librenms_plugin/tests/test_view_wiring.py
+++ b/netbox_librenms_plugin/tests/test_view_wiring.py
@@ -133,6 +133,34 @@ class TestPermissionMixinWiring:
         self._assert_has_permission_mixin(AddDeviceToLibreNMSView)
 
 
+class TestGenericViewPermissionWiring:
+    """Generic views must retain NetBox's queryset-restricting permission mixin."""
+
+    def test_generic_views_use_netbox_object_permission_mixin(self):
+        from django.contrib.auth.mixins import PermissionRequiredMixin
+        from utilities.views import ObjectPermissionRequiredMixin
+
+        from netbox_librenms_plugin.views.imports.list import LibreNMSImportView
+        from netbox_librenms_plugin.views.mapping_views import (
+            LocationMappingCreateView,
+            LocationMappingListView,
+        )
+        from netbox_librenms_plugin.views.status_check import DeviceStatusListView, VMStatusListView
+
+        generic_views = (
+            LocationMappingListView,
+            LocationMappingCreateView,
+            LibreNMSImportView,
+            DeviceStatusListView,
+            VMStatusListView,
+        )
+
+        for view_class in generic_views:
+            assert view_class.has_permission is ObjectPermissionRequiredMixin.has_permission
+            assert ObjectPermissionRequiredMixin in view_class.__mro__
+            assert PermissionRequiredMixin not in view_class.__mro__
+
+
 class TestRequiredObjectPermissionsWiring:
     """
     POST-only sync views that modify NetBox objects must declare required_object_permissions

--- a/netbox_librenms_plugin/tests/test_view_wiring.py
+++ b/netbox_librenms_plugin/tests/test_view_wiring.py
@@ -140,25 +140,36 @@ class TestGenericViewPermissionWiring:
         from django.contrib.auth.mixins import PermissionRequiredMixin
         from utilities.views import ObjectPermissionRequiredMixin
 
+        from netbox_librenms_plugin.constants import PERM_CHANGE_PLUGIN, PERM_VIEW_PLUGIN
         from netbox_librenms_plugin.views.imports.list import LibreNMSImportView
         from netbox_librenms_plugin.views.mapping_views import (
             LocationMappingCreateView,
             LocationMappingListView,
         )
+        from netbox_librenms_plugin.views.mixins import (
+            LibreNMSGenericPermissionMixin,
+            LibreNMSGenericWritePermissionMixin,
+        )
         from netbox_librenms_plugin.views.status_check import DeviceStatusListView, VMStatusListView
 
         generic_views = (
-            LocationMappingListView,
-            LocationMappingCreateView,
-            LibreNMSImportView,
-            DeviceStatusListView,
-            VMStatusListView,
+            (LocationMappingListView, LibreNMSGenericPermissionMixin, (PERM_VIEW_PLUGIN,)),
+            (
+                LocationMappingCreateView,
+                LibreNMSGenericWritePermissionMixin,
+                (PERM_VIEW_PLUGIN, PERM_CHANGE_PLUGIN),
+            ),
+            (LibreNMSImportView, LibreNMSGenericPermissionMixin, (PERM_VIEW_PLUGIN,)),
+            (DeviceStatusListView, LibreNMSGenericPermissionMixin, (PERM_VIEW_PLUGIN,)),
+            (VMStatusListView, LibreNMSGenericPermissionMixin, (PERM_VIEW_PLUGIN,)),
         )
 
-        for view_class in generic_views:
+        for view_class, plugin_mixin, expected_perms in generic_views:
             assert view_class.has_permission is ObjectPermissionRequiredMixin.has_permission
             assert ObjectPermissionRequiredMixin in view_class.__mro__
             assert PermissionRequiredMixin not in view_class.__mro__
+            assert plugin_mixin in view_class.__mro__, f"{view_class.__name__} is missing {plugin_mixin.__name__}"
+            assert tuple(view_class.additional_permissions) == expected_perms
 
 
 class TestRequiredObjectPermissionsWiring:

--- a/netbox_librenms_plugin/views/imports/list.py
+++ b/netbox_librenms_plugin/views/imports/list.py
@@ -17,12 +17,12 @@ from netbox_librenms_plugin.librenms_api import LibreNMSUnreachable
 from netbox_librenms_plugin.models import LibreNMSSettings
 from netbox_librenms_plugin.tables.device_status import DeviceImportTable
 from netbox_librenms_plugin.utils import get_user_pref
-from netbox_librenms_plugin.views.mixins import LibreNMSAPIMixin, LibreNMSPermissionMixin
+from netbox_librenms_plugin.views.mixins import LibreNMSAPIMixin, LibreNMSGenericPermissionMixin
 
 logger = logging.getLogger(__name__)
 
 
-class LibreNMSImportView(LibreNMSPermissionMixin, LibreNMSAPIMixin, generic.ObjectListView):
+class LibreNMSImportView(LibreNMSGenericPermissionMixin, LibreNMSAPIMixin, generic.ObjectListView):
     """Import devices from LibreNMS into NetBox with validation metadata."""
 
     queryset = Device.objects.none()

--- a/netbox_librenms_plugin/views/mapping_views.py
+++ b/netbox_librenms_plugin/views/mapping_views.py
@@ -71,13 +71,14 @@ from netbox_librenms_plugin.tables.mappings import (
     PortStackLagPatternTable,
 )
 from netbox_librenms_plugin.views.mixins import (
+    LibreNMSGenericPermissionMixin,
+    LibreNMSGenericWritePermissionMixin,
     LibreNMSPermissionMixin,
-    LibreNMSWritePermissionMixin,
     NetBoxObjectPermissionMixin,
 )
 
 
-class InterfaceTypeMappingListView(LibreNMSPermissionMixin, generic.ObjectListView):
+class InterfaceTypeMappingListView(LibreNMSGenericPermissionMixin, generic.ObjectListView):
     """
     Provides a view for listing all `InterfaceTypeMapping` objects.
     """
@@ -89,7 +90,7 @@ class InterfaceTypeMappingListView(LibreNMSPermissionMixin, generic.ObjectListVi
     template_name = "netbox_librenms_plugin/interfacetypemapping_list.html"
 
 
-class InterfaceTypeMappingCreateView(LibreNMSWritePermissionMixin, generic.ObjectEditView):
+class InterfaceTypeMappingCreateView(LibreNMSGenericWritePermissionMixin, generic.ObjectEditView):
     """
     Provides a view for creating a new `InterfaceTypeMapping` object.
     """
@@ -98,7 +99,8 @@ class InterfaceTypeMappingCreateView(LibreNMSWritePermissionMixin, generic.Objec
     form = InterfaceTypeMappingForm
 
 
-class InterfaceTypeMappingBulkImportView(LibreNMSWritePermissionMixin, generic.BulkImportView):
+@register_model_view(InterfaceTypeMapping, "bulk_import", path="import", detail=False)
+class InterfaceTypeMappingBulkImportView(LibreNMSGenericWritePermissionMixin, generic.BulkImportView):
     """
     Provides a view for bulk importing `InterfaceTypeMapping` objects from CSV, JSON, or YAML.
     Supports three import methods: direct import, file upload, and data file.
@@ -108,7 +110,7 @@ class InterfaceTypeMappingBulkImportView(LibreNMSWritePermissionMixin, generic.B
     model_form = InterfaceTypeMappingImportForm
 
 
-class InterfaceTypeMappingView(LibreNMSPermissionMixin, generic.ObjectView):
+class InterfaceTypeMappingView(LibreNMSGenericPermissionMixin, generic.ObjectView):
     """
     Provides a view for displaying details of a specific `InterfaceTypeMapping` object.
     """
@@ -116,7 +118,7 @@ class InterfaceTypeMappingView(LibreNMSPermissionMixin, generic.ObjectView):
     queryset = InterfaceTypeMapping.objects.all()
 
 
-class InterfaceTypeMappingEditView(LibreNMSWritePermissionMixin, generic.ObjectEditView):
+class InterfaceTypeMappingEditView(LibreNMSGenericWritePermissionMixin, generic.ObjectEditView):
     """
     Provides a view for editing a specific `InterfaceTypeMapping` object.
     """
@@ -125,7 +127,7 @@ class InterfaceTypeMappingEditView(LibreNMSWritePermissionMixin, generic.ObjectE
     form = InterfaceTypeMappingForm
 
 
-class InterfaceTypeMappingDeleteView(LibreNMSWritePermissionMixin, generic.ObjectDeleteView):
+class InterfaceTypeMappingDeleteView(LibreNMSGenericWritePermissionMixin, generic.ObjectDeleteView):
     """
     Provides a view for deleting a specific `InterfaceTypeMapping` object.
     """
@@ -133,7 +135,7 @@ class InterfaceTypeMappingDeleteView(LibreNMSWritePermissionMixin, generic.Objec
     queryset = InterfaceTypeMapping.objects.all()
 
 
-class InterfaceTypeMappingBulkDeleteView(LibreNMSWritePermissionMixin, generic.BulkDeleteView):
+class InterfaceTypeMappingBulkDeleteView(LibreNMSGenericWritePermissionMixin, generic.BulkDeleteView):
     """
     Provides a view for deleting multiple `InterfaceTypeMapping` objects.
     """
@@ -142,7 +144,7 @@ class InterfaceTypeMappingBulkDeleteView(LibreNMSWritePermissionMixin, generic.B
     table = InterfaceTypeMappingTable
 
 
-class InterfaceTypeMappingChangeLogView(LibreNMSPermissionMixin, generic.ObjectChangeLogView):
+class InterfaceTypeMappingChangeLogView(LibreNMSGenericPermissionMixin, generic.ObjectChangeLogView):
     """
     Provides a view for displaying the change log of a specific `InterfaceTypeMapping` object.
     """
@@ -153,7 +155,7 @@ class InterfaceTypeMappingChangeLogView(LibreNMSPermissionMixin, generic.ObjectC
 # --- DeviceTypeMapping views ---
 
 
-class DeviceTypeMappingListView(LibreNMSPermissionMixin, generic.ObjectListView):
+class DeviceTypeMappingListView(LibreNMSGenericPermissionMixin, generic.ObjectListView):
     """Provides a view for listing all DeviceTypeMapping objects."""
 
     queryset = DeviceTypeMapping.objects.select_related("netbox_device_type")
@@ -163,47 +165,48 @@ class DeviceTypeMappingListView(LibreNMSPermissionMixin, generic.ObjectListView)
     template_name = "netbox_librenms_plugin/devicetypemapping_list.html"
 
 
-class DeviceTypeMappingCreateView(LibreNMSWritePermissionMixin, generic.ObjectEditView):
+class DeviceTypeMappingCreateView(LibreNMSGenericWritePermissionMixin, generic.ObjectEditView):
     """Provides a view for creating a new DeviceTypeMapping object."""
 
     queryset = DeviceTypeMapping.objects.all()
     form = DeviceTypeMappingForm
 
 
-class DeviceTypeMappingBulkImportView(LibreNMSWritePermissionMixin, generic.BulkImportView):
+@register_model_view(DeviceTypeMapping, "bulk_import", path="import", detail=False)
+class DeviceTypeMappingBulkImportView(LibreNMSGenericWritePermissionMixin, generic.BulkImportView):
     """Provides a view for bulk importing DeviceTypeMapping objects."""
 
     queryset = DeviceTypeMapping.objects.all()
     model_form = DeviceTypeMappingImportForm
 
 
-class DeviceTypeMappingView(LibreNMSPermissionMixin, generic.ObjectView):
+class DeviceTypeMappingView(LibreNMSGenericPermissionMixin, generic.ObjectView):
     """Provides a view for displaying details of a specific DeviceTypeMapping object."""
 
     queryset = DeviceTypeMapping.objects.all()
 
 
-class DeviceTypeMappingEditView(LibreNMSWritePermissionMixin, generic.ObjectEditView):
+class DeviceTypeMappingEditView(LibreNMSGenericWritePermissionMixin, generic.ObjectEditView):
     """Provides a view for editing a specific DeviceTypeMapping object."""
 
     queryset = DeviceTypeMapping.objects.all()
     form = DeviceTypeMappingForm
 
 
-class DeviceTypeMappingDeleteView(LibreNMSWritePermissionMixin, generic.ObjectDeleteView):
+class DeviceTypeMappingDeleteView(LibreNMSGenericWritePermissionMixin, generic.ObjectDeleteView):
     """Provides a view for deleting a specific DeviceTypeMapping object."""
 
     queryset = DeviceTypeMapping.objects.all()
 
 
-class DeviceTypeMappingBulkDeleteView(LibreNMSWritePermissionMixin, generic.BulkDeleteView):
+class DeviceTypeMappingBulkDeleteView(LibreNMSGenericWritePermissionMixin, generic.BulkDeleteView):
     """Provides a view for deleting multiple DeviceTypeMapping objects."""
 
     queryset = DeviceTypeMapping.objects.all()
     table = DeviceTypeMappingTable
 
 
-class DeviceTypeMappingChangeLogView(LibreNMSPermissionMixin, generic.ObjectChangeLogView):
+class DeviceTypeMappingChangeLogView(LibreNMSGenericPermissionMixin, generic.ObjectChangeLogView):
     """Provides a view for displaying the change log of a specific DeviceTypeMapping object."""
 
     queryset = DeviceTypeMapping.objects.all()
@@ -212,7 +215,7 @@ class DeviceTypeMappingChangeLogView(LibreNMSPermissionMixin, generic.ObjectChan
 # --- ModuleTypeMapping views ---
 
 
-class ModuleTypeMappingListView(LibreNMSPermissionMixin, generic.ObjectListView):
+class ModuleTypeMappingListView(LibreNMSGenericPermissionMixin, generic.ObjectListView):
     """Provides a view for listing all ModuleTypeMapping objects."""
 
     queryset = ModuleTypeMapping.objects.select_related("netbox_module_type")
@@ -222,47 +225,48 @@ class ModuleTypeMappingListView(LibreNMSPermissionMixin, generic.ObjectListView)
     template_name = "netbox_librenms_plugin/moduletypemapping_list.html"
 
 
-class ModuleTypeMappingCreateView(LibreNMSWritePermissionMixin, generic.ObjectEditView):
+class ModuleTypeMappingCreateView(LibreNMSGenericWritePermissionMixin, generic.ObjectEditView):
     """Provides a view for creating a new ModuleTypeMapping object."""
 
     queryset = ModuleTypeMapping.objects.all()
     form = ModuleTypeMappingForm
 
 
-class ModuleTypeMappingBulkImportView(LibreNMSWritePermissionMixin, generic.BulkImportView):
+@register_model_view(ModuleTypeMapping, "bulk_import", path="import", detail=False)
+class ModuleTypeMappingBulkImportView(LibreNMSGenericWritePermissionMixin, generic.BulkImportView):
     """Provides a view for bulk importing ModuleTypeMapping objects."""
 
     queryset = ModuleTypeMapping.objects.all()
     model_form = ModuleTypeMappingImportForm
 
 
-class ModuleTypeMappingView(LibreNMSPermissionMixin, generic.ObjectView):
+class ModuleTypeMappingView(LibreNMSGenericPermissionMixin, generic.ObjectView):
     """Provides a view for displaying details of a specific ModuleTypeMapping object."""
 
     queryset = ModuleTypeMapping.objects.all()
 
 
-class ModuleTypeMappingEditView(LibreNMSWritePermissionMixin, generic.ObjectEditView):
+class ModuleTypeMappingEditView(LibreNMSGenericWritePermissionMixin, generic.ObjectEditView):
     """Provides a view for editing a specific ModuleTypeMapping object."""
 
     queryset = ModuleTypeMapping.objects.all()
     form = ModuleTypeMappingForm
 
 
-class ModuleTypeMappingDeleteView(LibreNMSWritePermissionMixin, generic.ObjectDeleteView):
+class ModuleTypeMappingDeleteView(LibreNMSGenericWritePermissionMixin, generic.ObjectDeleteView):
     """Provides a view for deleting a specific ModuleTypeMapping object."""
 
     queryset = ModuleTypeMapping.objects.all()
 
 
-class ModuleTypeMappingBulkDeleteView(LibreNMSWritePermissionMixin, generic.BulkDeleteView):
+class ModuleTypeMappingBulkDeleteView(LibreNMSGenericWritePermissionMixin, generic.BulkDeleteView):
     """Provides a view for deleting multiple ModuleTypeMapping objects."""
 
     queryset = ModuleTypeMapping.objects.all()
     table = ModuleTypeMappingTable
 
 
-class ModuleTypeMappingChangeLogView(LibreNMSPermissionMixin, generic.ObjectChangeLogView):
+class ModuleTypeMappingChangeLogView(LibreNMSGenericPermissionMixin, generic.ObjectChangeLogView):
     """Provides a view for displaying the change log of a specific ModuleTypeMapping object."""
 
     queryset = ModuleTypeMapping.objects.all()
@@ -271,7 +275,7 @@ class ModuleTypeMappingChangeLogView(LibreNMSPermissionMixin, generic.ObjectChan
 # --- ModuleBayMapping views ---
 
 
-class ModuleBayMappingListView(LibreNMSPermissionMixin, generic.ObjectListView):
+class ModuleBayMappingListView(LibreNMSGenericPermissionMixin, generic.ObjectListView):
     """Provides a view for listing all ModuleBayMapping objects."""
 
     queryset = ModuleBayMapping.objects.all()
@@ -281,47 +285,48 @@ class ModuleBayMappingListView(LibreNMSPermissionMixin, generic.ObjectListView):
     template_name = "netbox_librenms_plugin/modulebaymapping_list.html"
 
 
-class ModuleBayMappingCreateView(LibreNMSWritePermissionMixin, generic.ObjectEditView):
+class ModuleBayMappingCreateView(LibreNMSGenericWritePermissionMixin, generic.ObjectEditView):
     """Provides a view for creating a new ModuleBayMapping object."""
 
     queryset = ModuleBayMapping.objects.all()
     form = ModuleBayMappingForm
 
 
-class ModuleBayMappingBulkImportView(LibreNMSWritePermissionMixin, generic.BulkImportView):
+@register_model_view(ModuleBayMapping, "bulk_import", path="import", detail=False)
+class ModuleBayMappingBulkImportView(LibreNMSGenericWritePermissionMixin, generic.BulkImportView):
     """Provides a view for bulk importing ModuleBayMapping objects."""
 
     queryset = ModuleBayMapping.objects.all()
     model_form = ModuleBayMappingImportForm
 
 
-class ModuleBayMappingView(LibreNMSPermissionMixin, generic.ObjectView):
+class ModuleBayMappingView(LibreNMSGenericPermissionMixin, generic.ObjectView):
     """Provides a view for displaying details of a specific ModuleBayMapping object."""
 
     queryset = ModuleBayMapping.objects.all()
 
 
-class ModuleBayMappingEditView(LibreNMSWritePermissionMixin, generic.ObjectEditView):
+class ModuleBayMappingEditView(LibreNMSGenericWritePermissionMixin, generic.ObjectEditView):
     """Provides a view for editing a specific ModuleBayMapping object."""
 
     queryset = ModuleBayMapping.objects.all()
     form = ModuleBayMappingForm
 
 
-class ModuleBayMappingDeleteView(LibreNMSWritePermissionMixin, generic.ObjectDeleteView):
+class ModuleBayMappingDeleteView(LibreNMSGenericWritePermissionMixin, generic.ObjectDeleteView):
     """Provides a view for deleting a specific ModuleBayMapping object."""
 
     queryset = ModuleBayMapping.objects.all()
 
 
-class ModuleBayMappingBulkDeleteView(LibreNMSWritePermissionMixin, generic.BulkDeleteView):
+class ModuleBayMappingBulkDeleteView(LibreNMSGenericWritePermissionMixin, generic.BulkDeleteView):
     """Provides a view for deleting multiple ModuleBayMapping objects."""
 
     queryset = ModuleBayMapping.objects.all()
     table = ModuleBayMappingTable
 
 
-class ModuleBayMappingChangeLogView(LibreNMSPermissionMixin, generic.ObjectChangeLogView):
+class ModuleBayMappingChangeLogView(LibreNMSGenericPermissionMixin, generic.ObjectChangeLogView):
     """Provides a view for displaying the change log of a specific ModuleBayMapping object."""
 
     queryset = ModuleBayMapping.objects.all()
@@ -330,7 +335,7 @@ class ModuleBayMappingChangeLogView(LibreNMSPermissionMixin, generic.ObjectChang
 # --- NormalizationRule views ---
 
 
-class NormalizationRuleListView(LibreNMSPermissionMixin, generic.ObjectListView):
+class NormalizationRuleListView(LibreNMSGenericPermissionMixin, generic.ObjectListView):
     """Provides a view for listing all NormalizationRule objects."""
 
     queryset = NormalizationRule.objects.select_related("manufacturer")
@@ -340,47 +345,48 @@ class NormalizationRuleListView(LibreNMSPermissionMixin, generic.ObjectListView)
     template_name = "netbox_librenms_plugin/normalizationrule_list.html"
 
 
-class NormalizationRuleCreateView(LibreNMSWritePermissionMixin, generic.ObjectEditView):
+class NormalizationRuleCreateView(LibreNMSGenericWritePermissionMixin, generic.ObjectEditView):
     """Provides a view for creating a new NormalizationRule object."""
 
     queryset = NormalizationRule.objects.all()
     form = NormalizationRuleForm
 
 
-class NormalizationRuleBulkImportView(LibreNMSWritePermissionMixin, generic.BulkImportView):
+@register_model_view(NormalizationRule, "bulk_import", path="import", detail=False)
+class NormalizationRuleBulkImportView(LibreNMSGenericWritePermissionMixin, generic.BulkImportView):
     """Provides a view for bulk importing NormalizationRule objects."""
 
     queryset = NormalizationRule.objects.all()
     model_form = NormalizationRuleImportForm
 
 
-class NormalizationRuleView(LibreNMSPermissionMixin, generic.ObjectView):
+class NormalizationRuleView(LibreNMSGenericPermissionMixin, generic.ObjectView):
     """Provides a view for displaying details of a specific NormalizationRule object."""
 
     queryset = NormalizationRule.objects.all()
 
 
-class NormalizationRuleEditView(LibreNMSWritePermissionMixin, generic.ObjectEditView):
+class NormalizationRuleEditView(LibreNMSGenericWritePermissionMixin, generic.ObjectEditView):
     """Provides a view for editing a specific NormalizationRule object."""
 
     queryset = NormalizationRule.objects.all()
     form = NormalizationRuleForm
 
 
-class NormalizationRuleDeleteView(LibreNMSWritePermissionMixin, generic.ObjectDeleteView):
+class NormalizationRuleDeleteView(LibreNMSGenericWritePermissionMixin, generic.ObjectDeleteView):
     """Provides a view for deleting a specific NormalizationRule object."""
 
     queryset = NormalizationRule.objects.all()
 
 
-class NormalizationRuleBulkDeleteView(LibreNMSWritePermissionMixin, generic.BulkDeleteView):
+class NormalizationRuleBulkDeleteView(LibreNMSGenericWritePermissionMixin, generic.BulkDeleteView):
     """Provides a view for deleting multiple NormalizationRule objects."""
 
     queryset = NormalizationRule.objects.all()
     table = NormalizationRuleTable
 
 
-class NormalizationRuleChangeLogView(LibreNMSPermissionMixin, generic.ObjectChangeLogView):
+class NormalizationRuleChangeLogView(LibreNMSGenericPermissionMixin, generic.ObjectChangeLogView):
     """Provides a view for displaying the change log of a specific NormalizationRule object."""
 
     queryset = NormalizationRule.objects.all()
@@ -389,7 +395,7 @@ class NormalizationRuleChangeLogView(LibreNMSPermissionMixin, generic.ObjectChan
 # --- InventoryIgnoreRule views ---
 
 
-class InventoryIgnoreRuleListView(LibreNMSPermissionMixin, generic.ObjectListView):
+class InventoryIgnoreRuleListView(LibreNMSGenericPermissionMixin, generic.ObjectListView):
     """Provides a view for listing all InventoryIgnoreRule objects."""
 
     queryset = InventoryIgnoreRule.objects.all()
@@ -399,47 +405,48 @@ class InventoryIgnoreRuleListView(LibreNMSPermissionMixin, generic.ObjectListVie
     template_name = "netbox_librenms_plugin/inventoryignorerule_list.html"
 
 
-class InventoryIgnoreRuleCreateView(LibreNMSWritePermissionMixin, generic.ObjectEditView):
+class InventoryIgnoreRuleCreateView(LibreNMSGenericWritePermissionMixin, generic.ObjectEditView):
     """Provides a view for creating a new InventoryIgnoreRule object."""
 
     queryset = InventoryIgnoreRule.objects.all()
     form = InventoryIgnoreRuleForm
 
 
-class InventoryIgnoreRuleBulkImportView(LibreNMSWritePermissionMixin, generic.BulkImportView):
+@register_model_view(InventoryIgnoreRule, "bulk_import", path="import", detail=False)
+class InventoryIgnoreRuleBulkImportView(LibreNMSGenericWritePermissionMixin, generic.BulkImportView):
     """Provides a view for bulk importing InventoryIgnoreRule objects."""
 
     queryset = InventoryIgnoreRule.objects.all()
     model_form = InventoryIgnoreRuleImportForm
 
 
-class InventoryIgnoreRuleView(LibreNMSPermissionMixin, generic.ObjectView):
+class InventoryIgnoreRuleView(LibreNMSGenericPermissionMixin, generic.ObjectView):
     """Provides a view for displaying details of a specific InventoryIgnoreRule object."""
 
     queryset = InventoryIgnoreRule.objects.all()
 
 
-class InventoryIgnoreRuleEditView(LibreNMSWritePermissionMixin, generic.ObjectEditView):
+class InventoryIgnoreRuleEditView(LibreNMSGenericWritePermissionMixin, generic.ObjectEditView):
     """Provides a view for editing a specific InventoryIgnoreRule object."""
 
     queryset = InventoryIgnoreRule.objects.all()
     form = InventoryIgnoreRuleForm
 
 
-class InventoryIgnoreRuleDeleteView(LibreNMSWritePermissionMixin, generic.ObjectDeleteView):
+class InventoryIgnoreRuleDeleteView(LibreNMSGenericWritePermissionMixin, generic.ObjectDeleteView):
     """Provides a view for deleting a specific InventoryIgnoreRule object."""
 
     queryset = InventoryIgnoreRule.objects.all()
 
 
-class InventoryIgnoreRuleBulkDeleteView(LibreNMSWritePermissionMixin, generic.BulkDeleteView):
+class InventoryIgnoreRuleBulkDeleteView(LibreNMSGenericWritePermissionMixin, generic.BulkDeleteView):
     """Provides a view for deleting multiple InventoryIgnoreRule objects."""
 
     queryset = InventoryIgnoreRule.objects.all()
     table = InventoryIgnoreRuleTable
 
 
-class InventoryIgnoreRuleChangeLogView(LibreNMSPermissionMixin, generic.ObjectChangeLogView):
+class InventoryIgnoreRuleChangeLogView(LibreNMSGenericPermissionMixin, generic.ObjectChangeLogView):
     """Provides a view for displaying the change log of a specific InventoryIgnoreRule object."""
 
     queryset = InventoryIgnoreRule.objects.all()
@@ -467,7 +474,7 @@ class BulkExportYAMLView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixin, V
             int_pks = [int(pk) for pk in pks]
         except (ValueError, TypeError):
             return HttpResponseBadRequest("Invalid pk value.")
-        objects = self.queryset.filter(pk__in=int_pks).order_by("pk")
+        objects = self.queryset.model.objects.restrict(request.user, "view").filter(pk__in=int_pks).order_by("pk")
         if not objects:
             return HttpResponseBadRequest("No matching objects found.")
         yaml_parts = [obj.to_yaml() for obj in objects]
@@ -512,7 +519,7 @@ class LocationMappingBulkExportYAMLView(BulkExportYAMLView):
 # --- PlatformMapping views ---
 
 
-class PlatformMappingListView(LibreNMSPermissionMixin, generic.ObjectListView):
+class PlatformMappingListView(LibreNMSGenericPermissionMixin, generic.ObjectListView):
     """Provides a view for listing all PlatformMapping objects."""
 
     queryset = PlatformMapping.objects.select_related("netbox_platform")
@@ -522,47 +529,48 @@ class PlatformMappingListView(LibreNMSPermissionMixin, generic.ObjectListView):
     template_name = "netbox_librenms_plugin/platformmapping_list.html"
 
 
-class PlatformMappingCreateView(LibreNMSWritePermissionMixin, generic.ObjectEditView):
+class PlatformMappingCreateView(LibreNMSGenericWritePermissionMixin, generic.ObjectEditView):
     """Provides a view for creating a new PlatformMapping object."""
 
     queryset = PlatformMapping.objects.all()
     form = PlatformMappingForm
 
 
-class PlatformMappingBulkImportView(LibreNMSWritePermissionMixin, generic.BulkImportView):
+@register_model_view(PlatformMapping, "bulk_import", path="import", detail=False)
+class PlatformMappingBulkImportView(LibreNMSGenericWritePermissionMixin, generic.BulkImportView):
     """Provides a view for bulk importing PlatformMapping objects."""
 
     queryset = PlatformMapping.objects.all()
     model_form = PlatformMappingImportForm
 
 
-class PlatformMappingView(LibreNMSPermissionMixin, generic.ObjectView):
+class PlatformMappingView(LibreNMSGenericPermissionMixin, generic.ObjectView):
     """Provides a view for displaying details of a specific PlatformMapping object."""
 
     queryset = PlatformMapping.objects.all()
 
 
-class PlatformMappingEditView(LibreNMSWritePermissionMixin, generic.ObjectEditView):
+class PlatformMappingEditView(LibreNMSGenericWritePermissionMixin, generic.ObjectEditView):
     """Provides a view for editing a specific PlatformMapping object."""
 
     queryset = PlatformMapping.objects.all()
     form = PlatformMappingForm
 
 
-class PlatformMappingDeleteView(LibreNMSWritePermissionMixin, generic.ObjectDeleteView):
+class PlatformMappingDeleteView(LibreNMSGenericWritePermissionMixin, generic.ObjectDeleteView):
     """Provides a view for deleting a specific PlatformMapping object."""
 
     queryset = PlatformMapping.objects.all()
 
 
-class PlatformMappingBulkDeleteView(LibreNMSWritePermissionMixin, generic.BulkDeleteView):
+class PlatformMappingBulkDeleteView(LibreNMSGenericWritePermissionMixin, generic.BulkDeleteView):
     """Provides a view for deleting multiple PlatformMapping objects."""
 
     queryset = PlatformMapping.objects.all()
     table = PlatformMappingTable
 
 
-class PlatformMappingChangeLogView(LibreNMSPermissionMixin, generic.ObjectChangeLogView):
+class PlatformMappingChangeLogView(LibreNMSGenericPermissionMixin, generic.ObjectChangeLogView):
     """Provides a view for displaying the change log of a specific PlatformMapping object."""
 
     queryset = PlatformMapping.objects.all()
@@ -571,7 +579,7 @@ class PlatformMappingChangeLogView(LibreNMSPermissionMixin, generic.ObjectChange
 # --- LocationMapping views ---
 
 
-class LocationMappingListView(LibreNMSPermissionMixin, generic.ObjectListView):
+class LocationMappingListView(LibreNMSGenericPermissionMixin, generic.ObjectListView):
     """Provides a view for listing all LocationMapping objects."""
 
     queryset = LocationMapping.objects.select_related("content_type").prefetch_related("netbox_object")
@@ -581,7 +589,7 @@ class LocationMappingListView(LibreNMSPermissionMixin, generic.ObjectListView):
     template_name = "netbox_librenms_plugin/locationmapping_list.html"
 
 
-class LocationMappingCreateView(LibreNMSWritePermissionMixin, generic.ObjectEditView):
+class LocationMappingCreateView(LibreNMSGenericWritePermissionMixin, generic.ObjectEditView):
     """Provides a view for creating a new LocationMapping object."""
 
     queryset = LocationMapping.objects.all()
@@ -589,20 +597,21 @@ class LocationMappingCreateView(LibreNMSWritePermissionMixin, generic.ObjectEdit
     template_name = "netbox_librenms_plugin/locationmapping_edit.html"
 
 
-class LocationMappingBulkImportView(LibreNMSWritePermissionMixin, generic.BulkImportView):
+@register_model_view(LocationMapping, "bulk_import", path="import", detail=False)
+class LocationMappingBulkImportView(LibreNMSGenericWritePermissionMixin, generic.BulkImportView):
     """Provides a view for bulk importing LocationMapping objects."""
 
     queryset = LocationMapping.objects.all()
     model_form = LocationMappingImportForm
 
 
-class LocationMappingView(LibreNMSPermissionMixin, generic.ObjectView):
+class LocationMappingView(LibreNMSGenericPermissionMixin, generic.ObjectView):
     """Provides a view for displaying details of a specific LocationMapping object."""
 
     queryset = LocationMapping.objects.all()
 
 
-class LocationMappingEditView(LibreNMSWritePermissionMixin, generic.ObjectEditView):
+class LocationMappingEditView(LibreNMSGenericWritePermissionMixin, generic.ObjectEditView):
     """Provides a view for editing a specific LocationMapping object."""
 
     queryset = LocationMapping.objects.all()
@@ -610,20 +619,20 @@ class LocationMappingEditView(LibreNMSWritePermissionMixin, generic.ObjectEditVi
     template_name = "netbox_librenms_plugin/locationmapping_edit.html"
 
 
-class LocationMappingDeleteView(LibreNMSWritePermissionMixin, generic.ObjectDeleteView):
+class LocationMappingDeleteView(LibreNMSGenericWritePermissionMixin, generic.ObjectDeleteView):
     """Provides a view for deleting a specific LocationMapping object."""
 
     queryset = LocationMapping.objects.all()
 
 
-class LocationMappingBulkDeleteView(LibreNMSWritePermissionMixin, generic.BulkDeleteView):
+class LocationMappingBulkDeleteView(LibreNMSGenericWritePermissionMixin, generic.BulkDeleteView):
     """Provides a view for deleting multiple LocationMapping objects."""
 
     queryset = LocationMapping.objects.all()
     table = LocationMappingTable
 
 
-class LocationMappingChangeLogView(LibreNMSPermissionMixin, generic.ObjectChangeLogView):
+class LocationMappingChangeLogView(LibreNMSGenericPermissionMixin, generic.ObjectChangeLogView):
     """Provides a view for displaying the change log of a specific LocationMapping object."""
 
     queryset = LocationMapping.objects.all()
@@ -632,7 +641,7 @@ class LocationMappingChangeLogView(LibreNMSPermissionMixin, generic.ObjectChange
 # --- CarrierAutoInstallRule views ---
 
 
-class CarrierAutoInstallRuleListView(LibreNMSPermissionMixin, generic.ObjectListView):
+class CarrierAutoInstallRuleListView(LibreNMSGenericPermissionMixin, generic.ObjectListView):
     """Provides a view for listing all CarrierAutoInstallRule objects."""
 
     queryset = CarrierAutoInstallRule.objects.select_related("manufacturer", "carrier_module_type")
@@ -642,47 +651,48 @@ class CarrierAutoInstallRuleListView(LibreNMSPermissionMixin, generic.ObjectList
     template_name = "netbox_librenms_plugin/carrierautoinstallrule_list.html"
 
 
-class CarrierAutoInstallRuleCreateView(LibreNMSWritePermissionMixin, generic.ObjectEditView):
+class CarrierAutoInstallRuleCreateView(LibreNMSGenericWritePermissionMixin, generic.ObjectEditView):
     """Provides a view for creating a new CarrierAutoInstallRule object."""
 
     queryset = CarrierAutoInstallRule.objects.all()
     form = CarrierAutoInstallRuleForm
 
 
-class CarrierAutoInstallRuleBulkImportView(LibreNMSWritePermissionMixin, generic.BulkImportView):
+@register_model_view(CarrierAutoInstallRule, "bulk_import", path="import", detail=False)
+class CarrierAutoInstallRuleBulkImportView(LibreNMSGenericWritePermissionMixin, generic.BulkImportView):
     """Provides a view for bulk importing CarrierAutoInstallRule objects."""
 
     queryset = CarrierAutoInstallRule.objects.all()
     model_form = CarrierAutoInstallRuleImportForm
 
 
-class CarrierAutoInstallRuleView(LibreNMSPermissionMixin, generic.ObjectView):
+class CarrierAutoInstallRuleView(LibreNMSGenericPermissionMixin, generic.ObjectView):
     """Provides a view for displaying details of a specific CarrierAutoInstallRule object."""
 
     queryset = CarrierAutoInstallRule.objects.select_related("manufacturer", "carrier_module_type")
 
 
-class CarrierAutoInstallRuleEditView(LibreNMSWritePermissionMixin, generic.ObjectEditView):
+class CarrierAutoInstallRuleEditView(LibreNMSGenericWritePermissionMixin, generic.ObjectEditView):
     """Provides a view for editing a specific CarrierAutoInstallRule object."""
 
     queryset = CarrierAutoInstallRule.objects.all()
     form = CarrierAutoInstallRuleForm
 
 
-class CarrierAutoInstallRuleDeleteView(LibreNMSWritePermissionMixin, generic.ObjectDeleteView):
+class CarrierAutoInstallRuleDeleteView(LibreNMSGenericWritePermissionMixin, generic.ObjectDeleteView):
     """Provides a view for deleting a specific CarrierAutoInstallRule object."""
 
     queryset = CarrierAutoInstallRule.objects.all()
 
 
-class CarrierAutoInstallRuleBulkDeleteView(LibreNMSWritePermissionMixin, generic.BulkDeleteView):
+class CarrierAutoInstallRuleBulkDeleteView(LibreNMSGenericWritePermissionMixin, generic.BulkDeleteView):
     """Provides a view for deleting multiple CarrierAutoInstallRule objects."""
 
     queryset = CarrierAutoInstallRule.objects.all()
     table = CarrierAutoInstallRuleTable
 
 
-class CarrierAutoInstallRuleChangeLogView(LibreNMSPermissionMixin, generic.ObjectChangeLogView):
+class CarrierAutoInstallRuleChangeLogView(LibreNMSGenericPermissionMixin, generic.ObjectChangeLogView):
     """Provides a view for displaying the change log of a specific CarrierAutoInstallRule object."""
 
     queryset = CarrierAutoInstallRule.objects.all()
@@ -695,7 +705,7 @@ class CarrierAutoInstallRuleBulkExportYAMLView(BulkExportYAMLView):
 # --- PortStackLagPattern views ---
 
 
-class PortStackLagPatternListView(LibreNMSPermissionMixin, generic.ObjectListView):
+class PortStackLagPatternListView(LibreNMSGenericPermissionMixin, generic.ObjectListView):
     """Provides a view for listing all PortStackLagPattern objects."""
 
     queryset = PortStackLagPattern.objects.all()
@@ -705,47 +715,48 @@ class PortStackLagPatternListView(LibreNMSPermissionMixin, generic.ObjectListVie
     template_name = "netbox_librenms_plugin/portstacklagpattern_list.html"
 
 
-class PortStackLagPatternCreateView(LibreNMSWritePermissionMixin, generic.ObjectEditView):
+class PortStackLagPatternCreateView(LibreNMSGenericWritePermissionMixin, generic.ObjectEditView):
     """Provides a view for creating a new PortStackLagPattern object."""
 
     queryset = PortStackLagPattern.objects.all()
     form = PortStackLagPatternForm
 
 
-class PortStackLagPatternBulkImportView(LibreNMSWritePermissionMixin, generic.BulkImportView):
+@register_model_view(PortStackLagPattern, "bulk_import", path="import", detail=False)
+class PortStackLagPatternBulkImportView(LibreNMSGenericWritePermissionMixin, generic.BulkImportView):
     """Provides a view for bulk importing PortStackLagPattern objects from CSV/JSON/YAML."""
 
     queryset = PortStackLagPattern.objects.all()
     model_form = PortStackLagPatternImportForm
 
 
-class PortStackLagPatternView(LibreNMSPermissionMixin, generic.ObjectView):
+class PortStackLagPatternView(LibreNMSGenericPermissionMixin, generic.ObjectView):
     """Provides a view for displaying a PortStackLagPattern object."""
 
     queryset = PortStackLagPattern.objects.all()
 
 
-class PortStackLagPatternEditView(LibreNMSWritePermissionMixin, generic.ObjectEditView):
+class PortStackLagPatternEditView(LibreNMSGenericWritePermissionMixin, generic.ObjectEditView):
     """Provides a view for editing a PortStackLagPattern object."""
 
     queryset = PortStackLagPattern.objects.all()
     form = PortStackLagPatternForm
 
 
-class PortStackLagPatternDeleteView(LibreNMSWritePermissionMixin, generic.ObjectDeleteView):
+class PortStackLagPatternDeleteView(LibreNMSGenericWritePermissionMixin, generic.ObjectDeleteView):
     """Provides a view for deleting a PortStackLagPattern object."""
 
     queryset = PortStackLagPattern.objects.all()
 
 
-class PortStackLagPatternBulkDeleteView(LibreNMSWritePermissionMixin, generic.BulkDeleteView):
+class PortStackLagPatternBulkDeleteView(LibreNMSGenericWritePermissionMixin, generic.BulkDeleteView):
     """Provides a view for bulk deleting PortStackLagPattern objects."""
 
     queryset = PortStackLagPattern.objects.all()
     table = PortStackLagPatternTable
 
 
-class PortStackLagPatternChangeLogView(LibreNMSPermissionMixin, generic.ObjectChangeLogView):
+class PortStackLagPatternChangeLogView(LibreNMSGenericPermissionMixin, generic.ObjectChangeLogView):
     """Provides a view for displaying the changelog of a PortStackLagPattern object."""
 
     queryset = PortStackLagPattern.objects.all()

--- a/netbox_librenms_plugin/views/mapping_views.py
+++ b/netbox_librenms_plugin/views/mapping_views.py
@@ -1,6 +1,7 @@
 from django.http import HttpResponse, HttpResponseBadRequest
 from django.views import View
 from netbox.views import generic
+from utilities.views import register_model_view
 
 from netbox_librenms_plugin.filters import (
     CarrierAutoInstallRuleFilterSet,

--- a/netbox_librenms_plugin/views/mixins.py
+++ b/netbox_librenms_plugin/views/mixins.py
@@ -244,6 +244,28 @@ class LibreNMSWritePermissionMixin(LibreNMSPermissionMixin):
     permission_required = PERM_CHANGE_PLUGIN
 
 
+class LibreNMSGenericPermissionMixin:
+    """Add plugin read access to a NetBox generic view's object permission gate.
+
+    Use this only with NetBox generic views that inherit
+    ``ObjectPermissionRequiredMixin`` and define a queryset. It deliberately
+    does not inherit Django's ``PermissionRequiredMixin``: doing so would
+    shadow NetBox's ``has_permission()`` and prevent ``queryset.restrict()``
+    from enforcing object-level constraints.
+
+    Plain/cache-backed views must instead use ``LibreNMSPermissionMixin`` and
+    explicitly require permissions for each NetBox object they access.
+    """
+
+    additional_permissions = (PERM_VIEW_PLUGIN,)
+
+
+class LibreNMSGenericWritePermissionMixin(LibreNMSGenericPermissionMixin):
+    """Add plugin read and write access to a NetBox generic mutation view."""
+
+    additional_permissions = (PERM_VIEW_PLUGIN, PERM_CHANGE_PLUGIN)
+
+
 def relock_scoped_row(model, **lookup):
     """
     Re-lock a row whose id came from an ALREADY-RESOLVED object: the single audited exception.

--- a/netbox_librenms_plugin/views/status_check.py
+++ b/netbox_librenms_plugin/views/status_check.py
@@ -12,12 +12,12 @@ from netbox_librenms_plugin.forms import (
 )
 from netbox_librenms_plugin.tables.device_status import DeviceStatusTable
 from netbox_librenms_plugin.tables.VM_status import VMStatusTable
-from netbox_librenms_plugin.views.mixins import LibreNMSAPIMixin, LibreNMSPermissionMixin
+from netbox_librenms_plugin.views.mixins import LibreNMSAPIMixin, LibreNMSGenericPermissionMixin
 
 logger = logging.getLogger(__name__)
 
 
-class DeviceStatusListView(LibreNMSPermissionMixin, LibreNMSAPIMixin, generic.ObjectListView):
+class DeviceStatusListView(LibreNMSGenericPermissionMixin, LibreNMSAPIMixin, generic.ObjectListView):
     """
     Check the status of NetBox devices in LibreNMS.
     Shows NetBox devices with their LibreNMS status.
@@ -31,16 +31,26 @@ class DeviceStatusListView(LibreNMSPermissionMixin, LibreNMSAPIMixin, generic.Ob
     actions = {}
     title = "Device LibreNMS Status"
 
+    def get_required_permission(self):
+        """Return the NetBox permission required to view device status."""
+        from utilities.permissions import get_permission_for_model
+
+        return get_permission_for_model(Device, "view")
+
     def get_queryset(self, request):
         """
         Override get_queryset to return filtered devices and check LibreNMS status
         """
         # Only get devices if filters are applied
         if self.request.GET:
-            queryset = Device.objects.select_related("device_type__manufacturer").prefetch_related(
-                "site",
-                "location",
-                "rack",
+            queryset = (
+                Device.objects.restrict(request.user, "view")
+                .select_related("device_type__manufacturer")
+                .prefetch_related(
+                    "site",
+                    "location",
+                    "rack",
+                )
             )
 
             # Create a list to store device IDs and their status
@@ -71,7 +81,7 @@ class DeviceStatusListView(LibreNMSPermissionMixin, LibreNMSAPIMixin, generic.Ob
         return Device.objects.none()
 
 
-class VMStatusListView(LibreNMSPermissionMixin, LibreNMSAPIMixin, generic.ObjectListView):
+class VMStatusListView(LibreNMSGenericPermissionMixin, LibreNMSAPIMixin, generic.ObjectListView):
     """
     Check the status of virtual machines in NetBox against LibreNMS
     """
@@ -84,10 +94,16 @@ class VMStatusListView(LibreNMSPermissionMixin, LibreNMSAPIMixin, generic.Object
     actions = {}
     title = "Virtual Machine LibreNMS Status"
 
+    def get_required_permission(self):
+        """Return the NetBox permission required to view VM status."""
+        from utilities.permissions import get_permission_for_model
+
+        return get_permission_for_model(VirtualMachine, "view")
+
     def get_queryset(self, request):
         """Return VMs annotated with their LibreNMS status."""
         if self.request.GET:
-            queryset = VirtualMachine.objects.select_related("cluster", "site")
+            queryset = VirtualMachine.objects.restrict(request.user, "view").select_related("cluster", "site")
 
             # Create a list to store VM IDs and their status
             vm_status_map = {}


### PR DESCRIPTION
## Summary
Restore NetBox object-permission enforcement for plugin views backed by NetBox generic views, while preserving the existing plugin-level gate for cached LibreNMS data and plain action endpoints.

## Motivation / Problem
Bug

`LibreNMSPermissionMixin` inherited Django's `PermissionRequiredMixin`. When combined with NetBox generic views, Django's `has_permission()` shadowed NetBox's `ObjectPermissionRequiredMixin`, so generic views skipped normal model/object permission checks and `queryset.restrict()` scoping.

## Scope of Change

- NetBox models / ORM
- Tests
- Docs only
- Other: Plugin permission mixins and generic view wiring

## How Was This Tested?

- Unit tests: Yes. `pytest netbox_librenms_plugin/tests/test_permissions.py netbox_librenms_plugin/tests/test_view_wiring.py -q` (`233 passed`).
- Unit tests: Yes. `pytest netbox_librenms_plugin/tests/test_platform_mapping.py::TestBulkExportYAMLView -q` (`5 passed`).
- Runtime checks: Verified all 70 mapping generic views resolve `has_permission()` through NetBox's `ObjectPermissionRequiredMixin`, have no Django `PermissionRequiredMixin` in their MRO, and invoke `queryset.restrict()` with the combined model and plugin permission gate.
- Manual testing: No UI walkthrough performed.

## Risk Assessment

This changes authorization behavior for generic mapping/rule CRUD, import, and status views to match the documented two-tier permission model. Users who previously had only LibreNMS Settings permissions may now need the relevant NetBox model/object permissions, which is the intended security boundary. Plain/cache-backed sync actions retain their existing plugin-level and explicit object-permission checks.

No LibreNMS API calls, import mutations, or database schema changes are introduced.

## Backwards Compatibility

- No breaking changes to public APIs or database schema.
- Intentional access-control correction: generic NetBox-object views now require the documented NetBox model/object permissions in addition to LibreNMS Settings permissions.

## Other Notes

Generic write views require both `view_librenmssettings` and `change_librenmssettings`, consistent with the existing permissions documentation. Bulk YAML export now scopes submitted primary keys through NetBox's restricted manager, preventing constrained users from exporting out-of-scope records.